### PR TITLE
generator: explicit iOS class-collision + subclass-override + bare-Object policy (task 11)

### DIFF
--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -53,6 +53,39 @@ python3 scripts/generate_name_constants.py
 `scripts/check_wrapper_generator.py` runs the same generator in `--check` mode,
 so a Godot API refresh fails loudly if the committed name constants are stale.
 
+## iOS Generator Policy
+
+The iOS island is emitted under `IOS_AUDIT_ONLY` and has extra policy so a regen stays
+honest instead of silently dropping or clashing. These are locked by `check_ios_policies`
+in `scripts/check_wrapper_generator.py`:
+
+- **Bare-`Object` returns.** `get_collider()`-style methods that return the root Godot
+  `Object` wrap to `GodotObject?`. Desktop/Android find `GodotObject.wrap()` via a
+  `GodotObject.kt` file; on iOS `GodotObject` lives inside `IosGodotApi.kt`, so
+  `wrapper_has_wrap` special-cases `GodotObject` as always-present. Without this the iOS
+  regen drops every bare-`Object`-return method (a silent coverage loss), even though the
+  `ptrcallNoArgsRetObject` helper is fully wired (Node returns use it).
+
+- **Subclass-override openness.** Where a hand-written iOS subclass overrides a generated
+  method, the base method must be generated `open` — otherwise a regen drops the keyword and
+  the override stops compiling. `Node.createTween()` is emitted `open` (via the Node custom
+  member section) so the hand-written `SceneTree` subclass can override it with the correct
+  `SceneTree.create_tween` bind (the FPS F2 fix). Add such cases to the class's
+  `IOS_CUSTOM_MEMBER_SECTIONS` entry, not by hand-editing the generated file.
+
+- **Explicit class collisions.** Real Godot classes that are deliberately hand-written on iOS
+  (inside `IosGodotApi.kt` or a bespoke single-class file) are listed in
+  `IOS_HANDWRITTEN_COLLISION_CLASSES` with a reason. `--ios-emit-class <that class>` logs a
+  `collision:` line and skips it, instead of writing a `<Class>.kt` that duplicate-declares
+  the class and breaks the compile. When a class graduates to a real generated wrapper
+  (as `Time`/`InputMap`/`PhysicsServer3D` did), delete its entry so generation is allowed.
+
+Known residual regen drift (tracked, not yet closed): some committed wrappers differ from a
+fresh regen on **default-value expressions** (e.g. `Node3D.lookAt(up = Vector3.UP)` — the
+generator has no `Vector3` default-value case yet) and the **non-null `fromHandle`** on
+script-attachable base classes (`Resource`). These are cross-platform (they affect the
+desktop source too) and are separate from the iOS collision/override policy above.
+
 ## Coverage Triage
 
 For v0.3.0 wrapper work, use the coverage reports as the baseline instead of

--- a/scripts/check_wrapper_generator.py
+++ b/scripts/check_wrapper_generator.py
@@ -354,6 +354,60 @@ def check_ios_fixture(output_dir: Path) -> int:
     return 0
 
 
