### PR TITLE
generator: land Rect2i/Object/Color/Int/Object void shape + close task 22 triage

### DIFF
--- a/docs/contributing/api-coverage.md
+++ b/docs/contributing/api-coverage.md
@@ -13,8 +13,8 @@ Generated drafts are emitted to `build/wrapper-generator/drafts` during local ru
 | API classes | 1036 |  |
 | Classes with generated output | 844 | `██████████░░` 81.5% |
 | Classes with complete method generation | 753 | `█████████░░░` 72.7% |
-| Methods generated | 15321/16822 (91.1%) | `███████████░` 91.1% |
-| Methods skipped | 1501 |  |
+| Methods generated | 15322/16822 (91.1%) | `███████████░` 91.1% |
+| Methods skipped | 1500 |  |
 | Properties generated | 3657/4162 (87.9%) | `███████████░` 87.9% |
 | Signals generated | 503/503 (100.0%) | `████████████` 100.0% |
 
@@ -26,7 +26,7 @@ These numbers count only checked-in Kotlin API wrappers. Class coverage may incl
 Rows marked `inherited only` are promoted wrappers whose Godot class declares no own methods in `extension_api.json`; behavior comes from their parent wrapper.
 
 - Classes: 1032 / 1036 `████████████` 99.6%
-- Methods: 15273 / 15385 `████████████` 99.3% (callable methods; engine virtuals excluded — see below)
+- Methods: 15274 / 15385 `████████████` 99.3% (callable methods; engine virtuals excluded — see below)
 
 ## Virtual Methods
 
@@ -41,7 +41,7 @@ Rows marked `inherited only` are promoted wrappers whose Godot class declares no
 | Resources | 305/306 | `████████████` 99.7% | 2883/2891 | `████████████` 99.7% |
 | Input | 20/20 | `████████████` 100.0% | 238/238 | `████████████` 100.0% |
 | UI | 69/69 | `████████████` 100.0% | 1742/1741 | `████████████` 100.1% |
-| 2D | 112/112 | `████████████` 100.0% | 2028/2030 | `████████████` 99.9% |
+| 2D | 112/112 | `████████████` 100.0% | 2029/2030 | `████████████` 100.0% |
 | 3D | 170/171 | `████████████` 99.4% | 2994/3000 | `████████████` 99.8% |
 | Physics | 6/6 | `████████████` 100.0% | 55/55 | `████████████` 100.0% |
 | Rendering | 24/24 | `████████████` 100.0% | 790/794 | `████████████` 99.5% |
@@ -267,7 +267,7 @@ These notes summarize wrapper feedback from real ports. They are contextual sign
 | `DirectionalLight2D` | 2D | 2/2 | `████████` 100.0% |
 | `DirectionalLight3D` | 3D | 6/6 | `████████` 100.0% |
 | `DisplayServer` | Core | 287/287 | `████████` 100.0% |
-| `DrawableTexture2D` | 2D | 5/7 | `██████░░` 71.4% |
+| `DrawableTexture2D` | 2D | 6/7 | `███████░` 85.7% |
 | `ENetConnection` | Core | 18/18 | `████████` 100.0% |
 | `ENetMultiplayerPeer` | Multiplayer | 7/7 | `████████` 100.0% |
 | `ENetPacketPeer` | Core | 16/16 | `████████` 100.0% |

--- a/docs/contributing/wrapper-generator-report.md
+++ b/docs/contributing/wrapper-generator-report.md
@@ -17,8 +17,8 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | API classes | 1036 |
 | Classes with generated output | 844 |
 | Classes with complete method generation | 753 |
-| Methods generated | 15321/16822 (91.1%) |
-| Methods skipped | 1501 |
+| Methods generated | 15322/16822 (91.1%) |
+| Methods skipped | 1500 |
 | Properties generated | 3657/4162 (87.9%) |
 | Signals generated | 503/503 (100.0%) |
 
@@ -29,7 +29,7 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | Virtual/internal | 1437 |
 | Other | 49 |
 | Array / typed array | 8 |
