### PR TITLE
Android: document R8/minify blocked upstream in PanamaPort + repro harness

### DIFF
--- a/android/godot-plugin/plugin/consumer-rules.pro
+++ b/android/godot-plugin/plugin/consumer-rules.pro
@@ -5,8 +5,21 @@
 # reflective surfaces the Kanama runtime needs while leaving game script
 # classes free to be obfuscated by the game's own configuration.
 #
-# STATUS: scaffold — an R8-minified APK smoke pass is still a pending
-# validation gate (see docs/exporting/android.md).
+# STATUS: R8 minification is BLOCKED upstream (root-caused 2026-06-26). The
+# minified GDExtension loads and runs fine up to KanamaBinding.init; it then dies
+# in PanamaPort's FFI bootstrap (see the com.v7878.** note below). This is a
+# PanamaPort-vs-R8 incompatibility that consumer keep rules cannot resolve, so
+# these rules only cover the Kanama/Godot surface and silence PanamaPort warnings.
+# Ship Android release builds WITHOUT minify until upstream resolves it.
+
+# Godot Android native code and plugin startup resolve parts of the Java
+# template by JNI/reflection while bootstrapping the engine. Keep the Godot
+# Java surface when a game APK enables R8.
+-keep class org.godotengine.** { *; }
+-keep class com.godot.game.** { *; }
+
+# Godot discovers Android plugins through manifest metadata string values.
+-keep class net.multigesture.kanama.android.** { *; }
 
 # Bootstrap entry: bootstrap.c resolves this class and its static
 # init(JJJ)V method by name via JNI (FindClass / GetStaticMethodID).
@@ -29,7 +42,28 @@
 -keep @interface net.multigesture.kanama.annotation.** { *; }
 -keepattributes RuntimeVisibleAnnotations, RuntimeInvisibleAnnotations
 
-# PanamaPort (java.lang.foreign port for ART) relies on internal
-# reflection and Unsafe access.
--keep class com.v7878.** { *; }
+# PanamaPort (com.v7878.**) KNOWN LIMITATION: R8 minification is not currently
+# supported. PanamaPort's Android linker generates native downcall/upcall stubs
+# with Java pattern-matching `switch`es over sealed type families -- the storage
+# descriptors (_LLVMStorageDescriptor.LLVMStorage) and the MemoryLayout hierarchy
+# (_AndroidLinkerImpl.sdToLLVMType / layoutToLLVMType / layoutName). Godot 4.7's
+# R8 (AGP 8.6.1) mis-handles those switches when it optimizes the sealed types,
+# so they fall through to `default -> Utils.shouldNotReachHere()`, crashing
+# nativeLinker().downcallHandle() at startup (the "flickering splash + No loader
+# found for res://kotlin-src/*.kt" symptom; deobfuscated 2026-06-26).
+#
+# This is NOT fixable from keep rules: keeping the sealed types (in any form,
+# including -keep,allowoptimization) blocks the optimization that PanamaPort's
+# own @CheckDiscard rules (from R8Annotations) REQUIRE -- R8 must scalarize the
+# _ScopedMemoryAccess$SessionLock allocations in the _VarHandleSegmentAs*
+# accessors those layouts flow through -- so the build fails the discard check.
+# Keep them and the build breaks; don't and the switch breaks at runtime. The
+# fix must come from upstream (a PanamaPort release that keeps R8 from optimizing
+# its sealed switches, or a newer R8) -- PanamaPort Core tops out at v0.1.3 on
+# Maven Central today. Until then, ship Android without R8/minify (debug-signed
+# release or minifyEnabled=false). scripts/android_export_minified.sh reproduces
+# the failure for an upstream report.
+#
+# PanamaPort references desktop-only / hidden symbols on code paths it does not
+# take on Android; keep R8 from turning those into app warnings.
 -dontwarn com.v7878.**

--- a/docs/exporting/android.md
+++ b/docs/exporting/android.md
@@ -14,10 +14,12 @@ for testing Kanama games on Android.
 
 ## Current Status
 
