### PR TITLE
generator+ios: String (first non-POD) virtual return across all backends (task 13)

### DIFF
--- a/docs/contributing/api-coverage.md
+++ b/docs/contributing/api-coverage.md
@@ -30,7 +30,7 @@ Rows marked `inherited only` are promoted wrappers whose Godot class declares no
 
 ## Virtual Methods
 
-`extension_api.json` declares **1437** engine virtual methods (the `_*` callbacks). These are not wrapped as callable methods — a script overrides them with `@OverrideVirtual` (Phase 5), where the Kotlin function name is the virtual name (GDScript-style `fun _draw()`). The processor validates each override against a generated signature table (`scripts/generate_virtual_signature_table.py`, all virtuals) and dispatches it on both targets. They are reported here separately so they neither dilute callable-method coverage nor count as wrapper gaps. Practical marshalling bounds: desktop/Android cover the audited Variant shapes; iOS value-returns currently cover Bool/Int/Float/Vector2/Vector2i (string/packed/Variant returns deferred).
+`extension_api.json` declares **1437** engine virtual methods (the `_*` callbacks). These are not wrapped as callable methods — a script overrides them with `@OverrideVirtual` (Phase 5), where the Kotlin function name is the virtual name (GDScript-style `fun _draw()`). The processor validates each override against a generated signature table (`scripts/generate_virtual_signature_table.py`, all virtuals) and dispatches it on both targets. They are reported here separately so they neither dilute callable-method coverage nor count as wrapper gaps. Practical marshalling bounds (task 13): desktop/Android cover the audited scalar/POD Variant shapes plus String returns; iOS value-returns cover Bool/Int/Float/Vector2/Vector2i/String. Packed*/Variant virtual returns are deferred on all platforms (not yet in the audited return type set).
 
 ## Promoted Source By Area
 

--- a/docs/internals/active/wrapper-coverage-tracker.md
+++ b/docs/internals/active/wrapper-coverage-tracker.md
@@ -12,7 +12,7 @@ commands outside this public repo.
 | iOS audited type set | Done for demo/runtime use | POD/value types, strings, NodePath/StringName, typed arrays, Variant scalar returns, typed object arrays, Projection/Vector4/Plane, and generic Array cases were wired with matrix/ObjectCalls coverage. |
 | iOS script model | Done | iOS consumes the shared KSP model; the regex parser was deleted. |
 | iOS stubs/sugar | Done | 0 STUB / 0 SUGAR; remaining HANDWRITTEN entries are platform/runtime glue. |
-| Virtual methods | Done for current audited return set | `@OverrideVirtual` works across desktop/Android/iOS; iOS value returns cover the audited POD set. |
+| Virtual methods | Done for audited return set incl. String | `@OverrideVirtual` works across desktop/Android/iOS; iOS value returns cover the audited POD set plus String (task 13). Packed*/Variant virtual returns remain deferred (not yet in the audited return type set). |
 | iOS demo breadth | Done for Android-enabled public demos | See [ios-demo-port-tracker.md](./ios-demo-port-tracker.md). |
 | Stable mobile support | Not done | See [ios-backend-roadmap.md](./ios-backend-roadmap.md). |
 
@@ -67,7 +67,9 @@ commands outside this public repo.
 | 5.1 Design and signature table | done |
 | 5.2 JVM implementation | done |
 | 5.3 iOS void and audited value-returning virtuals | done |
+| 5.3c iOS String (first non-POD) virtual return | done (task 13) — variable-length destroy-after-read via `kanama_ios_pt_return_to_variant`; device self-test rows green |
 | 5.4 Coverage accounting | done |
+| 5.5 Packed*/Variant virtual returns | deferred — need new `TypeMapping` entries + JVM/iOS marshalling; land as their own audited shape families |
 
 ## Remaining Work
 