-| Missing helper shape | 4 |
+| Missing helper shape | 3 |
 | Blocked object wrapper | 2 |
 | Dictionary | 1 |
 
@@ -40,7 +40,6 @@ These are the highest-leverage ptrcall helper shapes to add next, excluding broa
 | Shape | Count |
 | --- | ---: |
 | `args=('RID', 'TypedObjectArray::OpenXRSpatialComponentData', 'Object', 'Object') return=void` | 2 |
-| `args=('Rect2i', 'Object', 'Color', 'int32', 'Object') return=void` | 1 |
 | `args=('Rect2i', 'TypedObjectArray::Texture2D', 'TypedObjectArray::DrawableTexture2D', 'Color', 'int32', 'Object') return=void` | 1 |
 | `args=('Object', 'bool', 'String', 'bitfield', 'bool') return=enum` | 1 |
 | `args=('Dictionary', 'int32', 'float', 'Transform2D', 'int32', 'int32', 'int32', 'int32', 'float', 'int64', 'PackedColorArray') return=RID` | 1 |
@@ -60,7 +59,6 @@ These are the highest-leverage ptrcall helper shapes to add next, excluding broa
 | `root Object methods are exposed through the hand-shaped GodotObject policy` | 49 |
 | `unsupported helper shape args=('RID', 'TypedObjectArray::OpenXRSpatialComponentData', 'Object', 'Object') return=void` | 2 |
 | `ownership-sensitive RefCounted lifetime method is hand-shaped` | 2 |
-| `unsupported helper shape args=('Rect2i', 'Object', 'Color', 'int32', 'Object') return=void` | 1 |
 | `unsupported helper shape args=('Rect2i', 'TypedObjectArray::Texture2D', 'TypedObjectArray::DrawableTexture2D', 'Color', 'int32', 'Object') return=void` | 1 |
 | `unsupported helper shape args=('Object', 'bool', 'String', 'bitfield', 'bool') return=enum` | 1 |
 | `unsupported helper shape args=('Dictionary', 'int32', 'float', 'Transform2D', 'int32', 'int32', 'int32', 'int32', 'float', 'int64', 'PackedColorArray') return=RID` | 1 |
@@ -166,6 +164,7 @@ These classes have every method covered by the conservative generator. Promotion
 | AStar3D | 25/28 (89.3%) | 1/1 | 0/0 | 3 |
 | CollisionObject2D | 36/41 (87.8%) | 5/5 | 5/5 | 5 |
 | Translation | 12/14 (85.7%) | 2/3 | 0/0 | 2 |
+| DrawableTexture2D | 6/7 (85.7%) | 0/0 | 0/0 | 1 |
 | SubViewportContainer | 6/7 (85.7%) | 3/3 | 0/0 | 1 |
 | Resource | 22/26 (84.6%) | 4/4 | 2/2 | 4 |
 | OpenXRSpatialAnchorCapability | 11/13 (84.6%) | 0/0 | 0/0 | 2 |

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -135,7 +135,7 @@ Once the class surface is broadly promoted, the remaining skips are a long tail
 of **data-type / shape** gaps, not missing classes. A full triage of the
 non-virtual skips and the skipped properties found:
 
-- **Non-virtual method skips (~64 after the Dictionary→Dictionary family):** the
+- **Non-virtual method skips (~63 after the two low-ABI families below):** the
   large majority are *intentional*, not gaps —
   - **~49 root `Object` methods** (`call`/`get`/`set`/`connect`/`emit_signal`/…)
     are deliberately routed through the hand-shaped `GodotObject` policy, not
@@ -143,17 +143,40 @@ non-virtual skips and the skipped properties found:
     `GodotObject`.
   - **2 `RefCounted` lifetime methods** (`reference`/`init_ref`) are
     ownership-sensitive and hand-shaped.
