### PR TITLE
Deliver RPC config metadata to iOS

### DIFF
--- a/docs/game-dev/multiplayer.md
+++ b/docs/game-dev/multiplayer.md
@@ -52,6 +52,11 @@ generated `*Rpcs` helpers for Kanama-owned methods. They keep the Godot method
 name and parameter list tied to the annotated Kotlin declaration, similar to
 generated signal helpers.
 
+Kanama delivers the `@Rpc` metadata to Godot when the script is registered, so
+Godot's normal `Node.rpc`, `Node.rpc_id`, and authority checks use the
+annotation's `mode`, `callLocal`, `transferMode`, and `channel` values on
+desktop, Android, and iOS.
+
 `callLocalX(...)` is generated only for `@Rpc(callLocal = true)` methods. That
 keeps local fallback explicit and prevents accidentally running non-local RPCs
 while offline.

--- a/docs/internals/active/ios-backend-roadmap.md
+++ b/docs/internals/active/ios-backend-roadmap.md
@@ -72,7 +72,9 @@ Exit gate: the iOS demo matrix and fresh-project path pass after a clean checkou
 
 Close or explicitly document the remaining runtime blockers:
 
-- `@Rpc` config delivery to Godot, needed for `tps-demo-kanama` and real multiplayer workflows.
+- `@Rpc` config delivery to Godot is wired for desktop/Android and the iOS C-shim path. Full
+  `tps-demo-kanama` iOS validation still depends on the remaining wrapper-coverage work tracked by
+  task 08.
 - AVAudioSession Ring/Silent behavior: resolved in the iOS shim by setting
   `AVAudioSessionCategoryAmbient` at startup, with the default and override guidance documented in
   `docs/exporting/ios.md`. Device-validated on iPhone 12 with the FPS demo:
@@ -181,7 +183,7 @@ Only after the above should docs move from "experimental mobile export" toward a
 | FPS | Playable | User-script resource lists, Tween, audio player churn, generated AnimatedSprite3D. |
 | third-person | Playable | Variant Vector3, AnimationTree playback, PackedStringArray script properties. |
 | City-Builder | Desktop-only by design | Desktop-focused controls (GridMap/custom-list); not a mobile target and not reassessed for mobile. |
-| tps-demo-kanama | API blocked on `@Rpc`; mobile UI deferred | `@Rpc` config delivery is task 03 in `kanama-tasks/`. Once landed, APIs work on all platforms; mobile playability (touch controls, mobile multiplayer UI) is deferred — see `kanama-tasks/DEFERRED.md`. |
+| tps-demo-kanama | RPC unblocked; iOS wrappers and mobile UI deferred | `@Rpc` config delivery is wired on all runtime paths. Full iOS launch still needs the task 08 wrapper gaps; mobile playability (touch controls, mobile multiplayer UI) is deferred — see `kanama-tasks/19-tps-mobile-virtual-joysticks.md`. |
 
 ## Validation Commands
 

--- a/docs/internals/active/ios-demo-port-tracker.md
+++ b/docs/internals/active/ios-demo-port-tracker.md
@@ -20,7 +20,7 @@ experimental: this is demo parity, not desktop-level support.
 | Starter-Kit-FPS | Playable | F1/F2 complete. `List<Weapon>` delivery, AnimatedSprite3D generation, Tween glue, and SceneTree tween creation fixed. |
 | godot-4-3d-third-person-controller | Playable | Attack crash, Mobile/Vulkan visuals, and `List<String>` animation-loop delivery fixed. |
 | Starter-Kit-City-Builder | Desktop-only by design | Desktop-focused controls (GridMap/custom-list); not a mobile target and not reassessed for mobile. |
-| tps-demo-kanama | API blocked on `@Rpc`; mobile UI deferred | Needs `@Rpc` config delivery (kanama-tasks task 03) before the multiplayer demo is meaningful at all. Once `@Rpc` lands, the APIs work on all platforms; mobile *playability* (touch controls, mobile multiplayer UI) is a separate UI effort — see `kanama-tasks/DEFERRED.md`. |
+| tps-demo-kanama | RPC unblocked; iOS wrappers and mobile UI deferred | `@Rpc` config delivery is wired on the shared desktop/Android path and the iOS C-shim path. Full iOS launch still needs the task 08 wrapper gaps; mobile *playability* is tracked separately in `kanama-tasks/19-tps-mobile-virtual-joysticks.md`. |
 
 ## Build / Deploy Pointers
 
@@ -151,7 +151,9 @@ Before copying regenerated files:
 
 ## Next Demo-Relevant Work
 
-- tps-demo-kanama: deliver `@Rpc` multiplayer config to Godot (kanama-tasks task 03). Once landed, mobile *playability* (touch controls, mobile multiplayer UI) is a separate deferred UI effort — see `kanama-tasks/DEFERRED.md`.
+- tps-demo-kanama: run focused multiplayer smoke checks after runtime changes. Full iOS launch still
+  needs task 08 wrapper coverage; mobile *playability* (touch controls, mobile multiplayer UI) is
+  tracked in `kanama-tasks/19-tps-mobile-virtual-joysticks.md`.
 - City-Builder: desktop-only by design (GridMap/custom-list, desktop-focused controls); not a mobile target and not reassessed for mobile.
 - Re-run the full physical-device demo matrix after the iOS export workflow is documented and after
   any generator/commonMain migration.

--- a/docs/internals/active/wrapper-coverage-tracker.md
+++ b/docs/internals/active/wrapper-coverage-tracker.md
@@ -46,7 +46,7 @@ commands outside this public repo.
 | 3.1 Platform-neutral script model | done |
 | 3.2 iOS consumes KSP model; regex parser removed | done |
 | 3.3 Generated per-signature trampolines | done |
-| 3.4 Lifecycle/input/RPC parse-side annotations | done; RPC config delivery still deferred |
+| 3.4 Lifecycle/input/RPC annotations | done; RPC config delivered on desktop/Android and iOS |
 | 3.5 Non-object signal payloads | done |
 
 ### Phase 4 — Retire Hand-Written iOS Surfaces
