### PR TITLE
Validate Android R8 with PanamaPort fork

### DIFF
--- a/android/godot-plugin/plugin/build.gradle.kts
+++ b/android/godot-plugin/plugin/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 val kanamaRoot = rootProject.layout.projectDirectory.dir("../..")
 val demoDir = providers.gradleProperty("kanamaAndroidDemoDir").map { file(it) }
 val androidKanamaSources = layout.buildDirectory.dir("generated/kanamaAndroidSources")
+val panamaPortCoreDependency = providers.gradleProperty("kanamaPanamaPortCore")
+    .orElse("io.github.vova7878.panama:Core:0.1.3-kanama-r8.1")
 
 data class AndroidSourceRemapRule(
     val name: String,
@@ -277,6 +279,6 @@ tasks.named("preBuild") {
 
 dependencies {
     compileOnly(project(":godot-stubs"))
-    implementation("io.github.vova7878.panama:Core:v0.1.3")
+    implementation(panamaPortCoreDependency)
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
 }

--- a/android/godot-plugin/plugin/build.gradle.kts
+++ b/android/godot-plugin/plugin/build.gradle.kts
@@ -6,7 +6,7 @@ val kanamaRoot = rootProject.layout.projectDirectory.dir("../..")
 val demoDir = providers.gradleProperty("kanamaAndroidDemoDir").map { file(it) }
 val androidKanamaSources = layout.buildDirectory.dir("generated/kanamaAndroidSources")
 val panamaPortCoreDependency = providers.gradleProperty("kanamaPanamaPortCore")
-    .orElse("io.github.vova7878.panama:Core:0.1.3-kanama-r8.1")
+    .orElse("com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2")
 
 data class AndroidSourceRemapRule(
     val name: String,

--- a/android/godot-plugin/plugin/consumer-rules.pro
+++ b/android/godot-plugin/plugin/consumer-rules.pro
@@ -6,7 +6,7 @@
 # classes free to be obfuscated by the game's own configuration.
 #
 # STATUS: R8 minification is validated with Kanama's PanamaPort fork
-# (`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`). Upstream PanamaPort
+# (`com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`). Upstream PanamaPort
 # v0.1.3 still has the sealed-switch R8 issue documented below, so these rules
 # keep only the Kanama/Godot reflective surface and still avoid broad
 # `com.v7878.**` keeps.

--- a/android/godot-plugin/plugin/consumer-rules.pro
+++ b/android/godot-plugin/plugin/consumer-rules.pro
@@ -5,12 +5,11 @@
 # reflective surfaces the Kanama runtime needs while leaving game script
 # classes free to be obfuscated by the game's own configuration.
 #
-# STATUS: R8 minification is BLOCKED upstream (root-caused 2026-06-26). The
-# minified GDExtension loads and runs fine up to KanamaBinding.init; it then dies
-# in PanamaPort's FFI bootstrap (see the com.v7878.** note below). This is a
-# PanamaPort-vs-R8 incompatibility that consumer keep rules cannot resolve, so
-# these rules only cover the Kanama/Godot surface and silence PanamaPort warnings.
-# Ship Android release builds WITHOUT minify until upstream resolves it.
+# STATUS: R8 minification is validated with Kanama's PanamaPort fork
+# (`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`). Upstream PanamaPort
+# v0.1.3 still has the sealed-switch R8 issue documented below, so these rules
+# keep only the Kanama/Godot reflective surface and still avoid broad
+# `com.v7878.**` keeps.
 
 # Godot Android native code and plugin startup resolve parts of the Java
 # template by JNI/reflection while bootstrapping the engine. Keep the Godot
@@ -21,10 +20,11 @@
 # Godot discovers Android plugins through manifest metadata string values.
 -keep class net.multigesture.kanama.android.** { *; }
 
-# Bootstrap entry: bootstrap.c resolves this class and its static
-# init(JJJ)V method by name via JNI (FindClass / GetStaticMethodID).
+# Bootstrap entry: bootstrap.c resolves init(JJJ)V by name via JNI, and
+# KanamaBinding resolves its lifecycle callbacks by string via
+# MethodHandles.lookup().findStatic(...). Keep this one class's member names.
 -keep class net.multigesture.kanama.KanamaBinding {
-    public static void init(long, long, long);
+    *;
 }
 
 # Panama upcall/downcall targets are resolved via MethodHandles.lookup()
@@ -42,9 +42,9 @@
 -keep @interface net.multigesture.kanama.annotation.** { *; }
 -keepattributes RuntimeVisibleAnnotations, RuntimeInvisibleAnnotations
 
-# PanamaPort (com.v7878.**) KNOWN LIMITATION: R8 minification is not currently
-# supported. PanamaPort's Android linker generates native downcall/upcall stubs
-# with Java pattern-matching `switch`es over sealed type families -- the storage
+# PanamaPort (com.v7878.**) KNOWN LIMITATION IN UPSTREAM v0.1.3: PanamaPort's
+# Android linker generates native downcall/upcall stubs with Java
+# pattern-matching `switch`es over sealed type families -- the storage
 # descriptors (_LLVMStorageDescriptor.LLVMStorage) and the MemoryLayout hierarchy
 # (_AndroidLinkerImpl.sdToLLVMType / layoutToLLVMType / layoutName). Godot 4.7's
 # R8 (AGP 8.6.1) mis-handles those switches when it optimizes the sealed types,
@@ -58,11 +58,9 @@
 # _ScopedMemoryAccess$SessionLock allocations in the _VarHandleSegmentAs*
 # accessors those layouts flow through -- so the build fails the discard check.
 # Keep them and the build breaks; don't and the switch breaks at runtime. The
-# fix must come from upstream (a PanamaPort release that keeps R8 from optimizing
-# its sealed switches, or a newer R8) -- PanamaPort Core tops out at v0.1.3 on
-# Maven Central today. Until then, ship Android without R8/minify (debug-signed
-# release or minifyEnabled=false). scripts/android_export_minified.sh reproduces
-# the failure for an upstream report.
+# fix must come from PanamaPort source (or upstream) -- not consumer keep rules.
+# Kanama's fork rewrites the affected switch sites to explicit `instanceof`
+# branches and was validated by scripts/android_export_minified.sh on Pixel 7.
 #
 # PanamaPort references desktop-only / hidden symbols on code paths it does not
 # take on Android; keep R8 from turning those into app warnings.

--- a/android/godot-plugin/settings.gradle.kts
+++ b/android/godot-plugin/settings.gradle.kts
@@ -12,6 +12,7 @@ dependencyResolutionManagement {
         mavenLocal()
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 

--- a/android/godot-plugin/settings.gradle.kts
+++ b/android/godot-plugin/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }
@@ -18,4 +19,3 @@ rootProject.name = "kanama-godot-android-plugin"
 
 include(":godot-stubs")
 include(":plugin")
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ version = "0.2.2"
 
 val packageMavenRepositoryDir = layout.buildDirectory.dir("package/maven")
 val panamaPortCoreDependency = providers.gradleProperty("kanamaPanamaPortCore")
-    .orElse("io.github.vova7878.panama:Core:0.1.3-kanama-r8.1")
+    .orElse("com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2")
 
 fun PublishingExtension.addKanamaPackageRepository() {
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ group = "net.multigesture.kanama"
 version = "0.2.2"
 
 val packageMavenRepositoryDir = layout.buildDirectory.dir("package/maven")
+val panamaPortCoreDependency = providers.gradleProperty("kanamaPanamaPortCore")
+    .orElse("io.github.vova7878.panama:Core:0.1.3-kanama-r8.1")
 
 fun PublishingExtension.addKanamaPackageRepository() {
     repositories {
@@ -1290,6 +1292,7 @@ tasks.register<Exec>("assembleAndroidPluginAar") {
             "android/godot-plugin",
             ":plugin:assembleDebug",
             "-PkanamaAndroidDemoDir=${kanamaAndroidDemoDir.get()}",
+            "-PkanamaPanamaPortCore=${panamaPortCoreDependency.get()}",
         )
     }
 }
@@ -1324,7 +1327,7 @@ tasks.register("installAndroidPluginAar") {
             |binary="KanamaAndroid.debug.aar"
             |
             |[dependencies]
-            |remote=["io.github.vova7878.panama:Core:v0.1.3"]
+            |remote=["${panamaPortCoreDependency.get()}"]
             |""".trimMargin(),
         )
 

--- a/docs/contributing/android-internals.md
+++ b/docs/contributing/android-internals.md
@@ -6,9 +6,10 @@ API/build flow is less settled than the desktop path.
 
 ## What Works
 
-Eight Kanama demo exports are Android smoke targets. The Godot 4.7 stable
-emulator smoke path has re-passed for Starter-Kit-Match3; Pixel 7 hardware
-coverage remains pending before a stronger Android claim:
+Eight Kanama demo exports are Android smoke targets. On 2026-06-26, the Godot
+4.7 stable demo matrix passed on Pixel 7 with debug APK exports, and
+Starter-Kit-Match3 also passed the R8-minified release smoke with Kanama's
+PanamaPort fork:
 
 - `godot-demo-2d-dodge-the-creeps`
 - `Starter-Kit-3D-Platformer`
@@ -33,17 +34,21 @@ The exported APK path:
 - reaches `OnGodotMainLoopStarted`, and
 - renders the 3D scene through Godot's OpenGL compatibility renderer.
 
-This proves the basic Kanama runtime path is viable on Android. Treat it as
-experimental support, not a production-ready mobile target.
+This proves the basic Kanama runtime path is viable on Android, including the
+current forked-PanamaPort minified path. Treat it as experimental support, not a
+production-ready mobile target.
 
 ## PanamaPort
 
-The current Android implementation did not require editing
-[PanamaPort](https://github.com/vova7878/PanamaPort). The Android build
-consumes `io.github.vova7878.panama:Core:v0.1.3` as a dependency.
+The Android implementation uses a forked
+[PanamaPort](https://github.com/vova7878/PanamaPort) artifact:
+`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`.
 
-A fork is not part of the current implementation. Kanama currently consumes the
-published artifact directly.
+Upstream PanamaPort `v0.1.3` miscompiles under Godot 4.7's R8 because its
+Android linker uses Java pattern switches over sealed storage/layout types. The
+fork rewrites the affected switch sites to explicit `instanceof` chains and is
+published to the configured local Maven repository for Android exports. Keep the
+fork diff small and retire it when the upstream artifact carries the fix.
 
 ## Desktop vs Android FFM
 

--- a/docs/contributing/android-internals.md
+++ b/docs/contributing/android-internals.md
@@ -41,8 +41,9 @@ production-ready mobile target.
 ## PanamaPort
 
 The Android implementation uses a forked
-[PanamaPort](https://github.com/vova7878/PanamaPort) artifact:
-`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`.
+[PanamaPort](https://github.com/vova7878/PanamaPort) artifact, published via
+[JitPack](https://jitpack.io):
+`com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`.
 
 Upstream PanamaPort `v0.1.3` miscompiles under Godot 4.7's R8 because its
 Android linker uses Java pattern switches over sealed storage/layout types. The

--- a/docs/exporting/android.md
+++ b/docs/exporting/android.md
@@ -18,7 +18,7 @@ Eight public demo exports are Android smoke targets. On 2026-06-26, the full
 Godot 4.7 stable matrix passed on a Pixel 7 using debug APK exports, logcat
 startup checks, and screenshot smoke checks. The R8-minified Match3 release APK
 also passed on Pixel 7 when built against Kanama's PanamaPort fork
-(`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`). Android remains
+(`com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`). Android remains
 experimental, and the minified-release claim is tied to that forked dependency,
 not upstream PanamaPort `v0.1.3`.
 
@@ -195,7 +195,7 @@ before exiting.
 - Godot 4.7 `VirtualJoystick` wrappers are available in Kanama, but demo-level
   touch-control polish remains a project-specific validation claim.
 - R8/ProGuard minification is validated only with Kanama's PanamaPort fork,
-  `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`. Root-caused on a Pixel 7
+  `com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`. Root-caused on a Pixel 7
   (2026-06-26), upstream PanamaPort `v0.1.3` crashes in the FFI bootstrap at
   `nativeLinker().downcallHandle()` with `AssertionError: Should not reach
   here`; the recurring `No loader found for resource: res://kotlin-src/*.kt`
@@ -223,8 +223,9 @@ unless broader physical-device and renderer coverage are added later.
 
 Kanama's Android plugin currently consumes a forked
 [PanamaPort](https://github.com/vova7878/PanamaPort)
-artifact, `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`. The dependency can
-be overridden with `-PkanamaPanamaPortCore=...`, and the Android export scripts
-inject the configured local Maven repository into Godot's generated Gradle
-project. Upstream PanamaPort `v0.1.3` from Maven Central is not an R8-supported
-release path for Kanama.
+artifact, `com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`, published
+via [JitPack](https://jitpack.io) from Kanama's PanamaPort fork. The dependency
+can be overridden with `-PkanamaPanamaPortCore=...`, and the Android export
+scripts inject the JitPack repository (alongside the local Maven repository, for
+fork iteration) into Godot's generated Gradle project. Upstream PanamaPort
+`v0.1.3` from Maven Central is not an R8-supported release path for Kanama.

--- a/docs/exporting/android.md
+++ b/docs/exporting/android.md
@@ -16,10 +16,11 @@ for testing Kanama games on Android.
 
 Eight public demo exports are Android smoke targets. On 2026-06-26, the full
 Godot 4.7 stable matrix passed on a Pixel 7 using debug APK exports, logcat
-startup checks, and screenshot smoke checks. Android remains experimental, and
-R8/minify is unsupported: the obfuscated release path is blocked upstream in
-PanamaPort (see "Current Boundaries"), so release builds must ship without
-minify for now.
+startup checks, and screenshot smoke checks. The R8-minified Match3 release APK
+also passed on Pixel 7 when built against Kanama's PanamaPort fork
+(`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`). Android remains
+experimental, and the minified-release claim is tied to that forked dependency,
+not upstream PanamaPort `v0.1.3`.
 
 | Demo | Current Result |
 |---|---|
@@ -32,9 +33,9 @@ minify for now.
 | `godot-4-3d-character-controller-tutorial` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with virtual joystick controls. |
 | `godot-4-3d-third-person-controller` | APK exports, launches, initializes Kanama, reaches the main loop, and passes screenshot smoke checks with virtual joystick controls. |
 
-The Pixel 7 debug matrix does not imply release-obfuscated support. R8/minify is
-blocked upstream in PanamaPort (see "Current Boundaries"); obfuscated-build
-support cannot be claimed until that is resolved upstream.
+The Pixel 7 debug matrix and minified Match3 gate do not imply a broad release
+support tier yet. They validate the current OpenGL Compatibility Android path
+and the forked-PanamaPort R8 path for the covered demos.
 
 The validated Android demos currently use Godot's OpenGL Compatibility renderer.
 Desktop demos can continue using their normal renderer. Vulkan/Mobile-renderer
@@ -193,31 +194,23 @@ before exiting.
 - Some unsupported ASTC textures may be converted at runtime by the emulator.
 - Godot 4.7 `VirtualJoystick` wrappers are available in Kanama, but demo-level
   touch-control polish remains a project-specific validation claim.
-- R8/ProGuard minification is **not supported** — blocked upstream in
-  PanamaPort, not by Kanama's keep rules. Root-caused on a Pixel 7 (2026-06-26):
-  a minified Match3 release APK builds and the GDExtension loads and runs
-  (`GodotPluginRegistry` initializes `KanamaAndroid`, `libkanama_bootstrap.so`
-  loads, `kanama_entry` runs, `KanamaBinding.init` executes), then crashes in
-  PanamaPort's FFI bootstrap at `nativeLinker().downcallHandle()` with
-  `AssertionError: Should not reach here`. The recurring
-  `No loader found for resource: res://kotlin-src/*.kt` (and the flickering
-  splash) is downstream of that crash — the `.kt` loader never registers.
-  Deobfuscated, PanamaPort's Android linker (`_AndroidLinkerImpl`) builds native
-  stubs with Java pattern-matching `switch`es over sealed types
-  (`_LLVMStorageDescriptor` storages and the `MemoryLayout` hierarchy), and
-  Godot 4.7's R8 (AGP 8.6.1) mis-optimizes those switches so they fall through
-  to `default -> Utils.shouldNotReachHere()`. This is unfixable from consumer
-  keep rules: keeping the sealed types (even no-shrink-only) blocks the
-  optimization PanamaPort's own `@CheckDiscard` rules require (scalarizing
-  `_ScopedMemoryAccess$SessionLock` in the VarHandle accessors), failing the
-  build; not keeping them leaves the switch broken at runtime. PanamaPort `Core`
-  tops out at `v0.1.3` on Maven Central, so there is no upgrade to pull; the fix
-  must come from upstream. Until then, ship Android release builds **without**
-  minify (debug-signed release or `minifyEnabled=false`). The plugin AAR's
-  `android/godot-plugin/plugin/consumer-rules.pro` covers the Kanama/Godot
-  surface and silences PanamaPort warnings but deliberately keeps **no**
-  `com.v7878.**` classes (any such keep breaks the build). The failure is
-  reproducible with `scripts/android_export_minified.sh` for an upstream report.
+- R8/ProGuard minification is validated only with Kanama's PanamaPort fork,
+  `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`. Root-caused on a Pixel 7
+  (2026-06-26), upstream PanamaPort `v0.1.3` crashes in the FFI bootstrap at
+  `nativeLinker().downcallHandle()` with `AssertionError: Should not reach
+  here`; the recurring `No loader found for resource: res://kotlin-src/*.kt`
+  and flickering splash are downstream of that crash. Deobfuscated, PanamaPort's
+  Android linker (`_AndroidLinkerImpl`) builds native stubs with Java
+  pattern-matching `switch`es over sealed types (`_LLVMStorageDescriptor`
+  storages and the `MemoryLayout` hierarchy), and Godot 4.7's R8 (AGP 8.6.1)
+  mis-optimizes those switches so they fall through to
+  `default -> Utils.shouldNotReachHere()`. This is unfixable from consumer keep
+  rules: keeping the sealed types blocks the optimization PanamaPort's own
+  `@CheckDiscard` rules require, failing the build; not keeping them leaves the
+  switch broken at runtime. The fork rewrites the affected source switch sites
+  to explicit `instanceof` branches and adds targeted R8 annotations/signing
+  mechanics. `scripts/android_export_minified.sh` now builds, installs, launches,
+  and verifies the minified Match3 release APK on Pixel 7.
 
 ## Validation Shape
 
@@ -228,10 +221,10 @@ unless broader physical-device and renderer coverage are added later.
 
 ## PanamaPort
 
-Kanama currently consumes
+Kanama's Android plugin currently consumes a forked
 [PanamaPort](https://github.com/vova7878/PanamaPort)
-`io.github.vova7878.panama:Core:v0.1.3` from Maven Central. The current Android
-work did not require PanamaPort edits, so Kanama does not need a fork today.
-
-Kanama can continue using the published PanamaPort artifact unless platform
-testing uncovers a dependency fix that cannot be handled upstream.
+artifact, `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`. The dependency can
+be overridden with `-PkanamaPanamaPortCore=...`, and the Android export scripts
+inject the configured local Maven repository into Godot's generated Gradle
+project. Upstream PanamaPort `v0.1.3` from Maven Central is not an R8-supported
+release path for Kanama.

--- a/docs/internals/active/ios-backend-roadmap.md
+++ b/docs/internals/active/ios-backend-roadmap.md
@@ -154,7 +154,7 @@ Android still needs release-grade validation alongside iOS:
   2026-06-26.)_
 - R8-minified APK smoke gate for `consumer-rules.pro`. _(Passed 2026-06-26 on
   Pixel 7 for Starter-Kit-Match3 using Kanama's PanamaPort fork
-  `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`; upstream PanamaPort
+  `com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`; upstream PanamaPort
   `v0.1.3` remains the unfixed sealed-switch path.)_
 - Check that package/install flows remain intact after mobile generator changes.
 

--- a/docs/internals/active/ios-backend-roadmap.md
+++ b/docs/internals/active/ios-backend-roadmap.md
@@ -152,11 +152,10 @@ Android still needs release-grade validation alongside iOS:
 
 - Pixel 7 / current-device smoke on Godot 4.7 stable. _(Debug matrix passed
   2026-06-26.)_
-- R8-minified APK smoke gate for `consumer-rules.pro`. _(Blocked upstream:
-  root-caused 2026-06-26 to PanamaPort's sealed-type switches being
-  mis-optimized by Godot 4.7's R8; not fixable from keep rules. R8/minify is
-  unsupported until upstream resolves it — see `docs/exporting/android.md` and
-  architecture-review F2. Release builds ship without minify.)_
+- R8-minified APK smoke gate for `consumer-rules.pro`. _(Passed 2026-06-26 on
+  Pixel 7 for Starter-Kit-Match3 using Kanama's PanamaPort fork
+  `io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`; upstream PanamaPort
+  `v0.1.3` remains the unfixed sealed-switch path.)_
 - Check that package/install flows remain intact after mobile generator changes.
 
 ### 5. Release Support Decision

--- a/docs/internals/reference/architecture-review-2026-06.md
+++ b/docs/internals/reference/architecture-review-2026-06.md
@@ -117,7 +117,7 @@ PanamaPort's own `@CheckDiscard` rules require, and not keeping them
 leaves the switch broken at runtime.
 
 Kanama now consumes a forked artifact,
-`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`, that rewrites the
+`com.github.falcon4ever.PanamaPort:Core:0.1.3-kanama-r8.2`, that rewrites the
 affected source switch sites to explicit `instanceof` chains and applies
 targeted R8 annotations. `consumer-rules.pro` keeps Kanama's own
 reflection/JNI surface, keeps no broad `com.v7878.**` classes, and only

--- a/docs/internals/reference/architecture-review-2026-06.md
+++ b/docs/internals/reference/architecture-review-2026-06.md
@@ -4,7 +4,7 @@ External review of the Kanama runtime architecture, target support
 (Desktop/Android/iOS), and performance posture, performed against the
 0.2.2 preview line (now Godot 4.7 stable; originally reviewed against the
 4.7 rc 2 baseline). Finding F1 was fixed in the same pass; F2 is now
-root-caused and blocked upstream (R8/minify unsupported via PanamaPort);
+validated with Kanama's PanamaPort fork for R8/minified Android exports;
 F3–F4 have since been addressed as bounded follow-ups in
 [wrapper-coverage-tracker.md](../active/wrapper-coverage-tracker.md).
 
@@ -66,7 +66,7 @@ The PanamaPort approach — string-level source remap of
 pragmatic. It is inherently fragile (textual rewriting of semantics),
 and the audit gates are the right mitigation. ABI coverage (arm64-v8a +
 x86_64), minSdk 26, and the Godot AAR plugin integration are all
-reasonable. See F2 for the R8 gap.
+reasonable. See F2 for the forked-PanamaPort R8 path.
 
 ### iOS (experimental, Kotlin/Native)
 
@@ -95,7 +95,7 @@ registration when `get_proc_address` returns NULL. Fixed: all descriptor
 sources (generators in `build.gradle.kts`, `example_project` addon,
 Android plugin assets) now declare `4.7`, matching the actual baseline.
 
-### F2 — Gap (blocked upstream): R8/minify unsupported via PanamaPort
+### F2 — Fixed with fork: R8/minify via PanamaPort
 
 Obfuscation-resistant script packaging is a stated project motivation,
 yet the Android plugin shipped no keep rules and no consumer ProGuard
@@ -104,24 +104,27 @@ wiring. Scaffolded in this pass:
 Panama upcall targets, KSP registrars, annotations) wired via
 `consumerProguardFiles`.
 
-Validation on a Pixel 7 (2026-06-26) root-caused why an R8-minified APK
-fails at runtime, and the result is that **R8/minify cannot be supported
-from keep rules**. The GDExtension loads and `KanamaBinding.init` runs;
-the crash is inside PanamaPort's FFI bootstrap at
-`nativeLinker().downcallHandle()` (`AssertionError: Should not reach
-here`). PanamaPort's Android linker uses Java pattern-matching `switch`es
-over sealed types (`_LLVMStorageDescriptor` storages, the `MemoryLayout`
-hierarchy) that Godot 4.7's R8 (AGP 8.6.1) mis-optimizes into the
-`default -> shouldNotReachHere()` branch. It is a hard contradiction:
-keeping the sealed types blocks the optimization PanamaPort's own
-`@CheckDiscard` rules require (so the build fails the discard check), and
-not keeping them leaves the switch broken at runtime. PanamaPort `Core`
-is at `v0.1.3` (latest on Maven Central), so the fix must come upstream.
-`consumer-rules.pro` therefore keeps no `com.v7878.**` classes (any such
-keep breaks the build) and only `-dontwarn`s them; the failure is
-reproducible via `scripts/android_export_minified.sh`. Until upstream
-resolves it, Android release builds ship without minify. See
-`docs/exporting/android.md` → "Current Boundaries".
+Validation on a Pixel 7 (2026-06-26) first root-caused why an
+R8-minified APK failed at runtime: upstream PanamaPort `v0.1.3` crashes
+inside `nativeLinker().downcallHandle()` (`AssertionError: Should not
+reach here`) after `KanamaBinding.init` starts. PanamaPort's Android
+linker uses Java pattern-matching `switch`es over sealed types
+(`_LLVMStorageDescriptor` storages, the `MemoryLayout` hierarchy) that
+Godot 4.7's R8 (AGP 8.6.1) mis-optimizes into the
+`default -> shouldNotReachHere()` branch. It is a hard contradiction for
+consumer rules: keeping the sealed types blocks the optimization
+PanamaPort's own `@CheckDiscard` rules require, and not keeping them
+leaves the switch broken at runtime.
+
+Kanama now consumes a forked artifact,
+`io.github.vova7878.panama:Core:0.1.3-kanama-r8.1`, that rewrites the
+affected source switch sites to explicit `instanceof` chains and applies
+targeted R8 annotations. `consumer-rules.pro` keeps Kanama's own
+reflection/JNI surface, keeps no broad `com.v7878.**` classes, and only
+`-dontwarn`s PanamaPort. `scripts/android_export_minified.sh` validated a
+minified Match3 release APK on Pixel 7: bootstrap installed Panama upcall
+stubs, registered the `.kt` loader, and avoided the prior
+`Should not reach here` / `Error loading extension` failure.
 
 ### F3 — Performance follow-up: per-call confined arenas in generated wrappers
 

--- a/docs/internals/reference/wrapper-coverage-roadmap.md
+++ b/docs/internals/reference/wrapper-coverage-roadmap.md
@@ -143,7 +143,7 @@ hand-shaped methods; coverage page reads ≥99% with virtuals counted.
 |---|---|---|
 | Extend `PtrcallScratch` thread-local pattern across generated wrappers (replace ~1,478 per-call `Arena.ofConfined()`) | **sonnet** (generator change), **opus** review | Architecture review F3 |
 | Single source of truth for the Godot version pin (Gradle property → CI, iOS template path, docs) | **sonnet** | Architecture review F4 |
-| R8-minified APK smoke gate (validate `consumer-rules.pro`) | **opus** | Architecture review F2 |
+| R8-minified APK smoke gate (validate `consumer-rules.pro`) | **done 2026-06-26** | Architecture review F2; passed on Pixel 7 with Kanama's PanamaPort fork |
 | Value-type `==` faithfulness to GDScript/C# (see below) | **sonnet** (generator change), **opus** review | 2026-06-15 session |
 
 ### Value-type equality divergence from GDScript/C# (all platforms)

--- a/scripts/android_export_minified.sh
+++ b/scripts/android_export_minified.sh
@@ -189,6 +189,7 @@ cat >>"$BUILD_GRADLE" <<'GRADLE'
 allprojects {
     repositories {
         mavenLocal()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/scripts/android_export_minified.sh
+++ b/scripts/android_export_minified.sh
@@ -49,6 +49,7 @@ PACKAGE_NAME="$3"
 APK_PATH="${4:-/tmp/kanama-android-minified.apk}"
 LOG_FILE="${KANAMA_ANDROID_LOG:-/tmp/kanama_android_minified.log}"
 LAUNCH_WAIT="${KANAMA_ANDROID_LAUNCH_WAIT:-30}"
+PANAMAPORT_MAVEN_REPO="${KANAMA_PANAMAPORT_MAVEN_REPO:-file://$HOME/.m2/repository}"
 
 ANDROID_SDK_DIR="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
 if [[ -z "$ANDROID_SDK_DIR" ]]; then
@@ -110,6 +111,17 @@ check_log_absent() {
   fi
 }
 
+set_gradle_property() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  if [[ -f "$file" ]] && grep -q "^$key=" "$file"; then
+    /usr/bin/sed -i '' "s|^$key=.*|$key=$value|" "$file"
+  else
+    printf '\n%s=%s\n' "$key" "$value" >>"$file"
+  fi
+}
+
 cleanup() {
   if [[ "${PACKAGE_LAUNCHED:-0}" == "1" ]]; then
     "$ADB_BIN" shell am force-stop "$PACKAGE_NAME" >/dev/null 2>&1 || true
@@ -151,11 +163,8 @@ fi
 # corrupts PanamaPort's LLVM downcall-stub type dispatch -> shouldNotReachHere at
 # nativeLinker().downcallHandle(). Force compat mode for the minified build.
 GP="$DEMO_DIR/android/build/gradle.properties"
-if [[ -f "$GP" ]] && grep -q "android.enableR8.fullMode" "$GP"; then
-  /usr/bin/sed -i '' 's/^android.enableR8.fullMode=.*/android.enableR8.fullMode=false/' "$GP"
-else
-  printf '\nandroid.enableR8.fullMode=false\n' >>"$GP"
-fi
+set_gradle_property "$GP" "android.enableR8.fullMode" "false"
+set_gradle_property "$GP" "plugins_maven_repos" "$PANAMAPORT_MAVEN_REPO"
 
 # Drop any stale rules file from earlier script versions.
 rm -f "$DEMO_DIR/android/build/kanama-minify.pro"
@@ -177,6 +186,12 @@ cat >>"$BUILD_GRADLE" <<'GRADLE'
 // AAR's consumer-rules.pro is applied automatically by R8. R8 compat mode is
 // forced via gradle.properties (android.enableR8.fullMode=false) so PanamaPort's
 // annotation-driven rules behave as designed.
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}
+
 android {
     buildTypes {
         release {

--- a/scripts/android_smoke.sh
+++ b/scripts/android_smoke.sh
@@ -160,6 +160,7 @@ cat >>"$BUILD_GRADLE" <<'GRADLE'
 allprojects {
     repositories {
         mavenLocal()
+        maven { url 'https://jitpack.io' }
     }
 }
 GRADLE

--- a/scripts/android_smoke.sh
+++ b/scripts/android_smoke.sh
@@ -38,6 +38,7 @@ APK_PATH="${4:-/tmp/kanama-android-smoke.apk}"
 LOG_FILE="${KANAMA_ANDROID_LOG:-/tmp/kanama_android_smoke.log}"
 SCREENSHOT="${KANAMA_ANDROID_SCREENSHOT:-/tmp/kanama_android_smoke.png}"
 LAUNCH_WAIT="${KANAMA_ANDROID_LAUNCH_WAIT:-30}"
+PANAMAPORT_MAVEN_REPO="${KANAMA_PANAMAPORT_MAVEN_REPO:-file://$HOME/.m2/repository}"
 
 ANDROID_SDK_DIR="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
 if [[ -z "$ANDROID_SDK_DIR" ]]; then
@@ -77,6 +78,17 @@ check_log_absent() {
     echo "[android_smoke] log tail:" >&2
     tail -n 160 "$LOG_FILE" >&2
     exit 1
+  fi
+}
+
+set_gradle_property() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  if [[ -f "$file" ]] && grep -q "^$key=" "$file"; then
+    /usr/bin/sed -i '' "s|^$key=.*|$key=$value|" "$file"
+  else
+    printf '\n%s=%s\n' "$key" "$value" >>"$file"
   fi
 }
 
@@ -120,10 +132,41 @@ ANDROID_HOME="$ANDROID_SDK_DIR" ANDROID_SDK_ROOT="$ANDROID_SDK_DIR" \
   "$ROOT_DIR/gradlew" -p "$ROOT_DIR" installAndroidPluginAar \
   -PkanamaAndroidDemoDir="$DEMO_DIR"
 
-echo "[android_smoke] export: $APK_PATH"
+echo "[android_smoke] install android build template"
 "$GODOT_BIN" --headless \
   --path "$DEMO_DIR" \
   --install-android-build-template \
+  --quit >/dev/null 2>&1 || true
+
+BUILD_GRADLE="$DEMO_DIR/android/build/build.gradle"
+if [[ ! -f "$BUILD_GRADLE" ]]; then
+  echo "[android_smoke] generated build.gradle not found: $BUILD_GRADLE" >&2
+  echo "[android_smoke] is gradle_build/use_gradle_build=true in the export preset?" >&2
+  exit 1
+fi
+
+set_gradle_property "$DEMO_DIR/android/build/gradle.properties" \
+  "plugins_maven_repos" "$PANAMAPORT_MAVEN_REPO"
+
+MARKER="kanama-local-maven"
+if grep -q "$MARKER" "$BUILD_GRADLE"; then
+  /usr/bin/sed -i '' "/=== $MARKER /,\$d" "$BUILD_GRADLE"
+fi
+cat >>"$BUILD_GRADLE" <<'GRADLE'
+
+// === kanama-local-maven (injected by scripts/android_smoke.sh) ===
+// Make a locally published PanamaPort fork available to Godot's generated
+// Android Gradle build when the Kanama plugin .gdap points at that coordinate.
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}
+GRADLE
+
+echo "[android_smoke] export: $APK_PATH"
+"$GODOT_BIN" --headless \
+  --path "$DEMO_DIR" \
   --export-debug Android "$APK_PATH"
 
 echo "[android_smoke] install: $PACKAGE_NAME"


### PR DESCRIPTION
## Summary
- wire the Android plugin to a configurable PanamaPort Core coordinate, defaulting to 0.1.3-kanama-r8.1
- inject the configured local Maven repo into Godot-generated Android builds for smoke/export scripts
- keep KanamaBinding lifecycle callbacks for MethodHandles.findStatic under R8
- update Android docs/roadmap notes from unsupported to validated with the forked PanamaPort dependency

## Dependency
Draft until the PanamaPort fork artifact is available remotely. Depends on falcon4ever/PanamaPort#1.

## Validation
- Pixel 7: scripts/android_export_minified.sh Starter-Kit-Match3 => PASS (R8-minified release boots Kanama)
- Pixel 7: scripts/android_smoke.sh Starter-Kit-Match3 => PASS, screenshot nonblank