--- a/example_project/VirtualOverrideProbe.kt
+++ b/example_project/VirtualOverrideProbe.kt
@@ -10,9 +10,10 @@ import java.lang.foreign.MemorySegment
 /**
  * Phase 5.2 probe: exercises `@OverrideVirtual` for arbitrary, value-returning
  * engine virtuals beyond the fixed lifecycle set. Attaches to `Control` and
- * overrides two of its virtuals — one returning a `Vector2`, one taking a
- * `Vector2` and returning a `Bool` — so the generated registrar must validate
- * the signatures against the engine table and emit return marshalling for both.
+ * overrides several of its virtuals — a `Vector2` return, a `Vector2`-in/`Bool`
+ * return, and (task 13) a `Vector2`-in/`String` return — so the generated
+ * registrar must validate each signature against the engine table and emit the
+ * matching return marshalling, including the non-POD `String` path.
  */
 @ScriptClass(attachTo = "Control")
 class VirtualOverrideProbe(godotObject: MemorySegment) : KanamaScript<Control>(godotObject, ::Control) {
@@ -22,4 +23,9 @@ class VirtualOverrideProbe(godotObject: MemorySegment) : KanamaScript<Control>(g
 
     @OverrideVirtual
     fun _has_point(at: Vector2): Boolean = at.x >= 0.0f && at.y >= 0.0f
+
+    // task 13 — non-POD (String) virtual return: exercises variantWriteRetExpr's STRING path
+    // (init/destroy-after-read) on desktop and the callVReturning String encode on iOS.
+    @OverrideVirtual
+    fun _get_tooltip(at: Vector2): String = "tip@${at.x.toInt()},${at.y.toInt()}"
 }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -1243,6 +1243,18 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         ObjectCalls.getMethodBind("Object", "get_class", 201670096L), n2cls)
     check("string-ret(get_class==Node2D)", cls == "Node2D")
 
+    // Virtual String-RETURN encode width (task 13 — non-POD virtual returns). A value-returning
+    // @OverrideVirtual whose Kotlin result is a String hands it back through a pointer in the fixed
+    // return scratch (kanama_ios_runtime_script_instance_call_v -> encodeIosReturn). A long (>32B)
+    // string must NOT truncate to the 32-byte buffer. This asserts the Kotlin encoder half; the C
+    // half (build the Godot Variant + destroy-after-read) is the "virtual-string-ret roundtrip"
+    // row in kanama_ios_ptrcall_selftest.
+    val vRetLong = "kanama-virtual-string-return-selftest-0123456789-abcdefghijklmnopqrstuvwxyz"
+    check("virtual-string-ret-encode(long>32B)",
+        net.multigesture.kanama.ios.kanamaIosVirtualStringReturnSelfTest(vRetLong) == vRetLong)
+    check("virtual-string-ret-encode(empty)",
+        net.multigesture.kanama.ios.kanamaIosVirtualStringReturnSelfTest("") == "")
+
     // StringName-return (Node.get_name): set a known name (StringName arg) then read it
     // back through ptrcallNoArgsRetStringName — exercises the StringName->String ctor
     // hop end to end. Deterministic; node name has no validation.

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
@@ -9,7 +9,10 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.FloatVar
 import kotlinx.cinterop.IntVar
 import kotlinx.cinterop.LongVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.free
 import kotlinx.cinterop.get
+import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.set
@@ -844,9 +847,58 @@ private fun encodeIosReturn(value: Any?, retTag: CPointer<IntVar>?, retBuf: CPoi
             val n = retBuf.reinterpret<IntVar>()
             n[0] = value.x; n[1] = value.y; retTag[0] = IOS_PT_VECTOR2I
         }
+        // Non-POD (task 13): a String return can exceed the fixed retBuf, so we hand back a
+        // pointer to a persistent scratch buffer; the C side (kanama_ios_pt_return_to_variant)
+        // builds the Godot String from it and destroys the temporary after copying.
+        is String -> {
+            val ptr = IosReturnStringScratch.encode(value)
+            retBuf.reinterpret<CPointerVar<ByteVar>>()[0] = ptr
+            retTag[0] = IOS_PT_STRING
+        }
         else -> retTag[0] = IOS_PT_VOID
     }
 }