@@ -76,13 +76,12 @@ These are the active forward-looking items. Keep the strategic ordering in
 1. **Stable iOS export workflow**: user-facing `docs/exporting/ios.md`, fresh-project path, and
    physical-device validation gate.
 2. **Android hardening**: current-device Godot 4.7 stable smoke plus R8-minified APK gate.
-3. **`@Rpc` config delivery**: required for multiplayer demo parity and real networked projects.
-4. **`commonMain` wrapper unification**: migrate toward shared generated wrappers with
+3. **`commonMain` wrapper unification**: migrate toward shared generated wrappers with
    `expect/actual ObjectCalls`.
-5. **Long-tail shapes**: Callable/vararg, conservative container policies, and non-POD virtual returns.
-6. **Generator policy cleanup**: explicit class-collision handling, subclass override generation, and
+4. **Long-tail shapes**: Callable/vararg, conservative container policies, and non-POD virtual returns.
+5. **Generator policy cleanup**: explicit class-collision handling, subclass override generation, and
    tighter fixture coverage for custom member/companion sections.
-7. **Optional iOS polish**: `GodotReal` centralization.
+6. **Optional iOS polish**: `GodotReal` centralization.
 
 ## Required Report Refreshes
 

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -29,6 +29,10 @@ import kotlinx.cinterop.value
 import net.multigesture.kanama.api.GodotObject
 import net.multigesture.kanama.api.IosCallableRegistry
 import net.multigesture.kanama.api.IosGodot
+import net.multigesture.kanama.ios.KanamaIosProjectRegistry
+import net.multigesture.kanama.ios.KanamaIosRpcConfig
+import net.multigesture.kanama.ios.KanamaIosRuntime
+import net.multigesture.kanama.ios.KanamaIosScriptDescriptor
 import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_construct_object
 import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_get_method_bind
 import net.multigesture.kanama.ios.cinterop.kanama_ios_godot_get_singleton
@@ -1822,6 +1826,48 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         for (i in sb.indices) sp[i] = sb[i]
         sp[sb.size] = 0
         check("callarg-decode(String)", decodeIosCallArg(16, sp) == "hello")
+    }
+
+    // @Rpc config delivery (descriptor -> accessor seam): register a synthetic descriptor with
+    // distinct non-zero values and assert the scriptResourceRpcConfig* accessors read them back in
+    // order. Pairs with the C-side _get_rpc_config Dictionary readback in
+    // kanama_ios_ptrcall_selftest. Distinct non-zero values catch field-swaps (mode/transferMode/
+    // channel) and out-of-order indexing.
+    run {
+        val rpcPath = "res://kanama_ios_rpc_selftest.kt"
+        KanamaIosProjectRegistry.register(
+            KanamaIosScriptDescriptor(
+                path = rpcPath,
+                baseType = "Node",
+                methods = emptyList(),
+                properties = emptyList(),
+                signals = emptyList(),
+                rpcConfigs = listOf(
+                    KanamaIosRpcConfig("net_score", mode = 1, callLocal = true, transferMode = 2, channel = 3),
+                    KanamaIosRpcConfig("sync_pos", mode = 2, callLocal = false, transferMode = 0, channel = 5),
+                ),
+                factory = { null },
+            ),
+        )
+        val handle = KanamaIosRuntime.createScriptResource(rpcPath)
+        check("rpc-config-count", KanamaIosRuntime.scriptResourceRpcConfigCount(handle) == 2)
+        check(
+            "rpc-config[0]",
+            KanamaIosRuntime.scriptResourceRpcConfigMethodName(handle, 0) == "net_score" &&
+                KanamaIosRuntime.scriptResourceRpcConfigMode(handle, 0) == 1 &&
+                KanamaIosRuntime.scriptResourceRpcConfigCallLocal(handle, 0) == 1 &&
+                KanamaIosRuntime.scriptResourceRpcConfigTransferMode(handle, 0) == 2 &&
+                KanamaIosRuntime.scriptResourceRpcConfigChannel(handle, 0) == 3,
+        )
+        check(
+            "rpc-config[1]",
+            KanamaIosRuntime.scriptResourceRpcConfigMethodName(handle, 1) == "sync_pos" &&
+                KanamaIosRuntime.scriptResourceRpcConfigMode(handle, 1) == 2 &&
+                KanamaIosRuntime.scriptResourceRpcConfigCallLocal(handle, 1) == 0 &&
+                KanamaIosRuntime.scriptResourceRpcConfigTransferMode(handle, 1) == 0 &&
+                KanamaIosRuntime.scriptResourceRpcConfigChannel(handle, 1) == 5,
+        )
+        KanamaIosRuntime.freeScriptResource(handle)
     }
 
     println("[kanama][ios][kn] OBJECTCALLS SELFTEST: $pass passed, $fail failed")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
@@ -45,12 +45,21 @@ internal data class KanamaIosScriptSignal(
     val name: String,
 )
 
+internal data class KanamaIosRpcConfig(
+    val methodName: String,
+    val mode: Int,
+    val callLocal: Boolean,
+    val transferMode: Int,
+    val channel: Int,
+)
+
 internal data class KanamaIosScriptDescriptor(
     val path: String,
     val baseType: String,
     val methods: List<KanamaIosScriptMethod>,
     val properties: List<KanamaIosScriptProperty>,
     val signals: List<KanamaIosScriptSignal>,
+    val rpcConfigs: List<KanamaIosRpcConfig> = emptyList(),
     val factory: (Long) -> KanamaIosScriptBridge?,
 )
 
