### PR TITLE
generator: land Dictionary→Dictionary shape + triage long-tail skips (task 22)

### DIFF
--- a/docs/contributing/api-coverage.md
+++ b/docs/contributing/api-coverage.md
@@ -12,9 +12,9 @@ Generated drafts are emitted to `build/wrapper-generator/drafts` during local ru
 | --- | ---: | --- |
 | API classes | 1036 |  |
 | Classes with generated output | 844 | `██████████░░` 81.5% |
-| Classes with complete method generation | 752 | `█████████░░░` 72.6% |
-| Methods generated | 15319/16822 (91.1%) | `███████████░` 91.1% |
-| Methods skipped | 1503 |  |
+| Classes with complete method generation | 753 | `█████████░░░` 72.7% |
+| Methods generated | 15321/16822 (91.1%) | `███████████░` 91.1% |
+| Methods skipped | 1501 |  |
 | Properties generated | 3657/4162 (87.9%) | `███████████░` 87.9% |
 | Signals generated | 503/503 (100.0%) | `████████████` 100.0% |
 
@@ -26,7 +26,7 @@ These numbers count only checked-in Kotlin API wrappers. Class coverage may incl
 Rows marked `inherited only` are promoted wrappers whose Godot class declares no own methods in `extension_api.json`; behavior comes from their parent wrapper.
 
 - Classes: 1032 / 1036 `████████████` 99.6%
-- Methods: 15271 / 15385 `████████████` 99.3% (callable methods; engine virtuals excluded — see below)
+- Methods: 15273 / 15385 `████████████` 99.3% (callable methods; engine virtuals excluded — see below)
 
 ## Virtual Methods
 
@@ -36,7 +36,7 @@ Rows marked `inherited only` are promoted wrappers whose Godot class declares no
 
 | Area | Classes | Class Coverage | Methods | Method Coverage |
 | --- | ---: | --- | ---: | --- |
-| Core | 224/226 | `████████████` 99.1% | 2875/2970 | `████████████` 96.8% |
+| Core | 224/226 | `████████████` 99.1% | 2877/2970 | `████████████` 96.9% |
 | Scene | 26/26 | `████████████` 100.0% | 923/923 | `████████████` 100.0% |
 | Resources | 305/306 | `████████████` 99.7% | 2883/2891 | `████████████` 99.7% |
 | Input | 20/20 | `████████████` 100.0% | 238/238 | `████████████` 100.0% |
@@ -352,7 +352,7 @@ These notes summarize wrapper feedback from real ports. They are contextual sign
 | `GDExtensionManager` | Core | 7/7 | `████████` 100.0% |
 | `GDScript` | Resources | 1/1 | `████████` 100.0% |
 | `GDScriptSyntaxHighlighter` | Resources | 0/0 | inherited only |
-| `GDScriptTextDocument` | Core | 19/21 | `███████░` 90.5% |
+| `GDScriptTextDocument` | Core | 21/21 | `████████` 100.0% |
 | `GDScriptWorkspace` | Core | 8/8 | `████████` 100.0% |
 | `GLTFAccessor` | Resources | 32/32 | `████████` 100.0% |
 | `GLTFAnimation` | Resources | 6/6 | `████████` 100.0% |

--- a/docs/contributing/wrapper-generator-report.md
+++ b/docs/contributing/wrapper-generator-report.md
@@ -16,9 +16,9 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | --- | ---: |
 | API classes | 1036 |
 | Classes with generated output | 844 |
-| Classes with complete method generation | 752 |
-| Methods generated | 15319/16822 (91.1%) |
-| Methods skipped | 1503 |
+| Classes with complete method generation | 753 |
+| Methods generated | 15321/16822 (91.1%) |
+| Methods skipped | 1501 |
 | Properties generated | 3657/4162 (87.9%) |
 | Signals generated | 503/503 (100.0%) |
 
@@ -30,8 +30,8 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | Other | 49 |
 | Array / typed array | 8 |
 | Missing helper shape | 4 |
-| Dictionary | 3 |
 | Blocked object wrapper | 2 |
