### PR TITLE
ios: deliver PackedStringArray @ScriptProperty (List<String>) + delivery guardrail

### DIFF
--- a/docs/internals/ios-demo-port-tracker.md
+++ b/docs/internals/ios-demo-port-tracker.md
@@ -24,7 +24,7 @@ session without replaying prior history.
 | **Racing** | playable + camera-follow + steering joystick (R1 validated) |
 | **Bunnymark** | playable; FPS + Bunnies readouts safe-area-inset (E1 validated) |
 | **FPS** | playable; weapons `List<Weapon>` @ScriptProperty delivered + AnimatedSprite3D generated (F1). KNOWN: intermittent SIGSEGV in Audio autoload `_ready` (pre-existing lambda-connect infra, see F2) |
-| third-person | **PLAYABLE on iPhone 15 Pro (T1)** — runs, all scripts init, self-tests 54/78. Fixed on-device: attack crash (Vector3 in Variant path) + visuals (Mobile renderer, not gl_compatibility). KNOWN: enemy walk animation (AnimationTree `travel()`) not driving on iOS |
+| third-person | **PLAYABLE on iPhone 15 Pro (T1), walk-anim fixed** — runs, all scripts init, self-tests 54/78. Fixed on-device: attack crash (Vector3 in Variant path) + visuals (Mobile renderer, not gl_compatibility) + enemy walk animation (`List<String>`/PackedStringArray `@ScriptProperty` delivery, see T1 card) |
 
 ## Build / deploy / debug (see private handoff for exact commands + UDIDs)
 - **Build-check a demo's scripts** (fast, no device): `./gradlew installIosAddon
@@ -155,6 +155,24 @@ works. Two on-device fixes landed after the first launch:
   + `isPlaying()`/`getCurrentNode()` right after travel() to see if state advances; check AnimationTree.active;
   compare the stored playback handle vs a re-fetched `get()` handle. (See [[ios_script_model_unification]]-era
   AnimationMixer.getStateMachinePlayback custom section — it wraps the raw Variant Object handle.)
+
+  **UPDATE 2026-06-24 — WALK ANIMATION FIXED + DEVICE-VALIDATED.** Root cause was neither hypothesis
+  above: the AnimationTree was active and `travel()` was advancing state (proven by `[anim-dbg]` logs:
+  `node='Walk' playing=true`). The bug was that `BeetlebotSkin._force_loop: List<String>` (scene-stored
+  `PackedStringArray("Bob","walk")`) was **silently dropped on iOS** — the emitter only generated
+  list-property delivery cases for engine-wrapper / user-script element types, so a `List<String>`
+  fell through to the C dispatch's `else { return 0; }`. With `forceLoop` empty, the Walk animation
+  never got `LOOP_LINEAR` → played once and froze (looked static); one-shot Attack animated fine
+  because it doesn't need looping. Same class of silent drop as the FPS `List<Weapon>` gap. FIX
+  (branch `fix/ios-string-list-property-delivery`, 4 layers): emitter advertises `List<String>` as
+  Variant type 34 (PACKED_STRING_ARRAY) + emits a `setPropertyStringArray` bridge branch; Kotlin
+  runtime gains `setPropertyStringArray` + a `kanama_ios_runtime_script_instance_set_property_string_array`
+  @CName entrypoint; the C shim's `set_property` dispatch gains a `PACKED_STRING_ARRAY` branch that
+  extracts the packed array (reusing the existing `g_variant_to_packed_string_array` + cached
+  size/operator_index_const trio) and hands a C string array to Kotlin. Plus a build-time guardrail
+  that warns on any `@ScriptProperty` with no iOS delivery case (0 warnings on this demo). Device:
+  `property string-array set count=2` logs confirm delivery; bug visibly walks + animates on the
+  iPhone 15 Pro. `[anim-dbg]` diagnostic prints stripped from `BeetlebotSkin.kt` (kanama-demos).
 
 ### T1 — original task notes (now done) ────────────────────────────────────────
 **169 → 0 compile errors.** All layers landed + committed/pushed: KSP dual-annotation fix, 7 wrappers,