+def _gen_ios(output_dir: Path, *class_names: str) -> subprocess.CompletedProcess:
+    """Run the iOS generator for one-or-more classes, capturing stdout+stderr."""
+    return subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/generate_api_wrapper.py"),
+            *sum((["--ios-emit-class", c] for c in class_names), []),
+            "--ios-output-dir",
+            str(output_dir),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def check_ios_policies(output_dir: Path) -> int:
+    """Lock the task-11 generator policies so a refactor can't silently regress them.
+
+    1. bare-`Object` returns are emitted on iOS (GodotObject wrap policy) — else regen
+       silently drops get_collider()-style methods.
+    2. Node.createTween() is generated `open` so the hand-written SceneTree subclass can
+       override it (the FPS F2 fix) — else regen re-breaks the SIGSEGV path.
+    3. a hand-written class (SceneTree) requested for emission is reported as a collision and
+       NOT written — else a duplicate-class file breaks the compile.
+    """
+    policy_dir = output_dir / "ios-policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+
+    _gen_ios(policy_dir, "KinematicCollision2D", "Node")
+    kc = (policy_dir / "KinematicCollision2D.kt").read_text(encoding="utf-8")
+    if "fun getCollider(): GodotObject?" not in kc:
+        print("[wrapper_generator] FAIL bare-Object return getCollider() dropped on iOS "
+              "(GodotObject wrap policy regressed)", file=sys.stderr)
+        return 1
+    node = (policy_dir / "Node.kt").read_text(encoding="utf-8")
+    if "open fun createTween(): Tween?" not in node:
+        print("[wrapper_generator] FAIL Node.createTween() is not generated `open` "
+              "(subclass-override policy regressed — breaks the SceneTree F2 fix)", file=sys.stderr)
+        return 1
+
+    collision = _gen_ios(policy_dir, "SceneTree")
+    if (policy_dir / "SceneTree.kt").exists():
+        print("[wrapper_generator] FAIL SceneTree.kt emitted despite being hand-written "
+              "(collision policy regressed)", file=sys.stderr)
+        return 1
+    if "collision: SceneTree is hand-written" not in collision.stderr:
+        print("[wrapper_generator] FAIL SceneTree collision not reported "
+              "(collision policy regressed)", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main() -> int:
     name_constants = subprocess.run(
         [sys.executable, str(ROOT / "scripts/generate_name_constants.py"), "--check"],
@@ -378,6 +432,8 @@ def main() -> int:
             if check_adopted_source(output_dir, class_name, allow_virtual_skips=True) != 0:
                 return 1
         if check_ios_fixture(output_dir) != 0:
+            return 1
+        if check_ios_policies(output_dir) != 0:
             return 1
 
     adopted = (

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from api_wrapper_candidates import CALL_SHAPES, CallShape, camel_name, const_name
@@ -175,6 +176,28 @@ IOS_AUDIT_ONLY = False
 # Otherwise the generated island won't compile (unresolved peer type / missing
 # `.wrap`). None = no constraint (desktop / single-class fixture default is set in main).
 IOS_EMIT_CLASSES: set[str] | None = None
+
+# Real Godot classes that are deliberately hand-written on iOS (inside IosGodotApi.kt or a
+# bespoke single-class file), so the generator must NOT emit a wrapper for them — a generated
+# `<Class>.kt` would duplicate-declare the class and break the compile. `scan_wrapper_classes`
+# only sees classes that own a `.kt` file, so the ones nested in IosGodotApi.kt are invisible to
+# it; without this registry, `--ios-emit-class SceneTree` would silently produce a colliding file.
+# main() logs + skips any requested class listed here, making the collision explicit (task 11,
+# generator policy). Retire an entry only when the class moves to a real generated wrapper (as
+# Time/InputMap/PhysicsServer3D did in task 10) — then delete it here so generation is allowed.
+IOS_HANDWRITTEN_COLLISION_CLASSES = {
+    "SceneTree": "hand-written Node subclass (createTween F2 fix + coroutine/companion glue) in IosGodotApi.kt",
+    "Tween": "hand-written Variant tween_property runtime in IosGodotApi.kt",
+    "Tweener": "hand-written Tween chaining glue in IosGodotApi.kt",
+    "PropertyTweener": "hand-written Tween chaining glue in IosGodotApi.kt",
+    "CallbackTweener": "hand-written Tween chaining glue in IosGodotApi.kt",
+    "ResourceLoader": "hand-written typed-loader glue (loadTexture2D/AudioStream/PackedScene) in IosGodotApi.kt",
+    "Engine": "hand-written singleton (get_main_loop -> MainLoop, no wrapper class) in Engine.kt",
+    "ProjectSettings": "hand-written singleton (getSettingDouble Variant->Double coercion) in ProjectSettings.kt",
+    "StaticBody3D": "hand-written thin Node3D subclass in IosGodotApi.kt",
+    "AudioStreamPlayer": "hand-written cinterop-glue Node subclass in IosGodotApi.kt",
+    "InputEventMouseButton": "hand-written cinterop-glue event wrapper in IosGodotApi.kt",
+}
 
 # Logical arg kinds the iOS generic dispatch + Kotlin layout marshal today. Scalars
 # widen per the width table (int*->int64/8B, float->double/8B); Vector2/3 components
@@ -482,7 +505,10 @@ IOS_CUSTOM_MEMBER_SECTIONS = {
     fun <T : Node> getNodeAsOrNull(path: String, className: String, ctor: (MemorySegment) -> T): T? =
         getNodeOrNull(path)?.takeIf { it.isClass(className) }?.let { ctor(it.handle) }
 
-    fun createTween(): Tween? =
+    // `open` so the hand-written SceneTree subclass (IosGodotApi.kt) can override createTween() with
+    // the correct SceneTree.create_tween bind — the FPS F2 fix. Generated here so a regen preserves
+    // the openness instead of silently dropping it (which would re-break the SIGSEGV path).
+    open fun createTween(): Tween? =
         IosGodot.nodeCreateTween(handle.address()).takeIf { it != 0L }?.let {
             Tween(MemorySegment.ofAddress(it))
         }
@@ -611,6 +637,13 @@ IOS_CUSTOM_COMPANION_MEMBER_SECTIONS = {
 
 
 def wrapper_has_wrap(api_dir: Path, class_name: str) -> bool:
+    # GodotObject is the hand-written universal base — it always exists on every platform with a
+    # `wrap(handle): GodotObject?` helper, but it does not live in a GodotObject.kt file on iOS
+    # (it is declared inside IosGodotApi.kt). Treat it as always-present so bare-`Object` returns
+    # (get_collider, shape_owner_get_owner, ...) stay emittable on iOS instead of being dropped on
+    # regen — matching desktop/Android, where GodotObject.kt makes the file check pass.
+    if class_name == "GodotObject":
+        return True
     path = api_dir / f"{class_name}.kt"
     if not path.exists():
         return False
@@ -2476,10 +2509,25 @@ def main() -> int:
     if args.ios_classes:
         global IOS_AUDIT_ONLY, IOS_EMIT_CLASSES
         IOS_AUDIT_ONLY = True
-        IOS_EMIT_CLASSES = set(args.ios_classes)
+        # Explicit class-collision handling (task 11): a class that is deliberately hand-written on
+        # iOS must not also be generated, or the two declarations collide at compile time. Log the
+        # collision and drop the request instead of silently emitting a clashing file.
+        requested = list(dict.fromkeys(args.ios_classes))
+        emit_names: list[str] = []
+        for class_name in requested:
+            reason = IOS_HANDWRITTEN_COLLISION_CLASSES.get(class_name)
+            if reason is not None:
+                print(
+                    f"[generate_api_wrapper] collision: {class_name} is hand-written on iOS "
+                    f"({reason}); skipping generation.",
+                    file=sys.stderr,
+                )
+                continue
+            emit_names.append(class_name)
+        IOS_EMIT_CLASSES = set(emit_names)
         ios_skip_lines: list[str] = []
         ios_classes: list[ApiClass] = []
-        for class_name in args.ios_classes:
+        for class_name in emit_names:
             cls = api_classes.get(class_name)
             if cls is None:
                 raise SystemExit(f"{class_name}: not found in {args.api}")


### PR DESCRIPTION
## Summary

Task 11 (Generator Policy Cleanup). Makes the iOS generator honest so a regen stops **silently dropping methods** or emitting **clashing files**, and locks each policy with a fixture. **No committed runtime `.kt` file changes** — the fixes make the generator *reproduce* what's already committed (verified), so the iOS runtime is byte-identical to the task-10 device-validated build.

## Root-caused drift (why committed iOS wrappers diverge from a fresh regen)

A clean iOS regen changed **14 of 242** files. Diagnosis:

| Cause | Fix in this PR |
|---|---|
| **Regen drops bare-`Object` returns** (`getCollider`, `getColliderShape`, `shapeOwnerGetOwner` → `GodotObject?`) across KinematicCollision2D/3D, CollisionObject2D/3D, RayCast3D, ShapeCast3D | ✅ `wrapper_has_wrap` special-cases `GodotObject` |
| **Regen drops `open` on `Node.createTween`** (the FPS F2 subclass-override enabler) | ✅ generated `open` via the Node custom section |
| **No explicit collision handling** — `--ios-emit-class SceneTree` would silently emit a duplicate-class file | ✅ `IOS_HANDWRITTEN_COLLISION_CLASSES` logs + skips |
| Cross-platform **default-value** drift (`Node3D.lookAt(up = Vector3.UP)`) + **non-null `fromHandle`** on `Resource` | ⏳ documented as deferred (affects desktop too — separate cross-platform reconciliation) |

### Why bare-`Object` returns are dropped on iOS but **not** desktop/Android
The generator gates object-returning methods on the return wrapper having a `wrap(handle)` helper, verified by looking for a `<Class>.kt` file. Desktop/Android keep `GodotObject` in its own `GodotObject.kt` (check passes → methods emitted). iOS keeps `GodotObject` **inside `IosGodotApi.kt`**, so the file check failed and the methods were dropped — purely an artifact of *where iOS declares the base class*, not a real coverage gap. The fix treats `GodotObject` (the universal hand-written base) as always-present.

## Exit-gate checklist

| Check | Status |
|---|---|
| Class-collision handling explicit + logged | ✅ `IOS_HANDWRITTEN_COLLISION_CLASSES` + `collision:` log |
| Subclass overrides generate without manual edits | ✅ `Node.createTween()` generated `open` |
| Custom sections / policies have fixture tests | ✅ new `check_ios_policies` |
| Regeneration produces stable output | ⚠️ **partial** — the dangerous drift (dropped Object-returns, lost `open`) is fixed; cross-platform default-value + non-null-factory drift is documented + deferred |
| `wrapper-maintenance.md` documents the policy | ✅ new "iOS Generator Policy" section |
| Demos run without regression | ✅ no runtime change; iOS compiles; task-10 device validation still valid |

## Validation
- ✅ `compileKotlinIosArm64`
- ✅ `check_wrapper_generator.py` (incl. new policy checks)
- ✅ `check_ios_no_silent_stubs.py`
- ✅ desktop generation is a **no-op** (verified `getCollider` unchanged on desktop)

## Deferred (documented in wrapper-maintenance.md)
Full cross-platform regen stability — extending `kotlin_default_expression` for composite defaults (`Vector3`, …) and a non-null-`fromHandle` policy for script-attachable base classes — touches desktop + Android + iOS committed wrappers and warrants its own reconciliation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)