+| Dictionary | 1 |
 
 ## Missing Helper Shapes
 
@@ -39,7 +39,6 @@ These are the highest-leverage ptrcall helper shapes to add next, excluding broa
 
 | Shape | Count |
 | --- | ---: |
-| `args=('Dictionary',) return=Dictionary` | 2 |
 | `args=('RID', 'TypedObjectArray::OpenXRSpatialComponentData', 'Object', 'Object') return=void` | 2 |
 | `args=('Rect2i', 'Object', 'Color', 'int32', 'Object') return=void` | 1 |
 | `args=('Rect2i', 'TypedObjectArray::Texture2D', 'TypedObjectArray::DrawableTexture2D', 'Color', 'int32', 'Object') return=void` | 1 |
@@ -59,7 +58,6 @@ These are the highest-leverage ptrcall helper shapes to add next, excluding broa
 | --- | ---: |
 | `internal/virtual callback methods are not emitted as public wrappers` | 1437 |
 | `root Object methods are exposed through the hand-shaped GodotObject policy` | 49 |
-| `unsupported helper shape args=('Dictionary',) return=Dictionary` | 2 |
 | `unsupported helper shape args=('RID', 'TypedObjectArray::OpenXRSpatialComponentData', 'Object', 'Object') return=void` | 2 |
 | `ownership-sensitive RefCounted lifetime method is hand-shaped` | 2 |
 | `unsupported helper shape args=('Rect2i', 'Object', 'Color', 'int32', 'Object') return=void` | 1 |
@@ -163,7 +161,6 @@ These classes have every method covered by the conservative generator. Promotion
 | BaseButton | 23/25 (92.0%) | 10/10 | 4/4 | 2 |
 | CollisionObject3D | 32/35 (91.4%) | 6/6 | 3/3 | 3 |
 | Node | 121/133 (91.0%) | 14/14 | 11/11 | 12 |
-| GDScriptTextDocument | 19/21 (90.5%) | 0/0 | 0/0 | 2 |
 | EditorDock | 27/30 (90.0%) | 12/12 | 2/2 | 3 |
 | AStar2D | 25/28 (89.3%) | 1/1 | 0/0 | 3 |
 | AStar3D | 25/28 (89.3%) | 1/1 | 0/0 | 3 |

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -129,6 +129,46 @@ generator capability. Treat low-coverage areas such as variant/dictionary
 helper shapes, typed arrays, and multiplayer/editor methods as API design work:
 add helper policy and audits before promoting wider wrappers.
 
+### Long-tail triage (task 22)
+
+Once the class surface is broadly promoted, the remaining skips are a long tail
+of **data-type / shape** gaps, not missing classes. A full triage of the
+non-virtual skips and the skipped properties found:
+
+- **Non-virtual method skips (~64 after the Dictionary→Dictionary family):** the
+  large majority are *intentional*, not gaps —
+  - **~49 root `Object` methods** (`call`/`get`/`set`/`connect`/`emit_signal`/…)
+    are deliberately routed through the hand-shaped `GodotObject` policy, not
+    regenerated per subclass. These are the escape hatches; keep them on
+    `GodotObject`.
+  - **2 `RefCounted` lifetime methods** (`reference`/`init_ref`) are
+    ownership-sensitive and hand-shaped.
+  - The rest are **wide / exotic ABI shapes** — RenderingDevice raytracing
+    (`blas_create`, `tlas_build`, `raytracing_pipeline_create`),
+    `TypedObjectArray` blit combos, `Signal`→Object, wide RID signatures. Each is
+    a large per-shape audit (JVM actual + iOS C-shim + width self-test); defer
+    with the report entry as the reason until a workflow needs it.
+  - The one clean low-ABI slice was **`Dictionary`→`Dictionary`** (`resolve`,
+    `rename` on `GDScriptTextDocument`), landed via the
+    `ptrcallWithDictionaryArgRetDictionary` helper. It reuses the existing
+    Dictionary-arg init + Dictionary-return read paths, so it is desktop+Android
+    only and cleanly iOS-skipped (`Dictionary` is not in `IOS_ARG_KINDS` /
+    `IOS_RET_KOTLIN` — no C-shim work, no device gate).
+- **~505 skipped properties are NOT a marshalling gap.** Triaged:
+  - **~415 are indexed / parameterized accessors** whose getter takes an
+    argument (e.g. `get_list_stream(i)`, `get_param(param)`). Godot lists them as
+    `foo/0`, `foo/1`, … pseudo-properties; they are not Kotlin `val`/`var`s by
+    design, and the underlying getter/setter **methods are already generated and
+    callable**. Not a gap.
+  - **~90 have no simple own getter method** — the getter is inherited (the
+    property surfaces on the parent wrapper and the getter method is inherited),
+    an engine virtual `_get_*` (task 13 territory), or an indexed inherited
+    getter. None are unlocked by a new marshalling shape.
+
+  Net: **no skipped property is a "quick win behind a shape."** Property coverage
+  advances only when its *getter method* becomes generatable (a new no-arg return
+  shape) or via ergonomic hand-shaping, never by widening property emission.
+
 ## KDoc Maintenance
 
 Public Godot-backed wrappers and builtin value types carry generated KDoc

