### PR TITLE
generator: reproduce Node3D.lookAt(up=Vector3.UP) + non-null Resource.fromHandle (task 11 finish)

### DIFF
--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -80,11 +80,22 @@ in `scripts/check_wrapper_generator.py`:
   the class and breaks the compile. When a class graduates to a real generated wrapper
   (as `Time`/`InputMap`/`PhysicsServer3D` did), delete its entry so generation is allowed.
 
-Known residual regen drift (tracked, not yet closed): some committed wrappers differ from a
-fresh regen on **default-value expressions** (e.g. `Node3D.lookAt(up = Vector3.UP)` — the
-generator has no `Vector3` default-value case yet) and the **non-null `fromHandle`** on
-script-attachable base classes (`Resource`). These are cross-platform (they affect the
-desktop source too) and are separate from the iOS collision/override policy above.
+Two cross-platform load-bearing wrapper shapes are reproduced by explicit policy (so a regen
+does not drop them), locked by `check_ios_policies`:
+
+- **Composite default-value overrides.** `KOTLIN_DEFAULT_EXPRESSION_OVERRIDES` injects a final
+  Kotlin default expression by exact `(class, method, arg)`. `Node3D.look_at(up = Vector3.UP)`
+  is the current entry — demos call the 1-arg `lookAt(target)` form and rely on it. Kept
+  surgical (per exact arg) so no other method silently gains a default.
+- **Non-null factory.** `NON_NULL_FROM_HANDLE_CLASSES` (currently `{Resource}`) emits
+  `fromHandle(handle): Resource` (non-null) so a `@ScriptClass(attachTo = "Resource")` script's
+  `(MemorySegment) -> Resource` selfFactory type-checks. The nullable `wrap` helper stays.
+
+Separately, the committed wrappers carry **broad pre-existing regen drift** unrelated to the
+policies above: a fresh regen changes ~273 of ~1027 desktop generated files (accumulated
+generator improvements that were never re-adopted into the committed sources). Closing that is a
+dedicated cross-platform re-adoption pass, not part of the policy work here — see the
+platform-convergence note in the roadmap.
 
 ## Coverage Triage
 

--- a/scripts/check_wrapper_generator.py
+++ b/scripts/check_wrapper_generator.py
@@ -396,6 +396,28 @@ def check_ios_policies(output_dir: Path) -> int:
               "(subclass-override policy regressed — breaks the SceneTree F2 fix)", file=sys.stderr)
         return 1
 