-  - The rest are **wide / exotic ABI shapes** — RenderingDevice raytracing
-    (`blas_create`, `tlas_build`, `raytracing_pipeline_create`),
-    `TypedObjectArray` blit combos, `Signal`→Object, wide RID signatures. Each is
-    a large per-shape audit (JVM actual + iOS C-shim + width self-test); defer
-    with the report entry as the reason until a workflow needs it.
-  - The one clean low-ABI slice was **`Dictionary`→`Dictionary`** (`resolve`,
-    `rename` on `GDScriptTextDocument`), landed via the
-    `ptrcallWithDictionaryArgRetDictionary` helper. It reuses the existing
-    Dictionary-arg init + Dictionary-return read paths, so it is desktop+Android
-    only and cleanly iOS-skipped (`Dictionary` is not in `IOS_ARG_KINDS` /
-    `IOS_RET_KOTLIN` — no C-shim work, no device gate).
+  - **Two clean low-ABI slices landed** — new call shapes that recombine
+    *already-audited* primitives and whose signature contains a type not in
+    `IOS_ARG_KINDS` / `IOS_RET_KOTLIN`, so they generate on desktop+Android and
+    are **cleanly iOS-skipped** (no C-shim helper, no self-test row, no device
+    gate — the same guardrail Dictionary uses):
+    - **`Dictionary`→`Dictionary`** (`GDScriptTextDocument.resolve`/`.rename`) via
+      `ptrcallWithDictionaryArgRetDictionary` — reuses the Dictionary-arg init +
+      Dictionary-return read paths. `Dictionary` is not an iOS arg/return kind.
+    - **`(Rect2i, Object, Color, int32, Object)`→`void`**
+      (`DrawableTexture2D.blit_rect`) via `ptrcallWithRect2iObjectColorIntObjectArgs`
+      — reuses the Rect2i/Object/Color/int cells. `Rect2i` is not an iOS arg kind.
+  - **The remaining ~12 are deferred with reason** (each still carries its
+    `unsupported helper shape …` entry in the generator report). They are *not*
+    quick wins — each needs either new marshalling primitives audited on the iOS
+    C-shim + a width-sensitive self-test row + a device gate, or lands on a
+    deliberately hand-shaped class:
+    - **New container-element marshalling** (no existing policy): RenderingDevice
+      raytracing — `blas_create` / `tlas_build` / `raytracing_pipeline_create`
+      (`TypedObjectArray::RD*`); `ImporterMesh.merge_importer_meshes`
+      (`TypedObjectArray::ImporterMesh` + `TypedTransform3DArray`);
+      `DrawableTexture2D.blit_rect_multi` + `RenderingServer.texture_drawable_blit_rect`
+      (`TypedObjectArray::Texture2D/DrawableTexture2D` + `TypedRIDArray` + `Rect2i`);
+      OpenXR `do_entity_update` (`TypedObjectArray::OpenXRSpatialComponentData`).
+    - **New scalar/Variant marshalling**: `Tween.tween_await` (`Signal` arg — no
+      Signal marshalling); `Font.find_variation` (11-arg `Dictionary`+wide → RID,
+      iOS-skips on `Dictionary` but desktop shape is very wide/rare).
+    - **On hand-shaped classes** (in `DESKTOP_HANDSHAPED`, so a shape addition
+      would not auto-adopt): `EditorExportPlatform.export_project`,
+      `OpenXRSpatialAnchorCapability.create_new_anchor`, `Tween.tween_await`,
+      `Font.find_variation`.
+
+    These belong with the exacting, device-sensitive per-shape work (adjacent to
+    task 13's spirit), not a broad-coverage pass — promote one only when a real
+    workflow needs it, with its iOS C-shim helper + self-test row + device gate.
 - **~505 skipped properties are NOT a marshalling gap.** Triaged:
   - **~415 are indexed / parameterized accessors** whose getter takes an
     argument (e.g. `get_list_stream(i)`, `get_param(param)`). Godot lists them as

--- a/scripts/api_wrapper_candidates.py
+++ b/scripts/api_wrapper_candidates.py
@@ -2592,6 +2592,10 @@ CALL_SHAPES: dict[tuple[tuple[str, ...], str], CallShape] = {
         "emptyList()",
     ),
     (("Rect2i", "Color"), "void"): CallShape("ptrcallWithRect2iAndColorArg", "Unit"),
+    (("Rect2i", "Object", "Color", "int32", "Object"), "void"): CallShape(
+        "ptrcallWithRect2iObjectColorIntObjectArgs",
+        "Unit",
+    ),
     (("Rect2i", "bool"), "void"): CallShape("ptrcallWithRect2iAndBoolArg", "Unit"),
     (("Rect2i", "float"), "void"): CallShape("ptrcallWithRect2iAndDoubleArg", "Unit"),
     (("Rect2i", "float"), "TypedPackedVector2Array"): CallShape(

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -14907,6 +14907,43 @@ object ObjectCalls {
         }
     }
 
+    fun ptrcallWithRect2iObjectColorIntObjectArgs(
+        methodBind: MemorySegment,
+        instance: MemorySegment,
+        rectValue: Rect2i,
+        firstObject: MemorySegment,
+        color: Color,
+        intValue: Int,
+        secondObject: MemorySegment,
+    ) {
+        Arena.ofConfined().use { arena ->
+            val rect = arena.allocate(16L, 4L)
+            rect.set(JAVA_INT, 0, rectValue.position.x)
+            rect.set(JAVA_INT, 4, rectValue.position.y)
+            rect.set(JAVA_INT, 8, rectValue.size.x)
+            rect.set(JAVA_INT, 12, rectValue.size.y)
+            val firstCell = arena.allocate(ADDRESS)
+            firstCell.set(ADDRESS, 0, firstObject)
+            val colorCell = arena.allocate(16L, 4L)
+            // Color components use fixed 32-bit storage, unlike scalar float method args.
+            colorCell.set(JAVA_FLOAT, 0, color.r)
+            colorCell.set(JAVA_FLOAT, 4, color.g)
+            colorCell.set(JAVA_FLOAT, 8, color.b)
+            colorCell.set(JAVA_FLOAT, 12, color.a)
+            val intCell = arena.allocate(JAVA_INT)
+            intCell.set(JAVA_INT, 0, intValue)
+            val secondCell = arena.allocate(ADDRESS)
+            secondCell.set(ADDRESS, 0, secondObject)
+            val args = arena.allocate(ADDRESS, 5)
+            args.setAtIndex(ADDRESS, 0, rect)
+            args.setAtIndex(ADDRESS, 1, firstCell)
+            args.setAtIndex(ADDRESS, 2, colorCell)
+            args.setAtIndex(ADDRESS, 3, intCell)
+            args.setAtIndex(ADDRESS, 4, secondCell)
+            objectMethodBindPtrcall.invoke(methodBind, instance, args, MemorySegment.NULL)
+        }
+    }
+
     fun ptrcallWithRect2iAndBoolArg(
         methodBind: MemorySegment,
         instance: MemorySegment,

--- a/src/main/kotlin/net/multigesture/kanama/api/DrawableTexture2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/DrawableTexture2D.kt
@@ -3,6 +3,7 @@ package net.multigesture.kanama.api
 import java.lang.foreign.MemorySegment
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.Rect2i
 
 /**
  * A 2D texture that supports drawing to itself via Blit calls.
@@ -47,6 +48,18 @@ class DrawableTexture2D(handle: MemorySegment) : Texture2D(handle) {
     }
 
     /**
+     * Draws to given `rect` on this texture by copying from the given `source`. A `modulate` color can
+     * be passed in for the shader to use, but defaults to White. The `mipmap` value can specify a draw
+     * to a lower mipmap level. The `material` parameter can take a ShaderMaterial with a TextureBlit
+     * Shader for custom drawing behavior.
+     *
+     * Generated from Godot docs: DrawableTexture2D.blit_rect
+     */
+    fun blitRect(rect: Rect2i, source: Texture2D?, modulate: Color, mipmap: Int = 0, material: Material?) {
+        ObjectCalls.ptrcallWithRect2iObjectColorIntObjectArgs(blitRectBind, handle, rect, source?.requireOpenHandle() ?: MemorySegment.NULL, modulate, mipmap, material?.requireOpenHandle() ?: MemorySegment.NULL)
+    }
+
+    /**
      * Re-calculates the mipmaps for this texture on demand.
      *
      * Generated from Godot docs: DrawableTexture2D.generate_mipmaps
@@ -86,6 +99,11 @@ class DrawableTexture2D(handle: MemorySegment) : Texture2D(handle) {
         private const val SETUP_HASH = 674365339L
         private val setupBind by lazy {
             ObjectCalls.getMethodBind("DrawableTexture2D", "setup", SETUP_HASH)
+        }
+
+        private const val BLIT_RECT_HASH = 319217173L
+        private val blitRectBind by lazy {
+            ObjectCalls.getMethodBind("DrawableTexture2D", "blit_rect", BLIT_RECT_HASH)
         }
 
         private const val GENERATE_MIPMAPS_HASH = 3218959716L


### PR DESCRIPTION
## Task 22 wrap-up — second low-ABI shape family + deferred-with-reason closure

Follow-up to #25. Lands the second (and last) genuinely low-ABI shape family, then formally closes the task-22 long-tail per the exit gate ("skip categories driven toward zero **or** each remaining entry has an explicit deferred-with-reason note").

### Shape family landed: `(Rect2i, Object, Color, int32, Object)` → `void`
- `CALL_SHAPES` entry + `ObjectCalls.ptrcallWithRect2iObjectColorIntObjectArgs` — recombines the already-audited Rect2i / Object / Color / int cells (no new marshalling primitives).
- Re-adopted `DrawableTexture2D` → **`blit_rect` promoted (5/7 → 6/7)**.
- **Desktop + Android only, cleanly iOS-skipped**: `Rect2i` is not in `IOS_ARG_KINDS`, so the iOS generator refuses it via the existing `IOS_AUDIT_ONLY` guardrail — no C-shim, no self-test row, no device gate (identical safety profile to the Dictionary family in #25).

### Task-22 triage closed (documented in `wrapper-maintenance.md`)
Both landable low-ABI slices are now done (`Dictionary`→`Dictionary` in #25, this one). The remaining **~12** non-virtual method skips are **deferred with an explicit reason** (each still carries its `unsupported helper shape …` entry in the generator report). None are quick wins — each needs one of:
- **New container-element marshalling** (no existing policy): RD raytracing (`blas_create`/`tlas_build`/`raytracing_pipeline_create`, `TypedObjectArray::RD*`), `ImporterMesh.merge_importer_meshes` (`TypedObjectArray::ImporterMesh` + `TypedTransform3DArray`), `blit_rect_multi` / `texture_drawable_blit_rect` (typed texture/RID arrays), OpenXR `do_entity_update`.
- **New scalar marshalling**: `Tween.tween_await` (`Signal` arg), `Font.find_variation` (11-arg `Dictionary`+wide).
- **On hand-shaped classes** (in `DESKTOP_HANDSHAPED`, so a shape addition wouldn't auto-adopt): `export_project`, `create_new_anchor`, `tween_await`, `find_variation`.

Each is an exacting, device-gated per-shape audit (JVM actual + iOS C-shim + width self-test) — promote one only when a real workflow needs it. The ~49 root-`Object`/`GodotObject`-policy skips + 2 `RefCounted` lifetime skips remain **intentional**. The ~505 skipped properties remain **not a marshalling gap** (415 indexed accessors already callable as methods; 90 inherited/virtual getters).

### Exit gate
- [x] Non-virtual skip categories driven down (2 low-ABI families landed) with every remaining entry deferred-with-reason.
- [x] ~505 properties triaged; none promotable behind a shape.
- [x] Escape hatches = the intentional `GodotObject.call/get/set` policy (documented).
- [x] Every promotion regen-clean under `check_full_drift_gate` on all platforms; no hand-edited wrappers.
- [x] `jar` + `compileKotlinIosArm64` + Android AAR (incl. R8-minified) green.

### Validation
- `check_wrapper_generator.py` drift-gate — green (desktop 985 / iOS 242).
- `./gradlew jar` + `compileKotlinIosArm64` + Android AAR — green.
- **Pixel R8-minified release smoke** (Bunnymark) — **PASS**.
- Reports refreshed (`--check` green); `mkdocs build --strict` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)