--- a/scripts/api_wrapper_candidates.py
+++ b/scripts/api_wrapper_candidates.py
@@ -191,6 +191,11 @@ CALL_SHAPES: dict[tuple[tuple[str, ...], str], CallShape] = {
         "List<Any?>",
         "emptyList()",
     ),
+    (("Dictionary",), "Dictionary"): CallShape(
+        "ptrcallWithDictionaryArgRetDictionary",
+        "Map<String, Any?>",
+        "emptyMap()",
+    ),
     (("Object",), "void"): CallShape("ptrcallWithObjectArgs", "Unit"),
     (("Object",), "bool"): CallShape("ptrcallWithObjectArgRetBool", "Boolean", "false"),
     (("Object",), "int64"): CallShape("ptrcallWithObjectArgRetLong", "Long", "0L"),

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -20841,6 +20841,30 @@ object ObjectCalls {
     }
 
     /**
+     * Calls [methodBind] with one Dictionary arg and decodes a Dictionary return as scalar key/value pairs.
+     */
+    fun ptrcallWithDictionaryArgRetDictionary(
+        methodBind: MemorySegment,
+        instance: MemorySegment,
+        values: Map<String, Any?>,
+    ): Map<String, Any?> {
+        Arena.ofConfined().use { arena ->
+            val dict = arena.allocate(8L, 8L)
+            val ret = arena.allocate(8L, 8L)
+            try {
+                BuiltinTypes.initDictionary(dict, values)
+                val arr = arena.allocate(ADDRESS, 1)
+                arr.setAtIndex(ADDRESS, 0, dict)
+                objectMethodBindPtrcall.invoke(methodBind, instance, arr, ret)
+                return BuiltinTypes.readDictionaryScalars(ret)
+            } finally {
+                BuiltinTypes.destroyTyped(VariantType.DICTIONARY, ret)
+                BuiltinTypes.destroyTyped(VariantType.DICTIONARY, dict)
+            }
+        }
+    }
+
+    /**
      * Calls [methodBind] with (int32, Dictionary) and no return value.
      */
     fun ptrcallWithIntAndDictionaryArg(

--- a/src/main/kotlin/net/multigesture/kanama/api/GDScriptTextDocument.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GDScriptTextDocument.kt
@@ -43,6 +43,14 @@ class GDScriptTextDocument(handle: MemorySegment) : RefCounted(handle) {
         return ObjectCalls.ptrcallWithDictionaryArgRetArray(completionBind, handle, params)
     }
 
+    fun resolve(params: Map<String, Any?>): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithDictionaryArgRetDictionary(resolveBind, handle, params)
+    }
+
+    fun rename(params: Map<String, Any?>): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithDictionaryArgRetDictionary(renameBind, handle, params)
+    }
+
     fun prepareRename(params: Map<String, Any?>): Any? {
         return ObjectCalls.ptrcallWithDictionaryArgRetVariantScalar(prepareRenameBind, handle, params)
     }