+
+// Persistent scratch for String virtual/method returns (task 13). The C return path reads a
+// `char *` out of the fixed 32-byte return buffer because a String payload can exceed it. The
+// buffer is reused across calls (grown as needed) rather than per-call allocated: script-instance
+// dispatch is synchronous on the main thread and C copies the bytes into a Godot String
+// immediately, before the next encode can overwrite them — a nested engine call fully completes its
+// own read before the outer encode runs. Mirrors the roadmap's "reuse PtrcallScratch-style
+// thread-locals, not per-call arenas".
+@OptIn(ExperimentalForeignApi::class)
+private object IosReturnStringScratch {
+    private var buf: CPointer<ByteVar>? = null
+    private var capacity: Int = 0
+
+    fun encode(value: String): CPointer<ByteVar> {
+        val bytes = value.encodeToByteArray()
+        val needed = bytes.size + 1
+        val existing = buf
+        val b: CPointer<ByteVar> = if (existing == null || capacity < needed) {
+            if (existing != null) nativeHeap.free(existing)
+            val fresh = nativeHeap.allocArray<ByteVar>(needed)
+            buf = fresh
+            capacity = needed
+            fresh
+        } else {
+            existing
+        }
+        for (i in bytes.indices) b[i] = bytes[i]
+        b[bytes.size] = 0
+        return b
+    }
+
+    // Kotlin-side width self-test hook (task 13): encode [value] and read it back through the same
+    // pointer the C side would, returning the decoded string so the OBJECTCALLS SELFTEST can assert
+    // a long (>32-byte) String survives the fixed-scratch return path uncorrupted.
+    fun selfTestRoundTrip(value: String): String = encode(value).toKString()
+}
+
+/** OBJECTCALLS-SELFTEST hook for the String virtual-return encoder (task 13). See scratch above. */
+@OptIn(ExperimentalForeignApi::class)
+internal fun kanamaIosVirtualStringReturnSelfTest(value: String): String =
+    IosReturnStringScratch.selfTestRoundTrip(value)
 
 @OptIn(ExperimentalNativeApi::class)
 @CName("kanama_ios_runtime_script_instance_free")

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -4085,6 +4085,32 @@ static void kanama_ios_pt_arg_to_variant(
     }
 }
 
+// Build the engine return Variant for a value-returning virtual/method from the PT-tagged return
+// scratch (task 13 — non-POD virtual returns). POD/fixed-width kinds (Bool/Int/Float/Vector2/
+// Vector2i/…) delegate to kanama_ios_pt_arg_to_variant, where ret_buf holds the value bytes inline.
+// Variable-length kinds (STRING) can exceed the fixed ret_buf, so the Kotlin encoder instead writes
+// a `char *` pointer into ret_buf; we build the Godot String from it, copy it into the return
+// Variant, then destroy the temporary. Destroy-after-read: the engine owns `out_variant` and takes
+// its own reference on construction, so the local String cell must be released here (same ownership
+// as the inbound String arg cells).
+static void kanama_ios_pt_return_to_variant(int32_t tag, const void *ret_buf, uint8_t out_variant[24]) {
+    if (tag == KANAMA_IOS_PT_STRING) {
+        const char *s = (ret_buf != NULL) ? *(const char *const *)ret_buf : NULL;
+        uint64_t cell = 0;
+        memset(out_variant, 0, 24);
+        kanama_ios_init_string(&cell, (s != NULL) ? s : "");
+        g_variant_from_string(out_variant, &cell);
+        kanama_ios_destroy_string(&cell);
+        return;
+    }
+    // POD return kinds carry no backing cell (cell_kind stays 0 — nothing to free).
+    uint64_t cell = 0;
+    int cell_kind = 0;
+    kanama_ios_pt_arg_to_variant(tag, ret_buf, out_variant, &cell, &cell_kind);
+    (void)cell;
+    (void)cell_kind;
+}
+
 // Generic Variant Object.call dispatch. Boxes each PT-tagged arg into a Variant,
 // invokes method_bind via object_method_bind_call (the Variant path, for varargs /
 // dynamic dispatch the ptrcall path can't express — Object::call, set_deferred,
