### PR TITLE
docs: reframe ios-backend-roadmap as the iOS sub-track

### DIFF
--- a/docs/internals/active/ios-backend-roadmap.md
+++ b/docs/internals/active/ios-backend-roadmap.md
@@ -6,6 +6,15 @@ Deep implementation notes live in [ios-backend-architecture.md](../reference/ios
 demo status lives in [ios-demo-port-tracker.md](./ios-demo-port-tracker.md); generated hand-written-site
 accounting lives in [ios-backend-handwritten.md](../reference/ios-backend-handwritten.md).
 
+> **Scope note (2026-07).** This is the **iOS sub-track**, not Kanama's whole strategy. The "fold back
+> into the broader wrapper-generator roadmap" described above has now happened: iOS reached demo parity
+> and tasks 21/22 unified all three platforms behind the full drift-gate (`check_full_drift_gate`,
+> committed == fresh regen) and resumed broad API coverage, so wrapper work lands once across desktop,
+> Android, and iOS. The **project-level** roadmap and current phase live in the task index
+> (`kanama-tasks/README.md`); Kanama is now in the release endgame (tasks 13 → 12 → 15 → 18). Treat the
+> iOS-specific gates below as largely complete and this document as reference for the iOS backend, not
+> the source of truth for overall direction.
+
 ## Current Position
 
 **Status refreshed 2026-06-25:** iOS is experimental but now covers the Android-enabled public demo set


### PR DESCRIPTION
Light roadmap-refresh follow-up. The strategy doc is titled *iOS Backend Roadmap* and is iOS-scoped, but the mission has folded iOS back into broad coverage (tasks 21/22: the full per-platform drift-gate + resumed coverage). This adds a short **scope note** so the doc reads as the **iOS sub-track**, not Kanama's overall strategy — pointing project-level direction at the task index (`kanama-tasks/README.md`) and the release endgame (13 → 12 → 15 → 18).

Chose a reframe-in-place note over a rename: the filename is referenced across ~20 files + the mkdocs nav, so renaming would be far from "light."

Docs-only; `mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)