### PR TITLE
docs(types): mark composite isZeroApprox as kanama convenience

### DIFF
--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/AABB.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/AABB.kt
@@ -15,7 +15,7 @@ data class AABB(
     fun isEqualApprox(other: AABB): Boolean =
         position.isEqualApprox(other.position) && size.isEqualApprox(other.size)
 
-    /** True if position and size are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if position and size are approximately zero. */
     fun isZeroApprox(): Boolean = position.isZeroApprox() && size.isZeroApprox()
 
     companion object {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Basis.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Basis.kt
@@ -27,7 +27,7 @@ data class Basis(
     fun isEqualApprox(other: Basis): Boolean =
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) && z.isEqualApprox(other.z)
 
-    /** True if every axis is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every axis is approximately zero. */
     fun isZeroApprox(): Boolean = x.isZeroApprox() && y.isZeroApprox() && z.isZeroApprox()
 
     /** Returns a copy with the x/y/z axis replaced (matches desktop Basis.withX/withY/withZ). */

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Projection.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Projection.kt
@@ -18,7 +18,7 @@ data class Projection(
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) &&
             z.isEqualApprox(other.z) && w.isEqualApprox(other.w)
 
-    /** True if every column is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every column is approximately zero. */
     fun isZeroApprox(): Boolean =
         x.isZeroApprox() && y.isZeroApprox() && z.isZeroApprox() && w.isZeroApprox()
 

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Rect2.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Rect2.kt
@@ -8,7 +8,7 @@ data class Rect2(
     fun isEqualApprox(other: Rect2): Boolean =
         position.isEqualApprox(other.position) && size.isEqualApprox(other.size)
 
-    /** True if position and size are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if position and size are approximately zero. */
     fun isZeroApprox(): Boolean = position.isZeroApprox() && size.isZeroApprox()
 
     val end: Vector2 get() = position + size

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform2D.kt
@@ -21,7 +21,7 @@ data class Transform2D(
     fun isEqualApprox(other: Transform2D): Boolean =
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) && origin.isEqualApprox(other.origin)
 
-    /** True if every column is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every column is approximately zero. */
     fun isZeroApprox(): Boolean = x.isZeroApprox() && y.isZeroApprox() && origin.isZeroApprox()
 
     companion object {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/types/Transform3D.kt
@@ -20,7 +20,7 @@ data class Transform3D(
     fun isEqualApprox(other: Transform3D): Boolean =
         basis.isEqualApprox(other.basis) && origin.isEqualApprox(other.origin)
 
-    /** True if basis and origin are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if basis and origin are approximately zero. */
     fun isZeroApprox(): Boolean = basis.isZeroApprox() && origin.isZeroApprox()
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/types/AABB.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/AABB.kt
@@ -28,7 +28,7 @@ data class AABB(
     fun isEqualApprox(other: AABB): Boolean =
         position.isEqualApprox(other.position) && size.isEqualApprox(other.size)
 
-    /** True if position and size are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if position and size are approximately zero. */
     fun isZeroApprox(): Boolean = position.isZeroApprox() && size.isZeroApprox()
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/types/Basis.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/Basis.kt
@@ -55,7 +55,7 @@ data class Basis(
     fun isEqualApprox(other: Basis): Boolean =
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) && z.isEqualApprox(other.z)
 
-    /** True if every axis is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every axis is approximately zero. */
     fun isZeroApprox(): Boolean = x.isZeroApprox() && y.isZeroApprox() && z.isZeroApprox()
 
     operator fun times(vector: Vector3): Vector3 =

--- a/src/main/kotlin/net/multigesture/kanama/types/Projection.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/Projection.kt
@@ -37,7 +37,7 @@ data class Projection(
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) &&
             z.isEqualApprox(other.z) && w.isEqualApprox(other.w)
 
-    /** True if every column is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every column is approximately zero. */
     fun isZeroApprox(): Boolean =
         x.isZeroApprox() && y.isZeroApprox() && z.isZeroApprox() && w.isZeroApprox()
 

--- a/src/main/kotlin/net/multigesture/kanama/types/Rect2.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/Rect2.kt
@@ -27,7 +27,7 @@ data class Rect2(
     fun isEqualApprox(other: Rect2): Boolean =
         position.isEqualApprox(other.position) && size.isEqualApprox(other.size)
 
-    /** True if position and size are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if position and size are approximately zero. */
     fun isZeroApprox(): Boolean = position.isZeroApprox() && size.isZeroApprox()
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/types/Transform2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/Transform2D.kt
@@ -35,7 +35,7 @@ data class Transform2D(
     fun isEqualApprox(other: Transform2D): Boolean =
         x.isEqualApprox(other.x) && y.isEqualApprox(other.y) && origin.isEqualApprox(other.origin)
 
-    /** True if every column is approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if every column is approximately zero. */
     fun isZeroApprox(): Boolean = x.isZeroApprox() && y.isZeroApprox() && origin.isZeroApprox()
 
     companion object {

--- a/src/main/kotlin/net/multigesture/kanama/types/Transform3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/types/Transform3D.kt
@@ -37,7 +37,7 @@ data class Transform3D(
     fun isEqualApprox(other: Transform3D): Boolean =
         basis.isEqualApprox(other.basis) && origin.isEqualApprox(other.origin)
 
-    /** True if basis and origin are approximately zero. */
+    /** kanama convenience (Godot has no composite `is_zero_approx`): true if basis and origin are approximately zero. */
     fun isZeroApprox(): Boolean = basis.isZeroApprox() && origin.isZeroApprox()
 
     operator fun times(vector: Vector3): Vector3 =


### PR DESCRIPTION
## What

Clarifies the doc comments on `isZeroApprox()` for the six composite value
types — `AABB`, `Rect2`, `Basis`, `Transform2D`, `Transform3D`, `Projection` —
on **both** desktop (`src/main`) and iOS (`ios-runtime`).

## Why

These helpers were added in bc8cca31 alongside `isEqualApprox`. But unlike
`isEqualApprox` (which faithfully mirrors Godot's engine method), `isZeroApprox`
has **no Godot equivalent** — Godot exposes `is_zero_approx` only on scalars and
`Vector2/3/4`, not on any of these composites. Sitting next to the genuinely
"Godot-style" `isEqualApprox` comment, the old wording could be read as implying
a Godot API that doesn't exist.

The helper itself is a reasonable kanama convenience (a composite is
"zero-approx" iff all its leaf components are) and stays — only the doc comment
is clarified.

## Scope

Comment-only. No behavior change, no API change. Compilation and the
`CompositeApproxTest` logic test are unaffected.