@@ -6078,11 +6104,10 @@ static void kanama_ios_script_instance_call(
             instance->runtime_handle, method_index, tags, ptrs, argc, &ret_tag, ret_buf);
 
         if (ret != NULL && ret_tag != KANAMA_IOS_PT_VOID) {
-            uint64_t ret_cell = 0;
-            int ret_cell_kind = 0;
-            kanama_ios_pt_arg_to_variant(ret_tag, ret_buf, (uint8_t *)ret, &ret_cell, &ret_cell_kind);
-            // Supported 5.3b return kinds (Bool/Int/Float/Vector2/Vector2i) are POD — no backing
-            // cell to destroy (ret_cell_kind stays 0). String-family returns are not yet emitted.
+            // Bool/Int/Float/Vector2/Vector2i are POD (bytes inline in ret_buf); String is
+            // variable-length (ret_buf holds a char* pointer, freed via destroy-after-read inside
+            // the helper). See kanama_ios_pt_return_to_variant.
+            kanama_ios_pt_return_to_variant(ret_tag, ret_buf, (uint8_t *)ret);
         }
 
         for (int32_t i = 0; i < argc; i++) {
@@ -7086,6 +7111,38 @@ static void kanama_ios_ptrcall_selftest(void) {
             node2d_str, class_buf, (int64_t)sizeof(class_buf));
         KANAMA_IOS_ST_CHECK("string-ret get_class==Node2D",
             class_len == 6 && strncmp(class_buf, "Node2D", 6) == 0);
+    }
+
+    // Virtual String-RETURN marshalling (task 13 — non-POD virtual returns). A value-returning
+    // virtual (e.g. Object._to_string) whose Kotlin result is a String hands it back to the engine
+    // via kanama_ios_pt_return_to_variant: the PT return scratch holds a char* pointer (NOT inline
+    // bytes), the helper builds a Godot String Variant and destroys the temporary. Width-sensitive:
+    // the probe string is >32 bytes so a regression that truncated to the fixed ret_buf, or treated
+    // the buffer as inline chars, fails here. Read the Variant back to utf8 and compare.
+    {
+        const char *long_str =
+            "kanama-virtual-string-return-selftest-0123456789-abcdefghijklmnopqrstuvwxyz";
+        uint8_t rb[32];
+        memset(rb, 0, sizeof(rb));
+        *(const char **)rb = long_str;
+        uint8_t ret_variant[24];
+        memset(ret_variant, 0, sizeof(ret_variant));
+        kanama_ios_pt_return_to_variant(KANAMA_IOS_PT_STRING, rb, ret_variant);
+        uint64_t raw_str = 0;
+        char *utf8 = NULL;
+        if (g_variant_to_string != NULL) {
+            g_variant_to_string(&raw_str, (GDExtensionVariantPtr)ret_variant);
+            utf8 = kanama_ios_string_to_utf8_dup((GDExtensionConstStringPtr)&raw_str);
+            if (g_string_destructor != NULL) {
+                g_string_destructor((GDExtensionStringPtr)&raw_str);
+            }
+        }
+        KANAMA_IOS_ST_CHECK("virtual-string-ret roundtrip(>32B)",
+            utf8 != NULL && strcmp(utf8, long_str) == 0);
+        free(utf8);
+        if (g_variant_destroy != NULL) {
+            g_variant_destroy((GDExtensionVariantPtr)ret_variant);
+        }
     }
 
     // StringName-return: Node.set_name("KanamaSN") -> get_name(). Exercises the

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -34,10 +34,13 @@ private val lifecycleIosVirtuals = setOf(
     "_input", "_unhandled_input", "_shortcut_input", "_unhandled_key_input",
 )
 
-/** Return types the iOS callVReturning encode + C pt_arg_to_variant can marshal (Phase 5.3b). */
+// Return types the iOS callVReturning encode + C kanama_ios_pt_return_to_variant can marshal.
+// POD/value returns (Bool/Int/Float/Vector2/Vector2i) landed in Phase 5.3b; STRING is the first
+// non-POD (variable-length, destroy-after-read) virtual return, task 13.
 private val iosReturnTypes = setOf(
     TypeMapping.BOOL, TypeMapping.INT, TypeMapping.FLOAT,
     TypeMapping.VECTOR2, TypeMapping.VECTOR2I,
+    TypeMapping.STRING,
 )
 
 internal data class IosMethod(
@@ -520,8 +523,8 @@ internal class IosScriptCodeEmitter(
             IosMethod(virtualName, kotlinMethodName, args, returnType)
         else -> {
             warn("[kanama-ios] $kotlinMethodName ($virtualName): @OverrideVirtual return type " +
-                "$returnType not yet marshalled on iOS (Phase 5.3b supports Bool/Int/Float/" +
-                "Vector2/Vector2i) — silent no-op")
+                "$returnType not yet marshalled on iOS (supported: Bool/Int/Float/Vector2/" +
+                "Vector2i/String) — silent no-op")
             null
         }
     }