-Eight public demo exports are Android smoke targets. The Godot 4.7 stable
-emulator smoke path has re-passed for Starter-Kit-Match3; Pixel 7 hardware
-startup/playability coverage is still pending for the stable baseline, so
-Android remains experimental:
+Eight public demo exports are Android smoke targets. On 2026-06-26, the full
+Godot 4.7 stable matrix passed on a Pixel 7 using debug APK exports, logcat
+startup checks, and screenshot smoke checks. Android remains experimental, and
+R8/minify is unsupported: the obfuscated release path is blocked upstream in
+PanamaPort (see "Current Boundaries"), so release builds must ship without
+minify for now.
 
 | Demo | Current Result |
 |---|---|
@@ -25,15 +27,14 @@ Android remains experimental:
 | `Starter-Kit-3D-Platformer` | APK exports, launches, loads seven Kotlin scripts, reaches the main loop, renders the 3D scene, and runs gameplay logic with mobile controls. |
 | `Starter-Kit-Match3` | APK exports, launches, initializes Kanama, and passes startup/screenshot smoke checks. |
 | `godot-demo-3d-squash-the-creeps` | APK exports, launches, initializes Kanama, and passes startup/screenshot smoke checks. |
-| `Starter-Kit-FPS` | Android export preset and smoke target with touch controls for startup/playability checks. |
-| `Starter-Kit-Racing` | Android export preset and smoke target with mobile steering controls. |
-| `godot-4-3d-character-controller-tutorial` | Android export preset and smoke target with virtual joystick controls. |
-| `godot-4-3d-third-person-controller` | Android export preset and smoke target with virtual joysticks and warmup coverage for gameplay hitches. |
+| `Starter-Kit-FPS` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with touch-control coverage. |
+| `Starter-Kit-Racing` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with mobile steering controls. |
+| `godot-4-3d-character-controller-tutorial` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with virtual joystick controls. |
+| `godot-4-3d-third-person-controller` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with virtual joystick controls. |
 
-Pixel 7 coverage in the last completed pre-stable matrix included manual
-playability checks for the Android-enabled demos in addition to
-startup/screenshot smoke checks. Re-run the hardware matrix before making a
-stronger Android support claim.
+The Pixel 7 debug matrix does not imply release-obfuscated support. R8/minify is
+blocked upstream in PanamaPort (see "Current Boundaries"); obfuscated-build
+support cannot be claimed until that is resolved upstream.
 
 The validated Android demos currently use Godot's OpenGL Compatibility renderer.
 Desktop demos can continue using their normal renderer. Vulkan/Mobile-renderer
@@ -192,11 +193,31 @@ before exiting.
 - Some unsupported ASTC textures may be converted at runtime by the emulator.
 - Godot 4.7 `VirtualJoystick` wrappers are available in Kanama, but demo-level
   touch-control polish remains a project-specific validation claim.
