### PR TITLE
generator: emit Vector2(0, 0) defaults as Vector2(0f, 0f)

### DIFF
--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
@@ -322,7 +322,7 @@ object Input {
         return ObjectCalls.ptrcallNoArgsRetLong(getCurrentCursorShapeBind, singleton)
     }
 
-    fun setCustomMouseCursor(image: Resource?, shape: Long = 0L, hotspot: Vector2) {
+    fun setCustomMouseCursor(image: Resource?, shape: Long = 0L, hotspot: Vector2 = Vector2(0f, 0f)) {
         ObjectCalls.ptrcallWithObjectLongAndVector2Arg(setCustomMouseCursorBind, singleton, image?.requireOpenHandle() ?: MemorySegment.NULL, shape, hotspot)
     }
 

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -769,6 +769,8 @@ def kotlin_default_expression(default_value: str | None, logical_kind: str) -> s
         return "emptyList()"
     if logical_kind == "Dictionary" and default_value == "{}":
         return "emptyMap()"
+    if logical_kind == "Vector2" and default_value in {"Vector2(0, 0)", "Vector2(0.0, 0.0)"}:
+        return "Vector2(0f, 0f)"
     return None
 
 


### PR DESCRIPTION
**PR B of 2** (split). Stacked on #13 (the revert) — base is `revert/generator-vector2-from-gate`; GitHub will retarget it to `main` once #13 merges.

Reintroduces, as its own properly-scoped change, the generator default-expression rule that #13 backed out of the iOS device-gate commit.

`kotlin_default_expression` had no rule for `Vector2` defaults, so a Godot method whose parameter defaults to `Vector2(0, 0)` had its default dropped in the generated wrapper. That produced a required parameter after an optional one (`Input.setCustomMouseCursor(image, shape = 0L, hotspot)`), forcing callers to pass `hotspot` even though Godot treats it as optional.

This renders such defaults as the float-literal `Vector2(0f, 0f)` and regenerates the affected wrapper so the parameter is properly optional.

Net code change vs current `main` (combined with #13): zero. The point is the clean, separated history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)