--- a/scripts/api_wrapper_coverage.py
+++ b/scripts/api_wrapper_coverage.py
@@ -160,9 +160,10 @@ def render_markdown(
             "(GDScript-style `fun _draw()`). The processor validates each override against a generated "
             "signature table (`scripts/generate_virtual_signature_table.py`, all virtuals) and dispatches "
             "it on both targets. They are reported here separately so they neither dilute callable-method "
-            "coverage nor count as wrapper gaps. Practical marshalling bounds: desktop/Android cover the "
-            "audited Variant shapes; iOS value-returns currently cover Bool/Int/Float/Vector2/Vector2i "
-            "(string/packed/Variant returns deferred).",
+            "coverage nor count as wrapper gaps. Practical marshalling bounds (task 13): desktop/Android "
+            "cover the audited scalar/POD Variant shapes plus String returns; iOS value-returns cover "
+            "Bool/Int/Float/Vector2/Vector2i/String. Packed*/Variant virtual returns are deferred on all "
+            "platforms (not yet in the audited return type set).",
             "",
             "## Promoted Source By Area",
             "",


### PR DESCRIPTION
## Task 13 — Non-POD virtual returns (Phase 5 long-tail), first family: **String**

Extends the audited `@OverrideVirtual` value-return set beyond POD
(Bool/Int/Float/Vector2/Vector2i) to **String** — the first non-POD virtual
return — across all three backends: JVM/Panama, KSP dispatch, and the iOS
C-shim. Landed per-family (not big-bang) per the task guidance.

### What was already there vs. new
- **Desktop/Android** already marshalled a String virtual return through the
  generated registrar (`variantWriteRetExpr` STRING: `initString` →
  `variantFromType(STRING)` → `destroyString`). No change needed; now exercised
  by a new `VirtualOverrideProbe._get_tooltip(Vector2): String`.
- **iOS** was the gap (`iosReturnTypes` excluded STRING → skipped+warned). Added:
  - **C-shim** `kanama_ios_pt_return_to_variant`: builds the engine return
    Variant from the PT return scratch. POD kinds stay inline; **STRING is
    variable-length**, so the Kotlin encoder writes a `char*` pointer into the
    fixed `ret_buf` and the helper builds the Godot String and destroys the
    temporary (**destroy-after-read**, same ownership as inbound String arg cells).
  - **iOS runtime** `encodeIosReturn` String branch backed by a reused
    `IosReturnStringScratch` buffer (grown as needed, not per-call allocated —
    the roadmap's "reuse PtrcallScratch-style thread-locals, not per-call arenas").
  - **Emitter**: `STRING` added to the audited `iosReturnTypes`.

### Validation
- **Width-sensitive self-test rows** (marshalling/ownership sensitive): Kotlin
  encode round-trip (`>32B` + empty) and a C variant round-trip (`>32B`, proving
  the pointer indirection, not inline truncation to the 32-byte scratch).
- **Device-validated iPhone 15 Pro (iOS 26.5)**: `PTRCALL SELFTEST MATRIX: 58
  passed, 0 failed`, `OBJECTCALLS SELFTEST: 84 passed, 0 failed` (+1 C / +2 Kotlin
  rows vs the 57C/82Kt baseline — exactly the added rows).
- Drift-gate green (desktop 985 / iOS 242); `./gradlew jar` +
  `compileKotlinIosArm64` + Android plugin AAR all green.

### Out of scope / deferred
- **Packed\*/Variant** virtual returns are deferred — each needs new
  `TypeMapping` entries + JVM/iOS marshalling, to land as their own audited shape
  families. Coverage note + tracker updated accordingly; no 100% claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)