-- R8/ProGuard minification is scaffolded but not yet validated. The plugin AAR
-  ships consumer keep rules (`android/godot-plugin/plugin/consumer-rules.pro`)
-  covering the JNI bootstrap entry, Panama upcall targets, KSP-generated
-  registrars, and PanamaPort internals. An R8-minified APK smoke pass is a
-  pending validation gate before claiming obfuscated-build support.
+- R8/ProGuard minification is **not supported** — blocked upstream in
+  PanamaPort, not by Kanama's keep rules. Root-caused on a Pixel 7 (2026-06-26):
+  a minified Match3 release APK builds and the GDExtension loads and runs
+  (`GodotPluginRegistry` initializes `KanamaAndroid`, `libkanama_bootstrap.so`
+  loads, `kanama_entry` runs, `KanamaBinding.init` executes), then crashes in
+  PanamaPort's FFI bootstrap at `nativeLinker().downcallHandle()` with
+  `AssertionError: Should not reach here`. The recurring
+  `No loader found for resource: res://kotlin-src/*.kt` (and the flickering
+  splash) is downstream of that crash — the `.kt` loader never registers.
+  Deobfuscated, PanamaPort's Android linker (`_AndroidLinkerImpl`) builds native
+  stubs with Java pattern-matching `switch`es over sealed types
+  (`_LLVMStorageDescriptor` storages and the `MemoryLayout` hierarchy), and
+  Godot 4.7's R8 (AGP 8.6.1) mis-optimizes those switches so they fall through
+  to `default -> Utils.shouldNotReachHere()`. This is unfixable from consumer
+  keep rules: keeping the sealed types (even no-shrink-only) blocks the
+  optimization PanamaPort's own `@CheckDiscard` rules require (scalarizing
+  `_ScopedMemoryAccess$SessionLock` in the VarHandle accessors), failing the
+  build; not keeping them leaves the switch broken at runtime. PanamaPort `Core`
+  tops out at `v0.1.3` on Maven Central, so there is no upgrade to pull; the fix
+  must come from upstream. Until then, ship Android release builds **without**
+  minify (debug-signed release or `minifyEnabled=false`). The plugin AAR's
+  `android/godot-plugin/plugin/consumer-rules.pro` covers the Kanama/Godot
+  surface and silences PanamaPort warnings but deliberately keeps **no**
+  `com.v7878.**` classes (any such keep breaks the build). The failure is
+  reproducible with `scripts/android_export_minified.sh` for an upstream report.
 
 ## Validation Shape
 

--- a/docs/internals/active/ios-backend-roadmap.md
+++ b/docs/internals/active/ios-backend-roadmap.md
@@ -150,8 +150,13 @@ Reduce ad hoc exceptions:
 
 Android still needs release-grade validation alongside iOS:
 
-- Pixel 7 / current-device smoke on Godot 4.7 stable.
-- R8-minified APK smoke gate for `consumer-rules.pro`.
+- Pixel 7 / current-device smoke on Godot 4.7 stable. _(Debug matrix passed
+  2026-06-26.)_
+- R8-minified APK smoke gate for `consumer-rules.pro`. _(Blocked upstream:
+  root-caused 2026-06-26 to PanamaPort's sealed-type switches being
+  mis-optimized by Godot 4.7's R8; not fixable from keep rules. R8/minify is
+  unsupported until upstream resolves it — see `docs/exporting/android.md` and
+  architecture-review F2. Release builds ship without minify.)_
 - Check that package/install flows remain intact after mobile generator changes.
 
 ### 5. Release Support Decision

--- a/docs/internals/reference/architecture-review-2026-06.md
+++ b/docs/internals/reference/architecture-review-2026-06.md
@@ -3,8 +3,9 @@
 External review of the Kanama runtime architecture, target support
 (Desktop/Android/iOS), and performance posture, performed against the
 0.2.2 preview line (now Godot 4.7 stable; originally reviewed against the
-4.7 rc 2 baseline). Findings F1–F2 were fixed in the same pass; F3–F4 have
-since been addressed as bounded follow-ups in
+4.7 rc 2 baseline). Finding F1 was fixed in the same pass; F2 is now
+root-caused and blocked upstream (R8/minify unsupported via PanamaPort);
+F3–F4 have since been addressed as bounded follow-ups in
 [wrapper-coverage-tracker.md](../active/wrapper-coverage-tracker.md).
 
 ## Verdict
@@ -94,16 +95,33 @@ registration when `get_proc_address` returns NULL. Fixed: all descriptor
 sources (generators in `build.gradle.kts`, `example_project` addon,
 Android plugin assets) now declare `4.7`, matching the actual baseline.
 
