### PR TITLE
Centralize GodotReal handling

### DIFF
--- a/ios-runtime/build.gradle.kts
+++ b/ios-runtime/build.gradle.kts
@@ -28,6 +28,8 @@ val configuredIosScriptDirs =
         .orElse(providers.gradleProperty("kanamaProjectScriptsDirs"))
         .orElse(providers.gradleProperty("kanamaProjectScriptsDir"))
 
+val kanamaPrecision = providers.gradleProperty("kanamaPrecision").orElse("single")
+
 kotlin {
     iosArm64()
     iosSimulatorArm64()
@@ -66,6 +68,21 @@ kotlin {
         val iosSimulatorArm64Main by getting {
             dependsOn(iosMain)
             iosScriptDirs(configuredIosScriptDirs.orNull).forEach { kotlin.srcDir(file(it)) }
+        }
+    }
+}
+
+tasks.configureEach {
+    if (name.startsWith("compileKotlinIos")) {
+        inputs.property("kanamaPrecision", kanamaPrecision)
+        doFirst {
+            val selected = kanamaPrecision.get()
+            if (selected != "single") {
+                throw GradleException(
+                    "iOS currently supports only single-precision Godot real_t; " +
+                        "-PkanamaPrecision=$selected is unsupported for :ios-runtime",
+                )
+            }
         }
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
@@ -671,7 +671,13 @@ object Mathf {
 
     // Godot's @GlobalScope.is_equal_approx (CMP_EPSILON fuzzy compare), via the shared iOS helper.
     fun isEqualApprox(a: Double, b: Double): Boolean =
-        net.multigesture.kanama.types.isEqualApprox(a, b)
+        if (a == b) {
+            true
+        } else {
+            val epsilon = 0.00001
+            val tolerance = kotlin.math.max(epsilon * kotlin.math.abs(a), epsilon)
+            kotlin.math.abs(a - b) < tolerance
+        }
 
     fun lerpAngle(from: Double, to: Double, weight: Double): Double {
         val difference = ((to - from + PI) % (PI * 2.0)) - PI
@@ -845,7 +851,7 @@ internal object IosGodot {
         }
 
     fun node2dSetPosition(node: Long, value: Vector2) {
-        kanama_ios_godot_node2d_set_position(node, value.x, value.y)
+        kanama_ios_godot_node2d_set_position(node, value.x.toDouble(), value.y.toDouble())
     }
 
     fun node2dGetScale(node: Long): Vector2 =
@@ -857,35 +863,35 @@ internal object IosGodot {
         }
 
     fun node2dSetScale(node: Long, value: Vector2) {
-        kanama_ios_godot_node2d_set_scale(node, value.x, value.y)
+        kanama_ios_godot_node2d_set_scale(node, value.x.toDouble(), value.y.toDouble())
     }
 
     fun node3dGetPosition(node: Long): Vector3 =
         node3dGetVector3(node, ::kanama_ios_godot_node3d_get_position)
 
     fun node3dSetPosition(node: Long, value: Vector3) {
-        kanama_ios_godot_node3d_set_position(node, value.x, value.y, value.z)
+        kanama_ios_godot_node3d_set_position(node, value.x.toDouble(), value.y.toDouble(), value.z.toDouble())
     }
 
     fun node3dGetRotation(node: Long): Vector3 =
         node3dGetVector3(node, ::kanama_ios_godot_node3d_get_rotation)
 
     fun node3dSetRotation(node: Long, value: Vector3) {
-        kanama_ios_godot_node3d_set_rotation(node, value.x, value.y, value.z)
+        kanama_ios_godot_node3d_set_rotation(node, value.x.toDouble(), value.y.toDouble(), value.z.toDouble())
     }
 
     fun node3dGetScale(node: Long): Vector3 =
         node3dGetVector3(node, ::kanama_ios_godot_node3d_get_scale)
 
     fun node3dSetScale(node: Long, value: Vector3) {
-        kanama_ios_godot_node3d_set_scale(node, value.x, value.y, value.z)
+        kanama_ios_godot_node3d_set_scale(node, value.x.toDouble(), value.y.toDouble(), value.z.toDouble())
     }
 
     fun node3dGetGlobalPosition(node: Long): Vector3 =
         node3dGetVector3(node, ::kanama_ios_godot_node3d_get_global_position)
 
     fun node3dSetGlobalPosition(node: Long, value: Vector3) {
-        kanama_ios_godot_node3d_set_global_position(node, value.x, value.y, value.z)
+        kanama_ios_godot_node3d_set_global_position(node, value.x.toDouble(), value.y.toDouble(), value.z.toDouble())
     }
 
     fun node3dRotateY(node: Long, angle: Double) {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/BuiltinCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/BuiltinCalls.kt
@@ -8,7 +8,6 @@ import kotlinx.cinterop.COpaquePointerVar
 import kotlinx.cinterop.CValuesRef
 import kotlinx.cinterop.DoubleVar
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.FloatVar
 import kotlinx.cinterop.IntVar
 import kotlinx.cinterop.LongVar
 import kotlinx.cinterop.MemScope
@@ -22,6 +21,8 @@ import kotlinx.cinterop.set
 import kotlinx.cinterop.value
 import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_builtin_call
 import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_get_builtin_method
+import net.multigesture.kanama.types.GodotRealArray
+import net.multigesture.kanama.types.GodotRealVar
 
 /**
  * iOS implementation of value-type (builtin) method calls — the analogue of [ObjectCalls]
@@ -31,8 +32,8 @@ import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_get_builtin_method
  * which calls `method(base, args, ret, argc)` with raw value byte buffers. Mirrors the
  * desktop `BuiltinTypes.call`.
  *
- * Marshalling note: value components are real_t = 4-byte float32 in single-precision iOS
- * builds, laid out in the same column-major order the [ObjectCalls] ptrcall helpers use.
+ * Marshalling note: value components are `real_t` in iOS builds, laid out in the same
+ * column-major order the [ObjectCalls] ptrcall helpers use.
  */
 object BuiltinCalls {
     // Godot Variant type ids (Variant::Type) — must match the engine enum.
@@ -53,8 +54,8 @@ object BuiltinCalls {
 
     /** An argument to a builtin method call (the value-type analogue of a ptrcall arg). */
     sealed interface BArg {
-        /** A struct value laid out as float32 [values] (Vector3/Basis/Transform3D/…); [tag] is its PT_*. */
-        data class Floats(val tag: Int, val values: FloatArray) : BArg
+        /** A struct value laid out as `real_t` [values] (Vector3/Basis/Transform3D/…); [tag] is its PT_*. */
+        data class Floats(val tag: Int, val values: GodotRealArray) : BArg
         /** A `bool` arg (1-byte). */
         data class Bool(val value: Boolean) : BArg
         /** A scalar `float`/`double` arg (8-byte double at ptrcall). */
@@ -64,13 +65,13 @@ object BuiltinCalls {
     fun getBuiltinMethod(variantType: Int, method: String, hash: Long): Long =
         kanama_ios_godot_get_builtin_method(variantType, method, hash)
 
-    // Marshal [base] (float32 components) + [args] (PT-tagged), then invoke the builtin
+    // Marshal [base] (real_t components) + [args] (PT-tagged), then invoke the builtin
     // method writing into the caller-supplied [ret] buffer. The ret encoding is the
-    // caller's choice (float32 components for a value-type return; an 8-byte double for a
+    // caller's choice (real_t components for a value-type return; an 8-byte double for a
     // scalar `float` return — see [callScalar]). Concentrates the arg layout/tags, mirroring
     // the desktop `BuiltinTypes` call helpers.
-    private fun MemScope.invokeBuiltin(methodPtr: Long, base: FloatArray, args: List<BArg>, ret: CValuesRef<*>?) {
-        val baseBuf = allocArray<FloatVar>(if (base.isNotEmpty()) base.size else 1)
+    private fun MemScope.invokeBuiltin(methodPtr: Long, base: GodotRealArray, args: List<BArg>, ret: CValuesRef<*>?) {
+        val baseBuf = allocArray<GodotRealVar>(if (base.isNotEmpty()) base.size else 1)
         for (i in base.indices) baseBuf[i] = base[i]
         val n = args.size
         val tags = allocArray<IntVar>(if (n > 0) n else 1)
@@ -78,7 +79,7 @@ object BuiltinCalls {
         args.forEachIndexed { i, a ->
             when (a) {
                 is BArg.Floats -> {
-                    val b = allocArray<FloatVar>(if (a.values.isNotEmpty()) a.values.size else 1)
+                    val b = allocArray<GodotRealVar>(if (a.values.isNotEmpty()) a.values.size else 1)
                     for (j in a.values.indices) b[j] = a.values[j]
                     tags[i] = a.tag; ptrs[i] = b.reinterpret<CPointed>()
                 }
@@ -96,21 +97,21 @@ object BuiltinCalls {
     }
 
     /**
-     * Call a builtin method whose base and return are value types laid out as float32
-     * components ([base] in, [retCount] floats out), with optional [args].
+     * Call a builtin method whose base and return are value types laid out as `real_t`
+     * components ([base] in, [retCount] values out), with optional [args].
      */
-    fun call(methodPtr: Long, base: FloatArray, retCount: Int, args: List<BArg> = emptyList()): FloatArray =
+    fun call(methodPtr: Long, base: GodotRealArray, retCount: Int, args: List<BArg> = emptyList()): GodotRealArray =
         memScoped {
-            val ret = allocArray<FloatVar>(if (retCount > 0) retCount else 1)
+            val ret = allocArray<GodotRealVar>(if (retCount > 0) retCount else 1)
             invokeBuiltin(methodPtr, base, args, ret)
-            FloatArray(retCount) { ret[it] }
+            GodotRealArray(retCount) { ret[it] }
         }
 
     /**
      * No-arg builtin method whose base and return are the same value type laid out as
-     * float32 components (inverse / transposed / orthonormalized / …).
+     * `real_t` components (inverse / transposed / orthonormalized / …).
      */
-    fun callNoArgsFloat32(methodPtr: Long, base: FloatArray): FloatArray =
+    fun callNoArgsFloat32(methodPtr: Long, base: GodotRealArray): GodotRealArray =
         call(methodPtr, base, base.size, emptyList())
 
     /**
@@ -121,7 +122,7 @@ object BuiltinCalls {
      * `BuiltinTypes`, which allocates a JAVA_DOUBLE ret). An `int`/`bool` scalar return
      * would need its own decode width.
      */
-    fun callScalar(methodPtr: Long, base: FloatArray, args: List<BArg> = emptyList()): Double =
+    fun callScalar(methodPtr: Long, base: GodotRealArray, args: List<BArg> = emptyList()): Double =
         memScoped {
             val ret = alloc<DoubleVar>()
             invokeBuiltin(methodPtr, base, args, ret.ptr)
@@ -133,7 +134,7 @@ object BuiltinCalls {
      * encodes a bool return as a single `uint8_t` (`PtrToArg<bool>` = uint8), so decode one
      * byte (≠ 0 → true).
      */
-    fun callBool(methodPtr: Long, base: FloatArray, args: List<BArg> = emptyList()): Boolean =
+    fun callBool(methodPtr: Long, base: GodotRealArray, args: List<BArg> = emptyList()): Boolean =
         memScoped {
             val ret = alloc<ByteVar>()
             invokeBuiltin(methodPtr, base, args, ret.ptr)
@@ -144,7 +145,7 @@ object BuiltinCalls {
      * Builtin method returning an `int` (max_axis_index / … ). Godot's ptr-ABI encodes an
      * int return as `int64_t` (`PtrToArg<int64_t>` is direct 8-byte), so decode a Long.
      */
-    fun callInt(methodPtr: Long, base: FloatArray, args: List<BArg> = emptyList()): Long =
+    fun callInt(methodPtr: Long, base: GodotRealArray, args: List<BArg> = emptyList()): Long =
         memScoped {
             val ret = alloc<LongVar>()
             invokeBuiltin(methodPtr, base, args, ret.ptr)

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -54,6 +54,7 @@ import net.multigesture.kanama.ios.decodeIosPropertyValue
 import net.multigesture.kanama.types.AABB
 import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.GodotReal
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Plane
 import net.multigesture.kanama.types.Quaternion
@@ -397,17 +398,17 @@ object ObjectCalls {
             v
         }
 
-    private fun floatLE(b: ByteArray, o: Int): Double =
-        Float.fromBits(
+    private fun realLE(b: ByteArray, o: Int) =
+        GodotReal.fromFloat(Float.fromBits(
             (b[o].toInt() and 0xFF) or ((b[o + 1].toInt() and 0xFF) shl 8) or
                 ((b[o + 2].toInt() and 0xFF) shl 16) or ((b[o + 3].toInt() and 0xFF) shl 24),
-        ).toDouble()
+        ))
 
     // Array[Plane] -> List<Plane> (e.g. Camera3D.get_frustum). Each record is 4 float32 LE
     // (normal.x, normal.y, normal.z, d). Phase 2.7i.
     fun ptrcallNoArgsRetPlaneList(methodBind: MemorySegment, instance: MemorySegment): List<Plane> =
         retTypedArrayBlob(methodBind, instance, PT_PLANE) { b, o, _ ->
-            Plane(Vector3(floatLE(b, o), floatLE(b, o + 4), floatLE(b, o + 8)), floatLE(b, o + 12))
+            Plane(Vector3(realLE(b, o), realLE(b, o + 4), realLE(b, o + 8)), realLE(b, o + 12))
         }
 
     // Generic Array -> List<Any?> (Phase 2.7j). The C side serializes each element as a
@@ -1122,7 +1123,7 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         ObjectCalls.getMethodBind("Node3D", "set_position", 3460891852L), n3, Vector3(1.0, 2.0, 3.0))
     val p = ObjectCalls.ptrcallNoArgsRetVector3(
         ObjectCalls.getMethodBind("Node3D", "get_position", 3360562783L), n3)
-    check("vector3", p.x == 1.0 && p.y == 2.0 && p.z == 3.0)
+    check("vector3", p.x.toDouble() == 1.0 && p.y.toDouble() == 2.0 && p.z.toDouble() == 3.0)
 
     // Generated-helper round-trip (T3.1): ptrcallWithVector3ArgRetVector3 lives in the
     // GENERATED ObjectCallsGenerated.kt (extension on ObjectCalls), not hand-written —
@@ -1134,7 +1135,7 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     val g = ObjectCalls.ptrcallWithVector3ArgRetVector3(
         ObjectCalls.getMethodBind("Node3D", "to_global", 192990374L), n3b, Vector3(10.0, 20.0, 30.0))
     println("[kanama][ios][kn] OBJECTCALLS SELFTEST generated-vector3 g=(${g.x}, ${g.y}, ${g.z})")
-    check("generated-vector3-arg-ret", g.x == 10.0 && g.y == 20.0 && g.z == 30.0)
+    check("generated-vector3-arg-ret", g.x.toDouble() == 10.0 && g.y.toDouble() == 20.0 && g.z.toDouble() == 30.0)
 
     ObjectCalls.ptrcallWithBoolArg(
         ObjectCalls.getMethodBind("Node3D", "set_visible", 2586408642L), n3, false)
@@ -1217,7 +1218,11 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         Rect2(Vector2(1.5, 2.5), Vector2(3.5, 4.5)))
     val r2 = ObjectCalls.ptrcallNoArgsRetRect2(
         ObjectCalls.getMethodBind("GPUParticles2D", "get_visibility_rect", 1639390495L), gp2d)
-    check("rect2", r2.position.x == 1.5 && r2.position.y == 2.5 && r2.size.x == 3.5 && r2.size.y == 4.5)
+    check(
+        "rect2",
+        r2.position.x.toDouble() == 1.5 && r2.position.y.toDouble() == 2.5 &&
+            r2.size.x.toDouble() == 3.5 && r2.size.y.toDouble() == 4.5,
+    )
 
     // String-return (Object.get_class -> "Node2D"): exercises ptrcallNoArgsRetString
     // through the full Kotlin -> dedicated C helper -> Godot path (string_to_utf8_chars
@@ -1628,7 +1633,11 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         ObjectCalls.getMethodBind("Node3D", "set_quaternion", 1727505552L), quatNode, qIn)
     val qOut = ObjectCalls.ptrcallNoArgsRetQuaternion(
         ObjectCalls.getMethodBind("Node3D", "get_quaternion", 1222331677L), quatNode)
-    fun nearly(a: Double, b: Double) = (if (a > b) a - b else b - a) < 1e-4
+    fun nearly(a: Number, b: Number): Boolean {
+        val left = a.toDouble()
+        val right = b.toDouble()
+        return (if (left > right) left - right else right - left) < 1e-4
+    }
     check("quaternion(set/get_quaternion)",
         nearly(qOut.x, qIn.x) && nearly(qOut.y, qIn.y) && nearly(qOut.z, qIn.z) && nearly(qOut.w, qIn.w))
 
@@ -1710,13 +1719,13 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     // cross product yields -0.0 in the zero slots, so compare component-wise with `==`
     // (numeric, treats -0.0 == 0.0) rather than data-class equals (Double.equals: -0.0 != 0.0).
     val cross = Vector3(1.0, 0.0, 0.0).cross(Vector3(0.0, 1.0, 0.0))
-    check("builtin-call(Vector3.cross x*y=z)", cross.x == 0.0 && cross.y == 0.0 && cross.z == 1.0)
+    check("builtin-call(Vector3.cross x*y=z)", cross.x.toDouble() == 0.0 && cross.y.toDouble() == 0.0 && cross.z.toDouble() == 1.0)
 
     // Vector2.rotated (arg path: Vector2 base + double scalar, new VT_VECTOR2): (1,0) by π/2 ->
     // (~0,1). Float trig, so component-wise tolerance ε (also avoids the -0.0 data-class trap).
     val rot = Vector2(1.0, 0.0).rotated(kotlin.math.PI / 2.0)
     check("builtin-call(Vector2.rotated pi/2)",
-        kotlin.math.abs(rot.x) < 1e-4 && kotlin.math.abs(rot.y - 1.0) < 1e-4)
+        kotlin.math.abs(rot.x.toDouble()) < 1e-4 && kotlin.math.abs(rot.y.toDouble() - 1.0) < 1e-4)
 
     // Quaternion.inverse (no-arg->Self, new VT_QUATERNION): for the unit quaternion 90° about Z
     // = (0,0,sin45,cos45) the inverse is the conjugate (z flips sign, w kept). Float divide by
@@ -1724,8 +1733,8 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     val s = 0.7071067811865476
     val qInv = Quaternion(0.0, 0.0, s, s).inverse()
     check("builtin-call(Quaternion.inverse 90z)",
-        kotlin.math.abs(qInv.x) < 1e-4 && kotlin.math.abs(qInv.y) < 1e-4 &&
-            kotlin.math.abs(qInv.z + s) < 1e-4 && kotlin.math.abs(qInv.w - s) < 1e-4)
+        kotlin.math.abs(qInv.x.toDouble()) < 1e-4 && kotlin.math.abs(qInv.y.toDouble()) < 1e-4 &&
+            kotlin.math.abs(qInv.z.toDouble() + s) < 1e-4 && kotlin.math.abs(qInv.w.toDouble() - s) < 1e-4)
 
     // Basis.scaled (arg path: Basis base + Vector3 arg): IDENTITY scaled by (2,3,4) -> diag(2,3,4).
     // Exact float32, but compare component-wise with `==` to dodge any -0.0 in the off-diagonal.
@@ -1769,12 +1778,15 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         val v2 = allocArray<FloatVar>(2)
         v2[0] = 1.5f; v2[1] = -2.5f
         val dv2 = decodeIosPropertyValue(6, v2.reinterpret(), 8) as? Vector2
-        check("setprop-decode(Vector2)", dv2 != null && dv2.x == 1.5 && dv2.y == -2.5)
+        check("setprop-decode(Vector2)", dv2 != null && dv2.x.toDouble() == 1.5 && dv2.y.toDouble() == -2.5)
 
         val v3 = allocArray<FloatVar>(3)
         v3[0] = 1.0f; v3[1] = 2.0f; v3[2] = 3.0f
         val dv3 = decodeIosPropertyValue(8, v3.reinterpret(), 12) as? Vector3
-        check("setprop-decode(Vector3)", dv3 != null && dv3.x == 1.0 && dv3.y == 2.0 && dv3.z == 3.0)
+        check(
+            "setprop-decode(Vector3)",
+            dv3 != null && dv3.x.toDouble() == 1.0 && dv3.y.toDouble() == 2.0 && dv3.z.toDouble() == 3.0,
+        )
 
         val path = "../SceneTarget3D"
         val pathBytes = path.encodeToByteArray()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCallsGenerated.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCallsGenerated.kt
@@ -24,6 +24,8 @@ import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_ptrcall
 import net.multigesture.kanama.types.AABB
 import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.GodotReal
+import net.multigesture.kanama.types.GodotRealVar
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Projection
 import net.multigesture.kanama.types.Quaternion
@@ -45,7 +47,7 @@ import net.multigesture.kanama.types.Vector4
  * generated Godot API wrappers' `ObjectCalls.<helper>(...)` calls resolve here. Every
  * helper marshals through the single generic C dispatch `kanama_ios_godot_ptrcall`,
  * applying the authoritative ptrcall width table (scalar float->double/8B, scalar
- * int->int64/8B, Vector components->float32, Object->8B handle, StringName built
+ * int->int64/8B, Vector components->GodotReal, Object->8B handle, StringName built
  * C-side). Helpers already hand-written in ObjectCalls.kt are the override set and
  * are NOT regenerated here.
  */
@@ -74,30 +76,30 @@ private const val PT_PROJECTION = 25
 
 fun ObjectCalls.ptrcallNoArgsRetAABB(methodBind: MemorySegment, instance: MemorySegment): AABB =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_AABB, ret)
-        AABB(Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble()), Vector3(ret[3].toDouble(), ret[4].toDouble(), ret[5].toDouble()))
+        AABB(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2])), Vector3(GodotReal.fromC(ret[3]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetBasis(methodBind: MemorySegment, instance: MemorySegment): Basis =
     memScoped {
-        val ret = allocArray<FloatVar>(9)
+        val ret = allocArray<GodotRealVar>(9)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_BASIS, ret)
-        Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble()))
+        Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetProjection(methodBind: MemorySegment, instance: MemorySegment): Projection =
     memScoped {
-        val ret = allocArray<FloatVar>(16)
+        val ret = allocArray<GodotRealVar>(16)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_PROJECTION, ret)
-        Projection(Vector4(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble()), Vector4(ret[4].toDouble(), ret[5].toDouble(), ret[6].toDouble(), ret[7].toDouble()), Vector4(ret[8].toDouble(), ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()), Vector4(ret[12].toDouble(), ret[13].toDouble(), ret[14].toDouble(), ret[15].toDouble()))
+        Projection(Vector4(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector4(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[6]), GodotReal.fromC(ret[7])), Vector4(GodotReal.fromC(ret[8]), GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])), Vector4(GodotReal.fromC(ret[12]), GodotReal.fromC(ret[13]), GodotReal.fromC(ret[14]), GodotReal.fromC(ret[15])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetQuaternion(methodBind: MemorySegment, instance: MemorySegment): Quaternion =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_QUATERNION, ret)
-        Quaternion(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble())
+        Quaternion(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3]))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetRID(methodBind: MemorySegment, instance: MemorySegment): RID =
@@ -109,16 +111,16 @@ fun ObjectCalls.ptrcallNoArgsRetRID(methodBind: MemorySegment, instance: MemoryS
 
 fun ObjectCalls.ptrcallNoArgsRetTransform2D(methodBind: MemorySegment, instance: MemorySegment): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetTransform3D(methodBind: MemorySegment, instance: MemorySegment): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetUInt32(methodBind: MemorySegment, instance: MemorySegment): Long =
@@ -130,7 +132,7 @@ fun ObjectCalls.ptrcallNoArgsRetUInt32(methodBind: MemorySegment, instance: Memo
 
 fun ObjectCalls.ptrcallWithAABBArg(methodBind: MemorySegment, instance: MemorySegment, a0: AABB) =
     memScoped {
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.position.x.toFloat(); c0[1] = a0.position.y.toFloat(); c0[2] = a0.position.z.toFloat(); c0[3] = a0.size.x.toFloat(); c0[4] = a0.size.y.toFloat(); c0[5] = a0.size.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.position.x); c0[1] = GodotReal.toC(a0.position.y); c0[2] = GodotReal.toC(a0.position.z); c0[3] = GodotReal.toC(a0.size.x); c0[4] = GodotReal.toC(a0.size.y); c0[5] = GodotReal.toC(a0.size.z)
         val types = allocArray<IntVar>(1); types[0] = PT_AABB
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -139,7 +141,7 @@ fun ObjectCalls.ptrcallWithAABBArg(methodBind: MemorySegment, instance: MemorySe
 
 fun ObjectCalls.ptrcallWithBasisArg(methodBind: MemorySegment, instance: MemorySegment, a0: Basis) =
     memScoped {
-        val c0 = allocArray<FloatVar>(9); c0[0] = a0.x.x.toFloat(); c0[1] = a0.y.x.toFloat(); c0[2] = a0.z.x.toFloat(); c0[3] = a0.x.y.toFloat(); c0[4] = a0.y.y.toFloat(); c0[5] = a0.z.y.toFloat(); c0[6] = a0.x.z.toFloat(); c0[7] = a0.y.z.toFloat(); c0[8] = a0.z.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(9); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.y.x); c0[2] = GodotReal.toC(a0.z.x); c0[3] = GodotReal.toC(a0.x.y); c0[4] = GodotReal.toC(a0.y.y); c0[5] = GodotReal.toC(a0.z.y); c0[6] = GodotReal.toC(a0.x.z); c0[7] = GodotReal.toC(a0.y.z); c0[8] = GodotReal.toC(a0.z.z)
         val types = allocArray<IntVar>(1); types[0] = PT_BASIS
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -241,35 +243,35 @@ fun ObjectCalls.ptrcallWithBoolTwoDoubleArgs(methodBind: MemorySegment, instance
 
 fun ObjectCalls.ptrcallWithDoubleAndBoolArgRetTransform2D(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Boolean): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val types = allocArray<IntVar>(2); types[0] = PT_FLOAT64; types[1] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithDoubleAndBoolArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Boolean): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val types = allocArray<IntVar>(2); types[0] = PT_FLOAT64; types[1] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithDoubleAndBoolArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Boolean): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
+        val ret = allocArray<GodotRealVar>(3)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val types = allocArray<IntVar>(2); types[0] = PT_FLOAT64; types[1] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithDoubleAndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Boolean) =
@@ -305,14 +307,14 @@ fun ObjectCalls.ptrcallWithDoubleAndTwoBoolArgs(methodBind: MemorySegment, insta
 
 fun ObjectCalls.ptrcallWithDoubleAndTwoBoolArgsRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Boolean, a2: Boolean): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val types = allocArray<IntVar>(3); types[0] = PT_FLOAT64; types[1] = PT_BOOL; types[2] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallWithDoubleArgRetColor(methodBind: MemorySegment, instance: MemorySegment, a0: Double): Color =
@@ -337,28 +339,28 @@ fun ObjectCalls.ptrcallWithDoubleArgRetObject(methodBind: MemorySegment, instanc
 
 fun ObjectCalls.ptrcallWithDoubleArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Double): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val types = allocArray<IntVar>(1); types[0] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithDoubleArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Double): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
+        val ret = allocArray<GodotRealVar>(3)
         val c0 = alloc<DoubleVar>(); c0.value = a0
         val types = allocArray<IntVar>(1); types[0] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithDoubleVector2TwoDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Double, a1: Vector2, a2: Double, a3: Double) =
     memScoped {
         val c0 = alloc<DoubleVar>(); c0.value = a0
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val types = allocArray<IntVar>(4); types[0] = PT_FLOAT64; types[1] = PT_VECTOR2; types[2] = PT_FLOAT64; types[3] = PT_FLOAT64
@@ -456,12 +458,12 @@ fun ObjectCalls.ptrcallWithFourIntArgsRetLong(methodBind: MemorySegment, instanc
 
 fun ObjectCalls.ptrcallWithFourStringNameAndFloatArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: String, a2: String, a3: String, a4: Double): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val types = allocArray<IntVar>(5); types[0] = PT_STRING_NAME; types[1] = PT_STRING_NAME; types[2] = PT_STRING_NAME; types[3] = PT_STRING_NAME; types[4] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = a1.cstr.ptr.reinterpret<CPointed>(); ptrs[2] = a2.cstr.ptr.reinterpret<CPointed>(); ptrs[3] = a3.cstr.ptr.reinterpret<CPointed>(); ptrs[4] = c4.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithIntAndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Boolean) =
@@ -540,24 +542,24 @@ fun ObjectCalls.ptrcallWithIntAndDoubleArgRetInt(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithIntAndDoubleArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Double): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithIntAndDoubleArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Double): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
+        val ret = allocArray<GodotRealVar>(3)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithIntAndLongArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Long) =
@@ -625,7 +627,7 @@ fun ObjectCalls.ptrcallWithIntAndObjectArgRetLong(methodBind: MemorySegment, ins
 fun ObjectCalls.ptrcallWithIntAndQuaternionArg(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Quaternion) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat(); c1[3] = a1.w.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z); c1[3] = GodotReal.toC(a1.w)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_QUATERNION
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -698,7 +700,7 @@ fun ObjectCalls.ptrcallWithIntAndThreeDoubleArgs(methodBind: MemorySegment, inst
 fun ObjectCalls.ptrcallWithIntAndTransform2DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Transform2D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(6); c1[0] = a1.x.x.toFloat(); c1[1] = a1.x.y.toFloat(); c1[2] = a1.y.x.toFloat(); c1[3] = a1.y.y.toFloat(); c1[4] = a1.origin.x.toFloat(); c1[5] = a1.origin.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(6); c1[0] = GodotReal.toC(a1.x.x); c1[1] = GodotReal.toC(a1.x.y); c1[2] = GodotReal.toC(a1.y.x); c1[3] = GodotReal.toC(a1.y.y); c1[4] = GodotReal.toC(a1.origin.x); c1[5] = GodotReal.toC(a1.origin.y)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -708,7 +710,7 @@ fun ObjectCalls.ptrcallWithIntAndTransform2DArg(methodBind: MemorySegment, insta
 fun ObjectCalls.ptrcallWithIntAndTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Transform3D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -740,7 +742,7 @@ fun ObjectCalls.ptrcallWithIntAndUInt32Args(methodBind: MemorySegment, instance:
 fun ObjectCalls.ptrcallWithIntAndVector2Arg(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Vector2) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -771,7 +773,7 @@ fun ObjectCalls.ptrcallWithIntAndVector2iArgRetBool(methodBind: MemorySegment, i
 fun ObjectCalls.ptrcallWithIntAndVector3Arg(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Vector3) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -840,12 +842,12 @@ fun ObjectCalls.ptrcallWithIntArgRetObject(methodBind: MemorySegment, instance: 
 
 fun ObjectCalls.ptrcallWithIntArgRetQuaternion(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Quaternion =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_QUATERNION, ret)
-        Quaternion(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble())
+        Quaternion(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3]))
     }
 
 fun ObjectCalls.ptrcallWithIntArgRetRID(methodBind: MemorySegment, instance: MemorySegment, a0: Int): RID =
@@ -860,32 +862,32 @@ fun ObjectCalls.ptrcallWithIntArgRetRID(methodBind: MemorySegment, instance: Mem
 
 fun ObjectCalls.ptrcallWithIntArgRetRect2(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Rect2 =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_RECT2, ret)
-        Rect2(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()))
+        Rect2(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])))
     }
 
 fun ObjectCalls.ptrcallWithIntArgRetTransform2D(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithIntArgRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallWithIntArgRetUInt32(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Long =
@@ -900,12 +902,12 @@ fun ObjectCalls.ptrcallWithIntArgRetUInt32(methodBind: MemorySegment, instance: 
 
 fun ObjectCalls.ptrcallWithIntArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithIntArgRetVector2i(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Vector2i =
@@ -920,12 +922,12 @@ fun ObjectCalls.ptrcallWithIntArgRetVector2i(methodBind: MemorySegment, instance
 
 fun ObjectCalls.ptrcallWithIntArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Int): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
+        val ret = allocArray<GodotRealVar>(3)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithIntBoolIntArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Boolean, a2: Int) =
@@ -977,26 +979,26 @@ fun ObjectCalls.ptrcallWithIntDoubleBoolArgsRetDouble(methodBind: MemorySegment,
 
 fun ObjectCalls.ptrcallWithIntDoubleBoolArgsRetQuaternion(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Double, a2: Boolean): Quaternion =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val types = allocArray<IntVar>(3); types[0] = PT_INT64; types[1] = PT_FLOAT64; types[2] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_QUATERNION, ret)
-        Quaternion(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble())
+        Quaternion(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3]))
     }
 
 fun ObjectCalls.ptrcallWithIntDoubleBoolArgsRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Double, a2: Boolean): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
+        val ret = allocArray<GodotRealVar>(3)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val types = allocArray<IntVar>(3); types[0] = PT_INT64; types[1] = PT_FLOAT64; types[2] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithIntDoubleLongTwoBoolArgsRetInt(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Double, a2: Long, a3: Boolean, a4: Boolean): Int =
@@ -1032,7 +1034,7 @@ fun ObjectCalls.ptrcallWithIntDoubleQuaternionArgsRetInt(methodBind: MemorySegme
         val ret = alloc<LongVar>()
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat(); c2[3] = a2.w.toFloat()
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z); c2[3] = GodotReal.toC(a2.w)
         val types = allocArray<IntVar>(3); types[0] = PT_INT64; types[1] = PT_FLOAT64; types[2] = PT_QUATERNION
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_INT64, ret.ptr)
@@ -1055,7 +1057,7 @@ fun ObjectCalls.ptrcallWithIntDoubleVector3ArgsRetInt(methodBind: MemorySegment,
         val ret = alloc<LongVar>()
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
-        val c2 = allocArray<FloatVar>(3); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat()
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
         val types = allocArray<IntVar>(3); types[0] = PT_INT64; types[1] = PT_FLOAT64; types[2] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_INT64, ret.ptr)
