### PR TITLE
Revert mis-scoped Vector2 default out of the iOS device-gate commit

### DIFF
--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
@@ -322,7 +322,7 @@ object Input {
         return ObjectCalls.ptrcallNoArgsRetLong(getCurrentCursorShapeBind, singleton)
     }
 
-    fun setCustomMouseCursor(image: Resource?, shape: Long = 0L, hotspot: Vector2 = Vector2(0f, 0f)) {
+    fun setCustomMouseCursor(image: Resource?, shape: Long = 0L, hotspot: Vector2) {
         ObjectCalls.ptrcallWithObjectLongAndVector2Arg(setCustomMouseCursorBind, singleton, image?.requireOpenHandle() ?: MemorySegment.NULL, shape, hotspot)
     }
 

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -769,8 +769,6 @@ def kotlin_default_expression(default_value: str | None, logical_kind: str) -> s
         return "emptyList()"
     if logical_kind == "Dictionary" and default_value == "{}":
         return "emptyMap()"
-    if logical_kind == "Vector2" and default_value in {"Vector2(0, 0)", "Vector2(0.0, 0.0)"}:
-        return "Vector2(0f, 0f)"
     return None
 
 


### PR DESCRIPTION
**PR A of 2** (split). Pairs with #14 (the reintroduce).

The iOS device-gate commit `3f49e91b` (task 02) also bundled an unrelated generator change — a `Vector2(0, 0)` → `Vector2(0f, 0f)` default-expression rule in `generate_api_wrapper.py` and its regenerated effect on `Input.setCustomMouseCursor`. The change is correct, but it has nothing to do with the device gate and got merged without its own scope.

Since `3f49e91b` is already published on `main` with several commits stacked on top, it can't be re-scoped by rewriting history. This PR backs the change out so it can be reintroduced as a standalone, properly-scoped commit in #14.

**Net effect across this PR and #14 is zero** — this exists only to give the generator default-expression change its own reviewable history. Merge this first, then #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)