-### F2 — Gap (scaffolded): no R8/ProGuard rules
+### F2 — Gap (blocked upstream): R8/minify unsupported via PanamaPort
 
 Obfuscation-resistant script packaging is a stated project motivation,
 yet the Android plugin shipped no keep rules and no consumer ProGuard
 wiring. Scaffolded in this pass:
 `android/godot-plugin/plugin/consumer-rules.pro` (JNI bootstrap entry,
-Panama upcall targets, KSP registrars, annotations, PanamaPort
-internals) wired via `consumerProguardFiles`. An R8-minified APK smoke
-pass remains a pending validation gate — the keep rules are conservative
-and unvalidated against an actual minified build.
+Panama upcall targets, KSP registrars, annotations) wired via
+`consumerProguardFiles`.
+
+Validation on a Pixel 7 (2026-06-26) root-caused why an R8-minified APK
+fails at runtime, and the result is that **R8/minify cannot be supported
+from keep rules**. The GDExtension loads and `KanamaBinding.init` runs;
+the crash is inside PanamaPort's FFI bootstrap at
+`nativeLinker().downcallHandle()` (`AssertionError: Should not reach
+here`). PanamaPort's Android linker uses Java pattern-matching `switch`es
+over sealed types (`_LLVMStorageDescriptor` storages, the `MemoryLayout`
+hierarchy) that Godot 4.7's R8 (AGP 8.6.1) mis-optimizes into the
+`default -> shouldNotReachHere()` branch. It is a hard contradiction:
+keeping the sealed types blocks the optimization PanamaPort's own
+`@CheckDiscard` rules require (so the build fails the discard check), and
+not keeping them leaves the switch broken at runtime. PanamaPort `Core`
+is at `v0.1.3` (latest on Maven Central), so the fix must come upstream.
+`consumer-rules.pro` therefore keeps no `com.v7878.**` classes (any such
+keep breaks the build) and only `-dontwarn`s them; the failure is
+reproducible via `scripts/android_export_minified.sh`. Until upstream
+resolves it, Android release builds ship without minify. See
+`docs/exporting/android.md` → "Current Boundaries".
 
 ### F3 — Performance follow-up: per-call confined arenas in generated wrappers
 