@@ -226,6 +235,24 @@ internal object KanamaIosRuntime {
 
     fun scriptResourceSignalName(handle: Long, signalIndex: Int): String =
         scriptResources[handle]?.descriptor?.signals?.getOrNull(signalIndex)?.name.orEmpty()
+
+    fun scriptResourceRpcConfigCount(handle: Long): Int =
+        scriptResources[handle]?.descriptor?.rpcConfigs?.size ?: 0
+
+    fun scriptResourceRpcConfigMethodName(handle: Long, rpcConfigIndex: Int): String =
+        scriptResources[handle]?.descriptor?.rpcConfigs?.getOrNull(rpcConfigIndex)?.methodName.orEmpty()
+
+    fun scriptResourceRpcConfigMode(handle: Long, rpcConfigIndex: Int): Int =
+        scriptResources[handle]?.descriptor?.rpcConfigs?.getOrNull(rpcConfigIndex)?.mode ?: 0
+
+    fun scriptResourceRpcConfigCallLocal(handle: Long, rpcConfigIndex: Int): Int =
+        if (scriptResources[handle]?.descriptor?.rpcConfigs?.getOrNull(rpcConfigIndex)?.callLocal == true) 1 else 0
+
+    fun scriptResourceRpcConfigTransferMode(handle: Long, rpcConfigIndex: Int): Int =
+        scriptResources[handle]?.descriptor?.rpcConfigs?.getOrNull(rpcConfigIndex)?.transferMode ?: 0
+
+    fun scriptResourceRpcConfigChannel(handle: Long, rpcConfigIndex: Int): Int =
+        scriptResources[handle]?.descriptor?.rpcConfigs?.getOrNull(rpcConfigIndex)?.channel ?: 0
 
     fun createScriptInstance(scriptHandle: Long, ownerObject: Long): Long {
         if (ownerObject == 0L) {
@@ -421,6 +448,7 @@ internal object KanamaIosRuntime {
             methods = listOf(KanamaIosScriptMethod("_ready")),
             properties = emptyList(),
             signals = emptyList(),
+            rpcConfigs = emptyList(),
             factory = { ownerObject -> BuiltInProbeScript(ownerObject) },
         )
     }
@@ -585,6 +613,42 @@ fun kanamaIosRuntimeScriptResourceSignalName(
 ) {
     writeCString(KanamaIosRuntime.scriptResourceSignalName(scriptHandle, signalIndex), buffer, bufferSize)
 }
+
+@OptIn(ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_count")
+fun kanamaIosRuntimeScriptResourceRpcConfigCount(scriptHandle: Long): Int =
+    KanamaIosRuntime.scriptResourceRpcConfigCount(scriptHandle)
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_method_name")
+fun kanamaIosRuntimeScriptResourceRpcConfigMethodName(
+    scriptHandle: Long,
+    rpcConfigIndex: Int,
+    buffer: CPointer<ByteVar>?,
+    bufferSize: Int,
+) {
+    writeCString(KanamaIosRuntime.scriptResourceRpcConfigMethodName(scriptHandle, rpcConfigIndex), buffer, bufferSize)
+}
+
+@OptIn(ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_mode")
+fun kanamaIosRuntimeScriptResourceRpcConfigMode(scriptHandle: Long, rpcConfigIndex: Int): Int =
+    KanamaIosRuntime.scriptResourceRpcConfigMode(scriptHandle, rpcConfigIndex)
+
+@OptIn(ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_call_local")
+fun kanamaIosRuntimeScriptResourceRpcConfigCallLocal(scriptHandle: Long, rpcConfigIndex: Int): Int =
+    KanamaIosRuntime.scriptResourceRpcConfigCallLocal(scriptHandle, rpcConfigIndex)
+
+@OptIn(ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_transfer_mode")
+fun kanamaIosRuntimeScriptResourceRpcConfigTransferMode(scriptHandle: Long, rpcConfigIndex: Int): Int =
+    KanamaIosRuntime.scriptResourceRpcConfigTransferMode(scriptHandle, rpcConfigIndex)
+
+@OptIn(ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_rpc_config_channel")
+fun kanamaIosRuntimeScriptResourceRpcConfigChannel(scriptHandle: Long, rpcConfigIndex: Int): Int =
+    KanamaIosRuntime.scriptResourceRpcConfigChannel(scriptHandle, rpcConfigIndex)
 
 @OptIn(ExperimentalNativeApi::class)
 @CName("kanama_ios_runtime_script_instance_create")

--- a/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
+++ b/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
@@ -11,6 +11,8 @@ import net.multigesture.kanama.annotations.OnUnhandledInput
 import net.multigesture.kanama.annotations.OnUnhandledKeyInput
 import net.multigesture.kanama.annotations.RegisterFunction
 import net.multigesture.kanama.annotations.Rpc
+import net.multigesture.kanama.annotations.RpcMode
+import net.multigesture.kanama.annotations.RpcTransferMode
 import net.multigesture.kanama.annotations.ScriptClass
 import net.multigesture.kanama.annotations.ScriptProperty
 import net.multigesture.kanama.annotations.Signal
@@ -129,8 +131,10 @@ class GateFixtureScript(godotObject: MemorySegment) : KanamaScript<Label>(godotO
     }
 
     // @Rpc rides on a @RegisterFunction method; the processor captures its RpcModel, keeps the
-    // method dispatchable on iOS via generic callV, and delivers _get_rpc_config to Godot.
-    @Rpc(callLocal = true)
+    // method dispatchable on iOS via generic callV, and delivers _get_rpc_config to Godot. Explicit,
+    // mutually-distinct mode/transferMode/channel values (rather than all-default) make this an
+    // honest delivery example whose fields are individually observable.
+    @Rpc(mode = RpcMode.ANY_PEER, callLocal = true, transferMode = RpcTransferMode.UNRELIABLE, channel = 4)
     @RegisterFunction("net_score")
     fun netScore(points: Long) {
         score += points

--- a/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
+++ b/ios-runtime/src/iosScriptFixtures/kotlin-src/GateFixtureScript.kt
@@ -128,9 +128,8 @@ class GateFixtureScript(godotObject: MemorySegment) : KanamaScript<Label>(godotO
         score += 1L
     }
 
-    // Phase 3.4 @Rpc parse-side: @Rpc rides on a @RegisterFunction method; the processor captures
-    // its RpcModel and the method stays dispatchable on iOS via the generic callV (full
-    // _get_rpc_config delivery to Godot multiplayer is a later phase).
+    // @Rpc rides on a @RegisterFunction method; the processor captures its RpcModel, keeps the
+    // method dispatchable on iOS via generic callV, and delivers _get_rpc_config to Godot.
     @Rpc(callLocal = true)
     @RegisterFunction("net_score")
     fun netScore(points: Long) {

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -230,6 +230,9 @@ static GDExtensionInterfaceVariantGetPtrDestructor g_variant_get_ptr_destructor 
 static GDExtensionInterfaceVariantGetPtrConstructor g_variant_get_ptr_constructor = NULL;
 static GDExtensionInterfaceVariantGetPtrBuiltinMethod g_variant_get_ptr_builtin_method = NULL;
 static GDExtensionInterfaceVariantGetPtrKeyedSetter g_variant_get_ptr_keyed_setter = NULL;
+// Keyed getter is used only by the debug self-test (kanama_ios_ptrcall_selftest) to read back
+// the rpc-config Dictionary; it is intentionally NOT part of the mandatory init gate.
+static GDExtensionInterfaceVariantGetPtrKeyedGetter g_variant_get_ptr_keyed_getter = NULL;
 static GDExtensionInterfaceGetVariantFromTypeConstructor g_get_variant_from_type_constructor = NULL;
 static GDExtensionInterfaceGetVariantToTypeConstructor g_get_variant_to_type_constructor = NULL;
 static GDExtensionInterfaceVariantDestroy g_variant_destroy = NULL;
@@ -334,6 +337,9 @@ static GDExtensionPtrConstructor g_packed_string_array_constructor = NULL;
 static GDExtensionPtrConstructor g_array_constructor = NULL;
 static GDExtensionPtrConstructor g_dictionary_constructor = NULL;
 static GDExtensionPtrKeyedSetter g_dictionary_keyed_setter = NULL;
+// Debug-self-test only (read-back of the rpc-config Dictionary); not in the mandatory init gate.
+static GDExtensionPtrKeyedGetter g_dictionary_keyed_getter = NULL;
+static GDExtensionTypeFromVariantConstructorFunc g_variant_to_dictionary = NULL;
 static GDExtensionPtrDestructor g_node_path_destructor = NULL;
 static GDExtensionPtrDestructor g_dictionary_destructor = NULL;
 static GDExtensionPtrBuiltInMethod g_packed_string_array_push_back = NULL;
@@ -705,6 +711,9 @@ static int kanama_ios_resolve_godot_api(void) {
     g_variant_get_ptr_keyed_setter = (GDExtensionInterfaceVariantGetPtrKeyedSetter)kanama_ios_lookup(
         "variant_get_ptr_keyed_setter"
     );
+    g_variant_get_ptr_keyed_getter = (GDExtensionInterfaceVariantGetPtrKeyedGetter)kanama_ios_lookup(
+        "variant_get_ptr_keyed_getter"
+    );
     g_get_variant_from_type_constructor = (GDExtensionInterfaceGetVariantFromTypeConstructor)kanama_ios_lookup(
         "get_variant_from_type_constructor"
     );
@@ -791,6 +800,13 @@ static int kanama_ios_resolve_godot_api(void) {
     g_array_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_ARRAY, 0);
     g_dictionary_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_DICTIONARY, 0);
     g_dictionary_keyed_setter = g_variant_get_ptr_keyed_setter(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
+    // Keyed getter + variant->Dictionary back off the debug self-test only. Resolve them
+    // opportunistically; they are deliberately excluded from the mandatory NULL gate below so a
+    // missing symbol can never fail production shim init.
+    if (g_variant_get_ptr_keyed_getter != NULL) {
+        g_dictionary_keyed_getter = g_variant_get_ptr_keyed_getter(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
+    }
+    g_variant_to_dictionary = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
     g_variant_to_bool = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_BOOL);
     g_variant_to_string = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_STRING);
     g_variant_to_float = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_FLOAT);
@@ -5081,6 +5097,54 @@ static void kanama_ios_dictionary_set_dictionary(
     g_variant_destroy(value_variant);
 }
 
+// Debug-only Dictionary read-back helpers mirroring the setters above. Used by
+// kanama_ios_ptrcall_selftest to verify the rpc-config Dictionary built by
+// kanama_ios_init_script_rpc_config_variant. They no-op to nil/0 if Godot did not expose the keyed
+// getter (it is not part of the mandatory init gate).
+static void kanama_ios_dictionary_get_variant(
+    GDExtensionConstTypePtr dictionary,
+    const char *key,
+    GDExtensionUninitializedVariantPtr out
+) {
+    if (dictionary == NULL || key == NULL || out == NULL || g_dictionary_keyed_getter == NULL) {
+        g_variant_new_nil(out);
+        return;
+    }
+    uint8_t key_variant[24];
+    memset(key_variant, 0, sizeof(key_variant));
+    kanama_ios_init_string_variant(key_variant, key);
+    g_dictionary_keyed_getter(dictionary, key_variant, out);
+    g_variant_destroy(key_variant);
+}
+
+static int64_t kanama_ios_dictionary_get_int(GDExtensionConstTypePtr dictionary, const char *key) {
+    uint8_t value_variant[24];
+    memset(value_variant, 0, sizeof(value_variant));
+    kanama_ios_dictionary_get_variant(dictionary, key, value_variant);
+    int64_t result = 0;
+    if (g_variant_to_int != NULL) {
+        GDExtensionInt decoded = 0;
+        g_variant_to_int(&decoded, value_variant);
+        result = (int64_t)decoded;
+    }
+    g_variant_destroy(value_variant);
+    return result;
+}
+
+static int kanama_ios_dictionary_get_bool(GDExtensionConstTypePtr dictionary, const char *key) {
+    uint8_t value_variant[24];
+    memset(value_variant, 0, sizeof(value_variant));
+    kanama_ios_dictionary_get_variant(dictionary, key, value_variant);
+    int result = 0;
+    if (g_variant_to_bool != NULL) {
+        GDExtensionBool decoded = 0;
+        g_variant_to_bool(&decoded, value_variant);
+        result = decoded != 0 ? 1 : 0;
+    }
+    g_variant_destroy(value_variant);
+    return result;
+}
+
 static void kanama_ios_init_script_rpc_config_variant(
     const KanamaIosExtensionInstance *script,
     GDExtensionUninitializedVariantPtr out
@@ -7823,6 +7887,48 @@ static void kanama_ios_ptrcall_selftest(void) {
         if (g_variant_destroy != NULL) { g_variant_destroy((GDExtensionVariantPtr)variant); }
     } else {
         KANAMA_IOS_ST_CHECK("setprop-packed-string-array", 0);
+    }
+
+    // @Rpc config delivery: build the _get_rpc_config Dictionary via the production helper from a
+    // synthetic descriptor, then read it back and assert each method's fields. Distinct non-zero
+    // values catch field-swaps (e.g. rpc_mode vs transfer_mode). Needs the debug-only keyed getter
+    // and variant->Dictionary; skip cleanly if Godot did not expose them.
+    if (g_dictionary_keyed_getter != NULL && g_variant_to_dictionary != NULL) {
+        KanamaIosRpcConfig probe_configs[2] = {
+            { "net_score", 1, 1, 2, 3 },
+            { "sync_pos", 2, 0, 0, 5 },
+        };
+        KanamaIosExtensionInstance probe;
+        memset(&probe, 0, sizeof(probe));
+        probe.script_rpc_configs = probe_configs;
+        probe.script_rpc_config_count = 2;
+
+        uint8_t root_variant[24];
+        memset(root_variant, 0, sizeof(root_variant));
+        kanama_ios_init_script_rpc_config_variant(&probe, root_variant);
+
+        uint64_t root_dict = 0;
+        g_variant_to_dictionary(&root_dict, root_variant);
+
+        int rpc_ok = 1;
+        for (int i = 0; i < 2; i++) {
+            const KanamaIosRpcConfig *expected = &probe_configs[i];
+            uint8_t method_variant[24];
+            memset(method_variant, 0, sizeof(method_variant));
+            kanama_ios_dictionary_get_variant(&root_dict, expected->method_name_text, method_variant);
+            uint64_t method_dict = 0;
+            g_variant_to_dictionary(&method_dict, method_variant);
+            rpc_ok = rpc_ok
+                && kanama_ios_dictionary_get_int(&method_dict, "rpc_mode") == expected->mode
+                && kanama_ios_dictionary_get_bool(&method_dict, "call_local") == expected->call_local
+                && kanama_ios_dictionary_get_int(&method_dict, "transfer_mode") == expected->transfer_mode
+                && kanama_ios_dictionary_get_int(&method_dict, "channel") == expected->channel;
+            g_dictionary_destructor(&method_dict);
+            g_variant_destroy(method_variant);
+        }
+        g_dictionary_destructor(&root_dict);
+        g_variant_destroy(root_variant);
+        KANAMA_IOS_ST_CHECK("script-rpc-config-dictionary", rpc_ok);
     }
 
     fprintf(stderr, "[kanama][ios][c] PTRCALL SELFTEST MATRIX: %d passed, %d failed\n", pass, fail);

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -55,6 +55,29 @@ extern void kanama_ios_runtime_script_resource_signal_name(
     char *buffer,
     int32_t buffer_size
 );
+extern int32_t kanama_ios_runtime_script_resource_rpc_config_count(int64_t script_handle);
+extern void kanama_ios_runtime_script_resource_rpc_config_method_name(
+    int64_t script_handle,
+    int32_t rpc_config_index,
+    char *buffer,
+    int32_t buffer_size
+);
+extern int32_t kanama_ios_runtime_script_resource_rpc_config_mode(
+    int64_t script_handle,
+    int32_t rpc_config_index
+);
+extern int32_t kanama_ios_runtime_script_resource_rpc_config_call_local(
+    int64_t script_handle,
+    int32_t rpc_config_index
+);
+extern int32_t kanama_ios_runtime_script_resource_rpc_config_transfer_mode(
+    int64_t script_handle,
+    int32_t rpc_config_index
+);
+extern int32_t kanama_ios_runtime_script_resource_rpc_config_channel(
+    int64_t script_handle,
+    int32_t rpc_config_index
+);
 extern int64_t kanama_ios_runtime_script_instance_create(int64_t script_handle, int64_t owner_object);
 extern void kanama_ios_runtime_script_instance_ready(int64_t instance_handle);
 // Generic per-signature inbound call: the C callback marshals every Variant arg into a
@@ -152,9 +175,18 @@ typedef enum {
     KANAMA_IOS_VIRTUAL_SCRIPT_HAS_METHOD,
     KANAMA_IOS_VIRTUAL_SCRIPT_HAS_SIGNAL,
     KANAMA_IOS_VIRTUAL_SCRIPT_METHOD_ARG_COUNT,
+    KANAMA_IOS_VIRTUAL_SCRIPT_RPC_CONFIG,
     KANAMA_IOS_VIRTUAL_RESOURCE_GET_TYPE,
     KANAMA_IOS_VIRTUAL_RESOURCE_LOAD,
 } KanamaIosVirtualId;
+
+typedef struct {
+    char *method_name_text;
+    int32_t mode;
+    int32_t call_local;
+    int32_t transfer_mode;
+    int32_t channel;
+} KanamaIosRpcConfig;
 
 typedef struct {
     KanamaIosClassKind kind;
@@ -172,6 +204,8 @@ typedef struct {
     uint64_t *script_signal_names;
     char **script_signal_name_texts;
     int32_t script_signal_count;
+    KanamaIosRpcConfig *script_rpc_configs;
+    int32_t script_rpc_config_count;
 } KanamaIosExtensionInstance;
 
 typedef struct {
@@ -195,6 +229,7 @@ static GDExtensionInterfaceStringToUtf8Chars g_string_to_utf8_chars = NULL;
 static GDExtensionInterfaceVariantGetPtrDestructor g_variant_get_ptr_destructor = NULL;
 static GDExtensionInterfaceVariantGetPtrConstructor g_variant_get_ptr_constructor = NULL;
 static GDExtensionInterfaceVariantGetPtrBuiltinMethod g_variant_get_ptr_builtin_method = NULL;
+static GDExtensionInterfaceVariantGetPtrKeyedSetter g_variant_get_ptr_keyed_setter = NULL;
 static GDExtensionInterfaceGetVariantFromTypeConstructor g_get_variant_from_type_constructor = NULL;
 static GDExtensionInterfaceGetVariantToTypeConstructor g_get_variant_to_type_constructor = NULL;
 static GDExtensionInterfaceVariantDestroy g_variant_destroy = NULL;
@@ -298,7 +333,9 @@ static GDExtensionPtrConstructor g_string_from_string_name_constructor = NULL;
 static GDExtensionPtrConstructor g_packed_string_array_constructor = NULL;
 static GDExtensionPtrConstructor g_array_constructor = NULL;
 static GDExtensionPtrConstructor g_dictionary_constructor = NULL;
+static GDExtensionPtrKeyedSetter g_dictionary_keyed_setter = NULL;
 static GDExtensionPtrDestructor g_node_path_destructor = NULL;
+static GDExtensionPtrDestructor g_dictionary_destructor = NULL;
 static GDExtensionPtrBuiltInMethod g_packed_string_array_push_back = NULL;
 // PackedStringArray read-back (ptrcall return -> List<String>): variable-length elements.
 static GDExtensionPtrDestructor g_packed_string_array_destructor = NULL;
@@ -371,6 +408,7 @@ static GDExtensionVariantFromTypeConstructorFunc g_variant_from_string_name = NU
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_int = NULL;
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_bool = NULL;
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_string = NULL;
+static GDExtensionVariantFromTypeConstructorFunc g_variant_from_dictionary = NULL;
 static GDExtensionVariantFromTypeConstructorFunc g_variant_from_packed_string_array = NULL;
 static int g_main_loop_callbacks_registered = 0;
 static int g_main_loop_callbacks_active = 0;
@@ -664,6 +702,9 @@ static int kanama_ios_resolve_godot_api(void) {
     g_variant_get_ptr_builtin_method = (GDExtensionInterfaceVariantGetPtrBuiltinMethod)kanama_ios_lookup(
         "variant_get_ptr_builtin_method"
     );
+    g_variant_get_ptr_keyed_setter = (GDExtensionInterfaceVariantGetPtrKeyedSetter)kanama_ios_lookup(
+        "variant_get_ptr_keyed_setter"
+    );
     g_get_variant_from_type_constructor = (GDExtensionInterfaceGetVariantFromTypeConstructor)kanama_ios_lookup(
         "get_variant_from_type_constructor"
     );
@@ -714,6 +755,7 @@ static int kanama_ios_resolve_godot_api(void) {
         g_variant_get_ptr_destructor == NULL ||
         g_variant_get_ptr_constructor == NULL ||
         g_variant_get_ptr_builtin_method == NULL ||
+        g_variant_get_ptr_keyed_setter == NULL ||
         g_get_variant_from_type_constructor == NULL ||
         g_get_variant_to_type_constructor == NULL ||
         g_variant_destroy == NULL ||
@@ -737,6 +779,7 @@ static int kanama_ios_resolve_godot_api(void) {
     g_string_name_destructor = g_variant_get_ptr_destructor(KANAMA_IOS_VARIANT_TYPE_STRING_NAME);
     g_string_destructor = g_variant_get_ptr_destructor(KANAMA_IOS_VARIANT_TYPE_STRING);
     g_node_path_destructor = g_variant_get_ptr_destructor(KANAMA_IOS_VARIANT_TYPE_NODE_PATH);
+    g_dictionary_destructor = g_variant_get_ptr_destructor(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
     g_node_path_from_string_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_NODE_PATH, 2);
     // String(from: StringName) — constructor index 2 in extension_api.json. Used to
     // marshal StringName ptrcall returns (no GDExtension StringName->utf8 exists).
@@ -747,6 +790,7 @@ static int kanama_ios_resolve_godot_api(void) {
     );
     g_array_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_ARRAY, 0);
     g_dictionary_constructor = g_variant_get_ptr_constructor(KANAMA_IOS_VARIANT_TYPE_DICTIONARY, 0);
+    g_dictionary_keyed_setter = g_variant_get_ptr_keyed_setter(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
     g_variant_to_bool = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_BOOL);
     g_variant_to_string = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_STRING);
     g_variant_to_float = g_get_variant_to_type_constructor(KANAMA_IOS_VARIANT_TYPE_FLOAT);
@@ -779,6 +823,7 @@ static int kanama_ios_resolve_godot_api(void) {
     g_variant_from_int = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_INT);
     g_variant_from_bool = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_BOOL);
     g_variant_from_string = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_STRING);
+    g_variant_from_dictionary = g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_DICTIONARY);
     g_variant_from_packed_string_array =
         g_get_variant_from_type_constructor(KANAMA_IOS_VARIANT_TYPE_PACKED_STRING_ARRAY);
 
@@ -786,11 +831,13 @@ static int kanama_ios_resolve_godot_api(void) {
         g_string_name_destructor == NULL ||
         g_string_destructor == NULL ||
         g_node_path_destructor == NULL ||
+        g_dictionary_destructor == NULL ||
         g_node_path_from_string_constructor == NULL ||
         g_string_from_string_name_constructor == NULL ||
         g_packed_string_array_constructor == NULL ||
         g_array_constructor == NULL ||
         g_dictionary_constructor == NULL ||
+        g_dictionary_keyed_setter == NULL ||
         g_variant_to_float == NULL ||
         g_variant_to_object == NULL ||
         g_variant_to_int == NULL ||
@@ -808,6 +855,7 @@ static int kanama_ios_resolve_godot_api(void) {
         g_variant_from_int == NULL ||
         g_variant_from_bool == NULL ||
         g_variant_from_string == NULL ||
+        g_variant_from_dictionary == NULL ||
         g_variant_from_packed_string_array == NULL
     ) {
         fprintf(stderr, "[kanama][ios][c] error: failed to resolve Godot builtin helpers\n");
@@ -1142,6 +1190,34 @@ static void kanama_ios_script_resource_init_metadata(KanamaIosExtensionInstance 
             instance->script_signal_name_texts[i] = kanama_ios_strdup(signal_name);
         }
     }
+
+    int32_t rpc_config_count = kanama_ios_runtime_script_resource_rpc_config_count(instance->script_handle);
+    if (rpc_config_count > 0) {
+        instance->script_rpc_configs = calloc((size_t)rpc_config_count, sizeof(KanamaIosRpcConfig));
+        if (instance->script_rpc_configs == NULL) {
+            return;
+        }
+        instance->script_rpc_config_count = rpc_config_count;
+        for (int32_t i = 0; i < rpc_config_count; i++) {
+            char method_name[128];
+            method_name[0] = '\0';
+            kanama_ios_runtime_script_resource_rpc_config_method_name(
+                instance->script_handle,
+                i,
+                method_name,
+                (int32_t)sizeof(method_name)
+            );
+            instance->script_rpc_configs[i].method_name_text = kanama_ios_strdup(method_name);
+            instance->script_rpc_configs[i].mode =
+                kanama_ios_runtime_script_resource_rpc_config_mode(instance->script_handle, i);
+            instance->script_rpc_configs[i].call_local =
+                kanama_ios_runtime_script_resource_rpc_config_call_local(instance->script_handle, i);
+            instance->script_rpc_configs[i].transfer_mode =
+                kanama_ios_runtime_script_resource_rpc_config_transfer_mode(instance->script_handle, i);
+            instance->script_rpc_configs[i].channel =
+                kanama_ios_runtime_script_resource_rpc_config_channel(instance->script_handle, i);
+        }
+    }
 }
 
 static void kanama_ios_script_resource_clear_metadata(KanamaIosExtensionInstance *instance) {
@@ -1182,6 +1258,12 @@ static void kanama_ios_script_resource_clear_metadata(KanamaIosExtensionInstance
         }
         free(instance->script_signal_name_texts);
     }
+    if (instance->script_rpc_configs != NULL) {
+        for (int32_t i = 0; i < instance->script_rpc_config_count; i++) {
+            free(instance->script_rpc_configs[i].method_name_text);
+        }
+        free(instance->script_rpc_configs);
+    }
     instance->script_method_names = NULL;
     instance->script_method_name_texts = NULL;
     instance->script_base_type_text = NULL;
@@ -1192,6 +1274,8 @@ static void kanama_ios_script_resource_clear_metadata(KanamaIosExtensionInstance
     instance->script_signal_names = NULL;
     instance->script_signal_name_texts = NULL;
     instance->script_signal_count = 0;
+    instance->script_rpc_configs = NULL;
+    instance->script_rpc_config_count = 0;
     instance->script_path = NULL;
     instance->script_method_count = 0;
 }
@@ -4936,6 +5020,96 @@ static void kanama_ios_init_empty_dictionary(GDExtensionTypePtr out) {
     g_dictionary_constructor(out, NULL);
 }
 
+static void kanama_ios_init_string_variant(GDExtensionUninitializedVariantPtr out, const char *value) {
+    uint64_t string_storage = 0;
+    kanama_ios_init_string(&string_storage, value != NULL ? value : "");
+    g_variant_from_string(out, &string_storage);
+    kanama_ios_destroy_string(&string_storage);
+}
+
+static void kanama_ios_init_int_variant(GDExtensionUninitializedVariantPtr out, int64_t value) {
+    GDExtensionInt int_storage = (GDExtensionInt)value;
+    g_variant_from_int(out, &int_storage);
+}
+
+static void kanama_ios_init_bool_variant(GDExtensionUninitializedVariantPtr out, int value) {
+    GDExtensionBool bool_storage = value != 0 ? 1 : 0;
+    g_variant_from_bool(out, &bool_storage);
+}
+
+static void kanama_ios_dictionary_set_variant(
+    GDExtensionTypePtr dictionary,
+    const char *key,
+    GDExtensionConstVariantPtr value_variant
+) {
+    if (dictionary == NULL || key == NULL || value_variant == NULL || g_dictionary_keyed_setter == NULL) {
+        return;
+    }
+
+    uint8_t key_variant[24];
+    memset(key_variant, 0, sizeof(key_variant));
+    kanama_ios_init_string_variant(key_variant, key);
+    g_dictionary_keyed_setter(dictionary, key_variant, value_variant);
+    g_variant_destroy(key_variant);
+}
+
+static void kanama_ios_dictionary_set_int(GDExtensionTypePtr dictionary, const char *key, int64_t value) {
+    uint8_t value_variant[24];
+    memset(value_variant, 0, sizeof(value_variant));
+    kanama_ios_init_int_variant(value_variant, value);
+    kanama_ios_dictionary_set_variant(dictionary, key, value_variant);
+    g_variant_destroy(value_variant);
+}
+
+static void kanama_ios_dictionary_set_bool(GDExtensionTypePtr dictionary, const char *key, int value) {
+    uint8_t value_variant[24];
+    memset(value_variant, 0, sizeof(value_variant));
+    kanama_ios_init_bool_variant(value_variant, value);
+    kanama_ios_dictionary_set_variant(dictionary, key, value_variant);
+    g_variant_destroy(value_variant);
+}
+
+static void kanama_ios_dictionary_set_dictionary(
+    GDExtensionTypePtr dictionary,
+    const char *key,
+    GDExtensionTypePtr value_dictionary
+) {
+    uint8_t value_variant[24];
+    memset(value_variant, 0, sizeof(value_variant));
+    g_variant_from_dictionary(value_variant, value_dictionary);
+    kanama_ios_dictionary_set_variant(dictionary, key, value_variant);
+    g_variant_destroy(value_variant);
+}
+
+static void kanama_ios_init_script_rpc_config_variant(
+    const KanamaIosExtensionInstance *script,
+    GDExtensionUninitializedVariantPtr out
+) {
+    if (script == NULL || script->script_rpc_config_count <= 0 || script->script_rpc_configs == NULL) {
+        g_variant_new_nil(out);
+        return;
+    }
+
+    uint64_t root_dictionary = 0;
+    kanama_ios_init_empty_dictionary(&root_dictionary);
+    for (int32_t i = 0; i < script->script_rpc_config_count; i++) {
+        const KanamaIosRpcConfig *config = &script->script_rpc_configs[i];
+        if (config->method_name_text == NULL || config->method_name_text[0] == '\0') {
+            continue;
+        }
+        uint64_t method_dictionary = 0;
+        kanama_ios_init_empty_dictionary(&method_dictionary);
+        kanama_ios_dictionary_set_int(&method_dictionary, "rpc_mode", config->mode);
+        kanama_ios_dictionary_set_bool(&method_dictionary, "call_local", config->call_local);
+        kanama_ios_dictionary_set_int(&method_dictionary, "transfer_mode", config->transfer_mode);
+        kanama_ios_dictionary_set_int(&method_dictionary, "channel", config->channel);
+        kanama_ios_dictionary_set_dictionary(&root_dictionary, config->method_name_text, &method_dictionary);
+        g_dictionary_destructor(&method_dictionary);
+    }
+    g_variant_from_dictionary(out, &root_dictionary);
+    g_dictionary_destructor(&root_dictionary);
+}
+
 static void kanama_ios_init_nil_variant(GDExtensionUninitializedVariantPtr out) {
     g_variant_new_nil(out);
 }
@@ -4993,7 +5167,7 @@ static void *kanama_ios_virtual_for_script(GDExtensionConstStringNamePtr name) {
     if (kanama_ios_string_name_eq(name, g_name__get_script_signal_list)) return (void *)KANAMA_IOS_VIRTUAL_ARRAY_EMPTY;
     if (kanama_ios_string_name_eq(name, g_name__get_constants)) return (void *)KANAMA_IOS_VIRTUAL_DICTIONARY_EMPTY;
     if (kanama_ios_string_name_eq(name, g_name__get_members)) return (void *)KANAMA_IOS_VIRTUAL_PACKED_EMPTY;
-    if (kanama_ios_string_name_eq(name, g_name__get_rpc_config)) return (void *)KANAMA_IOS_VIRTUAL_VARIANT_NIL;
+    if (kanama_ios_string_name_eq(name, g_name__get_rpc_config)) return (void *)KANAMA_IOS_VIRTUAL_SCRIPT_RPC_CONFIG;
     if (kanama_ios_string_name_eq(name, g_name__instance_has)) return (void *)KANAMA_IOS_VIRTUAL_BOOL_FALSE;
     if (kanama_ios_string_name_eq(name, g_name__is_placeholder_fallback_enabled)) return (void *)KANAMA_IOS_VIRTUAL_BOOL_TRUE;
     return NULL;
@@ -5160,6 +5334,12 @@ static void kanama_ios_call_virtual_with_data(
         }
         case KANAMA_IOS_VIRTUAL_SCRIPT_METHOD_ARG_COUNT:
             kanama_ios_init_nil_variant((GDExtensionUninitializedVariantPtr)ret);
+            break;
+        case KANAMA_IOS_VIRTUAL_SCRIPT_RPC_CONFIG:
+            kanama_ios_init_script_rpc_config_variant(
+                extension_instance,
+                (GDExtensionUninitializedVariantPtr)ret
+            );
             break;
         case KANAMA_IOS_VIRTUAL_RESOURCE_GET_TYPE:
             kanama_ios_init_string((uint64_t *)ret, "Script");

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -88,6 +88,14 @@ internal data class IosSignal(
     val kotlinName: String,
 )
 
+internal data class IosRpcConfig(
+    val godotName: String,
+    val mode: Int,
+    val callLocal: Boolean,
+    val transferMode: Int,
+    val channel: Int,
+)
+
 internal data class IosScript(
     val resourcePath: String,
     val packageName: String?,
@@ -96,6 +104,7 @@ internal data class IosScript(
     val methods: List<IosMethod>,
     val properties: List<IosProperty>,
     val signals: List<IosSignal>,
+    val rpcConfigs: List<IosRpcConfig>,
 )
 
 internal class IosScriptCodeEmitter(
@@ -149,6 +158,13 @@ internal class IosScriptCodeEmitter(
             script.signals.forEach { signal ->
                 builder.appendLine(
                     "                KanamaIosScriptSignal(${kotlinString(signal.godotName)}),",
+                )
+            }
+            builder.appendLine("            ),")
+            builder.appendLine("            rpcConfigs = listOf(")
+            script.rpcConfigs.forEach { rpc ->
+                builder.appendLine(
+                    "                KanamaIosRpcConfig(${kotlinString(rpc.godotName)}, ${rpc.mode}, ${rpc.callLocal}, ${rpc.transferMode}, ${rpc.channel}),",
                 )
             }
             builder.appendLine("            ),")
@@ -460,6 +476,17 @@ internal class IosScriptCodeEmitter(
             .distinctBy { it.godotName }
         val signals = model.signals.map { IosSignal(it.godotName, it.godotName) }
             .distinctBy { it.godotName }
+        val rpcConfigs = model.methods.mapNotNull { method ->
+            method.rpc?.let { rpc ->
+                IosRpcConfig(
+                    godotName = method.godotName,
+                    mode = rpc.mode,
+                    callLocal = rpc.callLocal,
+                    transferMode = rpc.transferMode,
+                    channel = rpc.channel,
+                )
+            }
+        }.distinctBy { it.godotName }
         return IosScript(
             resourcePath = resourcePath,
             packageName = packageName,
@@ -468,6 +495,7 @@ internal class IosScriptCodeEmitter(
             methods = methods,
             properties = properties,
             signals = signals,
+            rpcConfigs = rpcConfigs,
         )
     }
 


### PR DESCRIPTION
## Summary
- emit @Rpc metadata into generated iOS script descriptors
- expose RPC config metadata from Kotlin/Native and return the _get_rpc_config dictionary from the iOS C shim
- update multiplayer docs and iOS/internal trackers to mark the RPC blocker resolved without overclaiming full TPS iOS readiness

## Validation
- rtk ./gradlew :processor:jar
- rtk ./gradlew jar
- rtk env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew compileKotlinIosArm64
- rtk env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew compileIosDeviceDebugShim compileIosDeviceReleaseShim
- rtk env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./gradlew compileIosSimulatorDebugShim compileIosSimulatorReleaseShim
- rtk mkdocs build --strict
- rtk git diff --check
- TPS desktop smoke passed
- Pixel 7 Android smoke passed

## Remaining iOS work called out
- Full tps-demo-kanama iOS build/launch is still blocked by task 08 wrapper coverage gaps, including wrappers used by TPS such as CPUParticles3D, AnimationTree, DisplayServer, SceneMultiplayer, LightmapGI, ConfigFile, and ShaderMaterial.
- Mobile TPS playability is separate demo work and is now tracked as kanama-tasks task 19 for virtual joystick/touch controls, starting with Android validation.