### PR TITLE
generator: List<enum> typed exports — C# enum-array parity (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ versioning once public releases begin.
   as inspector defaults. `@ScriptClass` scripts on desktop/Android; the iOS
   property delivery is a documented deferral (warn-skips, keeps the Kotlin
   default).
+- `@Export` / `@ScriptProperty` now also works on **lists of Kotlin enums**
+  (`List<MyEnum>` / `MutableList<MyEnum>`,
+  [#40](https://github.com/falcon4ever/kanama/issues/40)). Matching C# enum-array
+  exports, the property registers as a typed int Array whose elements carry
+  `PROPERTY_HINT_ENUM` with the entry names (the inspector renders an array of
+  dropdowns); elements are stored as ordinals, `.tscn`-stored arrays deserialize
+  back into the list, and out-of-range stored elements clamp to a valid entry.
+  Same scope as scalar enum exports: `@ScriptClass` scripts on desktop/Android,
+  iOS property delivery warn-skips and keeps the Kotlin default. `Map<K, V>`
+  exports remain out of scope (non-String Dictionary keys are a policy gate).
 - `@OverrideVirtual` now supports **every Variant-expressible return type** in
   the Godot 4.7 virtual surface (170 additional virtuals). New Kotlin return
   types: all fixed-element packed arrays (`ByteArray`, `IntArray`, `LongArray`,

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -300,13 +300,16 @@ build/box round-trips in the on-device self-test matrix (the
 **iOS `@ScriptProperty` conversion deferrals (by design, warn-skipped
 fail-loud):** properties whose Kotlin field needs a conversion around the
 Variant slot are desktop/Android-only for now. That is the narrow scalars
-(`kotlin.Float`/`kotlin.Int` widened to the 64-bit FLOAT/INT slots) and Kotlin
+(`kotlin.Float`/`kotlin.Int` widened to the 64-bit FLOAT/INT slots), Kotlin
 `enum class` exports (task 32 — INT slot carrying the ordinal, registered with
-`PROPERTY_HINT_ENUM`). The model carries everything iOS needs
-(`enumFqName`/`enumEntries` are in the serialized script model, schema v3);
+`PROPERTY_HINT_ENUM`), and enum-list exports (task 38 — typed int Array of
+ordinals with a per-element enum hint). The model carries everything iOS needs
+(`enumFqName`/`enumEntries` and `arrayElementEnumFqName`/
+`arrayElementEnumEntries` are in the serialized script model, schema v4);
 what's missing is a set-property conversion hook in the iOS emitter, so
-`IosScriptCodeEmitter.toIosProperty` warns and keeps the Kotlin default. Both
-conversions belong to the same ios-runtime property-path follow-up slice.
+`IosScriptCodeEmitter.toIosProperty` warns and keeps the Kotlin default. All
+three conversions belong to the same ios-runtime property-path follow-up
+slice.
 
 ## KDoc Maintenance
 

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -62,6 +62,19 @@ Enum exports are supported on `@ScriptClass` scripts (`@ScriptProperty` /
 `@Export`); `@RegisterProperty` on `@RegisterClass` classes does not accept
 enum types yet.
 
+Lists of enums export too, as a typed int array whose elements render the
+same dropdown (C# `Difficulty[]` parity):
+
+```kotlin
+@ScriptProperty
+var unlockedModes: List<Difficulty> = emptyList()
+```
+
+Elements are stored as ordinals with the same clamp-on-stale-value and
+reordering trade-off as the scalar form. Defaults must be empty
+(`emptyList()` / `listOf()`); populate initial values in the scene or
+inspector.
+
 ## Inspector Buttons
 
 Use `@ToolButton` on a zero-argument function in a `@Tool @ScriptClass` to

--- a/docs/reference/c-sharp-compat.md
+++ b/docs/reference/c-sharp-compat.md
@@ -59,7 +59,7 @@ Legend: `SUPPORTED` means validated in smoke tests or real demo ports.
 | Godot value types | SUPPORTED | Vectors, transforms, colors, planes, AABB, `NodePath`, `RID`, and related helpers are covered for current promoted APIs. |
 | Object/resource handles | PARTIAL | Typed wrappers and closeable `Resource`/`RefCounted` handles are available; ownership-sensitive returns still require explicit policy. |
 | Packed strings and bytes | SUPPORTED | `PackedStringArray` maps to `List<String>` in supported APIs; `PackedByteArray` maps to `ByteArray` in file helpers. |
-| Typed exported arrays | PARTIAL | `List<String>`, `List<Texture2D>`, and same-project global resource-script arrays are supported. Broader typed arrays remain policy work. |
+| Typed exported arrays | PARTIAL | `List<String>`, `List<Texture2D>`, custom-enum arrays (`List<MyEnum>`), and same-project global resource-script arrays are supported. Broader typed arrays remain policy work. |
 | General Array/Dictionary/Variant APIs | PARTIAL | Selected dictionary/list shapes exist. Fully general heterogeneous containers are still a deliberate policy bucket. |
 | Callable | PARTIAL | Signal connections, lambda callbacks, and tween callable helpers exist for bounded shapes. General public Callable ownership remains intentionally constrained. |
 

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -118,6 +118,12 @@ class HelloScript(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, 
 	@ScriptProperty
 	var smokeDifficulty = SmokeDifficulty.NORMAL
 
+	// task 38 (issue #40) — enum-list export: registers as a typed int Array whose
+	// elements carry PROPERTY_HINT_ENUM ("2/2:EASY,NORMAL,HARD"), stored as ordinals;
+	// main.tscn overrides it to [HARD, EASY].
+	@ScriptProperty
+	var smokeJoints: List<SmokeDifficulty> = emptyList()
+
 	@ScriptProperty
 	var label: String = "hello"
 

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -62,6 +62,7 @@ func _ready() -> void:
 		if not has_export_group or not has_export_subgroup:
 			push_error("Kanama script export group/subgroup metadata missing")
 		_kanama_enum_export_smoke(properties)
+		_kanama_enum_list_export_smoke(properties)
 		var replace_smoke_scene = $ScriptNode.replace_smoke_scene()
 		print("[kanama:gd] kt script replace_smoke_scene = ", replace_smoke_scene)
 		if not replace_smoke_scene:
@@ -116,6 +117,33 @@ func _kanama_enum_export_smoke(properties: Array) -> void:
 		" clamp=", clamped == 2)
 	if not (enum_type and enum_hint and enum_hint_string and tscn_value == 2 and roundtrip == 0 and clamped == 2):
 		push_error("Kanama enum export metadata or round-trip failed")
+
+# task 38 — enum-list exports (List<enum>). Must register as an ARRAY property with
+# PROPERTY_HINT_TYPE_STRING and a per-element enum hint ("2/2:<entries>"), round-trip
+# ordinal arrays through set/get, and clamp out-of-range stored ints per element.
+func _kanama_enum_list_export_smoke(properties: Array) -> void:
+	var list_type := false
+	var list_hint := false
+	var list_hint_string := false
+	for property in properties:
+		if property.get("name", "") == "smoke_joints":
+			list_type = int(property.get("type", -1)) == TYPE_ARRAY
+			list_hint = int(property.get("hint", -1)) == PROPERTY_HINT_TYPE_STRING
+			list_hint_string = str(property.get("hint_string", "")) == "%d/%d:EASY,NORMAL,HARD" % [TYPE_INT, PROPERTY_HINT_ENUM]
+	var tscn_value = $ScriptNode.smoke_joints
+	$ScriptNode.smoke_joints = [0, 1]
+	var roundtrip = $ScriptNode.smoke_joints
+	$ScriptNode.smoke_joints = [99, -3]
+	var clamped = $ScriptNode.smoke_joints
+	$ScriptNode.smoke_joints = tscn_value
+	print("[kanama:gd] kt script enum list export type=", list_type,
+		" hint=", list_hint,
+		" hint_string=", list_hint_string,
+		" tscn=", tscn_value == [2, 0],
+		" roundtrip=", roundtrip == [0, 1],
+		" clamp=", clamped == [2, 0])
+	if not (list_type and list_hint and list_hint_string and tscn_value == [2, 0] and roundtrip == [0, 1] and clamped == [2, 0]):
+		push_error("Kanama enum-list export metadata or round-trip failed")
 
 # task 29 — virtual-return families. Calling an @OverrideVirtual method by name on a
 # script-attached host routes through the script instance dispatch (the same path the

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -135,14 +135,19 @@ func _kanama_enum_list_export_smoke(properties: Array) -> void:
 	var roundtrip = $ScriptNode.smoke_joints
 	$ScriptNode.smoke_joints = [99, -3]
 	var clamped = $ScriptNode.smoke_joints
+	# The inspector's Add Element/resize null-fills the (untyped) array it got from
+	# the getter; null elements must default to the first entry, not silently drop.
+	$ScriptNode.smoke_joints = [1, null]
+	var nullfill = $ScriptNode.smoke_joints
 	$ScriptNode.smoke_joints = tscn_value
 	print("[kanama:gd] kt script enum list export type=", list_type,
 		" hint=", list_hint,
 		" hint_string=", list_hint_string,
 		" tscn=", tscn_value == [2, 0],
 		" roundtrip=", roundtrip == [0, 1],
-		" clamp=", clamped == [2, 0])
-	if not (list_type and list_hint and list_hint_string and tscn_value == [2, 0] and roundtrip == [0, 1] and clamped == [2, 0]):
+		" clamp=", clamped == [2, 0],
+		" nullfill=", nullfill == [1, 0])
+	if not (list_type and list_hint and list_hint_string and tscn_value == [2, 0] and roundtrip == [0, 1] and clamped == [2, 0] and nullfill == [1, 0]):
 		push_error("Kanama enum-list export metadata or round-trip failed")
 
 # task 29 — virtual-return families. Calling an @OverrideVirtual method by name on a

--- a/example_project/main.tscn
+++ b/example_project/main.tscn
@@ -79,6 +79,7 @@ offset_bottom = 72.0
 script = ExtResource("2")
 label = "from_tscn"
 smoke_difficulty = 2
+smoke_joints = [2, 0]
 target_path = NodePath("../SceneTarget3D")
 
 [node name="NonToolScriptNode" type="Node" parent="." unique_id=193847562]

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -602,6 +602,29 @@ internal class IosScriptCodeEmitter(
     }
 
     private fun ScriptPropertyModel.toIosProperty(className: String): IosProperty {
+        // Enum-element lists (task 38) need the ordinal <-> entry conversion the iOS
+        // set-property path doesn't have yet: keep the Kotlin default, same boundary
+        // as the scalar enum exports below (no list delivery case is emitted).
+        if (arrayElementEnumFqName != null) {
+            warn(
+                "[kanama-ios] $className.$kotlinName (List<${arrayElementEnumFqName.substringAfterLast('.')}>) — " +
+                    "no iOS @ScriptProperty enum-list path yet, will keep its Kotlin default",
+            )
+            return IosProperty(
+                godotName = godotName,
+                kotlinName = kotlinName,
+                isObjectType = false,
+                godotClassName = "",
+                isList = false,
+                listElementClassName = "",
+                isNullable = nullable,
+                valueTypeClassName = "",
+                godotVariantType = 28, // ARRAY
+                customScriptFqName = "",
+                arrayElementCustomScriptFqName = "",
+                listElementIsString = false,
+            )
+        }
         val isList = type == TypeMapping.ARRAY
         val isObject = objectWrapperFqName != null
         // A user @ScriptClass-typed OBJECT property (e.g. `target: Vehicle?` exported via node_paths):

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -675,6 +675,8 @@ class KanamaProcessor(
                 scriptType.narrow,
                 scriptType.enumFqName,
                 scriptType.enumEntries,
+                scriptType.arrayElementEnumFqName,
+                scriptType.arrayElementEnumEntries,
             )
         }
 
@@ -1072,7 +1074,8 @@ class KanamaProcessor(
             }
 
             if (fq == "kotlin.collections.List" || fq == "kotlin.collections.MutableList") {
-                val elementFq = type.arguments.firstOrNull()?.type?.resolve()?.declaration?.qualifiedName?.asString()
+                val elementDecl = type.arguments.firstOrNull()?.type?.resolve()?.declaration
+                val elementFq = elementDecl?.qualifiedName?.asString()
                 if (elementFq == "kotlin.String") {
                     return ScriptPropertyTypeModel(
                         type = TypeMapping.ARRAY,
@@ -1103,6 +1106,30 @@ class KanamaProcessor(
                         hintString = "24/${customElement.propertyHint}:${customElement.simpleName}",
                         arrayElementCustomScriptFqName = customElement.fqName,
                         arrayElementCustomScriptIsResource = customElement.isExportableResource,
+                    )
+                }
+                // task 38 (issue #40): List<enum class> — a typed int Array whose elements
+                // carry PROPERTY_HINT_ENUM ("2/2:<entries>"), the array form of the task-32
+                // scalar enum export (C# enum-array parity). Elements are stored as ordinals.
+                val elementEnum = (elementDecl as? KSClassDeclaration)
+                    ?.takeIf { it.classKind == ClassKind.ENUM_CLASS }
+                if (elementEnum != null && elementFq != null) {
+                    val entries = elementEnum.declarations
+                        .filterIsInstance<KSClassDeclaration>()
+                        .filter { it.classKind == ClassKind.ENUM_ENTRY }
+                        .map { it.simpleName.asString() }
+                        .toList()
+                    if (entries.isEmpty()) {
+                        throw IllegalArgumentException(
+                            "$className.$propertyName: enum class '$elementFq' has no entries to export",
+                        )
+                    }
+                    return ScriptPropertyTypeModel(
+                        type = TypeMapping.ARRAY,
+                        hint = PROPERTY_HINT_TYPE_STRING,
+                        hintString = "2/$PROPERTY_HINT_ENUM:" + entries.joinToString(","),
+                        arrayElementEnumFqName = elementFq,
+                        arrayElementEnumEntries = entries,
                     )
                 }
             }
@@ -3149,6 +3176,12 @@ internal class ScriptCodeEmitter(
                 }
             property.arrayElementString ->
                 "val $localName = Arena.ofConfined().use { a -> BuiltinTypes.readVariantStringList($variantPtr, a) }"
+            // Stale stored ordinals (e.g. after entry removal) clamp into the entry
+            // range instead of indexing raw — same policy as the scalar enum export.
+            property.arrayElementEnumFqName != null -> {
+                val fq = property.arrayElementEnumFqName
+                "val $localName = Arena.ofConfined().use { a -> BuiltinTypes.readVariantLongList($variantPtr, a).map { i -> $fq.entries[i.toInt().coerceIn(0, $fq.entries.lastIndex)] } }"
+            }
             else -> variantReadExpr(property.type, variantPtr, localName)
         }
 
@@ -3235,6 +3268,8 @@ internal class ScriptCodeEmitter(
                 "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr.map { net.multigesture.kanama.api.GodotObject(it.godotObject) }, a) }"
             property.arrayElementString ->
                 "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr, a) }"
+            property.arrayElementEnumFqName != null ->
+                "Arena.ofConfined().use { a -> BuiltinTypes.initVariantFromAny(ret, $valueExpr.map { it.ordinal.toLong() }, a) }"
             else -> variantWriteRetExpr(property.type, valueExpr)
         }
 
@@ -3262,6 +3297,7 @@ internal class ScriptCodeEmitter(
             property.customScriptFqName != null -> "${property.customScriptFqName}?"
             property.arrayElementCustomScriptFqName != null -> "List<${property.arrayElementCustomScriptFqName}>"
             property.arrayElementString -> "List<String>"
+            property.arrayElementEnumFqName != null -> "List<${property.arrayElementEnumFqName}>"
             property.enumFqName != null -> property.enumFqName
             else -> property.narrow?.kotlinType ?: property.type.kotlinType
         }
@@ -3273,6 +3309,7 @@ internal class ScriptCodeEmitter(
             property.customScriptFqName != null -> "null"
             property.arrayElementCustomScriptFqName != null -> "emptyList()"
             property.arrayElementString -> "emptyList()"
+            property.arrayElementEnumFqName != null -> "emptyList()"
             property.enumFqName != null -> "${property.enumFqName}.entries.first()"
             else -> property.narrow?.zeroLiteral ?: property.type.kotlinLiteralZero
         }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModel.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModel.kt
@@ -174,6 +174,14 @@ internal data class ScriptPropertyModel(
     val enumFqName: String? = null,
     /** Ordered entry names of the enum class (ordinal order). Empty unless [enumFqName] is set. */
     val enumEntries: List<String> = emptyList(),
+    /**
+     * Set for `List<enum class>` properties (task 38, issue #40). The Variant slot is a
+     * typed int Array (hint string `"2/2:<entries>"`) carrying ordinals per element — the
+     * array form of the [enumFqName] scalar export (C# enum-array parity).
+     */
+    val arrayElementEnumFqName: String? = null,
+    /** Ordered entry names of the element enum. Empty unless [arrayElementEnumFqName] is set. */
+    val arrayElementEnumEntries: List<String> = emptyList(),
 )
 
 internal data class ScriptPropertyGroupModel(
@@ -196,6 +204,8 @@ internal data class ScriptPropertyTypeModel(
     val narrow: NarrowScalar? = null,
     val enumFqName: String? = null,
     val enumEntries: List<String> = emptyList(),
+    val arrayElementEnumFqName: String? = null,
+    val arrayElementEnumEntries: List<String> = emptyList(),
 )
 
 internal data class ScriptClassTypeInfo(

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModelJson.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModelJson.kt
@@ -9,7 +9,7 @@ package net.multigesture.kanama.processor
 // from that name. SCHEMA_VERSION is bumped whenever the shape changes; the consumer
 // fails closed on a mismatch.
 
-internal const val SCRIPT_MODEL_SCHEMA_VERSION = 3
+internal const val SCRIPT_MODEL_SCHEMA_VERSION = 4
 
 internal fun scriptModelToJson(model: ScriptModel): String {
     val sb = StringBuilder()
@@ -48,6 +48,8 @@ private fun JsonWriter.writeProperty(p: ScriptPropertyModel) = obj {
     field("arrayElementString", p.arrayElementString)
     nullableField("enumFqName", p.enumFqName)
     stringArrayField("enumEntries", p.enumEntries)
+    nullableField("arrayElementEnumFqName", p.arrayElementEnumFqName)
+    stringArrayField("arrayElementEnumEntries", p.arrayElementEnumEntries)
     objectOrNullField("exportCategory", p.exportCategory) { writeGroup(it) }
     objectOrNullField("exportGroup", p.exportGroup) { writeGroup(it) }
     objectOrNullField("exportSubgroup", p.exportSubgroup) { writeGroup(it) }

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -312,10 +312,10 @@ if ! rg -q 'val kt = SelfSmoke\(godotObject\)' "$self_smoke_registrar"; then
   echo "[local_ci] generated self-smoke registrar does not construct the KanamaScript base-class example" >&2
   exit 1
 fi
-# 14 = the example HelloScript's exported properties incl. metadata/tool-button
-# entries and the task-32 enum export (smoke_difficulty). Bump when the example
-# gains/loses an exported property.
-if ! rg -q 'propertyCount = 14' "$hello_script_registrar"; then
+# 15 = the example HelloScript's exported properties incl. metadata/tool-button
+# entries, the task-32 enum export (smoke_difficulty), and the task-38 enum-list
+# export (smoke_joints). Bump when the example gains/loses an exported property.
+if ! rg -q 'propertyCount = 15' "$hello_script_registrar"; then
   echo "[local_ci] generated script-property list count does not include metadata/tool-button entries" >&2
   exit 1
 fi

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -85,6 +85,9 @@ check "kt script export groups group=true subgroup=true"
 # round-trip via set/get, tscn-stored int deserialized into the enum slot, and
 # out-of-range stored ints clamped to a valid entry (no crash).
 check "kt script enum export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true"
+# task 38 — enum-list exports: ARRAY + PROPERTY_HINT_TYPE_STRING "2/2:<entries>",
+# ordinal-array round-trip via set/get, tscn deserialize, per-element clamp.
+check "kt script enum list export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"
@@ -183,7 +186,7 @@ check "DisplayServer passive clipboard=(true|false) image=(true|false) clipboard
 check "DisplayServer tts speaking=(true|false) paused=(true|false) voices=[0-9]+ vk_height=[0-9]+ active_popup=-?[0-9]+ window_instance=-?[0-9]+ window_screen=-?[0-9]+ can_draw=(true|false) focused=(true|false) maximize_allowed=(true|false) max_dbl=(true|false) min_dbl=(true|false)"
 check "DisplayServer accessibility screen_reader=-?[0-9]+ contrast=-?[0-9]+ reduce_animation=-?[0-9]+ reduce_transparency=-?[0-9]+ window_max=-?[0-9]+,-?[0-9]+ window_min=-?[0-9]+,-?[0-9]+ window_pos=-?[0-9]+,-?[0-9]+ window_pos_decorated=-?[0-9]+,-?[0-9]+ window_size=-?[0-9]+,-?[0-9]+ window_size_decorated=-?[0-9]+,-?[0-9]+"
 check "kt script methods size = 9"
-check "kt script properties size = 14"
+check "kt script properties size = 15"
 check "kt script signals size = 1"
 check "kt script replace_smoke_scene = true"
 check "kt script rpc config ok = true"

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -86,8 +86,9 @@ check "kt script export groups group=true subgroup=true"
 # out-of-range stored ints clamped to a valid entry (no crash).
 check "kt script enum export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true"
 # task 38 — enum-list exports: ARRAY + PROPERTY_HINT_TYPE_STRING "2/2:<entries>",
-# ordinal-array round-trip via set/get, tscn deserialize, per-element clamp.
-check "kt script enum list export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true"
+# ordinal-array round-trip via set/get, tscn deserialize, per-element clamp, and
+# inspector Add-Element null-fill defaulting to the first entry.
+check "kt script enum list export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true nullfill=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"

--- a/src/main/kotlin/binding/runtime/BuiltinTypes.kt
+++ b/src/main/kotlin/binding/runtime/BuiltinTypes.kt
@@ -316,6 +316,14 @@ object BuiltinTypes {
             else -> emptyList()
         }
 
+    /** Int-element Array read for enum-list script properties (task 38): non-numeric elements drop. */
+    fun readVariantLongList(variant: MemorySegment, arena: Arena): List<Long> =
+        when (val value = variantToScalar(variant, arena)) {
+            is List<*> -> value.mapNotNull { (it as? Number)?.toLong() }
+            is Number -> listOf(value.toLong())
+            else -> emptyList()
+        }
+
     fun readVariantNodePath(variant: MemorySegment, arena: Arena): NodePath =
         when (val value = variantToScalar(variant, arena)) {
             is NodePath -> value

--- a/src/main/kotlin/binding/runtime/BuiltinTypes.kt
+++ b/src/main/kotlin/binding/runtime/BuiltinTypes.kt
@@ -316,10 +316,15 @@ object BuiltinTypes {
             else -> emptyList()
         }
 
-    /** Int-element Array read for enum-list script properties (task 38): non-numeric elements drop. */
+    /**
+     * Int-element Array read for enum-list script properties (task 38). Non-numeric
+     * elements default to 0 instead of dropping: the inspector's Add Element/resize
+     * appends `null` slots (the script getter hands it an untyped Array, which
+     * null-fills on resize), and dropping them would make those edits silent no-ops.
+     */
     fun readVariantLongList(variant: MemorySegment, arena: Arena): List<Long> =
         when (val value = variantToScalar(variant, arena)) {
-            is List<*> -> value.mapNotNull { (it as? Number)?.toLong() }
+            is List<*> -> value.map { (it as? Number)?.toLong() ?: 0L }
             is Number -> listOf(value.toLong())
             else -> emptyList()
         }


### PR DESCRIPTION
Fixes the `List<enum>` half of #40.

`@Export` / `@ScriptProperty` on `List<MyEnum>` / `MutableList<MyEnum>` now registers a **typed int Array with a per-element enum hint** (`PROPERTY_HINT_TYPE_STRING`, hint string `"2/2:<entries>"`), matching what C# emits for `[Export] MyEnum[]`. The inspector renders an array of enum dropdowns; elements are stored as ordinals.

## What changed

- **Generator** (`scriptPropertyTypeModel`): new enum-element case in the existing typed-list branch, carried on `arrayElementEnumFqName` / `arrayElementEnumEntries` model fields (script-model schema v4). Composes the task-32 scalar-enum shape with the task-33-era typed-list plumbing — no new ABI, no C-shim.
- **Runtime read**: new `BuiltinTypes.readVariantLongList`, elements mapped ordinal → entry with a per-element clamp (`coerceIn`), so stale `.tscn` ordinals (e.g. after an entry removal) never crash script load — same policy as scalar enum exports.
- **Runtime write**: ordinals funneled through the existing `initVariantFromAny` list shape.
- **iOS**: warn-skip alongside the documented scalar-enum deferral (property keeps its Kotlin default; no silent misbehavior through the generic list path).
- **Validation**: `example_project` probe (`HelloScript.smokeJoints`, `main.tscn` stores `[2, 0]`) + a `runtime_smoke` row asserting registration metadata, `.tscn` deserialization, set/get round-trip, and out-of-range clamping (`[99, -3]` reads back `[2, 0]`). Property-count guards bumped 14 → 15.
- **Docs**: "Exporting Enums" gains the list form (including the ordinal-reorder trade-off); the c-sharp-compat typed-array row #40 quoted now lists enum arrays.

`Map<K, V>` exports (the other half of #40) remain out of scope: non-String Dictionary keys are a deliberate policy gate needing their own design pass — reporter asked to file separately.

## Gates

- `local_ci.sh` PASS end-to-end (incl. runtime/reload smokes and the KSP registrar guards)
- `runtime_smoke.sh` PASS with the new `kt script enum list export … clamp=true` row
- `mkdocs build --strict` green
- Drift-gate untouched (no wrapper regen; script-property generator only)

Remaining before merge: editor inspector spot-check (array of dropdowns renders, values survive scene save/load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)