+    # Composite default-value override: Node3D.lookAt(up = Vector3.UP) — demos call the 1-arg
+    # lookAt(target) form and rely on this default; a regen must not drop it.
+    _gen_ios(policy_dir, "Node3D")
+    node3d = (policy_dir / "Node3D.kt").read_text(encoding="utf-8")
+    if "up: Vector3 = Vector3.UP" not in node3d:
+        print("[wrapper_generator] FAIL Node3D.lookAt lost its `up = Vector3.UP` default "
+              "(composite default-value override regressed)", file=sys.stderr)
+        return 1
+
+    # Non-null factory policy: Resource.fromHandle must be non-null so KanamaScript's
+    # (MemorySegment) -> Resource selfFactory for @ScriptClass(attachTo = "Resource") type-checks.
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts/generate_api_wrapper.py"),
+         "--class", "Resource", "--output-dir", str(policy_dir)],
+        cwd=ROOT, check=True, capture_output=True,
+    )
+    resource = (policy_dir / "Resource.kt").read_text(encoding="utf-8")
+    if "fun fromHandle(handle: MemorySegment): Resource =" not in resource:
+        print("[wrapper_generator] FAIL Resource.fromHandle is not non-null "
+              "(script-attachable non-null factory policy regressed)", file=sys.stderr)
+        return 1
+
     collision = _gen_ios(policy_dir, "SceneTree")
     if (policy_dir / "SceneTree.kt").exists():
         print("[wrapper_generator] FAIL SceneTree.kt emitted despite being hand-written "

--- a/scripts/fixtures/wrapper_generator/ios/Node3D.kt
+++ b/scripts/fixtures/wrapper_generator/ios/Node3D.kt
@@ -368,7 +368,7 @@ open class Node3D(handle: MemorySegment) : Node(handle) {
         ObjectCalls.ptrcallNoArgs(setIdentityBind, handle)
     }
 
-    fun lookAt(target: Vector3, up: Vector3, useModelFront: Boolean = false) {
+    fun lookAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false) {
         ObjectCalls.ptrcallWithTwoVector3AndBoolArgs(lookAtBind, handle, target, up, useModelFront)
     }
 

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -343,6 +343,15 @@ METHOD_NAME_OVERRIDES = {
 DEFAULT_VALUE_OVERRIDES = {
     ("Time", "get_datetime_string_from_datetime_dict", "use_space"): "false",
 }
+
+# Final Kotlin default expressions injected by (class, method, arg), bypassing
+# kotlin_default_expression. Use for composite defaults the generic renderer can't express but that
+# a wrapper needs — kept surgical (per exact arg) so no other method silently gains a default.
+# Node3D.look_at up defaults to Godot's Vector3(0, 1, 0); demos call the 1-arg lookAt(target) form
+# and rely on the named Vector3.UP default, so reproduce it here rather than dropping it on regen.
+KOTLIN_DEFAULT_EXPRESSION_OVERRIDES = {
+    ("Node3D", "look_at", "up"): "Vector3.UP",
+}
 CUSTOM_MEMBER_SECTIONS = {
     "AnimationMixer": """
     fun setParameter(path: String, value: Any?) {
@@ -1449,7 +1458,9 @@ def render_method(
         strict=True,
     ):
         default_value = DEFAULT_VALUE_OVERRIDES.get((class_name, method.name, raw_name), default_value)
-        default_expression = kotlin_default_expression(default_value, kind)
+        default_expression = KOTLIN_DEFAULT_EXPRESSION_OVERRIDES.get(
+            (class_name, method.name, raw_name),
+        ) or kotlin_default_expression(default_value, kind)
         type_text = kotlin_type(kind, type_name, wrapper_classes, api_classes)
         param_texts.append(
             f"{name}: {type_text} = {default_expression}" if default_expression is not None else f"{name}: {type_text}",
@@ -1514,7 +1525,9 @@ def render_vararg_method(
         strict=True,
     ):
         default_value = DEFAULT_VALUE_OVERRIDES.get((class_name, method.name, raw_name), default_value)
-        default_expression = kotlin_default_expression(default_value, kind)
+        default_expression = KOTLIN_DEFAULT_EXPRESSION_OVERRIDES.get(
+            (class_name, method.name, raw_name),
+        ) or kotlin_default_expression(default_value, kind)
         type_text = kotlin_type(kind, type_name, wrapper_classes, api_classes)
         fixed_params.append(
             f"{name}: {type_text} = {default_expression}" if default_expression is not None else f"{name}: {type_text}",
@@ -1711,19 +1724,38 @@ def has_api_subclasses(class_name: str, api_classes: dict[str, ApiClass]) -> boo
     return any(candidate.inherits == class_name for candidate in api_classes.values())
 
 
+# Classes whose `fromHandle` must return a NON-NULL wrapper. KanamaScript's selfFactory is
+# `(MemorySegment) -> Self` (non-null); a `@ScriptClass(attachTo = "Resource")` script uses
+# `Resource::fromHandle` as that factory, so `Resource.fromHandle` must be `-> Resource`, not
+# `-> Resource?`. The nullable `wrap` helper stays for the general object-return path. Keep this
+# minimal — only classes actually used as a non-null script selfFactory base belong here.
+NON_NULL_FROM_HANDLE_CLASSES = {"Resource"}
+
+
 def render_wrap_helpers(class_name: str) -> str:
     # @JvmStatic is a JVM-only annotation; Kotlin/Native (iOS) rejects it. Omit it for
     # the iOS target — fromHandle works the same without it.
     lines = [] if IOS_AUDIT_ONLY else ["        @JvmStatic"]
-    lines.extend(
-        [
-            f"        fun fromHandle(handle: MemorySegment): {class_name}? =",
-            "            wrap(handle)",
-            "",
-            f"        internal fun wrap(handle: MemorySegment): {class_name}? =",
-            f"            if (handle.address() == 0L) null else {class_name}(handle)",
-        ],
-    )
+    if class_name in NON_NULL_FROM_HANDLE_CLASSES:
+        lines.extend(
+            [
+                f"        fun fromHandle(handle: MemorySegment): {class_name} =",
+                f"            {class_name}(handle)",
+                "",
+                f"        internal fun wrap(handle: MemorySegment): {class_name}? =",
+                f"            if (handle.address() == 0L) null else {class_name}(handle)",
+            ],
+        )
+    else:
+        lines.extend(
+            [
+                f"        fun fromHandle(handle: MemorySegment): {class_name}? =",
+                "            wrap(handle)",
+                "",
+                f"        internal fun wrap(handle: MemorySegment): {class_name}? =",
+                f"            if (handle.address() == 0L) null else {class_name}(handle)",
+            ],
+        )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

Finishes task 11's **documented deferral** — the two load-bearing wrapper shapes a fresh regen was dropping — via surgical generator policy. **No committed runtime wrapper `.kt` changed** (committed already carried these hand-edits; the generator now reproduces them, so they survive a regen).

- **`KOTLIN_DEFAULT_EXPRESSION_OVERRIDES`** — injects a final Kotlin default by exact `(class, method, arg)`. `Node3D.look_at(up = Vector3.UP)` is the entry (demos call the 1-arg `lookAt(target)` form and rely on it). Verified **zero cascade** — `Vector3.UP` appears only in `Node3D`. iOS `Node3D` is now fully regen-stable.
- **`NON_NULL_FROM_HANDLE_CLASSES = {Resource}`** — `fromHandle` returns non-null `Resource` so `KanamaScript`'s `(MemorySegment) -> Resource` selfFactory for `@ScriptClass(attachTo="Resource")` type-checks (FPS `Weapon`, City-Builder). Nullable `wrap` stays.

Both locked by `check_ios_policies`; iOS `Node3D` golden fixture refreshed (one line: the `up` default).

## Scope note (important)
A fresh regen still changes **~273 of ~1027 desktop generated files** — broad, pre-existing drift from generator improvements never re-adopted into committed sources. That is a **separate cross-platform re-adoption pass**, not this PR. Documented in `wrapper-maintenance.md`.

## Validation
- ✅ `compileKotlinIosArm64`
- ✅ `check_wrapper_generator.py` (incl. new Node3D/Resource policy checks)
- ✅ zero-cascade confirmed; no committed runtime wrapper changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)