@@ -1120,7 +1122,7 @@ fun ObjectCalls.ptrcallWithIntStringObjectArgsRetLong(methodBind: MemorySegment,
 fun ObjectCalls.ptrcallWithIntTransform3DDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Transform3D, a2: Double, a3: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val types = allocArray<IntVar>(4); types[0] = PT_INT64; types[1] = PT_TRANSFORM3D; types[2] = PT_FLOAT64; types[3] = PT_BOOL
@@ -1148,8 +1150,8 @@ fun ObjectCalls.ptrcallWithIntTwoDoubleTwoVector2ArgsRetInt(methodBind: MemorySe
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
-        val c3 = allocArray<FloatVar>(2); c3[0] = a3.x.toFloat(); c3[1] = a3.y.toFloat()
-        val c4 = allocArray<FloatVar>(2); c4[0] = a4.x.toFloat(); c4[1] = a4.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(2); c3[0] = GodotReal.toC(a3.x); c3[1] = GodotReal.toC(a3.y)
+        val c4 = allocArray<GodotRealVar>(2); c4[0] = GodotReal.toC(a4.x); c4[1] = GodotReal.toC(a4.y)
         val types = allocArray<IntVar>(5); types[0] = PT_INT64; types[1] = PT_FLOAT64; types[2] = PT_FLOAT64; types[3] = PT_VECTOR2; types[4] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>(); ptrs[4] = c4.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_INT64, ret.ptr)
@@ -1209,7 +1211,7 @@ fun ObjectCalls.ptrcallWithIntVector3ArgsRetDouble(methodBind: MemorySegment, in
     memScoped {
         val ret = alloc<DoubleVar>()
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_FLOAT64, ret.ptr)
@@ -1549,7 +1551,7 @@ fun ObjectCalls.ptrcallWithObjectAndLongArgsRetObject(methodBind: MemorySegment,
 fun ObjectCalls.ptrcallWithObjectAndRect2Arg(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Rect2) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val types = allocArray<IntVar>(2); types[0] = PT_OBJECT; types[1] = PT_RECT2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -1608,12 +1610,12 @@ fun ObjectCalls.ptrcallWithObjectArgRetRID(methodBind: MemorySegment, instance: 
 
 fun ObjectCalls.ptrcallWithObjectArgRetTransform2D(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<LongVar>(); c0.value = a0.address()
         val types = allocArray<IntVar>(1); types[0] = PT_OBJECT
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithObjectArgRetUInt32(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment): Long =
@@ -1686,7 +1688,7 @@ fun ObjectCalls.ptrcallWithObjectIntTransform3DArgs(methodBind: MemorySegment, i
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
-        val c2 = allocArray<FloatVar>(12); c2[0] = a2.basis.x.x.toFloat(); c2[1] = a2.basis.y.x.toFloat(); c2[2] = a2.basis.z.x.toFloat(); c2[3] = a2.basis.x.y.toFloat(); c2[4] = a2.basis.y.y.toFloat(); c2[5] = a2.basis.z.y.toFloat(); c2[6] = a2.basis.x.z.toFloat(); c2[7] = a2.basis.y.z.toFloat(); c2[8] = a2.basis.z.z.toFloat(); c2[9] = a2.origin.x.toFloat(); c2[10] = a2.origin.y.toFloat(); c2[11] = a2.origin.z.toFloat()
+        val c2 = allocArray<GodotRealVar>(12); c2[0] = GodotReal.toC(a2.basis.x.x); c2[1] = GodotReal.toC(a2.basis.y.x); c2[2] = GodotReal.toC(a2.basis.z.x); c2[3] = GodotReal.toC(a2.basis.x.y); c2[4] = GodotReal.toC(a2.basis.y.y); c2[5] = GodotReal.toC(a2.basis.z.y); c2[6] = GodotReal.toC(a2.basis.x.z); c2[7] = GodotReal.toC(a2.basis.y.z); c2[8] = GodotReal.toC(a2.basis.z.z); c2[9] = GodotReal.toC(a2.origin.x); c2[10] = GodotReal.toC(a2.origin.y); c2[11] = GodotReal.toC(a2.origin.z)
         val types = allocArray<IntVar>(3); types[0] = PT_OBJECT; types[1] = PT_INT64; types[2] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -1709,7 +1711,7 @@ fun ObjectCalls.ptrcallWithObjectLongAndVector2Arg(methodBind: MemorySegment, in
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
         val c1 = alloc<LongVar>(); c1.value = a1
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val types = allocArray<IntVar>(3); types[0] = PT_OBJECT; types[1] = PT_INT64; types[2] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -1744,7 +1746,7 @@ fun ObjectCalls.ptrcallWithObjectObjectIntTwoBoolArgs(methodBind: MemorySegment,
 fun ObjectCalls.ptrcallWithObjectRect2BoolColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Rect2, a2: Boolean, a3: Color, a4: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -1796,6 +1798,17 @@ fun ObjectCalls.ptrcallWithObjectStringIntLongArgs(methodBind: MemorySegment, in
         Unit
     }
 
+fun ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: String, a2: Boolean): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.address()
+        val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
+        val types = allocArray<IntVar>(3); types[0] = PT_OBJECT; types[1] = PT_STRING_NAME; types[2] = PT_BOOL
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = a1.cstr.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
+    }
+
 fun ObjectCalls.ptrcallWithObjectThreeStringArgsRetObject(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: String, a2: String, a3: String): MemorySegment =
     memScoped {
         val ret = alloc<LongVar>(); ret.value = 0
@@ -1821,8 +1834,8 @@ fun ObjectCalls.ptrcallWithObjectTwoIntArgsRetLong(methodBind: MemorySegment, in
 fun ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Rect2, a2: Rect2, a3: Color) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val types = allocArray<IntVar>(4); types[0] = PT_OBJECT; types[1] = PT_RECT2; types[2] = PT_RECT2; types[3] = PT_COLOR
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>()
@@ -1833,8 +1846,8 @@ fun ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(methodBind: MemorySegment,
 fun ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Rect2, a2: Rect2, a3: Color, a4: Double, a5: Double, a6: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<DoubleVar>(); c5.value = a5
@@ -1848,8 +1861,8 @@ fun ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(methodBind: Memory
 fun ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Rect2, a2: Rect2, a3: Color, a4: Boolean, a5: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
         val c5 = alloc<ByteVar>(); c5.value = if (a5) 1 else 0
@@ -1862,7 +1875,7 @@ fun ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(methodBind: MemorySegm
 fun ObjectCalls.ptrcallWithObjectVector2AndColorArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: Color) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val types = allocArray<IntVar>(3); types[0] = PT_OBJECT; types[1] = PT_VECTOR2; types[2] = PT_COLOR
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
@@ -1873,7 +1886,7 @@ fun ObjectCalls.ptrcallWithObjectVector2AndColorArgs(methodBind: MemorySegment, 
 fun ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Int, a4: Color, a5: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val c5 = alloc<DoubleVar>(); c5.value = a5
@@ -1886,7 +1899,7 @@ fun ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(methodBind: Mem
 fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Color, a7: Long, a8: Long, a9: Long, a10: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -1904,7 +1917,7 @@ fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleA
 fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Int, a8: Color, a9: Long, a10: Long, a11: Long, a12: Long, a13: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -1925,7 +1938,7 @@ fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDou
 fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Color, a8: Long, a9: Long, a10: Long, a11: Long, a12: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -1945,7 +1958,7 @@ fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubl
 fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Color, a8: Long, a9: Long, a10: Long, a11: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -1964,7 +1977,7 @@ fun ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoub
 fun ObjectCalls.ptrcallWithObjectVector2StringTwoIntColorDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: MemorySegment, a1: Vector2, a2: String, a3: Int, a4: Int, a5: Color, a6: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val c4 = alloc<LongVar>(); c4.value = a4.toLong()
         val c5 = allocArray<FloatVar>(4); c5[0] = a5.r; c5[1] = a5.g; c5[2] = a5.b; c5[3] = a5.a
@@ -1988,7 +2001,7 @@ fun ObjectCalls.ptrcallWithObjectVector2iAndDoubleArg(methodBind: MemorySegment,
 
 fun ObjectCalls.ptrcallWithQuaternionArg(methodBind: MemorySegment, instance: MemorySegment, a0: Quaternion) =
     memScoped {
-        val c0 = allocArray<FloatVar>(4); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat(); c0[3] = a0.w.toFloat()
+        val c0 = allocArray<GodotRealVar>(4); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z); c0[3] = GodotReal.toC(a0.w)
         val types = allocArray<IntVar>(1); types[0] = PT_QUATERNION
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -1998,7 +2011,7 @@ fun ObjectCalls.ptrcallWithQuaternionArg(methodBind: MemorySegment, instance: Me
 fun ObjectCalls.ptrcallWithRIDAndAABBArg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: AABB) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(6); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.position.z.toFloat(); c1[3] = a1.size.x.toFloat(); c1[4] = a1.size.y.toFloat(); c1[5] = a1.size.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(6); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.position.z); c1[3] = GodotReal.toC(a1.size.x); c1[4] = GodotReal.toC(a1.size.y); c1[5] = GodotReal.toC(a1.size.z)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_AABB
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2008,7 +2021,7 @@ fun ObjectCalls.ptrcallWithRIDAndAABBArg(methodBind: MemorySegment, instance: Me
 fun ObjectCalls.ptrcallWithRIDAndBasisArg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Basis) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(9); c1[0] = a1.x.x.toFloat(); c1[1] = a1.y.x.toFloat(); c1[2] = a1.z.x.toFloat(); c1[3] = a1.x.y.toFloat(); c1[4] = a1.y.y.toFloat(); c1[5] = a1.z.y.toFloat(); c1[6] = a1.x.z.toFloat(); c1[7] = a1.y.z.toFloat(); c1[8] = a1.z.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(9); c1[0] = GodotReal.toC(a1.x.x); c1[1] = GodotReal.toC(a1.y.x); c1[2] = GodotReal.toC(a1.z.x); c1[3] = GodotReal.toC(a1.x.y); c1[4] = GodotReal.toC(a1.y.y); c1[5] = GodotReal.toC(a1.z.y); c1[6] = GodotReal.toC(a1.x.z); c1[7] = GodotReal.toC(a1.y.z); c1[8] = GodotReal.toC(a1.z.z)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_BASIS
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2077,6 +2090,17 @@ fun ObjectCalls.ptrcallWithRIDAndIntArg(methodBind: MemorySegment, instance: Mem
         Unit
     }
 
+fun ObjectCalls.ptrcallWithRIDAndIntArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.toLong()
+        val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
+    }
+
 fun ObjectCalls.ptrcallWithRIDAndIntArgRetColor(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int): Color =
     memScoped {
         val ret = allocArray<FloatVar>(4)
@@ -2112,24 +2136,35 @@ fun ObjectCalls.ptrcallWithRIDAndIntArgRetRID(methodBind: MemorySegment, instanc
 
 fun ObjectCalls.ptrcallWithRIDAndIntArgRetTransform2D(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithRIDAndIntArgRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
+    }
+
+fun ObjectCalls.ptrcallWithRIDAndIntArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int): Vector3 =
+    memScoped {
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.toLong()
+        val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR3, ret)
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithRIDAndLongArg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long) =
@@ -2140,6 +2175,28 @@ fun ObjectCalls.ptrcallWithRIDAndLongArg(methodBind: MemorySegment, instance: Me
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
         Unit
+    }
+
+fun ObjectCalls.ptrcallWithRIDAndLongArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
+    }
+
+fun ObjectCalls.ptrcallWithRIDAndLongArgRetDouble(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long): Double =
+    memScoped {
+        val ret = alloc<DoubleVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_FLOAT64, ret.ptr)
+        ret.value
     }
 
 fun ObjectCalls.ptrcallWithRIDAndLongArgRetRID(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long): RID =
@@ -2156,7 +2213,7 @@ fun ObjectCalls.ptrcallWithRIDAndLongArgRetRID(methodBind: MemorySegment, instan
 fun ObjectCalls.ptrcallWithRIDAndRect2Arg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_RECT2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2199,7 +2256,7 @@ fun ObjectCalls.ptrcallWithRIDAndThreeIntArgs(methodBind: MemorySegment, instanc
 fun ObjectCalls.ptrcallWithRIDAndTransform2DArg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Transform2D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(6); c1[0] = a1.x.x.toFloat(); c1[1] = a1.x.y.toFloat(); c1[2] = a1.y.x.toFloat(); c1[3] = a1.y.y.toFloat(); c1[4] = a1.origin.x.toFloat(); c1[5] = a1.origin.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(6); c1[0] = GodotReal.toC(a1.x.x); c1[1] = GodotReal.toC(a1.x.y); c1[2] = GodotReal.toC(a1.y.x); c1[3] = GodotReal.toC(a1.y.y); c1[4] = GodotReal.toC(a1.origin.x); c1[5] = GodotReal.toC(a1.origin.y)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2209,7 +2266,7 @@ fun ObjectCalls.ptrcallWithRIDAndTransform2DArg(methodBind: MemorySegment, insta
 fun ObjectCalls.ptrcallWithRIDAndTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Transform3D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2261,6 +2318,17 @@ fun ObjectCalls.ptrcallWithRIDAndTwoLongArgsRetInt(methodBind: MemorySegment, in
         ret.value.toInt()
     }
 
+fun ObjectCalls.ptrcallWithRIDAndTwoVector3Args(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector3, a2: Vector3) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
+        val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_VECTOR3; types[2] = PT_VECTOR3
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
+        Unit
+    }
+
 fun ObjectCalls.ptrcallWithRIDAndUInt32Arg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
@@ -2274,7 +2342,7 @@ fun ObjectCalls.ptrcallWithRIDAndUInt32Arg(methodBind: MemorySegment, instance: 
 fun ObjectCalls.ptrcallWithRIDAndVector2Arg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2284,7 +2352,7 @@ fun ObjectCalls.ptrcallWithRIDAndVector2Arg(methodBind: MemorySegment, instance:
 fun ObjectCalls.ptrcallWithRIDAndVector3Arg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector3) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val types = allocArray<IntVar>(2); types[0] = PT_RID; types[1] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -2302,12 +2370,12 @@ fun ObjectCalls.ptrcallWithRIDArg(methodBind: MemorySegment, instance: MemorySeg
 
 fun ObjectCalls.ptrcallWithRIDArgRetAABB(methodBind: MemorySegment, instance: MemorySegment, a0: RID): AABB =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val types = allocArray<IntVar>(1); types[0] = PT_RID
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_AABB, ret)
-        AABB(Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble()), Vector3(ret[3].toDouble(), ret[4].toDouble(), ret[5].toDouble()))
+        AABB(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2])), Vector3(GodotReal.fromC(ret[3]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithRIDArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Boolean =
@@ -2372,22 +2440,32 @@ fun ObjectCalls.ptrcallWithRIDArgRetRID(methodBind: MemorySegment, instance: Mem
 
 fun ObjectCalls.ptrcallWithRIDArgRetRect2(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Rect2 =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val types = allocArray<IntVar>(1); types[0] = PT_RID
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_RECT2, ret)
-        Rect2(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()))
+        Rect2(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])))
     }
 
 fun ObjectCalls.ptrcallWithRIDArgRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val types = allocArray<IntVar>(1); types[0] = PT_RID
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
+    }
+
+fun ObjectCalls.ptrcallWithRIDArgRetUInt32(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Long =
+    memScoped {
+        val ret = alloc<LongVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val types = allocArray<IntVar>(1); types[0] = PT_RID
+        val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_INT64, ret.ptr)
+        ret.value
     }
 
 fun ObjectCalls.ptrcallWithRIDArgRetVector2i(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Vector2i =
@@ -2398,6 +2476,16 @@ fun ObjectCalls.ptrcallWithRIDArgRetVector2i(methodBind: MemorySegment, instance
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2I, ret)
         Vector2i(ret[0], ret[1])
+    }
+
+fun ObjectCalls.ptrcallWithRIDArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Vector3 =
+    memScoped {
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val types = allocArray<IntVar>(1); types[0] = PT_RID
+        val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithRIDArgRetVector3i(methodBind: MemorySegment, instance: MemorySegment, a0: RID): Vector3i =
@@ -2531,7 +2619,7 @@ fun ObjectCalls.ptrcallWithRIDBoolRect2Args(methodBind: MemorySegment, instance:
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_BOOL; types[2] = PT_RECT2
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -2659,7 +2747,7 @@ fun ObjectCalls.ptrcallWithRIDDoubleVector2TwoDoubleArgs(methodBind: MemorySegme
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<DoubleVar>(); c1.value = a1
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val types = allocArray<IntVar>(5); types[0] = PT_RID; types[1] = PT_FLOAT64; types[2] = PT_VECTOR2; types[3] = PT_FLOAT64; types[4] = PT_FLOAT64
@@ -2732,7 +2820,7 @@ fun ObjectCalls.ptrcallWithRIDIntAndTransform2DArg(methodBind: MemorySegment, in
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
-        val c2 = allocArray<FloatVar>(6); c2[0] = a2.x.x.toFloat(); c2[1] = a2.x.y.toFloat(); c2[2] = a2.y.x.toFloat(); c2[3] = a2.y.y.toFloat(); c2[4] = a2.origin.x.toFloat(); c2[5] = a2.origin.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(6); c2[0] = GodotReal.toC(a2.x.x); c2[1] = GodotReal.toC(a2.x.y); c2[2] = GodotReal.toC(a2.y.x); c2[3] = GodotReal.toC(a2.y.y); c2[4] = GodotReal.toC(a2.origin.x); c2[5] = GodotReal.toC(a2.origin.y)
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -2743,8 +2831,19 @@ fun ObjectCalls.ptrcallWithRIDIntAndTransform3DArg(methodBind: MemorySegment, in
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
-        val c2 = allocArray<FloatVar>(12); c2[0] = a2.basis.x.x.toFloat(); c2[1] = a2.basis.y.x.toFloat(); c2[2] = a2.basis.z.x.toFloat(); c2[3] = a2.basis.x.y.toFloat(); c2[4] = a2.basis.y.y.toFloat(); c2[5] = a2.basis.z.y.toFloat(); c2[6] = a2.basis.x.z.toFloat(); c2[7] = a2.basis.y.z.toFloat(); c2[8] = a2.basis.z.z.toFloat(); c2[9] = a2.origin.x.toFloat(); c2[10] = a2.origin.y.toFloat(); c2[11] = a2.origin.z.toFloat()
+        val c2 = allocArray<GodotRealVar>(12); c2[0] = GodotReal.toC(a2.basis.x.x); c2[1] = GodotReal.toC(a2.basis.y.x); c2[2] = GodotReal.toC(a2.basis.z.x); c2[3] = GodotReal.toC(a2.basis.x.y); c2[4] = GodotReal.toC(a2.basis.y.y); c2[5] = GodotReal.toC(a2.basis.z.y); c2[6] = GodotReal.toC(a2.basis.x.z); c2[7] = GodotReal.toC(a2.basis.y.z); c2[8] = GodotReal.toC(a2.basis.z.z); c2[9] = GodotReal.toC(a2.origin.x); c2[10] = GodotReal.toC(a2.origin.y); c2[11] = GodotReal.toC(a2.origin.z)
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_TRANSFORM3D
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
+        Unit
+    }
+
+fun ObjectCalls.ptrcallWithRIDIntAndVector3Arg(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Int, a2: Vector3) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.toLong()
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
+        val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
         Unit
@@ -2845,10 +2944,23 @@ fun ObjectCalls.ptrcallWithRIDObjectIntArgs(methodBind: MemorySegment, instance:
         Unit
     }
 
+fun ObjectCalls.ptrcallWithRIDRIDTransform3DRIDTransform3DArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: RID, a2: Transform3D, a3: RID, a4: Transform3D) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.value
+        val c2 = allocArray<GodotRealVar>(12); c2[0] = GodotReal.toC(a2.basis.x.x); c2[1] = GodotReal.toC(a2.basis.y.x); c2[2] = GodotReal.toC(a2.basis.z.x); c2[3] = GodotReal.toC(a2.basis.x.y); c2[4] = GodotReal.toC(a2.basis.y.y); c2[5] = GodotReal.toC(a2.basis.z.y); c2[6] = GodotReal.toC(a2.basis.x.z); c2[7] = GodotReal.toC(a2.basis.y.z); c2[8] = GodotReal.toC(a2.basis.z.z); c2[9] = GodotReal.toC(a2.origin.x); c2[10] = GodotReal.toC(a2.origin.y); c2[11] = GodotReal.toC(a2.origin.z)
+        val c3 = alloc<LongVar>(); c3.value = a3.value
+        val c4 = allocArray<GodotRealVar>(12); c4[0] = GodotReal.toC(a4.basis.x.x); c4[1] = GodotReal.toC(a4.basis.y.x); c4[2] = GodotReal.toC(a4.basis.z.x); c4[3] = GodotReal.toC(a4.basis.x.y); c4[4] = GodotReal.toC(a4.basis.y.y); c4[5] = GodotReal.toC(a4.basis.z.y); c4[6] = GodotReal.toC(a4.basis.x.z); c4[7] = GodotReal.toC(a4.basis.y.z); c4[8] = GodotReal.toC(a4.basis.z.z); c4[9] = GodotReal.toC(a4.origin.x); c4[10] = GodotReal.toC(a4.origin.y); c4[11] = GodotReal.toC(a4.origin.z)
+        val types = allocArray<IntVar>(5); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_TRANSFORM3D; types[3] = PT_RID; types[4] = PT_TRANSFORM3D
+        val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>(); ptrs[4] = c4.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_VOID, null)
+        Unit
+    }
+
 fun ObjectCalls.ptrcallWithRIDRect2BoolColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: Boolean, a3: Color, a4: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -2861,7 +2973,7 @@ fun ObjectCalls.ptrcallWithRIDRect2BoolColorBoolArgs(methodBind: MemorySegment, 
 fun ObjectCalls.ptrcallWithRIDRect2ColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: Color, a3: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_RECT2; types[2] = PT_COLOR; types[3] = PT_BOOL
@@ -2873,7 +2985,7 @@ fun ObjectCalls.ptrcallWithRIDRect2ColorBoolArgs(methodBind: MemorySegment, inst
 fun ObjectCalls.ptrcallWithRIDRect2IntArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: Int) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<LongVar>(); c2.value = a2.toLong()
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_RECT2; types[2] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
@@ -2884,7 +2996,7 @@ fun ObjectCalls.ptrcallWithRIDRect2IntArgs(methodBind: MemorySegment, instance: 
 fun ObjectCalls.ptrcallWithRIDRect2RIDBoolColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: RID, a3: Boolean, a4: Color, a5: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<LongVar>(); c2.value = a2.value
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
@@ -2898,9 +3010,9 @@ fun ObjectCalls.ptrcallWithRIDRect2RIDBoolColorBoolArgs(methodBind: MemorySegmen
 fun ObjectCalls.ptrcallWithRIDRect2RIDRect2ColorArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: RID, a3: Rect2, a4: Color) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<LongVar>(); c2.value = a2.value
-        val c3 = allocArray<FloatVar>(4); c3[0] = a3.position.x.toFloat(); c3[1] = a3.position.y.toFloat(); c3[2] = a3.size.x.toFloat(); c3[3] = a3.size.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(4); c3[0] = GodotReal.toC(a3.position.x); c3[1] = GodotReal.toC(a3.position.y); c3[2] = GodotReal.toC(a3.size.x); c3[3] = GodotReal.toC(a3.size.y)
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val types = allocArray<IntVar>(5); types[0] = PT_RID; types[1] = PT_RECT2; types[2] = PT_RID; types[3] = PT_RECT2; types[4] = PT_COLOR
         val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>(); ptrs[4] = c4.reinterpret<CPointed>()
@@ -2911,9 +3023,9 @@ fun ObjectCalls.ptrcallWithRIDRect2RIDRect2ColorArgs(methodBind: MemorySegment, 
 fun ObjectCalls.ptrcallWithRIDRect2RIDRect2ColorIntTwoDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: RID, a3: Rect2, a4: Color, a5: Int, a6: Double, a7: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<LongVar>(); c2.value = a2.value
-        val c3 = allocArray<FloatVar>(4); c3[0] = a3.position.x.toFloat(); c3[1] = a3.position.y.toFloat(); c3[2] = a3.size.x.toFloat(); c3[3] = a3.size.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(4); c3[0] = GodotReal.toC(a3.position.x); c3[1] = GodotReal.toC(a3.position.y); c3[2] = GodotReal.toC(a3.size.x); c3[3] = GodotReal.toC(a3.size.y)
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
         val c6 = alloc<DoubleVar>(); c6.value = a6
@@ -2927,9 +3039,9 @@ fun ObjectCalls.ptrcallWithRIDRect2RIDRect2ColorIntTwoDoubleArgs(methodBind: Mem
 fun ObjectCalls.ptrcallWithRIDRect2RIDRect2ColorTwoBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: RID, a3: Rect2, a4: Color, a5: Boolean, a6: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val c2 = alloc<LongVar>(); c2.value = a2.value
-        val c3 = allocArray<FloatVar>(4); c3[0] = a3.position.x.toFloat(); c3[1] = a3.position.y.toFloat(); c3[2] = a3.size.x.toFloat(); c3[3] = a3.size.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(4); c3[0] = GodotReal.toC(a3.position.x); c3[1] = GodotReal.toC(a3.position.y); c3[2] = GodotReal.toC(a3.size.x); c3[3] = GodotReal.toC(a3.size.y)
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val c5 = alloc<ByteVar>(); c5.value = if (a5) 1 else 0
         val c6 = alloc<ByteVar>(); c6.value = if (a6) 1 else 0
@@ -2964,8 +3076,8 @@ fun ObjectCalls.ptrcallWithRIDStringNameRIDIntArgs(methodBind: MemorySegment, in
 fun ObjectCalls.ptrcallWithRIDTransform3DVector3TwoColorUInt32Args(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Transform3D, a2: Vector3, a3: Color, a4: Color, a5: Long) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
-        val c2 = allocArray<FloatVar>(3); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val c5 = alloc<LongVar>(); c5.value = a5
@@ -2975,11 +3087,59 @@ fun ObjectCalls.ptrcallWithRIDTransform3DVector3TwoColorUInt32Args(methodBind: M
         Unit
     }
 
+fun ObjectCalls.ptrcallWithRIDTwoLongArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long, a2: Long): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val c2 = alloc<LongVar>(); c2.value = a2
+        val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
+    }
+
+fun ObjectCalls.ptrcallWithRIDTwoLongArgsRetDouble(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long, a2: Long): Double =
+    memScoped {
+        val ret = alloc<DoubleVar>()
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val c2 = alloc<LongVar>(); c2.value = a2
+        val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_FLOAT64, ret.ptr)
+        ret.value
+    }
+
+fun ObjectCalls.ptrcallWithRIDTwoLongBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long, a2: Long, a3: Boolean) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val c2 = alloc<LongVar>(); c2.value = a2
+        val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
+        val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_INT64; types[3] = PT_BOOL
+        val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 4, PT_VOID, null)
+        Unit
+    }
+
+fun ObjectCalls.ptrcallWithRIDTwoLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Long, a2: Long, a3: Double) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1
+        val c2 = alloc<LongVar>(); c2.value = a2
+        val c3 = alloc<DoubleVar>(); c3.value = a3
+        val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_INT64; types[2] = PT_INT64; types[3] = PT_FLOAT64
+        val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 4, PT_VOID, null)
+        Unit
+    }
+
 fun ObjectCalls.ptrcallWithRIDTwoRect2ColorTwoBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: Rect2, a3: Color, a4: Boolean, a5: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
         val c5 = alloc<ByteVar>(); c5.value = if (a5) 1 else 0
@@ -2992,11 +3152,11 @@ fun ObjectCalls.ptrcallWithRIDTwoRect2ColorTwoBoolArgs(methodBind: MemorySegment
 fun ObjectCalls.ptrcallWithRIDTwoRect2RIDTwoVector2TwoLongBoolColorArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Rect2, a2: Rect2, a3: RID, a4: Vector2, a5: Vector2, a6: Long, a7: Long, a8: Boolean, a9: Color) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = alloc<LongVar>(); c3.value = a3.value
-        val c4 = allocArray<FloatVar>(2); c4[0] = a4.x.toFloat(); c4[1] = a4.y.toFloat()
-        val c5 = allocArray<FloatVar>(2); c5[0] = a5.x.toFloat(); c5[1] = a5.y.toFloat()
+        val c4 = allocArray<GodotRealVar>(2); c4[0] = GodotReal.toC(a4.x); c4[1] = GodotReal.toC(a4.y)
+        val c5 = allocArray<GodotRealVar>(2); c5[0] = GodotReal.toC(a5.x); c5[1] = GodotReal.toC(a5.y)
         val c6 = alloc<LongVar>(); c6.value = a6
         val c7 = alloc<LongVar>(); c7.value = a7
         val c8 = alloc<ByteVar>(); c8.value = if (a8) 1 else 0
@@ -3010,8 +3170,8 @@ fun ObjectCalls.ptrcallWithRIDTwoRect2RIDTwoVector2TwoLongBoolColorArgs(methodBi
 fun ObjectCalls.ptrcallWithRIDTwoVector2ColorDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: Vector2, a3: Color, a4: Double, a5: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<ByteVar>(); c5.value = if (a5) 1 else 0
@@ -3024,7 +3184,7 @@ fun ObjectCalls.ptrcallWithRIDTwoVector2ColorDoubleBoolArgs(methodBind: MemorySe
 fun ObjectCalls.ptrcallWithRIDVector2ColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: Color, a3: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_VECTOR2; types[2] = PT_COLOR; types[3] = PT_BOOL
@@ -3036,7 +3196,7 @@ fun ObjectCalls.ptrcallWithRIDVector2ColorBoolArgs(methodBind: MemorySegment, in
 fun ObjectCalls.ptrcallWithRIDVector2DoubleColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: Double, a3: Color, a4: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -3049,7 +3209,7 @@ fun ObjectCalls.ptrcallWithRIDVector2DoubleColorBoolArgs(methodBind: MemorySegme
 fun ObjectCalls.ptrcallWithRIDVector2IntArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: Int) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<LongVar>(); c2.value = a2.toLong()
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_VECTOR2; types[2] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
@@ -3060,7 +3220,7 @@ fun ObjectCalls.ptrcallWithRIDVector2IntArgs(methodBind: MemorySegment, instance
 fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleIntColorThreeLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Color, a7: Long, a8: Long, a9: Long, a10: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -3078,7 +3238,7 @@ fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleIntColorThreeLongDoubleArgs
 fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Int, a8: Color, a9: Long, a10: Long, a11: Long, a12: Long, a13: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -3099,7 +3259,7 @@ fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleThreeIntColorFourLongDouble
 fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Color, a8: Long, a9: Long, a10: Long, a11: Long, a12: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -3119,7 +3279,7 @@ fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleTwoIntColorFourLongDoubleAr
 fun ObjectCalls.ptrcallWithRIDVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: String, a3: Long, a4: Double, a5: Int, a6: Int, a7: Color, a8: Long, a9: Long, a10: Long, a11: Double) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c3 = alloc<LongVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
@@ -3139,7 +3299,7 @@ fun ObjectCalls.ptrcallWithRIDVector2ThreeIntColorDoubleArgsRetDouble(methodBind
     memScoped {
         val ret = alloc<DoubleVar>()
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<LongVar>(); c2.value = a2.toLong()
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val c4 = alloc<LongVar>(); c4.value = a4.toLong()
@@ -3154,7 +3314,7 @@ fun ObjectCalls.ptrcallWithRIDVector2ThreeIntColorDoubleArgsRetDouble(methodBind
 fun ObjectCalls.ptrcallWithRIDVector2TwoDoubleColorBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: Vector2, a2: Double, a3: Double, a4: Color, a5: Boolean) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
@@ -3169,7 +3329,7 @@ fun ObjectCalls.ptrcallWithRIDVector2TwoIntColorDoubleArgsRetDouble(methodBind: 
     memScoped {
         val ret = alloc<DoubleVar>()
         val c0 = alloc<LongVar>(); c0.value = a0.value
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<LongVar>(); c2.value = a2.toLong()
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
@@ -3182,7 +3342,7 @@ fun ObjectCalls.ptrcallWithRIDVector2TwoIntColorDoubleArgsRetDouble(methodBind: 
 
 fun ObjectCalls.ptrcallWithRect2ColorBoolDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Rect2, a1: Color, a2: Boolean, a3: Double, a4: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(4); c0[0] = a0.position.x.toFloat(); c0[1] = a0.position.y.toFloat(); c0[2] = a0.size.x.toFloat(); c0[3] = a0.size.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(4); c0[0] = GodotReal.toC(a0.position.x); c0[1] = GodotReal.toC(a0.position.y); c0[2] = GodotReal.toC(a0.size.x); c0[3] = GodotReal.toC(a0.size.y)
         val c1 = allocArray<FloatVar>(4); c1[0] = a1.r; c1[1] = a1.g; c1[2] = a1.b; c1[3] = a1.a
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val c3 = alloc<DoubleVar>(); c3.value = a3
@@ -3279,7 +3439,7 @@ fun ObjectCalls.ptrcallWithStringAndThreeIntArgsRetObject(methodBind: MemorySegm
 
 fun ObjectCalls.ptrcallWithStringAndTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Transform3D) =
     memScoped {
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
         val types = allocArray<IntVar>(2); types[0] = PT_STRING; types[1] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -3352,6 +3512,17 @@ fun ObjectCalls.ptrcallWithStringBoolDoubleArgsRetLong(methodBind: MemorySegment
         ret.value
     }
 
+fun ObjectCalls.ptrcallWithStringBoolIntArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Boolean, a2: Int): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
+        val c2 = alloc<LongVar>(); c2.value = a2.toLong()
+        val types = allocArray<IntVar>(3); types[0] = PT_STRING; types[1] = PT_BOOL; types[2] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
+    }
+
 fun ObjectCalls.ptrcallWithStringIntAndLongArgs(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Int, a2: Long) =
     memScoped {
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
@@ -3385,7 +3556,7 @@ fun ObjectCalls.ptrcallWithStringIntStringArgsRetLong(methodBind: MemorySegment,
 
 fun ObjectCalls.ptrcallWithStringLongDoubleIntThreeLongArgsRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Long, a2: Double, a3: Int, a4: Long, a5: Long, a6: Long): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c1 = alloc<LongVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
@@ -3395,12 +3566,12 @@ fun ObjectCalls.ptrcallWithStringLongDoubleIntThreeLongArgsRetVector2(methodBind
         val types = allocArray<IntVar>(7); types[0] = PT_STRING; types[1] = PT_INT64; types[2] = PT_FLOAT64; types[3] = PT_INT64; types[4] = PT_INT64; types[5] = PT_INT64; types[6] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(7); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>(); ptrs[4] = c4.ptr.reinterpret<CPointed>(); ptrs[5] = c5.ptr.reinterpret<CPointed>(); ptrs[6] = c6.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 7, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithStringLongDoubleTwoIntFourLongArgsRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Long, a2: Double, a3: Int, a4: Int, a5: Long, a6: Long, a7: Long, a8: Long): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c1 = alloc<LongVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
@@ -3412,7 +3583,7 @@ fun ObjectCalls.ptrcallWithStringLongDoubleTwoIntFourLongArgsRetVector2(methodBi
         val types = allocArray<IntVar>(9); types[0] = PT_STRING; types[1] = PT_INT64; types[2] = PT_FLOAT64; types[3] = PT_INT64; types[4] = PT_INT64; types[5] = PT_INT64; types[6] = PT_INT64; types[7] = PT_INT64; types[8] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(9); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>(); ptrs[4] = c4.ptr.reinterpret<CPointed>(); ptrs[5] = c5.ptr.reinterpret<CPointed>(); ptrs[6] = c6.ptr.reinterpret<CPointed>(); ptrs[7] = c7.ptr.reinterpret<CPointed>(); ptrs[8] = c8.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 9, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithStringNameAndBoolArg(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: Boolean) =
@@ -3497,6 +3668,16 @@ fun ObjectCalls.ptrcallWithStringNameAndObjectArg(methodBind: MemorySegment, ins
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
         Unit
+    }
+
+fun ObjectCalls.ptrcallWithStringNameAndObjectArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: MemorySegment): Boolean =
+    memScoped {
+        val ret = alloc<ByteVar>()
+        val c1 = alloc<LongVar>(); c1.value = a1.address()
+        val types = allocArray<IntVar>(2); types[0] = PT_STRING_NAME; types[1] = PT_OBJECT
+        val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = a0.cstr.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_BOOL, ret.ptr)
+        ret.value.toInt() != 0
     }
 
 fun ObjectCalls.ptrcallWithStringNameAndObjectArgRetLong(methodBind: MemorySegment, instance: MemorySegment, a0: String, a1: MemorySegment): Long =
@@ -3709,7 +3890,7 @@ fun ObjectCalls.ptrcallWithStringObjectIntRect2ColorIntColorArgs(methodBind: Mem
     memScoped {
         val c1 = alloc<LongVar>(); c1.value = a1.address()
         val c2 = alloc<LongVar>(); c2.value = a2.toLong()
-        val c3 = allocArray<FloatVar>(4); c3[0] = a3.position.x.toFloat(); c3[1] = a3.position.y.toFloat(); c3[2] = a3.size.x.toFloat(); c3[3] = a3.size.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(4); c3[0] = GodotReal.toC(a3.position.x); c3[1] = GodotReal.toC(a3.position.y); c3[2] = GodotReal.toC(a3.size.x); c3[3] = GodotReal.toC(a3.size.y)
         val c4 = allocArray<FloatVar>(4); c4[0] = a4.r; c4[1] = a4.g; c4[2] = a4.b; c4[3] = a4.a
         val c5 = alloc<LongVar>(); c5.value = a5.toLong()
         val c6 = allocArray<FloatVar>(4); c6[0] = a6.r; c6[1] = a6.g; c6[2] = a6.b; c6[3] = a6.a
@@ -3883,9 +4064,9 @@ fun ObjectCalls.ptrcallWithThreeStringNameTwoDoubleBoolArgs(methodBind: MemorySe
 
 fun ObjectCalls.ptrcallWithThreeVector2AndIntArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Vector2, a2: Vector2, a3: Int) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val types = allocArray<IntVar>(4); types[0] = PT_VECTOR2; types[1] = PT_VECTOR2; types[2] = PT_VECTOR2; types[3] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -3895,9 +4076,9 @@ fun ObjectCalls.ptrcallWithThreeVector2AndIntArg(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithThreeVector3AndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3, a2: Vector3, a3: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
-        val c2 = allocArray<FloatVar>(3); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val types = allocArray<IntVar>(4); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3; types[2] = PT_VECTOR3; types[3] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -3907,9 +4088,9 @@ fun ObjectCalls.ptrcallWithThreeVector3AndBoolArgs(methodBind: MemorySegment, in
 
 fun ObjectCalls.ptrcallWithThreeVector3AndIntArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3, a2: Vector3, a3: Int) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
-        val c2 = allocArray<FloatVar>(3); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val types = allocArray<IntVar>(4); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3; types[2] = PT_VECTOR3; types[3] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -3919,7 +4100,7 @@ fun ObjectCalls.ptrcallWithThreeVector3AndIntArg(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithTransform2DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D) =
     memScoped {
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
         val types = allocArray<IntVar>(1); types[0] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -3929,9 +4110,9 @@ fun ObjectCalls.ptrcallWithTransform2DArg(methodBind: MemorySegment, instance: M
 fun ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D, a1: MemorySegment, a2: Transform2D): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
         val c1 = alloc<LongVar>(); c1.value = a1.address()
-        val c2 = allocArray<FloatVar>(6); c2[0] = a2.x.x.toFloat(); c2[1] = a2.x.y.toFloat(); c2[2] = a2.y.x.toFloat(); c2[3] = a2.y.y.toFloat(); c2[4] = a2.origin.x.toFloat(); c2[5] = a2.origin.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(6); c2[0] = GodotReal.toC(a2.x.x); c2[1] = GodotReal.toC(a2.x.y); c2[2] = GodotReal.toC(a2.y.x); c2[3] = GodotReal.toC(a2.y.y); c2[4] = GodotReal.toC(a2.origin.x); c2[5] = GodotReal.toC(a2.origin.y)
         val types = allocArray<IntVar>(3); types[0] = PT_TRANSFORM2D; types[1] = PT_OBJECT; types[2] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_BOOL, ret.ptr)
@@ -3941,8 +4122,8 @@ fun ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(methodBind: M
 fun ObjectCalls.ptrcallWithTransform2DVector2ArgsRetObject(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D, a1: Vector2): MemorySegment =
     memScoped {
         val ret = alloc<LongVar>(); ret.value = 0
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val types = allocArray<IntVar>(2); types[0] = PT_TRANSFORM2D; types[1] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_OBJECT, ret.ptr)
@@ -3952,8 +4133,8 @@ fun ObjectCalls.ptrcallWithTransform2DVector2ArgsRetObject(methodBind: MemorySeg
 fun ObjectCalls.ptrcallWithTransform2DVector2ObjectDoubleBoolArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D, a1: Vector2, a2: MemorySegment, a3: Double, a4: Boolean): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<LongVar>(); c2.value = a2.address()
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -3966,11 +4147,11 @@ fun ObjectCalls.ptrcallWithTransform2DVector2ObjectDoubleBoolArgsRetBool(methodB
 fun ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D, a1: Vector2, a2: MemorySegment, a3: Transform2D, a4: Vector2): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = alloc<LongVar>(); c2.value = a2.address()
-        val c3 = allocArray<FloatVar>(6); c3[0] = a3.x.x.toFloat(); c3[1] = a3.x.y.toFloat(); c3[2] = a3.y.x.toFloat(); c3[3] = a3.y.y.toFloat(); c3[4] = a3.origin.x.toFloat(); c3[5] = a3.origin.y.toFloat()
-        val c4 = allocArray<FloatVar>(2); c4[0] = a4.x.toFloat(); c4[1] = a4.y.toFloat()
+        val c3 = allocArray<GodotRealVar>(6); c3[0] = GodotReal.toC(a3.x.x); c3[1] = GodotReal.toC(a3.x.y); c3[2] = GodotReal.toC(a3.y.x); c3[3] = GodotReal.toC(a3.y.y); c3[4] = GodotReal.toC(a3.origin.x); c3[5] = GodotReal.toC(a3.origin.y)
+        val c4 = allocArray<GodotRealVar>(2); c4[0] = GodotReal.toC(a4.x); c4[1] = GodotReal.toC(a4.y)
         val types = allocArray<IntVar>(5); types[0] = PT_TRANSFORM2D; types[1] = PT_VECTOR2; types[2] = PT_OBJECT; types[3] = PT_TRANSFORM2D; types[4] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>(); ptrs[4] = c4.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_BOOL, ret.ptr)
@@ -3979,8 +4160,8 @@ fun ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool
 
 fun ObjectCalls.ptrcallWithTransform2DVector2TwoColorUInt32Args(methodBind: MemorySegment, instance: MemorySegment, a0: Transform2D, a1: Vector2, a2: Color, a3: Color, a4: Long) =
     memScoped {
-        val c0 = allocArray<FloatVar>(6); c0[0] = a0.x.x.toFloat(); c0[1] = a0.x.y.toFloat(); c0[2] = a0.y.x.toFloat(); c0[3] = a0.y.y.toFloat(); c0[4] = a0.origin.x.toFloat(); c0[5] = a0.origin.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(6); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.x.y); c0[2] = GodotReal.toC(a0.y.x); c0[3] = GodotReal.toC(a0.y.y); c0[4] = GodotReal.toC(a0.origin.x); c0[5] = GodotReal.toC(a0.origin.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<LongVar>(); c4.value = a4
@@ -3993,7 +4174,7 @@ fun ObjectCalls.ptrcallWithTransform2DVector2TwoColorUInt32Args(methodBind: Memo
 fun ObjectCalls.ptrcallWithTransform3DAndDoubleArgRetLong(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D, a1: Double): Long =
     memScoped {
         val ret = alloc<LongVar>()
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_TRANSFORM3D; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
@@ -4003,18 +4184,18 @@ fun ObjectCalls.ptrcallWithTransform3DAndDoubleArgRetLong(methodBind: MemorySegm
 
 fun ObjectCalls.ptrcallWithTransform3DAndLongArgsRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D, a1: Long): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
+        val ret = allocArray<GodotRealVar>(12)
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
         val c1 = alloc<LongVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_TRANSFORM3D; types[1] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallWithTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D) =
     memScoped {
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
         val types = allocArray<IntVar>(1); types[0] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -4024,8 +4205,8 @@ fun ObjectCalls.ptrcallWithTransform3DArg(methodBind: MemorySegment, instance: M
 fun ObjectCalls.ptrcallWithTransform3DVector3ObjectDoubleBoolIntArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D, a1: Vector3, a2: MemorySegment, a3: Double, a4: Boolean, a5: Int): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val c2 = alloc<LongVar>(); c2.value = a2.address()
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -4038,8 +4219,8 @@ fun ObjectCalls.ptrcallWithTransform3DVector3ObjectDoubleBoolIntArgsRetBool(meth
 
 fun ObjectCalls.ptrcallWithTransform3DVector3TwoColorUInt32Args(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D, a1: Vector3, a2: Color, a3: Color, a4: Long) =
     memScoped {
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<LongVar>(); c4.value = a4
@@ -4268,13 +4449,13 @@ fun ObjectCalls.ptrcallWithTwoIntArgsRetObject(methodBind: MemorySegment, instan
 
 fun ObjectCalls.ptrcallWithTwoIntArgsRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Int): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithTwoIntArgsRetVector2i(methodBind: MemorySegment, instance: MemorySegment, a0: Int, a1: Int): Vector2i =
@@ -4373,7 +4554,7 @@ fun ObjectCalls.ptrcallWithTwoIntVector2DoubleArgs(methodBind: MemorySegment, in
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.toLong()
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val types = allocArray<IntVar>(4); types[0] = PT_INT64; types[1] = PT_INT64; types[2] = PT_VECTOR2; types[3] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -4439,7 +4620,7 @@ fun ObjectCalls.ptrcallWithTwoObjectTransform2DColorArgs(methodBind: MemorySegme
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.address()
         val c1 = alloc<LongVar>(); c1.value = a1.address()
-        val c2 = allocArray<FloatVar>(6); c2[0] = a2.x.x.toFloat(); c2[1] = a2.x.y.toFloat(); c2[2] = a2.y.x.toFloat(); c2[3] = a2.y.y.toFloat(); c2[4] = a2.origin.x.toFloat(); c2[5] = a2.origin.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(6); c2[0] = GodotReal.toC(a2.x.x); c2[1] = GodotReal.toC(a2.x.y); c2[2] = GodotReal.toC(a2.y.x); c2[3] = GodotReal.toC(a2.y.y); c2[4] = GodotReal.toC(a2.origin.x); c2[5] = GodotReal.toC(a2.origin.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val types = allocArray<IntVar>(4); types[0] = PT_OBJECT; types[1] = PT_OBJECT; types[2] = PT_TRANSFORM2D; types[3] = PT_COLOR
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>()
@@ -4451,7 +4632,7 @@ fun ObjectCalls.ptrcallWithTwoRIDAndTransform2DArg(methodBind: MemorySegment, in
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.value
-        val c2 = allocArray<FloatVar>(6); c2[0] = a2.x.x.toFloat(); c2[1] = a2.x.y.toFloat(); c2[2] = a2.y.x.toFloat(); c2[3] = a2.y.y.toFloat(); c2[4] = a2.origin.x.toFloat(); c2[5] = a2.origin.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(6); c2[0] = GodotReal.toC(a2.x.x); c2[1] = GodotReal.toC(a2.x.y); c2[2] = GodotReal.toC(a2.y.x); c2[3] = GodotReal.toC(a2.y.y); c2[4] = GodotReal.toC(a2.origin.x); c2[5] = GodotReal.toC(a2.origin.y)
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -4462,7 +4643,7 @@ fun ObjectCalls.ptrcallWithTwoRIDAndVector2Arg(methodBind: MemorySegment, instan
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.value
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val types = allocArray<IntVar>(3); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -4505,7 +4686,7 @@ fun ObjectCalls.ptrcallWithTwoRIDRect2IntArgs(methodBind: MemorySegment, instanc
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.value
-        val c2 = allocArray<FloatVar>(4); c2[0] = a2.position.x.toFloat(); c2[1] = a2.position.y.toFloat(); c2[2] = a2.size.x.toFloat(); c2[3] = a2.size.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(4); c2[0] = GodotReal.toC(a2.position.x); c2[1] = GodotReal.toC(a2.position.y); c2[2] = GodotReal.toC(a2.size.x); c2[3] = GodotReal.toC(a2.size.y)
         val c3 = alloc<LongVar>(); c3.value = a3.toLong()
         val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_RECT2; types[3] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -4517,12 +4698,24 @@ fun ObjectCalls.ptrcallWithTwoRIDTransform2DColorRIDArgs(methodBind: MemorySegme
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0.value
         val c1 = alloc<LongVar>(); c1.value = a1.value
-        val c2 = allocArray<FloatVar>(6); c2[0] = a2.x.x.toFloat(); c2[1] = a2.x.y.toFloat(); c2[2] = a2.y.x.toFloat(); c2[3] = a2.y.y.toFloat(); c2[4] = a2.origin.x.toFloat(); c2[5] = a2.origin.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(6); c2[0] = GodotReal.toC(a2.x.x); c2[1] = GodotReal.toC(a2.x.y); c2[2] = GodotReal.toC(a2.y.x); c2[3] = GodotReal.toC(a2.y.y); c2[4] = GodotReal.toC(a2.origin.x); c2[5] = GodotReal.toC(a2.origin.y)
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
         val c4 = alloc<LongVar>(); c4.value = a4.value
         val types = allocArray<IntVar>(5); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_TRANSFORM2D; types[3] = PT_COLOR; types[4] = PT_RID
         val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.reinterpret<CPointed>(); ptrs[4] = c4.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_VOID, null)
+        Unit
+    }
+
+fun ObjectCalls.ptrcallWithTwoRIDTransform3DBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: RID, a2: Transform3D, a3: Boolean) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.value
+        val c2 = allocArray<GodotRealVar>(12); c2[0] = GodotReal.toC(a2.basis.x.x); c2[1] = GodotReal.toC(a2.basis.y.x); c2[2] = GodotReal.toC(a2.basis.z.x); c2[3] = GodotReal.toC(a2.basis.x.y); c2[4] = GodotReal.toC(a2.basis.y.y); c2[5] = GodotReal.toC(a2.basis.z.y); c2[6] = GodotReal.toC(a2.basis.x.z); c2[7] = GodotReal.toC(a2.basis.y.z); c2[8] = GodotReal.toC(a2.basis.z.z); c2[9] = GodotReal.toC(a2.origin.x); c2[10] = GodotReal.toC(a2.origin.y); c2[11] = GodotReal.toC(a2.origin.z)
+        val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
+        val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_TRANSFORM3D; types[3] = PT_BOOL
+        val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 4, PT_VOID, null)
         Unit
     }
 
@@ -4535,6 +4728,19 @@ fun ObjectCalls.ptrcallWithTwoRIDTwoIntArgs(methodBind: MemorySegment, instance:
         val types = allocArray<IntVar>(4); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_INT64; types[3] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 4, PT_VOID, null)
+        Unit
+    }
+
+fun ObjectCalls.ptrcallWithTwoRIDVector3RIDVector3Args(methodBind: MemorySegment, instance: MemorySegment, a0: RID, a1: RID, a2: Vector3, a3: RID, a4: Vector3) =
+    memScoped {
+        val c0 = alloc<LongVar>(); c0.value = a0.value
+        val c1 = alloc<LongVar>(); c1.value = a1.value
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
+        val c3 = alloc<LongVar>(); c3.value = a3.value
+        val c4 = allocArray<GodotRealVar>(3); c4[0] = GodotReal.toC(a4.x); c4[1] = GodotReal.toC(a4.y); c4[2] = GodotReal.toC(a4.z)
+        val types = allocArray<IntVar>(5); types[0] = PT_RID; types[1] = PT_RID; types[2] = PT_VECTOR3; types[3] = PT_RID; types[4] = PT_VECTOR3
+        val ptrs = allocArray<COpaquePointerVar>(5); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>(); ptrs[4] = c4.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 5, PT_VOID, null)
         Unit
     }
 
@@ -4666,8 +4872,8 @@ fun ObjectCalls.ptrcallWithTwoUInt32AndDoubleArg(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithTwoVector2Args(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Vector2) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR2; types[1] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -4676,8 +4882,8 @@ fun ObjectCalls.ptrcallWithTwoVector2Args(methodBind: MemorySegment, instance: M
 
 fun ObjectCalls.ptrcallWithTwoVector2ColorDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Vector2, a2: Color, a3: Double, a4: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = alloc<ByteVar>(); c4.value = if (a4) 1 else 0
@@ -4689,8 +4895,8 @@ fun ObjectCalls.ptrcallWithTwoVector2ColorDoubleBoolArgs(methodBind: MemorySegme
 
 fun ObjectCalls.ptrcallWithTwoVector2ColorTwoDoubleTwoBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Vector2, a2: Color, a3: Double, a4: Double, a5: Boolean, a6: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = alloc<DoubleVar>(); c3.value = a3
         val c4 = alloc<DoubleVar>(); c4.value = a4
@@ -4716,8 +4922,8 @@ fun ObjectCalls.ptrcallWithTwoVector2iAndObjectArgRetVector2i(methodBind: Memory
 
 fun ObjectCalls.ptrcallWithTwoVector3AndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3, a2: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val types = allocArray<IntVar>(3); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3; types[2] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
@@ -4727,8 +4933,8 @@ fun ObjectCalls.ptrcallWithTwoVector3AndBoolArgs(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithTwoVector3Args(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -4800,7 +5006,7 @@ fun ObjectCalls.ptrcallWithUInt32AndObjectArg(methodBind: MemorySegment, instanc
 fun ObjectCalls.ptrcallWithUInt32AndTransform2DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Long, a1: Transform2D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0
-        val c1 = allocArray<FloatVar>(6); c1[0] = a1.x.x.toFloat(); c1[1] = a1.x.y.toFloat(); c1[2] = a1.y.x.toFloat(); c1[3] = a1.y.y.toFloat(); c1[4] = a1.origin.x.toFloat(); c1[5] = a1.origin.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(6); c1[0] = GodotReal.toC(a1.x.x); c1[1] = GodotReal.toC(a1.x.y); c1[2] = GodotReal.toC(a1.y.x); c1[3] = GodotReal.toC(a1.y.y); c1[4] = GodotReal.toC(a1.origin.x); c1[5] = GodotReal.toC(a1.origin.y)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_TRANSFORM2D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -4810,7 +5016,7 @@ fun ObjectCalls.ptrcallWithUInt32AndTransform2DArg(methodBind: MemorySegment, in
 fun ObjectCalls.ptrcallWithUInt32AndTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Long, a1: Transform3D) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0
-        val c1 = allocArray<FloatVar>(12); c1[0] = a1.basis.x.x.toFloat(); c1[1] = a1.basis.y.x.toFloat(); c1[2] = a1.basis.z.x.toFloat(); c1[3] = a1.basis.x.y.toFloat(); c1[4] = a1.basis.y.y.toFloat(); c1[5] = a1.basis.z.y.toFloat(); c1[6] = a1.basis.x.z.toFloat(); c1[7] = a1.basis.y.z.toFloat(); c1[8] = a1.basis.z.z.toFloat(); c1[9] = a1.origin.x.toFloat(); c1[10] = a1.origin.y.toFloat(); c1[11] = a1.origin.z.toFloat()
+        val c1 = allocArray<GodotRealVar>(12); c1[0] = GodotReal.toC(a1.basis.x.x); c1[1] = GodotReal.toC(a1.basis.y.x); c1[2] = GodotReal.toC(a1.basis.z.x); c1[3] = GodotReal.toC(a1.basis.x.y); c1[4] = GodotReal.toC(a1.basis.y.y); c1[5] = GodotReal.toC(a1.basis.z.y); c1[6] = GodotReal.toC(a1.basis.x.z); c1[7] = GodotReal.toC(a1.basis.y.z); c1[8] = GodotReal.toC(a1.basis.z.z); c1[9] = GodotReal.toC(a1.origin.x); c1[10] = GodotReal.toC(a1.origin.y); c1[11] = GodotReal.toC(a1.origin.z)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -4820,7 +5026,7 @@ fun ObjectCalls.ptrcallWithUInt32AndTransform3DArg(methodBind: MemorySegment, in
 fun ObjectCalls.ptrcallWithUInt32AndVector2Args(methodBind: MemorySegment, instance: MemorySegment, a0: Long, a1: Vector2) =
     memScoped {
         val c0 = alloc<LongVar>(); c0.value = a0
-        val c1 = allocArray<FloatVar>(2); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat()
+        val c1 = allocArray<GodotRealVar>(2); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y)
         val types = allocArray<IntVar>(2); types[0] = PT_INT64; types[1] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.ptr.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VOID, null)
@@ -4878,37 +5084,37 @@ fun ObjectCalls.ptrcallWithUInt32ArgRetObject(methodBind: MemorySegment, instanc
 
 fun ObjectCalls.ptrcallWithUInt32ArgRetTransform2D(methodBind: MemorySegment, instance: MemorySegment, a0: Long): Transform2D =
     memScoped {
-        val ret = allocArray<FloatVar>(6)
+        val ret = allocArray<GodotRealVar>(6)
         val c0 = alloc<LongVar>(); c0.value = a0
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM2D, ret)
-        Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()), Vector2(ret[4].toDouble(), ret[5].toDouble()))
+        Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))
     }
 
 fun ObjectCalls.ptrcallWithUInt32ArgRetTransform3D(methodBind: MemorySegment, instance: MemorySegment, a0: Long): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         val c0 = alloc<LongVar>(); c0.value = a0
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallWithUInt32ArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Long): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = alloc<LongVar>(); c0.value = a0
         val types = allocArray<IntVar>(1); types[0] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithVector2AndBoolArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR2; types[1] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
@@ -4918,18 +5124,18 @@ fun ObjectCalls.ptrcallWithVector2AndBoolArg(methodBind: MemorySegment, instance
 
 fun ObjectCalls.ptrcallWithVector2AndDoubleArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR2; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithVector2AndIntArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Int) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<LongVar>(); c1.value = a1.toLong()
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR2; types[1] = PT_INT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
@@ -4940,7 +5146,7 @@ fun ObjectCalls.ptrcallWithVector2AndIntArg(methodBind: MemorySegment, instance:
 fun ObjectCalls.ptrcallWithVector2ArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_BOOL, ret.ptr)
@@ -4950,7 +5156,7 @@ fun ObjectCalls.ptrcallWithVector2ArgRetBool(methodBind: MemorySegment, instance
 fun ObjectCalls.ptrcallWithVector2ArgRetDouble(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Double =
     memScoped {
         val ret = alloc<DoubleVar>()
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_FLOAT64, ret.ptr)
@@ -4960,7 +5166,7 @@ fun ObjectCalls.ptrcallWithVector2ArgRetDouble(methodBind: MemorySegment, instan
 fun ObjectCalls.ptrcallWithVector2ArgRetLong(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Long =
     memScoped {
         val ret = alloc<LongVar>()
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_INT64, ret.ptr)
@@ -4969,18 +5175,18 @@ fun ObjectCalls.ptrcallWithVector2ArgRetLong(methodBind: MemorySegment, instance
 
 fun ObjectCalls.ptrcallWithVector2ArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val ret = allocArray<GodotRealVar>(2)
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithVector2ArgRetVector2i(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Vector2i =
     memScoped {
         val ret = allocArray<IntVar>(2)
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2I, ret)
@@ -4989,18 +5195,18 @@ fun ObjectCalls.ptrcallWithVector2ArgRetVector2i(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithVector2ArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithVector2BoolFloatBoolArgsRetObject(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Boolean, a2: Double, a3: Boolean): MemorySegment =
     memScoped {
         val ret = alloc<LongVar>(); ret.value = 0
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
@@ -5012,7 +5218,7 @@ fun ObjectCalls.ptrcallWithVector2BoolFloatBoolArgsRetObject(methodBind: MemoryS
 
 fun ObjectCalls.ptrcallWithVector2DoubleColorBoolDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Color, a3: Boolean, a4: Double, a5: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = allocArray<FloatVar>(4); c2[0] = a2.r; c2[1] = a2.g; c2[2] = a2.b; c2[3] = a2.a
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
@@ -5026,9 +5232,9 @@ fun ObjectCalls.ptrcallWithVector2DoubleColorBoolDoubleBoolArgs(methodBind: Memo
 
 fun ObjectCalls.ptrcallWithVector2DoubleVector2Args(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Vector2) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
-        val c2 = allocArray<FloatVar>(2); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat()
+        val c2 = allocArray<GodotRealVar>(2); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y)
         val types = allocArray<IntVar>(3); types[0] = PT_VECTOR2; types[1] = PT_FLOAT64; types[2] = PT_VECTOR2
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 3, PT_VOID, null)
@@ -5037,7 +5243,7 @@ fun ObjectCalls.ptrcallWithVector2DoubleVector2Args(methodBind: MemorySegment, i
 
 fun ObjectCalls.ptrcallWithVector2FourDoubleIntColorDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Double, a3: Double, a4: Double, a5: Int, a6: Color, a7: Double, a8: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<DoubleVar>(); c3.value = a3
@@ -5055,8 +5261,8 @@ fun ObjectCalls.ptrcallWithVector2FourDoubleIntColorDoubleBoolArgs(methodBind: M
 fun ObjectCalls.ptrcallWithVector2Rect2ArgsRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Rect2): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
-        val c1 = allocArray<FloatVar>(4); c1[0] = a1.position.x.toFloat(); c1[1] = a1.position.y.toFloat(); c1[2] = a1.size.x.toFloat(); c1[3] = a1.size.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
+        val c1 = allocArray<GodotRealVar>(4); c1[0] = GodotReal.toC(a1.position.x); c1[1] = GodotReal.toC(a1.position.y); c1[2] = GodotReal.toC(a1.size.x); c1[3] = GodotReal.toC(a1.size.y)
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR2; types[1] = PT_RECT2
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 2, PT_BOOL, ret.ptr)
@@ -5065,7 +5271,7 @@ fun ObjectCalls.ptrcallWithVector2Rect2ArgsRetBool(methodBind: MemorySegment, in
 
 fun ObjectCalls.ptrcallWithVector2ThreeDoubleIntColorDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Double, a3: Double, a4: Int, a5: Color, a6: Double, a7: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<DoubleVar>(); c3.value = a3
@@ -5081,7 +5287,7 @@ fun ObjectCalls.ptrcallWithVector2ThreeDoubleIntColorDoubleBoolArgs(methodBind: 
 
 fun ObjectCalls.ptrcallWithVector2TwoDoubleColorBoolDoubleBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Double, a3: Color, a4: Boolean, a5: Double, a6: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = allocArray<FloatVar>(4); c3[0] = a3.r; c3[1] = a3.g; c3[2] = a3.b; c3[3] = a3.a
@@ -5097,7 +5303,7 @@ fun ObjectCalls.ptrcallWithVector2TwoDoubleColorBoolDoubleBoolArgs(methodBind: M
 fun ObjectCalls.ptrcallWithVector2TwoDoubleTwoLongArgsRetInt(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2, a1: Double, a2: Double, a3: Long, a4: Long): Int =
     memScoped {
         val ret = alloc<LongVar>()
-        val c0 = allocArray<FloatVar>(2); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat()
+        val c0 = allocArray<GodotRealVar>(2); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<LongVar>(); c3.value = a3
@@ -5235,12 +5441,12 @@ fun ObjectCalls.ptrcallWithVector2iArgRetObject(methodBind: MemorySegment, insta
 
 fun ObjectCalls.ptrcallWithVector2iArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2i): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
+        val ret = allocArray<GodotRealVar>(2)
         val c0 = allocArray<IntVar>(2); c0[0] = a0.x; c0[1] = a0.y
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR2I
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithVector2iArgRetVector2i(methodBind: MemorySegment, instance: MemorySegment, a0: Vector2i): Vector2i =
@@ -5267,7 +5473,7 @@ fun ObjectCalls.ptrcallWithVector2iIntVector2iIntArgs(methodBind: MemorySegment,
 
 fun ObjectCalls.ptrcallWithVector3AndDoubleArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Double) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR3; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
@@ -5278,7 +5484,7 @@ fun ObjectCalls.ptrcallWithVector3AndDoubleArg(methodBind: MemorySegment, instan
 fun ObjectCalls.ptrcallWithVector3ArgRetBool(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3): Boolean =
     memScoped {
         val ret = alloc<ByteVar>()
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_BOOL, ret.ptr)
@@ -5288,7 +5494,7 @@ fun ObjectCalls.ptrcallWithVector3ArgRetBool(methodBind: MemorySegment, instance
 fun ObjectCalls.ptrcallWithVector3ArgRetDouble(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3): Double =
     memScoped {
         val ret = alloc<DoubleVar>()
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_FLOAT64, ret.ptr)
@@ -5297,28 +5503,28 @@ fun ObjectCalls.ptrcallWithVector3ArgRetDouble(methodBind: MemorySegment, instan
 
 fun ObjectCalls.ptrcallWithVector3ArgRetVector2(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3): Vector2 =
     memScoped {
-        val ret = allocArray<FloatVar>(2)
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val ret = allocArray<GodotRealVar>(2)
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR2, ret)
-        Vector2(ret[0].toDouble(), ret[1].toDouble())
+        Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))
     }
 
 fun ObjectCalls.ptrcallWithVector3ArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }
 
 fun ObjectCalls.ptrcallWithVector3BoolFloatBoolIntArgsRetObject(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Boolean, a2: Double, a3: Boolean, a4: Int): MemorySegment =
     memScoped {
         val ret = alloc<LongVar>(); ret.value = 0
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val c1 = alloc<ByteVar>(); c1.value = if (a1) 1 else 0
         val c2 = alloc<DoubleVar>(); c2.value = a2
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/ApproxMath.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/ApproxMath.kt
@@ -5,16 +5,16 @@ import kotlin.math.abs
 /**
  * iOS shadow of the desktop [ApproxMath] — Godot's fuzzy float comparison (`Math::is_equal_approx` /
  * `is_zero_approx`), replicated locally so the value-type helpers match the engine without a
- * per-component engine round-trip. Components are `Double` on iOS (single-precision engine values
- * widened at the C-shim boundary). `CMP_EPSILON` is Godot's `0.00001`.
+ * per-component engine round-trip. Components use [real_t], currently single precision on iOS.
+ * `CMP_EPSILON` is Godot's `0.00001`.
  */
-internal const val CMP_EPSILON: Double = 0.00001
+internal val CMP_EPSILON: real_t = GodotReal.fromNumber(0.00001)
 
-internal fun isEqualApprox(a: Double, b: Double): Boolean {
+internal fun isEqualApprox(a: real_t, b: real_t): Boolean {
     if (a == b) return true
     var tolerance = CMP_EPSILON * abs(a)
     if (tolerance < CMP_EPSILON) tolerance = CMP_EPSILON
     return abs(a - b) < tolerance
 }
 
-internal fun isZeroApprox(value: Double): Boolean = abs(value) < CMP_EPSILON
+internal fun isZeroApprox(value: real_t): Boolean = abs(value) < CMP_EPSILON

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Basis.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Basis.kt
@@ -41,25 +41,25 @@ data class Basis(
 
     /** Returns the inverse of this basis. Computed by Godot. */
     fun inverse(): Basis =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(inverseBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(inverseBind, toGodotRealArray()))
 
     /** Returns the transpose of this basis (rows and columns swapped). */
     fun transposed(): Basis =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(transposedBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(transposedBind, toGodotRealArray()))
 
     /** Returns this basis with its axes orthogonalized and normalized (Gram-Schmidt). */
     fun orthonormalized(): Basis =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(orthonormalizedBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(orthonormalizedBind, toGodotRealArray()))
 
     /**
      * Returns a copy of this basis scaled by [scale] (each row multiplied by the matching
      * [scale] component). IDENTITY scaled by (sx,sy,sz) is diag(sx,sy,sz).
      */
     fun scaled(scale: Vector3): Basis =
-        fromFloat32(BuiltinCalls.call(scaledBind, toFloat32(), 9, listOf(
+        fromGodotRealArray(BuiltinCalls.call(scaledBind, toGodotRealArray(), 9, listOf(
             BuiltinCalls.BArg.Floats(
                 BuiltinCalls.PT_VECTOR3,
-                floatArrayOf(scale.x.toFloat(), scale.y.toFloat(), scale.z.toFloat()),
+                vector3Array(scale),
             ),
         )))
 
@@ -68,12 +68,12 @@ data class Basis(
      * decoded to Double). A negative determinant means the basis flips orientation.
      */
     fun determinant(): Double =
-        BuiltinCalls.callScalar(determinantBind, toFloat32())
+        BuiltinCalls.callScalar(determinantBind, toGodotRealArray())
 
     /** Returns the scale component of this basis, computed by Godot (matches Basis.get_scale). */
     fun getScale(): Vector3 {
-        val c = BuiltinCalls.call(getScaleBind, toFloat32(), 3)
-        return Vector3(c[0].toDouble(), c[1].toDouble(), c[2].toDouble())
+        val c = BuiltinCalls.call(getScaleBind, toGodotRealArray(), 3)
+        return Vector3(GodotReal.fromC(c[0]), GodotReal.fromC(c[1]), GodotReal.fromC(c[2]))
     }
 
     /**
@@ -81,8 +81,8 @@ data class Basis(
      * (orthonormalization + negative-scale handling match the engine; Basis.get_rotation_quaternion).
      */
     fun getRotationQuaternion(): Quaternion {
-        val c = BuiltinCalls.call(getRotationQuaternionBind, toFloat32(), 4)
-        return Quaternion(c[0].toDouble(), c[1].toDouble(), c[2].toDouble(), c[3].toDouble())
+        val c = BuiltinCalls.call(getRotationQuaternionBind, toGodotRealArray(), 4)
+        return Quaternion(GodotReal.fromC(c[0]), GodotReal.fromC(c[1]), GodotReal.fromC(c[2]), GodotReal.fromC(c[3]))
     }
 
     /**
@@ -108,13 +108,19 @@ data class Basis(
         }
     }
 
-    // Column-major 9 float32, matching the ObjectCalls Basis ptrcall layout.
-    private fun toFloat32(): FloatArray =
-        floatArrayOf(
-            x.x.toFloat(), y.x.toFloat(), z.x.toFloat(),
-            x.y.toFloat(), y.y.toFloat(), z.y.toFloat(),
-            x.z.toFloat(), y.z.toFloat(), z.z.toFloat(),
-        )
+    // Column-major real_t values, matching the ObjectCalls Basis ptrcall layout.
+    private fun toGodotRealArray(): GodotRealArray =
+        GodotRealArray(9).also {
+            it[0] = GodotReal.toC(x.x)
+            it[1] = GodotReal.toC(y.x)
+            it[2] = GodotReal.toC(z.x)
+            it[3] = GodotReal.toC(x.y)
+            it[4] = GodotReal.toC(y.y)
+            it[5] = GodotReal.toC(z.y)
+            it[6] = GodotReal.toC(x.z)
+            it[7] = GodotReal.toC(y.z)
+            it[8] = GodotReal.toC(z.z)
+        }
 
     companion object {
         // Godot CMP_EPSILON (used by the Euler decomposition gimbal checks).
@@ -178,23 +184,30 @@ data class Basis(
          * so the call passes an empty base (mirrors the desktop `base = NULL`).
          */
         fun lookingAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false): Basis =
-            fromFloat32(BuiltinCalls.call(lookingAtBind, floatArrayOf(), 9, listOf(
+            fromGodotRealArray(BuiltinCalls.call(lookingAtBind, GodotRealArray(0), 9, listOf(
                 BuiltinCalls.BArg.Floats(
                     BuiltinCalls.PT_VECTOR3,
-                    floatArrayOf(target.x.toFloat(), target.y.toFloat(), target.z.toFloat()),
+                    vector3Array(target),
                 ),
                 BuiltinCalls.BArg.Floats(
                     BuiltinCalls.PT_VECTOR3,
-                    floatArrayOf(up.x.toFloat(), up.y.toFloat(), up.z.toFloat()),
+                    vector3Array(up),
                 ),
                 BuiltinCalls.BArg.Bool(useModelFront),
             )))
 
-        private fun fromFloat32(c: FloatArray): Basis =
+        private fun vector3Array(v: Vector3): GodotRealArray =
+            GodotRealArray(3).also {
+                it[0] = GodotReal.toC(v.x)
+                it[1] = GodotReal.toC(v.y)
+                it[2] = GodotReal.toC(v.z)
+            }
+
+        private fun fromGodotRealArray(c: GodotRealArray): Basis =
             Basis(
-                Vector3(c[0].toDouble(), c[3].toDouble(), c[6].toDouble()),
-                Vector3(c[1].toDouble(), c[4].toDouble(), c[7].toDouble()),
-                Vector3(c[2].toDouble(), c[5].toDouble(), c[8].toDouble()),
+                Vector3(GodotReal.fromC(c[0]), GodotReal.fromC(c[3]), GodotReal.fromC(c[6])),
+                Vector3(GodotReal.fromC(c[1]), GodotReal.fromC(c[4]), GodotReal.fromC(c[7])),
+                Vector3(GodotReal.fromC(c[2]), GodotReal.fromC(c[5]), GodotReal.fromC(c[8])),
             )
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Plane.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Plane.kt
@@ -9,10 +9,10 @@ package net.multigesture.kanama.types
  */
 data class Plane(
     val normal: Vector3,
-    val d: Double,
+    val d: real_t,
 ) {
     constructor(x: Number, y: Number, z: Number, d: Number) :
-        this(Vector3(x, y, z), d.toDouble())
+        this(Vector3(x, y, z), GodotReal.fromNumber(d))
 
     // Match GDScript/C# `==`: signed zero equal (-0.0 == 0.0), NaN reflexive. `normal` delegates to
     // Vector3.equals (also fixed); `d` is compared/hashed the same way. See wrapper-coverage-roadmap.md.
@@ -25,6 +25,6 @@ data class Plane(
     override fun hashCode(): Int = 31 * normal.hashCode() + (d + 0.0).hashCode()
 
     companion object {
-        val ZERO = Plane(Vector3.ZERO, 0.0)
+        val ZERO = Plane(Vector3.ZERO, GodotReal.fromNumber(0.0))
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Quaternion.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Quaternion.kt
@@ -11,13 +11,18 @@ import net.multigesture.kanama.binding.runtime.BuiltinCalls
  * methods (e.g. [inverse]) route through the BuiltinCalls value-type call path.
  */
 data class Quaternion(
-    val x: Double,
-    val y: Double,
-    val z: Double,
-    val w: Double,
+    val x: real_t,
+    val y: real_t,
+    val z: real_t,
+    val w: real_t,
 ) {
     constructor(x: Number, y: Number, z: Number, w: Number) :
-        this(x.toDouble(), y.toDouble(), z.toDouble(), w.toDouble())
+        this(
+            GodotReal.fromNumber(x),
+            GodotReal.fromNumber(y),
+            GodotReal.fromNumber(z),
+            GodotReal.fromNumber(w),
+        )
 
     // Match GDScript/C# `==`: signed zero equal (-0.0 == 0.0), NaN reflexive. See
     // wrapper-coverage-roadmap.md. hashCode canonicalizes signed zero so equal quaternions hash equal.
@@ -49,7 +54,7 @@ data class Quaternion(
      * conjugate (negated x/y/z).
      */
     fun inverse(): Quaternion =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(inverseBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(inverseBind, toGodotRealArray()))
 
     /**
      * Spherically interpolates toward [to] by [weight] (0..1), computed by Godot so the
@@ -57,13 +62,18 @@ data class Quaternion(
      * are assumed normalized (matches Godot Quaternion.slerp).
      */
     fun slerp(to: Quaternion, weight: Double): Quaternion =
-        fromFloat32(BuiltinCalls.call(slerpBind, toFloat32(), 4, listOf(
-            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_QUATERNION, to.toFloat32()),
+        fromGodotRealArray(BuiltinCalls.call(slerpBind, toGodotRealArray(), 4, listOf(
+            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_QUATERNION, to.toGodotRealArray()),
             BuiltinCalls.BArg.Real(weight),
         )))
 
-    private fun toFloat32(): FloatArray =
-        floatArrayOf(x.toFloat(), y.toFloat(), z.toFloat(), w.toFloat())
+    private fun toGodotRealArray(): GodotRealArray =
+        GodotRealArray(4).also {
+            it[0] = GodotReal.toC(x)
+            it[1] = GodotReal.toC(y)
+            it[2] = GodotReal.toC(z)
+            it[3] = GodotReal.toC(w)
+        }
 
     companion object {
         val IDENTITY = Quaternion(0.0, 0.0, 0.0, 1.0)
@@ -83,14 +93,23 @@ data class Quaternion(
          * computed by Godot. `from_euler` is a *static* builtin, so the call passes an empty base.
          */
         fun fromEuler(euler: Vector3): Quaternion =
-            fromFloat32(BuiltinCalls.call(fromEulerBind, floatArrayOf(), 4, listOf(
+            fromGodotRealArray(BuiltinCalls.call(fromEulerBind, GodotRealArray(0), 4, listOf(
                 BuiltinCalls.BArg.Floats(
                     BuiltinCalls.PT_VECTOR3,
-                    floatArrayOf(euler.x.toFloat(), euler.y.toFloat(), euler.z.toFloat()),
+                    GodotRealArray(3).also {
+                        it[0] = GodotReal.toC(euler.x)
+                        it[1] = GodotReal.toC(euler.y)
+                        it[2] = GodotReal.toC(euler.z)
+                    },
                 ),
             )))
 
-        private fun fromFloat32(c: FloatArray): Quaternion =
-            Quaternion(c[0].toDouble(), c[1].toDouble(), c[2].toDouble(), c[3].toDouble())
+        private fun fromGodotRealArray(c: GodotRealArray): Quaternion =
+            Quaternion(
+                GodotReal.fromC(c[0]),
+                GodotReal.fromC(c[1]),
+                GodotReal.fromC(c[2]),
+                GodotReal.fromC(c[3]),
+            )
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Real.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Real.kt
@@ -1,0 +1,30 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package net.multigesture.kanama.types
+
+import kotlinx.cinterop.FloatVar
+
+/**
+ * Godot's `real_t` scalar on iOS.
+ *
+ * iOS currently supports the single-precision Godot template path only. Keep this API shape in
+ * sync with the JVM `GodotReal` surface so future precision changes are centralized here instead
+ * of scattered across value types and ptrcall helpers.
+ */
+typealias real_t = Float
+
+typealias GodotRealVar = FloatVar
+
+typealias GodotRealArray = FloatArray
+
+object GodotReal {
+    const val SIZE_BYTES: Long = 4L
+    const val ALIGN_BYTES: Long = 4L
+
+    fun fromNumber(value: Number): real_t = value.toFloat()
+    fun fromDouble(value: Double): real_t = value.toFloat()
+    fun fromFloat(value: Float): real_t = value
+
+    fun toC(value: real_t): Float = value
+    fun fromC(value: Float): real_t = value
+}

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform3D.kt
@@ -36,18 +36,18 @@ data class Transform3D(
     fun withOrigin(value: Vector3): Transform3D = copy(origin = value)
 
     fun inverse(): Transform3D =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(inverseBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(inverseBind, toGodotRealArray()))
 
     /**
      * Returns the full (affine) inverse of this transform — the true matrix inverse, valid
      * even when the [basis] has scale or shear (unlike [inverse], which assumes orthonormal).
      */
     fun affineInverse(): Transform3D =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(affineInverseBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(affineInverseBind, toGodotRealArray()))
 
     /** Returns a copy of this transform with its [basis] orthonormalized (Gram-Schmidt). */
     fun orthonormalized(): Transform3D =
-        fromFloat32(BuiltinCalls.callNoArgsFloat32(orthonormalizedBind, toFloat32()))
+        fromGodotRealArray(BuiltinCalls.callNoArgsFloat32(orthonormalizedBind, toGodotRealArray()))
 
     /**
      * Returns a copy of this transform rotated so the forward axis (-Z) points toward
@@ -56,7 +56,7 @@ data class Transform3D(
      * [useModelFront] is true the +Z axis (asset front) is treated as forward instead.
      */
     fun lookingAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false): Transform3D =
-        fromFloat32(BuiltinCalls.call(lookingAtBind, toFloat32(), 12, listOf(
+        fromGodotRealArray(BuiltinCalls.call(lookingAtBind, toGodotRealArray(), 12, listOf(
             BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, vec3(target)),
             BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, vec3(up)),
             BuiltinCalls.BArg.Bool(useModelFront),
@@ -67,8 +67,8 @@ data class Transform3D(
      * (0 = this, 1 = [to]); the rotation is interpolated via quaternion slerp.
      */
     fun interpolateWith(to: Transform3D, weight: Double): Transform3D =
-        fromFloat32(BuiltinCalls.call(interpolateWithBind, toFloat32(), 12, listOf(
-            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_TRANSFORM3D, to.toFloat32()),
+        fromGodotRealArray(BuiltinCalls.call(interpolateWithBind, toGodotRealArray(), 12, listOf(
+            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_TRANSFORM3D, to.toGodotRealArray()),
             BuiltinCalls.BArg.Real(weight),
         )))
 
@@ -78,7 +78,7 @@ data class Transform3D(
      * `translated_local` instead (not yet wired on iOS).
      */
     fun translated(offset: Vector3): Transform3D =
-        fromFloat32(BuiltinCalls.call(translatedBind, toFloat32(), 12, listOf(
+        fromGodotRealArray(BuiltinCalls.call(translatedBind, toGodotRealArray(), 12, listOf(
             BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, vec3(offset)),
         )))
 
@@ -94,14 +94,22 @@ data class Transform3D(
     fun scaledLocal(scale: Vector3): Transform3D =
         Transform3D(Basis(basis.x * scale.x, basis.y * scale.y, basis.z * scale.z), origin)
 
-    // Column-major 12 float32, matching the ObjectCalls Transform3D ptrcall layout.
-    private fun toFloat32(): FloatArray =
-        floatArrayOf(
-            basis.x.x.toFloat(), basis.y.x.toFloat(), basis.z.x.toFloat(),
-            basis.x.y.toFloat(), basis.y.y.toFloat(), basis.z.y.toFloat(),
-            basis.x.z.toFloat(), basis.y.z.toFloat(), basis.z.z.toFloat(),
-            origin.x.toFloat(), origin.y.toFloat(), origin.z.toFloat(),
-        )
+    // Column-major real_t values, matching the ObjectCalls Transform3D ptrcall layout.
+    private fun toGodotRealArray(): GodotRealArray =
+        GodotRealArray(12).also {
+            it[0] = GodotReal.toC(basis.x.x)
+            it[1] = GodotReal.toC(basis.y.x)
+            it[2] = GodotReal.toC(basis.z.x)
+            it[3] = GodotReal.toC(basis.x.y)
+            it[4] = GodotReal.toC(basis.y.y)
+            it[5] = GodotReal.toC(basis.z.y)
+            it[6] = GodotReal.toC(basis.x.z)
+            it[7] = GodotReal.toC(basis.y.z)
+            it[8] = GodotReal.toC(basis.z.z)
+            it[9] = GodotReal.toC(origin.x)
+            it[10] = GodotReal.toC(origin.y)
+            it[11] = GodotReal.toC(origin.z)
+        }
 
     companion object {
         val IDENTITY = Transform3D(Basis.IDENTITY, Vector3.ZERO)
@@ -128,17 +136,21 @@ data class Transform3D(
             BuiltinCalls.getBuiltinMethod(BuiltinCalls.VT_TRANSFORM3D, "translated", 1405596198L)
         }
 
-        private fun vec3(v: Vector3): FloatArray =
-            floatArrayOf(v.x.toFloat(), v.y.toFloat(), v.z.toFloat())
+        private fun vec3(v: Vector3): GodotRealArray =
+            GodotRealArray(3).also {
+                it[0] = GodotReal.toC(v.x)
+                it[1] = GodotReal.toC(v.y)
+                it[2] = GodotReal.toC(v.z)
+            }
 
-        private fun fromFloat32(c: FloatArray): Transform3D =
+        private fun fromGodotRealArray(c: GodotRealArray): Transform3D =
             Transform3D(
                 basis = Basis(
-                    Vector3(c[0].toDouble(), c[3].toDouble(), c[6].toDouble()),
-                    Vector3(c[1].toDouble(), c[4].toDouble(), c[7].toDouble()),
-                    Vector3(c[2].toDouble(), c[5].toDouble(), c[8].toDouble()),
+                    Vector3(GodotReal.fromC(c[0]), GodotReal.fromC(c[3]), GodotReal.fromC(c[6])),
+                    Vector3(GodotReal.fromC(c[1]), GodotReal.fromC(c[4]), GodotReal.fromC(c[7])),
+                    Vector3(GodotReal.fromC(c[2]), GodotReal.fromC(c[5]), GodotReal.fromC(c[8])),
                 ),
-                origin = Vector3(c[9].toDouble(), c[10].toDouble(), c[11].toDouble()),
+                origin = Vector3(GodotReal.fromC(c[9]), GodotReal.fromC(c[10]), GodotReal.fromC(c[11])),
             )
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector2.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector2.kt
@@ -5,10 +5,10 @@ import kotlin.math.atan2
 import kotlin.math.sqrt
 
 data class Vector2(
-    val x: Double,
-    val y: Double,
+    val x: real_t,
+    val y: real_t,
 ) {
-    constructor(x: Number, y: Number) : this(x.toDouble(), y.toDouble())
+    constructor(x: Number, y: Number) : this(GodotReal.fromNumber(x), GodotReal.fromNumber(y))
 
     // Match GDScript/C# `==`: signed zero equal (-0.0 == 0.0), NaN reflexive. See
     // wrapper-coverage-roadmap.md. hashCode canonicalizes signed zero so equal vectors hash equal.
@@ -39,16 +39,16 @@ data class Vector2(
         Vector2(x - other.x, y - other.y)
 
     operator fun times(scale: Number): Vector2 =
-        Vector2(x * scale.toDouble(), y * scale.toDouble())
+        Vector2(x.toDouble() * scale.toDouble(), y.toDouble() * scale.toDouble())
 
     operator fun div(scale: Number): Vector2 =
-        Vector2(x / scale.toDouble(), y / scale.toDouble())
+        Vector2(x.toDouble() / scale.toDouble(), y.toDouble() / scale.toDouble())
 
     operator fun unaryMinus(): Vector2 =
         Vector2(-x, -y)
 
     fun lengthSquared(): Double =
-        x * x + y * y
+        (x * x + y * y).toDouble()
 
     fun length(): Double =
         sqrt(lengthSquared())
@@ -64,7 +64,7 @@ data class Vector2(
         Vector2(x.coerceIn(min.x, max.x), y.coerceIn(min.y, max.y))
 
     fun angle(): Double =
-        atan2(y, x)
+        atan2(y.toDouble(), x.toDouble())
 
     fun withX(value: Number): Vector2 = Vector2(value, y)
 
@@ -75,12 +75,15 @@ data class Vector2(
      * builtin call path (so the rotation direction matches the engine exactly).
      */
     fun rotated(angle: Double): Vector2 =
-        fromFloat32(BuiltinCalls.call(rotatedBind, toFloat32(), 2, listOf(
+        fromGodotRealArray(BuiltinCalls.call(rotatedBind, toGodotRealArray(), 2, listOf(
             BuiltinCalls.BArg.Real(angle),
         )))
 
-    private fun toFloat32(): FloatArray =
-        floatArrayOf(x.toFloat(), y.toFloat())
+    private fun toGodotRealArray(): GodotRealArray =
+        GodotRealArray(2).also {
+            it[0] = GodotReal.toC(x)
+            it[1] = GodotReal.toC(y)
+        }
 
     companion object {
         val ZERO = Vector2(0.0, 0.0)
@@ -94,7 +97,7 @@ data class Vector2(
             BuiltinCalls.getBuiltinMethod(BuiltinCalls.VT_VECTOR2, "rotated", 2544004089L)
         }
 
-        private fun fromFloat32(c: FloatArray): Vector2 =
-            Vector2(c[0].toDouble(), c[1].toDouble())
+        private fun fromGodotRealArray(c: GodotRealArray): Vector2 =
+            Vector2(GodotReal.fromC(c[0]), GodotReal.fromC(c[1]))
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector3.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector3.kt
@@ -6,11 +6,12 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 data class Vector3(
-    val x: Double,
-    val y: Double,
-    val z: Double,
+    val x: real_t,
+    val y: real_t,
+    val z: real_t,
 ) {
-    constructor(x: Number, y: Number, z: Number) : this(x.toDouble(), y.toDouble(), z.toDouble())
+    constructor(x: Number, y: Number, z: Number) :
+        this(GodotReal.fromNumber(x), GodotReal.fromNumber(y), GodotReal.fromNumber(z))
 
     // Match GDScript/C# `==`: signed zero equal (-0.0 == 0.0), NaN reflexive. See
     // wrapper-coverage-roadmap.md. hashCode canonicalizes signed zero so equal vectors hash equal.
@@ -52,16 +53,16 @@ data class Vector3(
         Vector3(-x, -y, -z)
 
     fun withX(value: Number): Vector3 =
-        copy(x = value.toDouble())
+        copy(x = GodotReal.fromNumber(value))
 
     fun withY(value: Number): Vector3 =
-        copy(y = value.toDouble())
+        copy(y = GodotReal.fromNumber(value))
 
     fun withZ(value: Number): Vector3 =
-        copy(z = value.toDouble())
+        copy(z = GodotReal.fromNumber(value))
 
     fun lengthSquared(): Double =
-        x * x + y * y + z * z
+        (x * x + y * y + z * z).toDouble()
 
     fun length(): Double =
         sqrt(lengthSquared())
@@ -90,14 +91,14 @@ data class Vector3(
         val a = axis.normalized()
         val c = cos(angle)
         val s = sin(angle)
-        val dot = x * a.x + y * a.y + z * a.z
-        val cx = a.y * z - a.z * y
-        val cy = a.z * x - a.x * z
-        val cz = a.x * y - a.y * x
+        val dot = x.toDouble() * a.x + y.toDouble() * a.y + z.toDouble() * a.z
+        val cx = a.y.toDouble() * z - a.z.toDouble() * y
+        val cy = a.z.toDouble() * x - a.x.toDouble() * z
+        val cz = a.x.toDouble() * y - a.y.toDouble() * x
         return Vector3(
-            x * c + cx * s + a.x * dot * (1.0 - c),
-            y * c + cy * s + a.y * dot * (1.0 - c),
-            z * c + cz * s + a.z * dot * (1.0 - c),
+            x.toDouble() * c + cx * s + a.x.toDouble() * dot * (1.0 - c),
+            y.toDouble() * c + cy * s + a.y.toDouble() * dot * (1.0 - c),
+            z.toDouble() * c + cz * s + a.z.toDouble() * dot * (1.0 - c),
         )
     }
 
@@ -106,8 +107,8 @@ data class Vector3(
      * value-type builtin call path (so the handedness/ordering matches the engine exactly).
      */
     fun cross(with: Vector3): Vector3 =
-        fromFloat32(BuiltinCalls.call(crossBind, toFloat32(), 3, listOf(
-            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, with.toFloat32()),
+        fromGodotRealArray(BuiltinCalls.call(crossBind, toGodotRealArray(), 3, listOf(
+            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, with.toGodotRealArray()),
         )))
 
     /**
@@ -115,8 +116,8 @@ data class Vector3(
      * value-type builtin call path (scalar `real_t` return decoded to Double).
      */
     fun dot(with: Vector3): Double =
-        BuiltinCalls.callScalar(dotBind, toFloat32(), listOf(
-            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, with.toFloat32()),
+        BuiltinCalls.callScalar(dotBind, toGodotRealArray(), listOf(
+            BuiltinCalls.BArg.Floats(BuiltinCalls.PT_VECTOR3, with.toGodotRealArray()),
         ))
 
     /** Euclidean distance from this point to [to] (matches Godot Vector3.distance_to). */
@@ -156,17 +157,21 @@ data class Vector3(
      * return decoded from the ptr-ABI's uint8).
      */
     fun isNormalized(): Boolean =
-        BuiltinCalls.callBool(isNormalizedBind, toFloat32())
+        BuiltinCalls.callBool(isNormalizedBind, toGodotRealArray())
 
     /**
      * Returns the index (0 = x, 1 = y, 2 = z) of this vector's largest component, computed
      * by Godot (int return decoded from the ptr-ABI's int64).
      */
     fun maxAxisIndex(): Int =
-        BuiltinCalls.callInt(maxAxisIndexBind, toFloat32()).toInt()
+        BuiltinCalls.callInt(maxAxisIndexBind, toGodotRealArray()).toInt()
 
-    private fun toFloat32(): FloatArray =
-        floatArrayOf(x.toFloat(), y.toFloat(), z.toFloat())
+    private fun toGodotRealArray(): GodotRealArray =
+        GodotRealArray(3).also {
+            it[0] = GodotReal.toC(x)
+            it[1] = GodotReal.toC(y)
+            it[2] = GodotReal.toC(z)
+        }
 
     companion object {
         val ZERO = Vector3(0.0, 0.0, 0.0)
@@ -191,7 +196,7 @@ data class Vector3(
             BuiltinCalls.getBuiltinMethod(BuiltinCalls.VT_VECTOR3, "max_axis_index", 3173160232L)
         }
 
-        private fun fromFloat32(c: FloatArray): Vector3 =
-            Vector3(c[0].toDouble(), c[1].toDouble(), c[2].toDouble())
+        private fun fromGodotRealArray(c: GodotRealArray): Vector3 =
+            Vector3(GodotReal.fromC(c[0]), GodotReal.fromC(c[1]), GodotReal.fromC(c[2]))
     }
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector4.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Vector4.kt
@@ -9,13 +9,18 @@ import kotlin.math.sqrt
  * iOS marshalling note: at ptrcall a Vector4 is 4 `real_t` (float32 on single-precision iOS).
  */
 data class Vector4(
-    val x: Double,
-    val y: Double,
-    val z: Double,
-    val w: Double,
+    val x: real_t,
+    val y: real_t,
+    val z: real_t,
+    val w: real_t,
 ) {
     constructor(x: Number, y: Number, z: Number, w: Number) :
-        this(x.toDouble(), y.toDouble(), z.toDouble(), w.toDouble())
+        this(
+            GodotReal.fromNumber(x),
+            GodotReal.fromNumber(y),
+            GodotReal.fromNumber(z),
+            GodotReal.fromNumber(w),
+        )
 
     // Match GDScript/C# `==`: signed zero equal (-0.0 == 0.0), NaN reflexive. See
     // wrapper-coverage-roadmap.md. hashCode canonicalizes signed zero so equal vectors hash equal.
@@ -52,11 +57,16 @@ data class Vector4(
         Vector4(x - other.x, y - other.y, z - other.z, w - other.w)
 
     operator fun times(scale: Number): Vector4 =
-        Vector4(x * scale.toDouble(), y * scale.toDouble(), z * scale.toDouble(), w * scale.toDouble())
+        Vector4(
+            x.toDouble() * scale.toDouble(),
+            y.toDouble() * scale.toDouble(),
+            z.toDouble() * scale.toDouble(),
+            w.toDouble() * scale.toDouble(),
+        )
 
     operator fun unaryMinus(): Vector4 = Vector4(-x, -y, -z, -w)
 
-    fun lengthSquared(): Double = x * x + y * y + z * z + w * w
+    fun lengthSquared(): Double = (x * x + y * y + z * z + w * w).toDouble()
 
     fun length(): Double = sqrt(lengthSquared())
 

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -1443,9 +1443,25 @@ internal enum class TypeMapping(
     FLOAT("FLOAT", "JAVA_DOUBLE", 8, "0.0", "Double"),
     BOOL("BOOL", "JAVA_BYTE", 1, "false", "Boolean"),
     STRING("STRING", "JAVA_LONG", 8, "\"\"", "String", needsScratchDestroy = true),
-    VECTOR2("VECTOR2", "JAVA_FLOAT", 8, "net.multigesture.kanama.types.Vector2(0f, 0f)", "net.multigesture.kanama.types.Vector2"),
+    VECTOR2(
+        "VECTOR2",
+        "JAVA_FLOAT",
+        8,
+        "net.multigesture.kanama.types.Vector2(0f, 0f)",
+        "net.multigesture.kanama.types.Vector2",
+        scratchAllocationExpr = "net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 2L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES",
+        ptrcallSizeBytesExpr = "net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 2L",
+    ),
     VECTOR2I("VECTOR2I", "JAVA_INT", 8, "net.multigesture.kanama.types.Vector2i(0, 0)", "net.multigesture.kanama.types.Vector2i"),
-    VECTOR3("VECTOR3", "JAVA_FLOAT", 12, "net.multigesture.kanama.types.Vector3(0f, 0f, 0f)", "net.multigesture.kanama.types.Vector3"),
+    VECTOR3(
+        "VECTOR3",
+        "JAVA_FLOAT",
+        12,
+        "net.multigesture.kanama.types.Vector3(0f, 0f, 0f)",
+        "net.multigesture.kanama.types.Vector3",
+        scratchAllocationExpr = "net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 3L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES",
+        ptrcallSizeBytesExpr = "net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 3L",
+    ),
     VECTOR3I("VECTOR3I", "JAVA_INT", 12, "net.multigesture.kanama.types.Vector3i(0, 0, 0)", "net.multigesture.kanama.types.Vector3i"),
     QUATERNION(
         "QUATERNION",
@@ -1481,9 +1497,9 @@ internal enum class TypeMapping(
     fun readFromScratch(s: String): String = when (this) {
         BOOL   -> "$s.get(JAVA_BYTE, 0) != 0.toByte()"
         STRING -> "GodotStrings.readString($s)"
-        VECTOR2 -> "net.multigesture.kanama.types.Vector2($s.get(JAVA_FLOAT, 0), $s.get(JAVA_FLOAT, 4))"
+        VECTOR2 -> "net.multigesture.kanama.types.Vector2(net.multigesture.kanama.types.GodotReal.readIndex($s, 0), net.multigesture.kanama.types.GodotReal.readIndex($s, 1))"
         VECTOR2I -> "net.multigesture.kanama.types.Vector2i($s.get(JAVA_INT, 0), $s.get(JAVA_INT, 4))"
-        VECTOR3 -> "net.multigesture.kanama.types.Vector3($s.get(JAVA_FLOAT, 0), $s.get(JAVA_FLOAT, 4), $s.get(JAVA_FLOAT, 8))"
+        VECTOR3 -> "net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex($s, 0), net.multigesture.kanama.types.GodotReal.readIndex($s, 1), net.multigesture.kanama.types.GodotReal.readIndex($s, 2))"
         VECTOR3I -> "net.multigesture.kanama.types.Vector3i($s.get(JAVA_INT, 0), $s.get(JAVA_INT, 4), $s.get(JAVA_INT, 8))"
         QUATERNION -> "net.multigesture.kanama.types.Quaternion(net.multigesture.kanama.types.GodotReal.readIndex($s, 0), net.multigesture.kanama.types.GodotReal.readIndex($s, 1), net.multigesture.kanama.types.GodotReal.readIndex($s, 2), net.multigesture.kanama.types.GodotReal.readIndex($s, 3))"
         BASIS -> "net.multigesture.kanama.types.Basis(net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex($s, 0), net.multigesture.kanama.types.GodotReal.readIndex($s, 3), net.multigesture.kanama.types.GodotReal.readIndex($s, 6)), net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex($s, 1), net.multigesture.kanama.types.GodotReal.readIndex($s, 4), net.multigesture.kanama.types.GodotReal.readIndex($s, 7)), net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex($s, 2), net.multigesture.kanama.types.GodotReal.readIndex($s, 5), net.multigesture.kanama.types.GodotReal.readIndex($s, 8)))"
@@ -1497,9 +1513,9 @@ internal enum class TypeMapping(
     fun writeToScratch(s: String, v: String): String = when (this) {
         BOOL   -> "$s.set(JAVA_BYTE, 0, if ($v) 1.toByte() else 0.toByte())"
         STRING -> "GodotStrings.initString($s, $v)"
-        VECTOR2 -> "{ $s.set(JAVA_FLOAT, 0, $v.x); $s.set(JAVA_FLOAT, 4, $v.y) }"
+        VECTOR2 -> "{ net.multigesture.kanama.types.GodotReal.writeIndex($s, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 1, $v.y) }"
         VECTOR2I -> "{ $s.set(JAVA_INT, 0, $v.x); $s.set(JAVA_INT, 4, $v.y) }"
-        VECTOR3 -> "{ $s.set(JAVA_FLOAT, 0, $v.x); $s.set(JAVA_FLOAT, 4, $v.y); $s.set(JAVA_FLOAT, 8, $v.z) }"
+        VECTOR3 -> "{ net.multigesture.kanama.types.GodotReal.writeIndex($s, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 1, $v.y); net.multigesture.kanama.types.GodotReal.writeIndex($s, 2, $v.z) }"
         VECTOR3I -> "{ $s.set(JAVA_INT, 0, $v.x); $s.set(JAVA_INT, 4, $v.y); $s.set(JAVA_INT, 8, $v.z) }"
         QUATERNION -> "{ net.multigesture.kanama.types.GodotReal.writeIndex($s, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 1, $v.y); net.multigesture.kanama.types.GodotReal.writeIndex($s, 2, $v.z); net.multigesture.kanama.types.GodotReal.writeIndex($s, 3, $v.w) }"
         BASIS -> "{ net.multigesture.kanama.types.GodotReal.writeIndex($s, 0, $v.x.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 1, $v.y.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 2, $v.z.x); net.multigesture.kanama.types.GodotReal.writeIndex($s, 3, $v.x.y); net.multigesture.kanama.types.GodotReal.writeIndex($s, 4, $v.y.y); net.multigesture.kanama.types.GodotReal.writeIndex($s, 5, $v.z.y); net.multigesture.kanama.types.GodotReal.writeIndex($s, 6, $v.x.z); net.multigesture.kanama.types.GodotReal.writeIndex($s, 7, $v.y.z); net.multigesture.kanama.types.GodotReal.writeIndex($s, 8, $v.z.z) }"
@@ -1517,9 +1533,9 @@ internal enum class TypeMapping(
     fun readPtrcallArg(ptr: String): String = when (this) {
         BOOL   -> "$ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_BYTE, 0) != 0.toByte()"
         STRING -> "GodotStrings.readString($ptr)"
-        VECTOR2 -> "net.multigesture.kanama.types.Vector2($ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_FLOAT, 0), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_FLOAT, 4))"
+        VECTOR2 -> "run { val p = $ptr.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.Vector2(net.multigesture.kanama.types.GodotReal.readIndex(p, 0), net.multigesture.kanama.types.GodotReal.readIndex(p, 1)) }"
         VECTOR2I -> "net.multigesture.kanama.types.Vector2i($ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_INT, 0), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_INT, 4))"
-        VECTOR3 -> "net.multigesture.kanama.types.Vector3($ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_FLOAT, 0), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_FLOAT, 4), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_FLOAT, 8))"
+        VECTOR3 -> "run { val p = $ptr.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex(p, 0), net.multigesture.kanama.types.GodotReal.readIndex(p, 1), net.multigesture.kanama.types.GodotReal.readIndex(p, 2)) }"
         VECTOR3I -> "net.multigesture.kanama.types.Vector3i($ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_INT, 0), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_INT, 4), $ptr.reinterpret($ptrcallSizeBytesExpr).get(JAVA_INT, 8))"
         QUATERNION -> "run { val p = $ptr.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.Quaternion(net.multigesture.kanama.types.GodotReal.readIndex(p, 0), net.multigesture.kanama.types.GodotReal.readIndex(p, 1), net.multigesture.kanama.types.GodotReal.readIndex(p, 2), net.multigesture.kanama.types.GodotReal.readIndex(p, 3)) }"
         BASIS -> "run { val p = $ptr.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.Basis(net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex(p, 0), net.multigesture.kanama.types.GodotReal.readIndex(p, 3), net.multigesture.kanama.types.GodotReal.readIndex(p, 6)), net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex(p, 1), net.multigesture.kanama.types.GodotReal.readIndex(p, 4), net.multigesture.kanama.types.GodotReal.readIndex(p, 7)), net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex(p, 2), net.multigesture.kanama.types.GodotReal.readIndex(p, 5), net.multigesture.kanama.types.GodotReal.readIndex(p, 8))) }"
@@ -1536,9 +1552,9 @@ internal enum class TypeMapping(
     fun writePtrcallReturn(v: String): String = when (this) {
         BOOL   -> "rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_BYTE, 0, if ($v) 1.toByte() else 0.toByte())"
         STRING -> "GodotStrings.initString(rRet, $v)"
-        VECTOR2 -> "{ rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_FLOAT, 0, $v.x); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_FLOAT, 4, $v.y) }"
+        VECTOR2 -> "{ val p = rRet.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.GodotReal.writeIndex(p, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 1, $v.y) }"
         VECTOR2I -> "{ rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_INT, 0, $v.x); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_INT, 4, $v.y) }"
-        VECTOR3 -> "{ rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_FLOAT, 0, $v.x); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_FLOAT, 4, $v.y); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_FLOAT, 8, $v.z) }"
+        VECTOR3 -> "{ val p = rRet.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.GodotReal.writeIndex(p, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 1, $v.y); net.multigesture.kanama.types.GodotReal.writeIndex(p, 2, $v.z) }"
         VECTOR3I -> "{ rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_INT, 0, $v.x); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_INT, 4, $v.y); rRet.reinterpret($ptrcallSizeBytesExpr).set(JAVA_INT, 8, $v.z) }"
         QUATERNION -> "{ val p = rRet.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.GodotReal.writeIndex(p, 0, $v.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 1, $v.y); net.multigesture.kanama.types.GodotReal.writeIndex(p, 2, $v.z); net.multigesture.kanama.types.GodotReal.writeIndex(p, 3, $v.w) }"
         BASIS -> "{ val p = rRet.reinterpret($ptrcallSizeBytesExpr); net.multigesture.kanama.types.GodotReal.writeIndex(p, 0, $v.x.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 1, $v.y.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 2, $v.z.x); net.multigesture.kanama.types.GodotReal.writeIndex(p, 3, $v.x.y); net.multigesture.kanama.types.GodotReal.writeIndex(p, 4, $v.y.y); net.multigesture.kanama.types.GodotReal.writeIndex(p, 5, $v.z.y); net.multigesture.kanama.types.GodotReal.writeIndex(p, 6, $v.x.z); net.multigesture.kanama.types.GodotReal.writeIndex(p, 7, $v.y.z); net.multigesture.kanama.types.GodotReal.writeIndex(p, 8, $v.z.z) }"
@@ -2816,9 +2832,9 @@ internal class ScriptCodeEmitter(
         TypeMapping.BOOL   -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(JAVA_BYTE); VariantConverters.variantToType(VariantType.BOOL).invoke(d, $variantPtr); d.get(JAVA_BYTE, 0) != 0.toByte() }"
         TypeMapping.STRING -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(8L, 8L); VariantConverters.variantToType(VariantType.STRING).invoke(d, $variantPtr); val s = GodotStrings.readString(d); GodotStrings.destroyString(d); s }"
         TypeMapping.NODE_PATH -> "val $localName = Arena.ofConfined().use { a -> BuiltinTypes.readVariantNodePath($variantPtr, a) }"
-        TypeMapping.VECTOR2 -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(8L, 4L); VariantConverters.variantToType(VariantType.VECTOR2).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector2(d.get(JAVA_FLOAT, 0), d.get(JAVA_FLOAT, 4)) }"
+        TypeMapping.VECTOR2 -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 2L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES); VariantConverters.variantToType(VariantType.VECTOR2).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector2(net.multigesture.kanama.types.GodotReal.readIndex(d, 0), net.multigesture.kanama.types.GodotReal.readIndex(d, 1)) }"
         TypeMapping.VECTOR2I -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(8L, 4L); VariantConverters.variantToType(VariantType.VECTOR2I).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector2i(d.get(JAVA_INT, 0), d.get(JAVA_INT, 4)) }"
-        TypeMapping.VECTOR3 -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(12L, 4L); VariantConverters.variantToType(VariantType.VECTOR3).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector3(d.get(JAVA_FLOAT, 0), d.get(JAVA_FLOAT, 4), d.get(JAVA_FLOAT, 8)) }"
+        TypeMapping.VECTOR3 -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 3L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES); VariantConverters.variantToType(VariantType.VECTOR3).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector3(net.multigesture.kanama.types.GodotReal.readIndex(d, 0), net.multigesture.kanama.types.GodotReal.readIndex(d, 1), net.multigesture.kanama.types.GodotReal.readIndex(d, 2)) }"
         TypeMapping.VECTOR3I -> "val $localName = Arena.ofConfined().use { a -> val d = a.allocate(12L, 4L); VariantConverters.variantToType(VariantType.VECTOR3I).invoke(d, $variantPtr); net.multigesture.kanama.types.Vector3i(d.get(JAVA_INT, 0), d.get(JAVA_INT, 4), d.get(JAVA_INT, 8)) }"
         TypeMapping.QUATERNION -> "val $localName = Arena.ofConfined().use { a -> BuiltinTypes.readVariantScalar($variantPtr, a) as? net.multigesture.kanama.types.Quaternion ?: net.multigesture.kanama.types.Quaternion.IDENTITY }"
         TypeMapping.BASIS -> "val $localName = Arena.ofConfined().use { a -> BuiltinTypes.readVariantScalar($variantPtr, a) as? net.multigesture.kanama.types.Basis ?: net.multigesture.kanama.types.Basis.IDENTITY }"
@@ -2886,9 +2902,9 @@ internal class ScriptCodeEmitter(
         TypeMapping.BOOL   -> "Arena.ofConfined().use { a -> val s = a.allocate(JAVA_BYTE); s.set(JAVA_BYTE, 0, if ($valueExpr) 1.toByte() else 0.toByte()); VariantConverters.variantFromType(VariantType.BOOL).invoke(ret, s) }"
         TypeMapping.STRING -> "Arena.ofConfined().use { a -> val s = a.allocate(8L, 8L); GodotStrings.initString(s, $valueExpr); VariantConverters.variantFromType(VariantType.STRING).invoke(ret, s); GodotStrings.destroyString(s) }"
         TypeMapping.NODE_PATH -> "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr, a) }"
-        TypeMapping.VECTOR2 -> "Arena.ofConfined().use { a -> val s = a.allocate(8L, 4L); s.set(JAVA_FLOAT, 0, $valueExpr.x); s.set(JAVA_FLOAT, 4, $valueExpr.y); VariantConverters.variantFromType(VariantType.VECTOR2).invoke(ret, s) }"
+        TypeMapping.VECTOR2 -> "Arena.ofConfined().use { a -> val s = a.allocate(net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 2L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES); net.multigesture.kanama.types.GodotReal.writeIndex(s, 0, $valueExpr.x); net.multigesture.kanama.types.GodotReal.writeIndex(s, 1, $valueExpr.y); VariantConverters.variantFromType(VariantType.VECTOR2).invoke(ret, s) }"
         TypeMapping.VECTOR2I -> "Arena.ofConfined().use { a -> val s = a.allocate(8L, 4L); s.set(JAVA_INT, 0, $valueExpr.x); s.set(JAVA_INT, 4, $valueExpr.y); VariantConverters.variantFromType(VariantType.VECTOR2I).invoke(ret, s) }"
-        TypeMapping.VECTOR3 -> "Arena.ofConfined().use { a -> val s = a.allocate(12L, 4L); s.set(JAVA_FLOAT, 0, $valueExpr.x); s.set(JAVA_FLOAT, 4, $valueExpr.y); s.set(JAVA_FLOAT, 8, $valueExpr.z); VariantConverters.variantFromType(VariantType.VECTOR3).invoke(ret, s) }"
+        TypeMapping.VECTOR3 -> "Arena.ofConfined().use { a -> val s = a.allocate(net.multigesture.kanama.types.GodotReal.SIZE_BYTES * 3L, net.multigesture.kanama.types.GodotReal.ALIGN_BYTES); net.multigesture.kanama.types.GodotReal.writeIndex(s, 0, $valueExpr.x); net.multigesture.kanama.types.GodotReal.writeIndex(s, 1, $valueExpr.y); net.multigesture.kanama.types.GodotReal.writeIndex(s, 2, $valueExpr.z); VariantConverters.variantFromType(VariantType.VECTOR3).invoke(ret, s) }"
         TypeMapping.VECTOR3I -> "Arena.ofConfined().use { a -> val s = a.allocate(12L, 4L); s.set(JAVA_INT, 0, $valueExpr.x); s.set(JAVA_INT, 4, $valueExpr.y); s.set(JAVA_INT, 8, $valueExpr.z); VariantConverters.variantFromType(VariantType.VECTOR3I).invoke(ret, s) }"
         TypeMapping.QUATERNION -> "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr, a) }"
         TypeMapping.BASIS -> "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr, a) }"

--- a/scripts/fixtures/wrapper_generator/ios/ObjectCallsGenerated.kt
+++ b/scripts/fixtures/wrapper_generator/ios/ObjectCallsGenerated.kt
@@ -24,6 +24,8 @@ import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_ptrcall
 import net.multigesture.kanama.types.AABB
 import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.GodotReal
+import net.multigesture.kanama.types.GodotRealVar
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Projection
 import net.multigesture.kanama.types.Quaternion
@@ -45,7 +47,7 @@ import net.multigesture.kanama.types.Vector4
  * generated Godot API wrappers' `ObjectCalls.<helper>(...)` calls resolve here. Every
  * helper marshals through the single generic C dispatch `kanama_ios_godot_ptrcall`,
  * applying the authoritative ptrcall width table (scalar float->double/8B, scalar
- * int->int64/8B, Vector components->float32, Object->8B handle, StringName built
+ * int->int64/8B, Vector components->GodotReal, Object->8B handle, StringName built
  * C-side). Helpers already hand-written in ObjectCalls.kt are the override set and
  * are NOT regenerated here.
  */
@@ -61,28 +63,28 @@ private const val PT_QUATERNION = 20
 
 fun ObjectCalls.ptrcallNoArgsRetBasis(methodBind: MemorySegment, instance: MemorySegment): Basis =
     memScoped {
-        val ret = allocArray<FloatVar>(9)
+        val ret = allocArray<GodotRealVar>(9)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_BASIS, ret)
-        Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble()))
+        Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8])))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetQuaternion(methodBind: MemorySegment, instance: MemorySegment): Quaternion =
     memScoped {
-        val ret = allocArray<FloatVar>(4)
+        val ret = allocArray<GodotRealVar>(4)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_QUATERNION, ret)
-        Quaternion(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble())
+        Quaternion(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3]))
     }
 
 fun ObjectCalls.ptrcallNoArgsRetTransform3D(methodBind: MemorySegment, instance: MemorySegment): Transform3D =
     memScoped {
-        val ret = allocArray<FloatVar>(12)
+        val ret = allocArray<GodotRealVar>(12)
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), null, null, 0, PT_TRANSFORM3D, ret)
-        Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))
+        Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))
     }
 
 fun ObjectCalls.ptrcallWithBasisArg(methodBind: MemorySegment, instance: MemorySegment, a0: Basis) =
     memScoped {
-        val c0 = allocArray<FloatVar>(9); c0[0] = a0.x.x.toFloat(); c0[1] = a0.y.x.toFloat(); c0[2] = a0.z.x.toFloat(); c0[3] = a0.x.y.toFloat(); c0[4] = a0.y.y.toFloat(); c0[5] = a0.z.y.toFloat(); c0[6] = a0.x.z.toFloat(); c0[7] = a0.y.z.toFloat(); c0[8] = a0.z.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(9); c0[0] = GodotReal.toC(a0.x.x); c0[1] = GodotReal.toC(a0.y.x); c0[2] = GodotReal.toC(a0.z.x); c0[3] = GodotReal.toC(a0.x.y); c0[4] = GodotReal.toC(a0.y.y); c0[5] = GodotReal.toC(a0.z.y); c0[6] = GodotReal.toC(a0.x.z); c0[7] = GodotReal.toC(a0.y.z); c0[8] = GodotReal.toC(a0.z.z)
         val types = allocArray<IntVar>(1); types[0] = PT_BASIS
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -99,7 +101,7 @@ fun ObjectCalls.ptrcallWithNodePathArg(methodBind: MemorySegment, instance: Memo
 
 fun ObjectCalls.ptrcallWithQuaternionArg(methodBind: MemorySegment, instance: MemorySegment, a0: Quaternion) =
     memScoped {
-        val c0 = allocArray<FloatVar>(4); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat(); c0[3] = a0.w.toFloat()
+        val c0 = allocArray<GodotRealVar>(4); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z); c0[3] = GodotReal.toC(a0.w)
         val types = allocArray<IntVar>(1); types[0] = PT_QUATERNION
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -108,9 +110,9 @@ fun ObjectCalls.ptrcallWithQuaternionArg(methodBind: MemorySegment, instance: Me
 
 fun ObjectCalls.ptrcallWithThreeVector3AndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3, a2: Vector3, a3: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
-        val c2 = allocArray<FloatVar>(3); c2[0] = a2.x.toFloat(); c2[1] = a2.y.toFloat(); c2[2] = a2.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
+        val c2 = allocArray<GodotRealVar>(3); c2[0] = GodotReal.toC(a2.x); c2[1] = GodotReal.toC(a2.y); c2[2] = GodotReal.toC(a2.z)
         val c3 = alloc<ByteVar>(); c3.value = if (a3) 1 else 0
         val types = allocArray<IntVar>(4); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3; types[2] = PT_VECTOR3; types[3] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(4); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.reinterpret<CPointed>(); ptrs[3] = c3.ptr.reinterpret<CPointed>()
@@ -120,7 +122,7 @@ fun ObjectCalls.ptrcallWithThreeVector3AndBoolArgs(methodBind: MemorySegment, in
 
 fun ObjectCalls.ptrcallWithTransform3DArg(methodBind: MemorySegment, instance: MemorySegment, a0: Transform3D) =
     memScoped {
-        val c0 = allocArray<FloatVar>(12); c0[0] = a0.basis.x.x.toFloat(); c0[1] = a0.basis.y.x.toFloat(); c0[2] = a0.basis.z.x.toFloat(); c0[3] = a0.basis.x.y.toFloat(); c0[4] = a0.basis.y.y.toFloat(); c0[5] = a0.basis.z.y.toFloat(); c0[6] = a0.basis.x.z.toFloat(); c0[7] = a0.basis.y.z.toFloat(); c0[8] = a0.basis.z.z.toFloat(); c0[9] = a0.origin.x.toFloat(); c0[10] = a0.origin.y.toFloat(); c0[11] = a0.origin.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(12); c0[0] = GodotReal.toC(a0.basis.x.x); c0[1] = GodotReal.toC(a0.basis.y.x); c0[2] = GodotReal.toC(a0.basis.z.x); c0[3] = GodotReal.toC(a0.basis.x.y); c0[4] = GodotReal.toC(a0.basis.y.y); c0[5] = GodotReal.toC(a0.basis.z.y); c0[6] = GodotReal.toC(a0.basis.x.z); c0[7] = GodotReal.toC(a0.basis.y.z); c0[8] = GodotReal.toC(a0.basis.z.z); c0[9] = GodotReal.toC(a0.origin.x); c0[10] = GodotReal.toC(a0.origin.y); c0[11] = GodotReal.toC(a0.origin.z)
         val types = allocArray<IntVar>(1); types[0] = PT_TRANSFORM3D
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VOID, null)
@@ -129,8 +131,8 @@ fun ObjectCalls.ptrcallWithTransform3DArg(methodBind: MemorySegment, instance: M
 
 fun ObjectCalls.ptrcallWithTwoVector3AndBoolArgs(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Vector3, a2: Boolean) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
-        val c1 = allocArray<FloatVar>(3); c1[0] = a1.x.toFloat(); c1[1] = a1.y.toFloat(); c1[2] = a1.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
+        val c1 = allocArray<GodotRealVar>(3); c1[0] = GodotReal.toC(a1.x); c1[1] = GodotReal.toC(a1.y); c1[2] = GodotReal.toC(a1.z)
         val c2 = alloc<ByteVar>(); c2.value = if (a2) 1 else 0
         val types = allocArray<IntVar>(3); types[0] = PT_VECTOR3; types[1] = PT_VECTOR3; types[2] = PT_BOOL
         val ptrs = allocArray<COpaquePointerVar>(3); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.reinterpret<CPointed>(); ptrs[2] = c2.ptr.reinterpret<CPointed>()
@@ -140,7 +142,7 @@ fun ObjectCalls.ptrcallWithTwoVector3AndBoolArgs(methodBind: MemorySegment, inst
 
 fun ObjectCalls.ptrcallWithVector3AndDoubleArg(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3, a1: Double) =
     memScoped {
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val c1 = alloc<DoubleVar>(); c1.value = a1
         val types = allocArray<IntVar>(2); types[0] = PT_VECTOR3; types[1] = PT_FLOAT64
         val ptrs = allocArray<COpaquePointerVar>(2); ptrs[0] = c0.reinterpret<CPointed>(); ptrs[1] = c1.ptr.reinterpret<CPointed>()
@@ -150,10 +152,10 @@ fun ObjectCalls.ptrcallWithVector3AndDoubleArg(methodBind: MemorySegment, instan
 
 fun ObjectCalls.ptrcallWithVector3ArgRetVector3(methodBind: MemorySegment, instance: MemorySegment, a0: Vector3): Vector3 =
     memScoped {
-        val ret = allocArray<FloatVar>(3)
-        val c0 = allocArray<FloatVar>(3); c0[0] = a0.x.toFloat(); c0[1] = a0.y.toFloat(); c0[2] = a0.z.toFloat()
+        val ret = allocArray<GodotRealVar>(3)
+        val c0 = allocArray<GodotRealVar>(3); c0[0] = GodotReal.toC(a0.x); c0[1] = GodotReal.toC(a0.y); c0[2] = GodotReal.toC(a0.z)
         val types = allocArray<IntVar>(1); types[0] = PT_VECTOR3
         val ptrs = allocArray<COpaquePointerVar>(1); ptrs[0] = c0.reinterpret<CPointed>()
         kanama_ios_godot_ptrcall(methodBind.address(), instance.address(), types, ptrs, 1, PT_VECTOR3, ret)
-        Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())
+        Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))
     }

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -1972,6 +1972,8 @@ import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_ptrcall
 import net.multigesture.kanama.types.AABB
 import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.GodotReal
+import net.multigesture.kanama.types.GodotRealVar
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Projection
 import net.multigesture.kanama.types.Quaternion
@@ -1993,7 +1995,7 @@ import net.multigesture.kanama.types.Vector4
  * generated Godot API wrappers' `ObjectCalls.<helper>(...)` calls resolve here. Every
  * helper marshals through the single generic C dispatch `kanama_ios_godot_ptrcall`,
  * applying the authoritative ptrcall width table (scalar float->double/8B, scalar
- * int->int64/8B, Vector components->float32, Object->8B handle, StringName built
+ * int->int64/8B, Vector components->GodotReal, Object->8B handle, StringName built
  * C-side). Helpers already hand-written in ObjectCalls.kt are the override set and
  * are NOT regenerated here.
  */
@@ -2051,7 +2053,7 @@ def ios_arg_layout(kind: str, index: int) -> tuple[str, str, list[str], str]:
         return (
             "Vector2",
             "PT_VECTOR2",
-            [f"val {c} = allocArray<FloatVar>(2); {c}[0] = {a}.x.toFloat(); {c}[1] = {a}.y.toFloat()"],
+            [f"val {c} = allocArray<GodotRealVar>(2); {c}[0] = GodotReal.toC({a}.x); {c}[1] = GodotReal.toC({a}.y)"],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "Vector2i":
@@ -2066,7 +2068,7 @@ def ios_arg_layout(kind: str, index: int) -> tuple[str, str, list[str], str]:
         return (
             "Vector3",
             "PT_VECTOR3",
-            [f"val {c} = allocArray<FloatVar>(3); {c}[0] = {a}.x.toFloat(); {c}[1] = {a}.y.toFloat(); {c}[2] = {a}.z.toFloat()"],
+            [f"val {c} = allocArray<GodotRealVar>(3); {c}[0] = GodotReal.toC({a}.x); {c}[1] = GodotReal.toC({a}.y); {c}[2] = GodotReal.toC({a}.z)"],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "Vector3i":
@@ -2086,12 +2088,11 @@ def ios_arg_layout(kind: str, index: int) -> tuple[str, str, list[str], str]:
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "Rect2":
-        # 4x float32 = 16 bytes (position.x, position.y, size.x, size.y).
-        # Components are real_t = float32 on single-precision iOS.
+        # 4x real_t (position.x, position.y, size.x, size.y).
         return (
             "Rect2",
             "PT_RECT2",
-            [f"val {c} = allocArray<FloatVar>(4); {c}[0] = {a}.position.x.toFloat(); {c}[1] = {a}.position.y.toFloat(); {c}[2] = {a}.size.x.toFloat(); {c}[3] = {a}.size.y.toFloat()"],
+            [f"val {c} = allocArray<GodotRealVar>(4); {c}[0] = GodotReal.toC({a}.position.x); {c}[1] = GodotReal.toC({a}.position.y); {c}[2] = GodotReal.toC({a}.size.x); {c}[3] = GodotReal.toC({a}.size.y)"],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "StringName":
@@ -2104,45 +2105,42 @@ def ios_arg_layout(kind: str, index: int) -> tuple[str, str, list[str], str]:
         # CONSTRUCT tag: the dispatch builds a NodePath from the path C string.
         return ("NodePath", "PT_NODE_PATH", [], f"{a}.path.cstr.ptr.reinterpret<CPointed>()")
     if kind == "Basis":
-        # 9x float32, column-major: [x.x, y.x, z.x, x.y, y.y, z.y, x.z, y.z, z.z]
-        # (the three axes are the columns). POD passthrough — components are real_t=float32.
+        # 9x real_t, column-major: [x.x, y.x, z.x, x.y, y.y, z.y, x.z, y.z, z.z].
         return (
             "Basis",
             "PT_BASIS",
             [
-                f"val {c} = allocArray<FloatVar>(9); "
-                f"{c}[0] = {a}.x.x.toFloat(); {c}[1] = {a}.y.x.toFloat(); {c}[2] = {a}.z.x.toFloat(); "
-                f"{c}[3] = {a}.x.y.toFloat(); {c}[4] = {a}.y.y.toFloat(); {c}[5] = {a}.z.y.toFloat(); "
-                f"{c}[6] = {a}.x.z.toFloat(); {c}[7] = {a}.y.z.toFloat(); {c}[8] = {a}.z.z.toFloat()"
+                f"val {c} = allocArray<GodotRealVar>(9); "
+                f"{c}[0] = GodotReal.toC({a}.x.x); {c}[1] = GodotReal.toC({a}.y.x); {c}[2] = GodotReal.toC({a}.z.x); "
+                f"{c}[3] = GodotReal.toC({a}.x.y); {c}[4] = GodotReal.toC({a}.y.y); {c}[5] = GodotReal.toC({a}.z.y); "
+                f"{c}[6] = GodotReal.toC({a}.x.z); {c}[7] = GodotReal.toC({a}.y.z); {c}[8] = GodotReal.toC({a}.z.z)"
             ],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "Transform2D":
-        # 6x float32: the three columns (x axis, y axis, origin), each a Vector2. POD
-        # passthrough — components are real_t=float32 on single-precision iOS. Unlike
-        # Basis/Transform3D the columns ARE the stored axes, so no column-major reshuffle.
+        # 6x real_t: the three columns (x axis, y axis, origin), each a Vector2.
         return (
             "Transform2D",
             "PT_TRANSFORM2D",
             [
-                f"val {c} = allocArray<FloatVar>(6); "
-                f"{c}[0] = {a}.x.x.toFloat(); {c}[1] = {a}.x.y.toFloat(); "
-                f"{c}[2] = {a}.y.x.toFloat(); {c}[3] = {a}.y.y.toFloat(); "
-                f"{c}[4] = {a}.origin.x.toFloat(); {c}[5] = {a}.origin.y.toFloat()"
+                f"val {c} = allocArray<GodotRealVar>(6); "
+                f"{c}[0] = GodotReal.toC({a}.x.x); {c}[1] = GodotReal.toC({a}.x.y); "
+                f"{c}[2] = GodotReal.toC({a}.y.x); {c}[3] = GodotReal.toC({a}.y.y); "
+                f"{c}[4] = GodotReal.toC({a}.origin.x); {c}[5] = GodotReal.toC({a}.origin.y)"
             ],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "Transform3D":
-        # 12x float32: 9 column-major basis components then the 3 origin components.
+        # 12x real_t: 9 column-major basis components then the 3 origin components.
         return (
             "Transform3D",
             "PT_TRANSFORM3D",
             [
-                f"val {c} = allocArray<FloatVar>(12); "
-                f"{c}[0] = {a}.basis.x.x.toFloat(); {c}[1] = {a}.basis.y.x.toFloat(); {c}[2] = {a}.basis.z.x.toFloat(); "
-                f"{c}[3] = {a}.basis.x.y.toFloat(); {c}[4] = {a}.basis.y.y.toFloat(); {c}[5] = {a}.basis.z.y.toFloat(); "
-                f"{c}[6] = {a}.basis.x.z.toFloat(); {c}[7] = {a}.basis.y.z.toFloat(); {c}[8] = {a}.basis.z.z.toFloat(); "
-                f"{c}[9] = {a}.origin.x.toFloat(); {c}[10] = {a}.origin.y.toFloat(); {c}[11] = {a}.origin.z.toFloat()"
+                f"val {c} = allocArray<GodotRealVar>(12); "
+                f"{c}[0] = GodotReal.toC({a}.basis.x.x); {c}[1] = GodotReal.toC({a}.basis.y.x); {c}[2] = GodotReal.toC({a}.basis.z.x); "
+                f"{c}[3] = GodotReal.toC({a}.basis.x.y); {c}[4] = GodotReal.toC({a}.basis.y.y); {c}[5] = GodotReal.toC({a}.basis.z.y); "
+                f"{c}[6] = GodotReal.toC({a}.basis.x.z); {c}[7] = GodotReal.toC({a}.basis.y.z); {c}[8] = GodotReal.toC({a}.basis.z.z); "
+                f"{c}[9] = GodotReal.toC({a}.origin.x); {c}[10] = GodotReal.toC({a}.origin.y); {c}[11] = GodotReal.toC({a}.origin.z)"
             ],
             f"{c}.reinterpret<CPointed>()",
         )
@@ -2150,22 +2148,22 @@ def ios_arg_layout(kind: str, index: int) -> tuple[str, str, list[str], str]:
         # POD passthrough: a Godot RID is a single uint64 (8 bytes).
         return ("RID", "PT_RID", [f"val {c} = alloc<LongVar>(); {c}.value = {a}.value"], f"{c}.ptr.reinterpret<CPointed>()")
     if kind == "Quaternion":
-        # 4x float32 [x, y, z, w] — POD passthrough.
+        # 4x real_t [x, y, z, w] — POD passthrough.
         return (
             "Quaternion",
             "PT_QUATERNION",
-            [f"val {c} = allocArray<FloatVar>(4); {c}[0] = {a}.x.toFloat(); {c}[1] = {a}.y.toFloat(); {c}[2] = {a}.z.toFloat(); {c}[3] = {a}.w.toFloat()"],
+            [f"val {c} = allocArray<GodotRealVar>(4); {c}[0] = GodotReal.toC({a}.x); {c}[1] = GodotReal.toC({a}.y); {c}[2] = GodotReal.toC({a}.z); {c}[3] = GodotReal.toC({a}.w)"],
             f"{c}.reinterpret<CPointed>()",
         )
     if kind == "AABB":
-        # 6x float32: position xyz then size xyz — POD passthrough.
+        # 6x real_t: position xyz then size xyz — POD passthrough.
         return (
             "AABB",
             "PT_AABB",
             [
-                f"val {c} = allocArray<FloatVar>(6); "
-                f"{c}[0] = {a}.position.x.toFloat(); {c}[1] = {a}.position.y.toFloat(); {c}[2] = {a}.position.z.toFloat(); "
-                f"{c}[3] = {a}.size.x.toFloat(); {c}[4] = {a}.size.y.toFloat(); {c}[5] = {a}.size.z.toFloat()"
+                f"val {c} = allocArray<GodotRealVar>(6); "
+                f"{c}[0] = GodotReal.toC({a}.position.x); {c}[1] = GodotReal.toC({a}.position.y); {c}[2] = GodotReal.toC({a}.position.z); "
+                f"{c}[3] = GodotReal.toC({a}.size.x); {c}[4] = GodotReal.toC({a}.size.y); {c}[5] = GodotReal.toC({a}.size.z)"
             ],
             f"{c}.reinterpret<CPointed>()",
         )
@@ -2185,16 +2183,16 @@ def ios_ret_layout(kotlin_return: str) -> tuple[str | None, str, list[str], str,
     if kotlin_return == "Double":
         return ("Double", "PT_FLOAT64", ["val ret = alloc<DoubleVar>()"], "ret.ptr", "ret.value")
     if kotlin_return == "Vector2":
-        return ("Vector2", "PT_VECTOR2", ["val ret = allocArray<FloatVar>(2)"], "ret", "Vector2(ret[0].toDouble(), ret[1].toDouble())")
+        return ("Vector2", "PT_VECTOR2", ["val ret = allocArray<GodotRealVar>(2)"], "ret", "Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]))")
     if kotlin_return == "Vector2i":
         return ("Vector2i", "PT_VECTOR2I", ["val ret = allocArray<IntVar>(2)"], "ret", "Vector2i(ret[0], ret[1])")
     if kotlin_return == "Vector3":
         return (
             "Vector3",
             "PT_VECTOR3",
-            ["val ret = allocArray<FloatVar>(3)"],
+            ["val ret = allocArray<GodotRealVar>(3)"],
             "ret",
-            "Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble())",
+            "Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]))",
         )
     if kotlin_return == "Vector3i":
         return ("Vector3i", "PT_VECTOR3I", ["val ret = allocArray<IntVar>(3)"], "ret", "Vector3i(ret[0], ret[1], ret[2])")
@@ -2206,55 +2204,56 @@ def ios_ret_layout(kotlin_return: str) -> tuple[str | None, str, list[str], str,
         return (
             "Rect2",
             "PT_RECT2",
-            ["val ret = allocArray<FloatVar>(4)"],
+            ["val ret = allocArray<GodotRealVar>(4)"],
             "ret",
-            "Rect2(Vector2(ret[0].toDouble(), ret[1].toDouble()), Vector2(ret[2].toDouble(), ret[3].toDouble()))",
+            "Rect2(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), "
+            "Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])))",
         )
     if kotlin_return == "Basis":
-        # 9x float32, column-major (see ios_arg_layout). Reassemble the column axes.
+        # 9x real_t, column-major (see ios_arg_layout). Reassemble the column axes.
         return (
             "Basis",
             "PT_BASIS",
-            ["val ret = allocArray<FloatVar>(9)"],
+            ["val ret = allocArray<GodotRealVar>(9)"],
             "ret",
-            "Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), "
-            "Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), "
-            "Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble()))",
+            "Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), "
+            "Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), "
+            "Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8])))",
         )
     if kotlin_return == "Transform2D":
-        # 6x float32: the three columns (x axis, y axis, origin), each a Vector2.
+        # 6x real_t: the three columns (x axis, y axis, origin), each a Vector2.
         return (
             "Transform2D",
             "PT_TRANSFORM2D",
-            ["val ret = allocArray<FloatVar>(6)"],
+            ["val ret = allocArray<GodotRealVar>(6)"],
             "ret",
-            "Transform2D(Vector2(ret[0].toDouble(), ret[1].toDouble()), "
-            "Vector2(ret[2].toDouble(), ret[3].toDouble()), "
-            "Vector2(ret[4].toDouble(), ret[5].toDouble()))",
+            "Transform2D(Vector2(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1])), "
+            "Vector2(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), "
+            "Vector2(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))",
         )
     if kotlin_return == "Transform3D":
-        # 12x float32: 9 column-major basis + 3 origin.
+        # 12x real_t: 9 column-major basis + 3 origin.
         return (
             "Transform3D",
             "PT_TRANSFORM3D",
-            ["val ret = allocArray<FloatVar>(12)"],
+            ["val ret = allocArray<GodotRealVar>(12)"],
             "ret",
-            "Transform3D(Basis(Vector3(ret[0].toDouble(), ret[3].toDouble(), ret[6].toDouble()), "
-            "Vector3(ret[1].toDouble(), ret[4].toDouble(), ret[7].toDouble()), "
-            "Vector3(ret[2].toDouble(), ret[5].toDouble(), ret[8].toDouble())), "
-            "Vector3(ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()))",
+            "Transform3D(Basis(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[3]), GodotReal.fromC(ret[6])), "
+            "Vector3(GodotReal.fromC(ret[1]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[7])), "
+            "Vector3(GodotReal.fromC(ret[2]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[8]))), "
+            "Vector3(GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])))",
         )
     if kotlin_return == "Projection":
         # 16x float32, column-major: 4 Vector4 columns (x, y, z, w).
         return (
             "Projection",
             "PT_PROJECTION",
-            ["val ret = allocArray<FloatVar>(16)"],
+            ["val ret = allocArray<GodotRealVar>(16)"],
             "ret",
-            "Projection(Vector4(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble()), "
-            "Vector4(ret[4].toDouble(), ret[5].toDouble(), ret[6].toDouble(), ret[7].toDouble()), "
-            "Vector4(ret[8].toDouble(), ret[9].toDouble(), ret[10].toDouble(), ret[11].toDouble()), "
-            "Vector4(ret[12].toDouble(), ret[13].toDouble(), ret[14].toDouble(), ret[15].toDouble()))",
+            "Projection(Vector4(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3])), "
+            "Vector4(GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5]), GodotReal.fromC(ret[6]), GodotReal.fromC(ret[7])), "
+            "Vector4(GodotReal.fromC(ret[8]), GodotReal.fromC(ret[9]), GodotReal.fromC(ret[10]), GodotReal.fromC(ret[11])), "
+            "Vector4(GodotReal.fromC(ret[12]), GodotReal.fromC(ret[13]), GodotReal.fromC(ret[14]), GodotReal.fromC(ret[15])))",
         )
     if kotlin_return == "RID":
         return ("RID", "PT_RID", ["val ret = alloc<LongVar>(); ret.value = 0"], "ret.ptr", "RID(ret.value)")
@@ -2262,18 +2261,18 @@ def ios_ret_layout(kotlin_return: str) -> tuple[str | None, str, list[str], str,
         return (
             "Quaternion",
             "PT_QUATERNION",
-            ["val ret = allocArray<FloatVar>(4)"],
+            ["val ret = allocArray<GodotRealVar>(4)"],
             "ret",
-            "Quaternion(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble(), ret[3].toDouble())",
+            "Quaternion(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2]), GodotReal.fromC(ret[3]))",
         )
     if kotlin_return == "AABB":
         return (
             "AABB",
             "PT_AABB",
-            ["val ret = allocArray<FloatVar>(6)"],
+            ["val ret = allocArray<GodotRealVar>(6)"],
             "ret",
-            "AABB(Vector3(ret[0].toDouble(), ret[1].toDouble(), ret[2].toDouble()), "
-            "Vector3(ret[3].toDouble(), ret[4].toDouble(), ret[5].toDouble()))",
+            "AABB(Vector3(GodotReal.fromC(ret[0]), GodotReal.fromC(ret[1]), GodotReal.fromC(ret[2])), "
+            "Vector3(GodotReal.fromC(ret[3]), GodotReal.fromC(ret[4]), GodotReal.fromC(ret[5])))",
         )
     if kotlin_return == "MemorySegment":
         return ("MemorySegment", "PT_OBJECT", ["val ret = alloc<LongVar>(); ret.value = 0"], "ret.ptr", "MemorySegment.ofAddress(ret.value)")


### PR DESCRIPTION
## Summary
- add an iOS real_t/GodotReal surface and route iOS value-type components through it
- update iOS ObjectCalls generation and KSP Vector2/Vector3 marshalling to use GodotReal layout helpers
- add an explicit iOS guard for unsupported -PkanamaPrecision=double

## Validation
- ./gradlew jar
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew compileKotlinIosArm64
- python3 scripts/check_wrapper_generator.py
- ./gradlew jar -PkanamaPrecision=double
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew compileKotlinIosArm64 -PkanamaPrecision=double (expected failure with explicit unsupported iOS precision message)
- git diff --check