### PR TITLE
docs: reassess F3 per-call-arena follow-up as profile-driven deferral (task 12)

### DIFF
--- a/docs/internals/reference/architecture-review-2026-06.md
+++ b/docs/internals/reference/architecture-review-2026-06.md
@@ -139,6 +139,34 @@ destroy-after-read is required. Confined arena create/close is cheap
 individually, but it is measurable overhead on per-frame call chains
 (transform getters/setters, input polling).
 
+**Reassessed 2026-07 (task 12) — recommend deferring until profile-driven.**
+Two premises above no longer hold after the convergence work:
+
+- **`ObjectCalls.kt` is hand-written, not generated.** Post-convergence the
+  single generator (`scripts/generate_api_wrapper.py`) emits only the *iOS*
+  `ObjectCallsGenerated.kt`; the desktop `ObjectCalls.kt` is the hand-written
+  reference template. So there is no "change the generator + regenerate" path —
+  any change is a direct hand-transform of the 40k-line file.
+- **The hot subset is already done.** The F3 first pass moved exactly the
+  per-frame no-arg fixed-size *return* getters (Vector2/3/3i/2i, Quaternion,
+  Basis, Transform3D, Rect2, Color, Array/Object list rets) onto the thread-local
+  `PtrcallScratch`. Those are the transform/vector polling calls that dominate a
+  per-frame chain.
+
+Remaining scope of the 1,506 confined-arena helpers: only **~4** are safe
+fixed-size no-arg return conversions still outstanding (Rect2i/AABB/Plane/
+Transform2D); **~29** no-arg returns are *variable-size* and must keep arenas
+(String, `Packed*List`, Array, Dictionary, Callable, typed lists — destroy-after-
+read); the other **~1,473 take arguments** and would need a scratch matrix keyed
+by (type × arg-position) plus per-N args-pointer arrays — an aliasing-sensitive,
+memory-corruption-prone refactor for modest, unmeasured, per-frame benefit.
+
+Conclusion: the highest-value/lowest-risk slice shipped in F3. The remainder is
+premature optimization without a profiled bottleneck — defer until a real
+workload measures a per-frame arena cost worth the risk, then convert only the
+specific hot helpers that show up, with dedicated non-aliasing cells + a
+Bunnymark/A-B measurement.
+
 ### F4 — Maintenance follow-up (fixed): scattered Godot version pins
 
 The Godot 4.7-rc2 pin appears independently in the iOS export template

--- a/docs/internals/reference/wrapper-coverage-roadmap.md
+++ b/docs/internals/reference/wrapper-coverage-roadmap.md
@@ -143,7 +143,7 @@ hand-shaped methods; coverage page reads ≥99% with virtuals counted.
 
 | Task | Model | Source |
 |---|---|---|
-| Extend `PtrcallScratch` thread-local pattern across generated wrappers (replace ~1,478 per-call `Arena.ofConfined()`) | **sonnet** (generator change), **opus** review | Architecture review F3 |
+| Extend `PtrcallScratch` thread-local pattern across generated wrappers (~1,478 per-call `Arena.ofConfined()`) — **deferred, profile-driven** (task 12 reassessment): `ObjectCalls.kt` is hand-written not generated, the hot per-frame getters already moved to the scratch in F3, and the remainder is ~4 safe conversions + ~1,473 aliasing-sensitive arg-helpers for unmeasured benefit. See F3 "Reassessed 2026-07". | **defer** | Architecture review F3 |
 | Single source of truth for the Godot version pin (Gradle property → CI, iOS template path, docs) | **sonnet** | Architecture review F4 |
 | R8-minified APK smoke gate (validate `consumer-rules.pro`) | **done 2026-06-26** | Architecture review F2; passed on Pixel 7 with Kanama's PanamaPort fork |
 | Value-type `==` faithfulness to GDScript/C# (see below) | **sonnet** (generator change), **opus** review | 2026-06-15 session |


### PR DESCRIPTION
Records the **task 12** reassessment: postpone the per-call-arena optimization as
profile-driven, and correct two stale premises in the F3 follow-up.

### Why
- **`ObjectCalls.kt` is hand-written**, not generated. Post-convergence the single
  generator emits only the *iOS* `ObjectCallsGenerated.kt`; the desktop file is the
  reference template — there is no "edit the generator + regenerate" path.
- **The hot subset already shipped** in the F3 first pass (per-frame no-arg
  transform/vector getters on `PtrcallScratch`).
- Remaining scope of the 1,506 confined-arena helpers: **~4** safe fixed-size
  conversions, **~29** variable-size (must keep arenas for destroy-after-read),
  **~1,473** aliasing-sensitive arg-helpers for **unmeasured** benefit.

Conclusion: premature optimization without a profiled bottleneck. Revisit
profile-driven — convert only the specific hot helpers a real workload surfaces,
with dedicated non-aliasing cells + a Bunnymark A/B.

Docs only: `architecture-review-2026-06.md` (F3) + `wrapper-coverage-roadmap.md`
standing follow-up. `kanama-tasks/` (spec + tracker) updated out-of-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)