@@ -134,6 +142,16 @@ class GDScriptTextDocument(handle: MemorySegment) : RefCounted(handle) {
         private const val COMPLETION_HASH = 3877611628L
         private val completionBind by lazy {
             ObjectCalls.getMethodBind("GDScriptTextDocument", "completion", COMPLETION_HASH)
+        }
+
+        private const val RESOLVE_HASH = 1333564645L
+        private val resolveBind by lazy {
+            ObjectCalls.getMethodBind("GDScriptTextDocument", "resolve", RESOLVE_HASH)
+        }
+
+        private const val RENAME_HASH = 1333564645L
+        private val renameBind by lazy {
+            ObjectCalls.getMethodBind("GDScriptTextDocument", "rename", RENAME_HASH)
         }
 
         private const val PREPARERENAME_HASH = 3762224011L


### PR DESCRIPTION
## Task 22 — Resume broad Godot API coverage (first slice)

Now that task 21 unified the three wrapper trees behind `check_full_drift_gate`, a shape/policy added to the **one** generator lands on desktop + Android + iOS at once. This is the first reviewable slice: **triage the long tail, then land one clean low-ABI shape family** end-to-end.

### Shape family landed: `Dictionary` → `Dictionary`
- `CALL_SHAPES[(("Dictionary",), "Dictionary")]` + `ObjectCalls.ptrcallWithDictionaryArgRetDictionary` (JVM/Panama actual). It reuses the already-audited Dictionary-arg `initDictionary` and Dictionary-return `readDictionaryScalars` paths — no new marshalling primitives.
- Re-adopted `GDScriptTextDocument` → **21/21** (`resolve`, `rename`); +2 callable methods overall (15319 → 15321).
- **Desktop + Android only, cleanly iOS-skipped**: `Dictionary` is not in `IOS_ARG_KINDS`/`IOS_RET_KOTLIN`, so the iOS generator refuses it via the existing `IOS_AUDIT_ONLY` guardrail — no C-shim helper, no self-test row, no device gate required. This is the honest, gate-consistent outcome, not a guess.

### Triage (the exit-gate work), documented in `wrapper-maintenance.md`
- **~505 skipped properties are NOT a marshalling gap:** ~415 are indexed/parameterized accessors whose getter takes an argument (`get_list_stream(i)`, `get_param(param)`) — the getter/setter **methods are already generated and callable**; ~90 have no simple own getter (inherited getter → property surfaces on the parent, or an engine virtual `_get_*`). None are unlocked by a new shape.
- **~64 remaining non-virtual method skips:** ~49 are the intentional root-`Object`/`GodotObject` policy (the `call`/`get`/`set`/`connect`/… escape hatches, kept on `GodotObject`), 2 are `RefCounted` lifetime, and the rest are **wide/exotic ABI shapes** (RenderingDevice raytracing, `TypedObjectArray` blit combos, `Signal`→Object, wide RID) deferred-with-reason as follow-up slices.

### Validation
- `python3 scripts/check_wrapper_generator.py` — drift-gate **green** (desktop 985 / iOS 242).
- `./gradlew jar` — green.
- `DEVELOPER_DIR=… ./gradlew compileKotlinIosArm64` — green (no-op on iOS, as expected).
- Android plugin AAR (`assembleAndroidPluginAar`) — green; new helper + wrappers present in generated Android sources.
- **Pixel R8-minified release smoke** (`scripts/android_export_minified.sh`, Bunnymark) — **PASS** (boots past PanamaPort FFI bootstrap; `binding.runtime.**` kept by consumer-rules).
- Coverage/generator reports refreshed; `--check` green.

### Notes
- No hand-edited generated `.kt` — everything flows through the generator + re-adopt.
- KDoc: `GDScriptTextDocument` has no Godot XML docs, so the focused `sync_kdoc --classes GDScriptTextDocument` is a no-op; diff is purely additive. The repo-wide 4.7-stable KDoc refresh is deliberately **out of scope** here (task 23).
- Task 22 is multi-session; this lands the pattern + triage. Remaining wide-shape families are the next slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)