--- a/scripts/android_export_minified.sh
+++ b/scripts/android_export_minified.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproducible R8-minified Android release smoke for the Kanama plugin.
+#
+# Godot's stock Android Gradle template ships no minify support, and a forked
+# `android_source.zip` would be version-locked to one Godot release. Instead
+# this script PATCHES the generated `<demo>/android/build/build.gradle` after
+# the template is installed, so it survives Godot export-template upgrades.
+#
+# Flow:
+#   - build + install the Kanama Android plugin AAR into the demo,
+#   - install/refresh the Godot Android build template,
+#   - inject `minifyEnabled true` into the release buildType,
+#   - export a *release* APK (R8 runs, consumer-rules.pro applies),
+#   - install, launch, and assert Kanama starts past the PanamaPort FFI
+#     bootstrap (the R8 gate this validates).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/android_export_minified.sh /path/to/godot /path/to/demo package.name [/path/to/output.apk]
+
+Required environment:
+  ANDROID_HOME or ANDROID_SDK_ROOT
+
+Optional environment:
+  ADB=/path/to/adb
+  KANAMA_DEMO_JAVA_HOME=/path/to/jdk25
+  KANAMA_ANDROID_LOG=/path/to/logcat.txt
+  KANAMA_ANDROID_LAUNCH_WAIT=30
+  # Release signing (defaults to the standard Android debug keystore so the
+  # minified release APK is installable without per-machine editor settings):
+  KANAMA_RELEASE_KEYSTORE=$HOME/.android/debug.keystore
+  KANAMA_RELEASE_KEYSTORE_USER=androiddebugkey
+  KANAMA_RELEASE_KEYSTORE_PASSWORD=android
+EOF
+}
+
+if [[ $# -lt 3 || $# -gt 4 ]]; then
+  usage
+  exit 2
+fi
+
+GODOT_BIN="$1"
+DEMO_DIR="$2"
+PACKAGE_NAME="$3"
+APK_PATH="${4:-/tmp/kanama-android-minified.apk}"
+LOG_FILE="${KANAMA_ANDROID_LOG:-/tmp/kanama_android_minified.log}"
+LAUNCH_WAIT="${KANAMA_ANDROID_LAUNCH_WAIT:-30}"
+
+ANDROID_SDK_DIR="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [[ -z "$ANDROID_SDK_DIR" ]]; then
+  echo "[android_minified] missing ANDROID_HOME or ANDROID_SDK_ROOT" >&2
+  exit 2
+fi
+ADB_BIN="${ADB:-$ANDROID_SDK_DIR/platform-tools/adb}"
+
+if [[ ! -x "$GODOT_BIN" ]]; then
+  echo "[android_minified] Godot binary is not executable: $GODOT_BIN" >&2
+  exit 2
+fi
+if [[ ! -d "$DEMO_DIR" ]]; then
+  echo "[android_minified] demo directory does not exist: $DEMO_DIR" >&2
+  exit 2
+fi
+if [[ ! -x "$ADB_BIN" ]]; then
+  echo "[android_minified] adb is not executable: $ADB_BIN" >&2
+  exit 2
+fi
+
+# --- Release signing: default to the standard Android debug keystore. --------
+KEYSTORE="${KANAMA_RELEASE_KEYSTORE:-$HOME/.android/debug.keystore}"
+KEYSTORE_USER="${KANAMA_RELEASE_KEYSTORE_USER:-androiddebugkey}"
+KEYSTORE_PASSWORD="${KANAMA_RELEASE_KEYSTORE_PASSWORD:-android}"
+if [[ ! -f "$KEYSTORE" && "$KEYSTORE" == "$HOME/.android/debug.keystore" ]]; then
+  echo "[android_minified] generating Android debug keystore at $KEYSTORE"
+  mkdir -p "$(dirname "$KEYSTORE")"
+  keytool -genkeypair -v -keystore "$KEYSTORE" -storepass android -keypass android \
+    -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
+    -dname "CN=Android Debug,O=Android,C=US"
+fi
+if [[ ! -f "$KEYSTORE" ]]; then
+  echo "[android_minified] release keystore not found: $KEYSTORE" >&2
+  exit 2
+fi
+# Godot reads these env vars for headless release signing.
+export GODOT_ANDROID_KEYSTORE_RELEASE_PATH="$KEYSTORE"
+export GODOT_ANDROID_KEYSTORE_RELEASE_USER="$KEYSTORE_USER"
+export GODOT_ANDROID_KEYSTORE_RELEASE_PASSWORD="$KEYSTORE_PASSWORD"
+
+check_log() {
+  local pattern="$1"
+  if ! rg -q "$pattern" "$LOG_FILE"; then
+    echo "[android_minified] missing log pattern: $pattern" >&2
+    echo "[android_minified] log tail:" >&2
+    tail -n 200 "$LOG_FILE" >&2
+    exit 1
+  fi
+}
+
+check_log_absent() {
+  local pattern="$1"
+  if rg -q "$pattern" "$LOG_FILE"; then
+    echo "[android_minified] unexpected log pattern: $pattern" >&2
+    echo "[android_minified] log tail:" >&2
+    tail -n 200 "$LOG_FILE" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  if [[ "${PACKAGE_LAUNCHED:-0}" == "1" ]]; then
+    "$ADB_BIN" shell am force-stop "$PACKAGE_NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[android_minified] demo: $DEMO_DIR"
+if [[ -x "$DEMO_DIR/gradlew" ]]; then
+  echo "[android_minified] build demo scripts"
+  if [[ -n "${KANAMA_DEMO_JAVA_HOME:-}" ]]; then
+    JAVA_HOME="$KANAMA_DEMO_JAVA_HOME" "$DEMO_DIR/gradlew" -p "$DEMO_DIR" jar
+  else
+    "$DEMO_DIR/gradlew" -p "$DEMO_DIR" jar
+  fi
+fi
+
+echo "[android_minified] build + install Kanama AAR"
+ANDROID_HOME="$ANDROID_SDK_DIR" ANDROID_SDK_ROOT="$ANDROID_SDK_DIR" \
+  "$ROOT_DIR/gradlew" -p "$ROOT_DIR" installAndroidPluginAar \
+  -PkanamaAndroidDemoDir="$DEMO_DIR"
+
+# 1) Install/refresh the Godot Android build template (regenerates build.gradle).
+echo "[android_minified] install android build template"
+"$GODOT_BIN" --headless --path "$DEMO_DIR" --install-android-build-template --quit >/dev/null 2>&1 || true
+
+BUILD_GRADLE="$DEMO_DIR/android/build/build.gradle"
+if [[ ! -f "$BUILD_GRADLE" ]]; then
+  echo "[android_minified] generated build.gradle not found: $BUILD_GRADLE" >&2
+  echo "[android_minified] is gradle_build/use_gradle_build=true in the export preset?" >&2
+  exit 1
+fi
+
+# 2) Inject minify into the generated build.gradle (idempotent, marker-guarded).
+#    Re-opens the existing release buildType, so we don't depend on the template's
+#    internal block layout. Survives Godot template upgrades.
+# PanamaPort's annotation-driven R8 rules (R8Annotations) are written against
+# R8 compat mode. AGP 8+ defaults to R8 full mode, which is more aggressive and
+# corrupts PanamaPort's LLVM downcall-stub type dispatch -> shouldNotReachHere at
+# nativeLinker().downcallHandle(). Force compat mode for the minified build.
+GP="$DEMO_DIR/android/build/gradle.properties"
+if [[ -f "$GP" ]] && grep -q "android.enableR8.fullMode" "$GP"; then
+  /usr/bin/sed -i '' 's/^android.enableR8.fullMode=.*/android.enableR8.fullMode=false/' "$GP"
+else
+  printf '\nandroid.enableR8.fullMode=false\n' >>"$GP"
+fi
+
+# Drop any stale rules file from earlier script versions.
+rm -f "$DEMO_DIR/android/build/kanama-minify.pro"
+
+# Re-apply the patch fresh every run. --install-android-build-template does not
+# always regenerate build.gradle, so a skip-if-present guard would reuse a stale
+# patch; strip our previous block (marker -> EOF) and re-append.
+MARKER="kanama-r8-minify"
+if grep -q "$MARKER" "$BUILD_GRADLE"; then
+  /usr/bin/sed -i '' "/=== $MARKER /,\$d" "$BUILD_GRADLE"
+fi
+echo "[android_minified] patching $BUILD_GRADLE (enable R8 on release)"
+cat >>"$BUILD_GRADLE" <<'GRADLE'
+
+// === kanama-r8-minify (injected by scripts/android_export_minified.sh) ===
+// Godot's stock Android template ships no minify support. Enable R8 on the
+// release build here, on the generated output, so this survives Godot
+// export-template upgrades instead of forking android_source.zip. The Kanama
+// AAR's consumer-rules.pro is applied automatically by R8. R8 compat mode is
+// forced via gradle.properties (android.enableR8.fullMode=false) so PanamaPort's
+// annotation-driven rules behave as designed.
+android {
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt')
+        }
+    }
+}
+GRADLE
+
+# 3) Export the release APK WITHOUT reinstalling the template (keeps the patch).
+echo "[android_minified] export release (R8): $APK_PATH"
+"$GODOT_BIN" --headless \
+  --path "$DEMO_DIR" \
+  --export-release Android "$APK_PATH"
+
+if [[ ! -f "$APK_PATH" ]]; then
+  echo "[android_minified] export did not produce an APK: $APK_PATH" >&2
+  exit 1
+fi
+
+echo "[android_minified] install: $PACKAGE_NAME"
+"$ADB_BIN" start-server >/dev/null
+"$ADB_BIN" install -r "$APK_PATH" >/dev/null
+"$ADB_BIN" logcat -c
+"$ADB_BIN" shell am force-stop "$PACKAGE_NAME" >/dev/null 2>&1 || true
+"$ADB_BIN" shell monkey -p "$PACKAGE_NAME" -c android.intent.category.LAUNCHER 1 >/dev/null
+PACKAGE_LAUNCHED=1
+sleep "$LAUNCH_WAIT"
+APP_PID="$("$ADB_BIN" shell pidof -s "$PACKAGE_NAME" 2>/dev/null | tr -d '\r' || true)"
+if [[ -n "$APP_PID" ]]; then
+  "$ADB_BIN" logcat --pid "$APP_PID" -d >"$LOG_FILE"
+else
+  "$ADB_BIN" logcat -d >"$LOG_FILE"
+fi
+
+# Positive: Kanama started past the PanamaPort FFI bootstrap and registered.
+check_log "Initializing Godot plugin KanamaAndroid"
+check_log "registered KanamaResourceFormatLoader for \\.kt"
+
+# Negative: the R8 failure signatures must be gone.
+check_log_absent "Should not reach here"
+check_log_absent "GDExtension initialization function 'kanama_entry' returned an error"
+check_log_absent "Error loading extension"
+check_log_absent "No loader found for resource: res://kotlin-src"
+check_log_absent "FATAL EXCEPTION"
+
+echo "[android_minified] PASS (R8-minified release boots Kanama)"


### PR DESCRIPTION
## What

Android R8-minified release APKs get stuck/flickering at the splash screen. This PR **root-causes** it, records it as a known limitation, and lands a reproducible harness — it does **not** claim to fix R8 (that needs an upstream PanamaPort change, tracked as task 20).

## Root cause (Pixel 7, 2026-06-26)

The GDExtension loads fine and `KanamaBinding.init` runs; the crash is inside PanamaPort at the first `nativeLinker().downcallHandle()`:

```
java.lang.AssertionError: Should not reach here
  at com.v7878.unsafe.Utils.shouldNotReachHere()
  at com.v7878.foreign._AndroidLinkerImpl.sdToLLVMType(...)
  at com.v7878.foreign._AbstractAndroidLinker.downcallHandle(...)
```

`_AndroidLinkerImpl` builds native stubs with Java pattern-matching `switch`es over sealed types (`_LLVMStorageDescriptor` storages and the `MemoryLayout` hierarchy). Godot 4.7's R8 (AGP 8.6.1) mis-optimizes those sealed types so the switch falls through to `default -> shouldNotReachHere()`. The recurring `No loader found for resource: res://kotlin-src/*.kt` (and the flicker) is **downstream** of this crash — the `.kt` loader never registers.

## Why keep rules can't fix it

Hard contradiction, proven across ~10 device cycles:
- **Keep the sealed types** (any form) → R8 can't scalarize `_ScopedMemoryAccess$SessionLock` in the VarHandle accessors, which PanamaPort's own `@CheckDiscard` rules require → `R8: Discard checks failed` → build fails.
- **Don't keep them** → runtime `shouldNotReachHere`.

PanamaPort `Core` is at `v0.1.3` (latest on Maven Central), so the fix must come upstream.

## Changes

- `consumer-rules.pro` — remove the `com.v7878.**` keeps (any keep breaks the build), document the contradiction, keep only `-dontwarn`.
- `docs/exporting/android.md` — R8/minify marked **unsupported** with the precise root cause + "ship release without minify."
- architecture-review **F2** + roadmap "Android Hardening" — reframed from *scaffolded/pending* to *blocked upstream*.
- `scripts/android_export_minified.sh` — reproducible R8 minify harness. Patches Godot's generated Gradle build (survives export-template upgrades; no forked `android_source.zip`), exports a real R8 release APK, installs, and asserts startup. Currently fails by design — it's the gate/repro.

## Follow-up

Tracked as **kanama-tasks #20 — Fork PanamaPort for Android R8**: annotate PanamaPort's sealed switch sites with its own R8 annotations (which coexist with `@CheckDiscard` where consumer keeps can't), or replace the pattern-switches; build a fork, validate with the harness, and file upstream.

Debug and non-minified release builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)