--- a/docs/internals/ios-demo-port-tracker.md
+++ b/docs/internals/ios-demo-port-tracker.md
@@ -144,20 +144,11 @@ works. Two on-device fixes landed after the first launch:
   `rendering_method.mobile="gl_compatibility"` — too low-tier for its Forward+-authored visuals (HDR
   tonemap, glow, screen-space water shader). Switched to `"mobile"` (Vulkan/MoltenVK); device-confirmed
   exposure + water correct. (Other demos keep gl_compatibility; they don't use those features.)
-- **KNOWN-OPEN — enemy walk animation:** BeetleBot calls `beetleSkin.walk()` every physics frame →
-  `BeetlebotSkin` runs `AnimationNodeStateMachinePlayback.travel("walk")`, but the bug doesn't animate
-  (floats to the player). The `travel()` binding is correct (`ptrcallWithStringNameAndBoolArg`, hash
-  3823612587) and `_ready` (which does `animationTree.getStateMachinePlayback("parameters/StateMachine/
-  playback")`) completes; the secondary-action timer also calls travel(). HYPOTHESES: (a) the playback
-  Ref obtained via the Variant `get("parameters/.../playback")` path isn't the AnimationTree's *live*
-  playback (RefCounted liveness / a fresh instance) so travel() drives a detached object; (b) the
-  AnimationTree isn't `active`/processing on iOS. NEXT (device round-trips): temp-log the playback handle
-  + `isPlaying()`/`getCurrentNode()` right after travel() to see if state advances; check AnimationTree.active;
-  compare the stored playback handle vs a re-fetched `get()` handle. (See [[ios_script_model_unification]]-era
-  AnimationMixer.getStateMachinePlayback custom section — it wraps the raw Variant Object handle.)
-
-  **UPDATE 2026-06-24 — WALK ANIMATION FIXED + DEVICE-VALIDATED.** Root cause was neither hypothesis
-  above: the AnimationTree was active and `travel()` was advancing state (proven by `[anim-dbg]` logs:
+- **Enemy walk animation (FIXED + device-validated):** BeetleBot calls `beetleSkin.walk()` every
+  physics frame → `BeetlebotSkin` runs `AnimationNodeStateMachinePlayback.travel("walk")`. Early
+  investigation suspected either a detached playback Ref from the Variant
+  `get("parameters/.../playback")` path or an inactive AnimationTree, but device logs ruled both
+  out: the AnimationTree was active and `travel()` was advancing state (proven by `[anim-dbg]` logs:
   `node='Walk' playing=true`). The bug was that `BeetlebotSkin._force_loop: List<String>` (scene-stored
   `PackedStringArray("Bob","walk")`) was **silently dropped on iOS** — the emitter only generated
   list-property delivery cases for engine-wrapper / user-script element types, so a `List<String>`

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
@@ -3,6 +3,7 @@ package net.multigesture.kanama.ios
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.COpaquePointerVar
 import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CPointerVar
 import kotlinx.cinterop.DoubleVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.FloatVar
@@ -75,6 +76,13 @@ internal interface KanamaIosScriptBridge {
         false
 
     fun setPropertyObjectArray(propertyIndex: Int, values: LongArray): Boolean =
+        false
+
+    // `List<String>` (Godot PackedStringArray) @ScriptProperty delivery. The C side extracts the
+    // packed array's elements to utf8 C strings and hands them here; the generated
+    // setPropertyStringArray branch assigns the list to the field. See the C
+    // PACKED_STRING_ARRAY set-property dispatch case + the emitter's string-list block.
+    fun setPropertyStringArray(propertyIndex: Int, values: List<String>): Boolean =
         false
 
     // Value-type @ScriptProperty delivery (NodePath/Vector2/Vector3/Color). [value] is the
@@ -335,6 +343,19 @@ internal object KanamaIosRuntime {
         val ok = instance.bridge.setPropertyObjectArray(propertyIndex, values)
         if (ok) {
             log("property array set handle=$handle index=$propertyIndex count=${values.size} path=${instance.resource.path}")
+        }
+        return ok
+    }
+
+    fun setScriptInstancePropertyStringArray(handle: Long, propertyIndex: Int, values: List<String>): Boolean {
+        val instance = scriptInstances[handle]
+        if (instance == null) {
+            log("property string-array set skipped for missing script instance handle=$handle")
+            return false
+        }
+        val ok = instance.bridge.setPropertyStringArray(propertyIndex, values)
+        if (ok) {
+            log("property string-array set handle=$handle index=$propertyIndex count=${values.size} path=${instance.resource.path}")
         }
         return ok
     }
@@ -608,6 +629,22 @@ fun kanamaIosRuntimeScriptInstanceSetPropertyArray(
         LongArray(count) { i -> objects[i] }
     }
     return if (KanamaIosRuntime.setScriptInstancePropertyArray(instanceHandle, propertyIndex, values)) 1 else 0
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_instance_set_property_string_array")
+fun kanamaIosRuntimeScriptInstanceSetPropertyStringArray(
+    instanceHandle: Long,
+    propertyIndex: Int,
+    strings: CPointer<CPointerVar<ByteVar>>?,
+    count: Int,
+): Int {
+    val values: List<String> = if (strings == null || count <= 0) {
+        emptyList()
+    } else {
+        List(count) { i -> strings[i]?.toKString() ?: "" }
+    }
+    return if (KanamaIosRuntime.setScriptInstancePropertyStringArray(instanceHandle, propertyIndex, values)) 1 else 0
 }
 
 // PT_* tags — must match the KANAMA_IOS_PT_* enum in kanama_ios_shim.c. NODE_PATH/STRING ship a

--- a/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
+++ b/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
@@ -24,7 +24,8 @@ import net.multigesture.kanama.types.Vector3
 // Parallel-run gate fixture (Phase 3.2). Exercises the common iOS bridge shapes so the
 // `checkIosScriptRegistryParity` task can prove the KSP processor emits the same registry as
 // the legacy regex parser: ZERO/DOUBLE/OBJECT/LONG bridge kinds, a zero-arg helper method, a
-// scalar Long + String @ScriptProperty, and a @Signal. Uses only iOS-available wrappers.
+// scalar Long + String + List<String> @ScriptProperty, and a @Signal. Uses only iOS-available
+// wrappers.
 @ScriptClass(attachTo = "Label")
 class GateFixtureScript(godotObject: MemorySegment) : KanamaScript<Label>(godotObject, ::Label) {
     @ScriptProperty
@@ -32,6 +33,9 @@ class GateFixtureScript(godotObject: MemorySegment) : KanamaScript<Label>(godotO
 
     @ScriptProperty
     var title: String = ""
+
+    @ScriptProperty
+    var forceLoop: List<String> = emptyList()
 
     // Value-type @ScriptProperty delivery (Phase 3.2 Step 5 / 2.6). The motivating case is the
     // platformer `view: NodePath`; offset/aim exercise the Vector2/Vector3 set-property paths.

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -86,6 +86,15 @@ extern int32_t kanama_ios_runtime_script_instance_set_property_string(
     int32_t property_index,
     const char *value
 );
+// `List<String>` (Godot PackedStringArray) @ScriptProperty delivery. The C dispatch extracts
+// each packed-array element to a utf8 C string and passes them here; the Kotlin runtime hands
+// a List<String> to the generated setPropertyStringArray bridge branch.
+extern int32_t kanama_ios_runtime_script_instance_set_property_string_array(
+    int64_t instance_handle,
+    int32_t property_index,
+    const char *const *strings,
+    int32_t count
+);
 // Value-type (NodePath/Vector2/Vector3/Color) @ScriptProperty delivery: the C side extracts
 // the Variant into a PT-tagged raw byte buffer and hands it across. NODE_PATH ships its utf8
 // path bytes (PT_NODE_PATH); Vector2/3/Color ship their float32 components (PT_VECTOR2/
@@ -305,6 +314,7 @@ static GDExtensionTypeFromVariantConstructorFunc g_variant_to_color = NULL;
 static GDExtensionTypeFromVariantConstructorFunc g_variant_to_node_path = NULL;
 static GDExtensionTypeFromVariantConstructorFunc g_variant_to_string_name = NULL;
 static GDExtensionTypeFromVariantConstructorFunc g_variant_to_plane = NULL;
+static GDExtensionTypeFromVariantConstructorFunc g_variant_to_packed_string_array = NULL;
 static GDExtensionPtrConstructor g_string_from_node_path_constructor = NULL;
 static GDExtensionPtrBuiltInMethod g_array_size_method = NULL;
 static GDExtensionPtrBuiltInMethod g_array_get_method = NULL;
@@ -744,6 +754,8 @@ static int kanama_ios_resolve_godot_api(void) {
     g_variant_to_node_path = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_NODE_PATH);
     g_variant_to_string_name = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_STRING_NAME);
     g_variant_to_plane = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_PLANE);
+    g_variant_to_packed_string_array = g_get_variant_to_type_constructor(
+        KANAMA_IOS_VARIANT_TYPE_PACKED_STRING_ARRAY);
     // String(from: NodePath) — constructor index 3 in extension_api.json. Lets the set-property
     // value path turn a NodePath Variant into utf8 (no GDExtension NodePath->utf8 exists).
     g_string_from_node_path_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_STRING, 3);
@@ -6191,6 +6203,55 @@ static GDExtensionBool kanama_ios_script_instance_set_property(
         int32_t ok = kanama_ios_runtime_script_instance_set_property_value(
             instance->runtime_handle, property_index, KANAMA_IOS_PT_COLOR,
             (const uint8_t *)comps, (int32_t)sizeof(comps));
+        return (GDExtensionBool)ok;
+    } else if (type == KANAMA_IOS_VARIANT_TYPE_PACKED_STRING_ARRAY
+               && g_variant_to_packed_string_array != NULL) {
+        // List<String> @ScriptProperty delivery. Extract the PackedStringArray from the Variant
+        // into its opaque storage, then iterate via the cached size/operator_index_const builtins
+        // (same trio the no-arg ptrcall return helper uses), dup each element to utf8, and hand
+        // the C string array to the Kotlin runtime entrypoint.
+        kanama_ios_cache_packed_string_methods();
+        if (g_packed_string_array_size_method == NULL ||
+            g_packed_string_array_operator_index_const == NULL) {
+            return 0;
+        }
+        KANAMA_IOS_PACKED_ARRAY_STORAGE(array_storage);
+        g_variant_to_packed_string_array(
+            (GDExtensionUninitializedTypePtr)array_storage,
+            (GDExtensionVariantPtr)(intptr_t)value);
+        int64_t count = 0;
+        g_packed_string_array_size_method(array_storage, NULL, &count, 0);
+        if (count < 0) {
+            count = 0;
+        }
+        const char **strings = NULL;
+        if (count > 0) {
+            strings = (const char **)calloc((size_t)count, sizeof(char *));
+            if (strings == NULL) {
+                if (g_packed_string_array_destructor != NULL) {
+                    g_packed_string_array_destructor(array_storage);
+                }
+                return 0;
+            }
+            for (int64_t i = 0; i < count; i++) {
+                GDExtensionStringPtr str = g_packed_string_array_operator_index_const(
+                    array_storage, (GDExtensionInt)i);
+                strings[i] = (str != NULL)
+                    ? kanama_ios_string_to_utf8_dup((GDExtensionConstStringPtr)str)
+                    : NULL;
+            }
+        }
+        int32_t ok = kanama_ios_runtime_script_instance_set_property_string_array(
+            instance->runtime_handle, property_index, strings, (int32_t)count);
+        if (strings != NULL) {
+            for (int64_t i = 0; i < count; i++) {
+                free((void *)strings[i]);
+            }
+            free(strings);
+        }
+        if (g_packed_string_array_destructor != NULL) {
+            g_packed_string_array_destructor(array_storage);
+        }
         return (GDExtensionBool)ok;
     } else {
         return 0;

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -366,6 +366,7 @@ static GDExtensionVariantFromTypeConstructorFunc g_variant_from_string_name = NU
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_int = NULL;
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_bool = NULL;
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_string = NULL;
+static GDExtensionVariantFromTypeConstructorFunc g_variant_from_packed_string_array = NULL;
 static int g_main_loop_callbacks_registered = 0;
 static int g_main_loop_callbacks_active = 0;
 static int g_main_loop_callback_frame_count = 0;
@@ -773,6 +774,8 @@ static int kanama_ios_resolve_godot_api(void) {
     g_variant_from_int = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_INT);
     g_variant_from_bool = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_BOOL);
     g_variant_from_string = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_STRING);
+    g_variant_from_packed_string_array =
+        g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_PACKED_STRING_ARRAY);
 
     if (
         g_string_name_destructor == NULL ||
@@ -799,7 +802,8 @@ static int kanama_ios_resolve_godot_api(void) {
         g_variant_from_string_name == NULL ||
         g_variant_from_int == NULL ||
         g_variant_from_bool == NULL ||
-        g_variant_from_string == NULL
+        g_variant_from_string == NULL ||
+        g_variant_from_packed_string_array == NULL
     ) {
         fprintf(stderr, "[kanama][ios][c] error: failed to resolve Godot builtin helpers\n");
         return 0;
@@ -7600,6 +7604,40 @@ static void kanama_ios_ptrcall_selftest(void) {
         if (g_variant_destroy != NULL) { g_variant_destroy((GDExtensionVariantPtr)variant); }
     } else {
         KANAMA_IOS_ST_CHECK("setprop-vector3", 0);
+    }
+    // PackedStringArray round-trip: build the same Variant shape Godot delivers for
+    // List<String> @ScriptProperty values, extract it through the set-property primitive, and
+    // verify the utf8 element path used by kanama_ios_script_instance_set_property.
+    if (g_variant_from_packed_string_array != NULL && g_variant_to_packed_string_array != NULL) {
+        kanama_ios_cache_packed_string_methods();
+        KANAMA_IOS_PACKED_ARRAY_STORAGE(in_array);
+        KANAMA_IOS_PACKED_ARRAY_STORAGE(out_array);
+        kanama_ios_init_packed_string_array_one(in_array, "walk");
+        uint8_t variant[24] = {0};
+        g_variant_from_packed_string_array(
+            (GDExtensionUninitializedVariantPtr)variant,
+            (GDExtensionTypePtr)in_array);
+        g_variant_to_packed_string_array(
+            (GDExtensionUninitializedTypePtr)out_array,
+            (GDExtensionVariantPtr)variant);
+        int64_t count = 0;
+        if (g_packed_string_array_size_method != NULL) {
+            g_packed_string_array_size_method(out_array, NULL, &count, 0);
+        }
+        GDExtensionStringPtr str = (g_packed_string_array_operator_index_const != NULL && count == 1)
+            ? g_packed_string_array_operator_index_const(out_array, 0)
+            : NULL;
+        char *utf8 = kanama_ios_string_to_utf8_dup((GDExtensionConstStringPtr)str);
+        KANAMA_IOS_ST_CHECK("setprop-packed-string-array",
+            count == 1 && utf8 != NULL && strcmp(utf8, "walk") == 0);
+        free(utf8);
+        if (g_packed_string_array_destructor != NULL) {
+            g_packed_string_array_destructor(out_array);
+            g_packed_string_array_destructor(in_array);
+        }
+        if (g_variant_destroy != NULL) { g_variant_destroy((GDExtensionVariantPtr)variant); }
+    } else {
+        KANAMA_IOS_ST_CHECK("setprop-packed-string-array", 0);
     }
 
     fprintf(stderr, "[kanama][ios][c] PTRCALL SELFTEST MATRIX: %d passed, %d failed\n", pass, fail);

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -73,9 +73,14 @@ internal data class IosProperty(
     // Kotlin script instance via iosScriptInstanceForOwner. Empty for non-custom-script properties.
     val customScriptFqName: String = "",
     // FQ name of a user @ScriptClass element type for a `List<UserScript>` property (e.g. FPS
-    // `weapons: List<Weapon>`). Each delivered owner handle is resolved to its live Kotlin script
-    // instance. Empty unless the array element is a user @ScriptClass type.
+    // `weapons: List<Weapon>`). Each delivered owner handle is resolved to its live Kotlin
+    // script instance. Empty unless the array element is a user @ScriptClass type.
     val arrayElementCustomScriptFqName: String = "",
+    // True for a `List<String>` property (Godot PackedStringArray). Delivered as a string list
+    // via the set-property string-array path (the engine ships the scene-stored
+    // PackedStringArray, the C dispatch extracts each element, the runtime hands a
+    // List<String> to the generated bridge). See `setPropertyStringArray`.
+    val listElementIsString: Boolean = false,
 )
 
 internal data class IosSignal(
@@ -259,6 +264,18 @@ internal class IosScriptCodeEmitter(
                 builder.appendLine("        else -> false")
                 builder.appendLine("    }")
             }
+            val stringListProperties = script.properties.filter { it.isList && it.listElementIsString }
+            if (stringListProperties.isNotEmpty()) {
+                builder.appendLine()
+                builder.appendLine("    override fun setPropertyStringArray(propertyIndex: Int, values: List<String>): Boolean = when (propertyIndex) {")
+                script.properties.forEachIndexed { index, property ->
+                    if (property.isList && property.listElementIsString) {
+                        builder.appendLine("        $index -> { script.${property.kotlinName} = values; true }")
+                    }
+                }
+                builder.appendLine("        else -> false")
+                builder.appendLine("    }")
+            }
             val valueProperties = script.properties.filter { it.valueTypeClassName.isNotEmpty() }
             if (valueProperties.isNotEmpty()) {
                 builder.appendLine()
@@ -271,9 +288,43 @@ internal class IosScriptCodeEmitter(
                 builder.appendLine("        else -> false")
                 builder.appendLine("    }")
             }
+            // Guardrail: warn on any @ScriptProperty that gets NO iOS delivery case across the
+            // set-property blocks above. Such a property silently keeps its Kotlin default (the
+            // scene-stored value is dropped) — the class of bug that hid the third-person
+            // BeetlebotSkin._force_loop (List<String>) and FPS List<Weapon> drops. The conditions
+            // here mirror the five blocks exactly so the warning fires only for genuine gaps.
+            script.properties.forEach { property ->
+                if (!hasIosPropertyDeliveryCase(property)) {
+                    warn(
+                        "[kanama-ios] ${script.className}.${property.kotlinName} — no iOS " +
+                            "@ScriptProperty delivery case; the scene-stored value will be " +
+                            "silently dropped (kept its Kotlin default).",
+                    )
+                }
+            }
             builder.appendLine("}")
         }
         return builder.toString()
+    }
+
+    /** True iff [property] gets a delivery case in one of the set-property* blocks. */
+    private fun hasIosPropertyDeliveryCase(property: IosProperty): Boolean {
+        if (property.isObjectType && property.godotClassName.isNotEmpty()) return true
+        if (property.customScriptFqName.isNotEmpty()) return true
+        if (!property.isObjectType && !property.isList && property.godotClassName == "String") return true
+        if (!property.isObjectType && !property.isList && property.godotClassName.isNotEmpty() &&
+            property.godotClassName != "String"
+        ) {
+            return true
+        }
+        if (property.isList && property.listElementIsString) return true
+        if (property.isList && (property.listElementClassName.isNotEmpty() ||
+                property.arrayElementCustomScriptFqName.isNotEmpty())
+        ) {
+            return true
+        }
+        if (property.valueTypeClassName.isNotEmpty()) return true
+        return false
     }
 
     /** `<Class>Signals` / `<Class>Methods` / `<Class>Names` helper objects. */
@@ -513,6 +564,7 @@ internal class IosScriptCodeEmitter(
         }
         val godotVariantType = when {
             isObject -> 24 // OBJECT
+            isList && arrayElementString -> 34 // PACKED_STRING_ARRAY (List<String>)
             isList -> 28 // ARRAY
             else -> godotVariantTypeFor(type)
         }
@@ -528,6 +580,7 @@ internal class IosScriptCodeEmitter(
             godotVariantType = godotVariantType,
             customScriptFqName = customScript,
             arrayElementCustomScriptFqName = if (isList) arrayElementCustomScriptFqName.orEmpty() else "",
+            listElementIsString = isList && arrayElementString,
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes the last open issue from the iOS third-person demo port (T1): the enemy beetle's **walk animation froze** on iOS. Adds iOS delivery for `List<String>` (`@Export`/`@ScriptProperty` backed by a Godot `PackedStringArray`) — a property type the iOS emitter previously had no delivery case for, so scene-stored values were **silently dropped**. Also adds a **build-time guardrail** that warns on any `@ScriptProperty` with no iOS delivery case, so this class of silent bug is caught at build time going forward.

Device-validated on iPhone 15 Pro: the beetle now visibly walks + animates.

---

## Context for reviewers (self-contained — no transcript needed)

Kanama's iOS backend delivers scene-stored `@ScriptProperty`/`@Export` values to Kotlin script instances through a chain: the engine calls a C `set_property` callback → the C dispatch decodes the Variant by type → it calls a Kotlin `@CName` entrypoint → the generated per-script bridge assigns the value to the field. The iOS KSP emitter (`IosScriptCodeEmitter`) generates one `setProperty*` override block per delivery shape:

- `setProperty(Long)` — objects, ints, bools, floats
- `setPropertyString(String)` — strings
- `setPropertyObjectArray(LongArray)` — `List<EngineWrapper>` and `List<UserScript>`
- `setPropertyValue(Any)` — value types (NodePath/Vector2/Vector3/Color)

A property whose type matches **none** of those blocks gets no generated case. On the C side, a Variant type with no dispatch branch hits `else { return 0; }` — the value is silently dropped, and the Kotlin field keeps its default. There is no compile error and no warning; you only discover it via odd runtime behavior.

### The bug

`BeetlebotSkin._force_loop: List<String>` is `@Export`-ed and the scene stores `PackedStringArray("Bob", "walk")`. `_ready` iterates `forceLoop` and sets each named animation to `Animation.LOOP_LINEAR`:

```kotlin
for (animationName in forceLoop) {
    animationPlayer.getAnimation(animationName)?.setLoopMode(Animation.LOOP_LINEAR)
}
```

On iOS, `forceLoop` was always empty (the `PackedStringArray` was dropped), so `Walk` never got `LOOP_LINEAR` → it played once and froze on frame 0 (looked static). The one-shot `Attack` animation played fine because it doesn't need looping. This is why "attack animates but walk doesn't" was the observed symptom.

This is the same class of silent drop as the earlier FPS `List<Weapon>` gap (which was fixed by adding the `setPropertyObjectArray` user-script path).

> **Note for reviewers:** an earlier investigation hypothesis was that `AnimationNodeStateMachinePlayback.travel()` wasn't driving the `AnimationTree` on iOS. That was ruled out on-device: `[anim-dbg]` diagnostic logs proved `travel()` advances state correctly (`getCurrentNode()=='Walk'`, `playing=true`, `active=true`). The real cause was purely the missing property delivery.

---

## The fix (4 layers, all additive)

### Layer 1 — Emitter (`processor/.../IosScriptCodeEmitter.kt`)
- `IosProperty` gains `listElementIsString: Boolean` (populated from the existing `ScriptPropertyModel.arrayElementString` flag — no model change needed).
- A new `setPropertyStringArray(propertyIndex: Int, values: List<String>)` override block is emitted for scripts that have string-list properties, assigning `values` directly to the field.
- The advertised Godot Variant type for a string list is now **34 (`PACKED_STRING_ARRAY`)** instead of 28 (`ARRAY`), so the engine ships the scene-stored packed array natively and the C dispatch routes it to the new branch. (Chosen over keeping type 28 + decoding string elements in the generic-Array branch because 34 is semantically correct and lets the engine deliver the native packed array. Verified empirically: the engine delivers the value with type 34.)

### Layer 2 — Kotlin runtime (`ios-runtime/.../ios/KanamaIosRuntime.kt`)
- `KanamaIosScriptBridge.setPropertyStringArray(propertyIndex: Int, values: List<String>): Boolean` (default `false`).
- `KanamaIosRuntime.setScriptInstancePropertyStringArray(handle, index, values)` (mirrors the existing `setScriptInstancePropertyString`/`setScriptInstancePropertyArray`, with a `property string-array set` log line).
- `@CName("kanama_ios_runtime_script_instance_set_property_string_array")` top-level entrypoint taking `CPointer<CPointerVar<ByteVar>>?` + count, mapping each C string via `toKString()` to a `List<String>`.

### Layer 3 — C shim (`ios/bootstrap/kanama_ios_shim.c`)
- Resolves `g_variant_to_packed_string_array` via the existing `g_get_variant_to_type_constructor` (no new lookup).
- Adds a `KANAMA_IOS_VARIANT_TYPE_PACKED_STRING_ARRAY` branch to `kanama_ios_script_instance_set_property`: extracts the packed array from the Variant into opaque storage (`KANAMA_IOS_PACKED_ARRAY_STORAGE`), iterates via the **already-cached** `g_packed_string_array_size_method` + `g_packed_string_array_operator_index_const` trio (same primitives the no-arg `ptrcall_ret_packed_string_array` helper uses), dups each element to utf8 with `kanama_ios_string_to_utf8_dup`, hands the `const char *const *` array to the Kotlin entrypoint, then frees everything (strings + the packed array destructor).
- Adds the `extern` decl for the new Kotlin entrypoint.
- **No new method-bind hashes, no new builtin lookups** — reuses existing packed-string infrastructure.

### Layer 4 — Guardrail (`processor/.../IosScriptCodeEmitter.kt`)
- After the five `setProperty*` blocks, the emitter now calls `warn("[kanama-ios] <Class>.<prop> — no iOS @ScriptProperty delivery case; the scene-stored value will be silently dropped")` for any property that gets no case in any block.
- `hasIosPropertyDeliveryCase(property)` mirrors the five blocks' conditions exactly, so the warning fires only for genuine gaps.
- Severity is **build warning only** (non-blocking) per a deliberate choice: it surfaces the issue in addon build output without failing CI on pre-existing drops in other demos. The `warn` channel already exists and is wired to `env.logger.warn` (`KanamaProcessor.kt:782`).

---

## Suggested review focus

The highest-risk / highest-leverage parts, in order:

1. **C memory management (`kanama_ios_shim.c` PACKED_STRING_ARRAY branch).** The branch allocates a `const char **` array + per-element utf8 dups, then must free them all on every return path (including the `calloc`-failure early return, which still runs the packed-array destructor). Verify no leak on the failure path and that the packed-array destructor always runs after `g_variant_to_packed_string_array`.
2. **Variant type 34 vs 28 decision (emitter `toIosProperty`).** Advertising `PACKED_STRING_ARRAY` means the engine delivers the scene-stored value natively; if a reviewer prefers keeping `ARRAY` (28) and decoding string elements inside the existing generic-Array C branch, that's the main alternative. The PR chose 34 for semantic correctness + native delivery, verified empirically on-device.
3. **Guardrail condition parity (`hasIosPropertyDeliveryCase`).** Its conditions must mirror the five `setProperty*` blocks *exactly*, else it either cries wolf (false warning on a delivered property) or misses a real drop. Worth a line-by-line cross-check against the five `when` blocks above it.
4. **Additivity / no regression to other demos.** The emitter change only adds a new block + a new Variant-type branch; existing `setProperty*` blocks are untouched. The guardrail is warning-only, so it cannot break a building demo. The C change adds a new `else if` branch before the existing fallthrough `else { return 0; }`, so prior types route unchanged.

---

## Verification

### Codegen + compile
- `installIosAddon` builds clean (full Xcode + cinterop regen, ~3min).
- Generated `BeetlebotSkinIosBridge` confirms the fix:
  - `KanamaIosScriptProperty("_force_loop", 34)` (Variant type 34)
  - `override fun setPropertyStringArray(...): 0 -> { script.forceLoop = values; true }`
- Guardrail: `:ios-runtime:kspKotlinIosArm64` on the full third-person demo (28 scripts) emits **0** silent-drop warnings — every `@ScriptProperty` now has a delivery case.

### Device (iPhone 15 Pro)
- Deployed via `ios_device_run.sh`. App launches, all script instances init, self-tests 54/78 (ptrcall) + 78/78 (ObjectCalls), no crashes.
- Console confirms delivery at scene load: `property string-array set handle=68 index=0 count=2 path=res://kotlin-src/BeetlebotSkin.kt` (5 BeetlebotSkin instances, `count=2` = `"Bob"` + `"walk"`).
- **User-confirmed on device: the beetle now visibly walks with animation** (previously it floated to the player with a static mesh).
- Validated twice: once with diagnostic `[anim-dbg]` prints (proved `travel()` advances to `Walk`/`playing=true`), then after stripping those prints (clean build, no behavior change, delivery still fires).

---

## Files changed

| File | Change |
| --- | --- |
| `processor/.../IosScriptCodeEmitter.kt` | `IosProperty.listElementIsString`; `setPropertyStringArray` block; Variant type 34 for string lists; silent-drop guardrail + `hasIosPropertyDeliveryCase` |
| `ios-runtime/.../ios/KanamaIosRuntime.kt` | `setPropertyStringArray` bridge method + runtime dispatcher + `@CName` entrypoint; `CPointerVar` import |
| `ios/bootstrap/kanama_ios_shim.c` | `g_variant_to_packed_string_array` resolution; `PACKED_STRING_ARRAY` dispatch branch; extern decl for the Kotlin entrypoint |
| `docs/internals/ios-demo-port-tracker.md` | T1 walk-anim moved from KNOWN-OPEN → FIXED + device-validated, with root-cause + fix summary |

3 source files (+153/-2), 1 doc.

---

## Scope / non-goals

- **Only `List<String>` is handled.** Other `List<ValueType>` (e.g. `List<Vector2>`, `List<Int>`) still have no iOS delivery case and will now emit the guardrail warning (which is the intended surfacing). Wiring those is a separate follow-up if a demo needs it.
- The advertised-Variant-type choice (34 vs 28) was verified empirically for `List<String>` only.
- No `kanama-demos` change is required for the fix — the demo source was already correct (works on Android as-is). The `[anim-dbg]` diagnostic `println`s added during investigation were uncommitted working-tree edits and have been stripped (reverted to the committed state); there is no kanama-demos commit in this PR.

## Follow-ups (tracked, not in this PR)
- Full systematic `int32 → Long` return widening (separate, needs ~a dozen new Long-return ptrcall helpers first).
- `PropertyTweener.from` overloads beyond `Color`.

## How to validate/reproduce
- Build-check: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew installIosAddon -PkanamaIosProjectDir=<demoDir> -PkanamaIosProjectScriptsDir=<demoDir>/kotlin-src`
- Guardrail warnings: `./gradlew :ios-runtime:kspKotlinIosArm64 -PkanamaIosProjectScriptsDir=<demoDir>/kotlin-src --rerun-tasks` (look for `[kanama-ios] ... no iOS @ScriptProperty delivery case`)
- Device: see `docs/internals/ios-demo-port-tracker.md` "Build / deploy / debug" + the private handoff for exact commands/UDIDs.