### PR TITLE
Fix throwing away new instances initiated with ClassDB

### DIFF
--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ClassDB.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ClassDB.kt
@@ -39,7 +39,7 @@ object ClassDB {
     }
 
     fun instantiate(classValue: String): Any? {
-        return ObjectCalls.ptrcallWithStringNameArgRetVariantScalar(instantiateBind, singleton, classValue)
+        return ObjectCalls.ptrcallWithStringNameArgRetVariantScalarRetained(instantiateBind, singleton, classValue)
     }
 
     fun classGetApiType(classValue: String): Long {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -1190,6 +1190,28 @@ object ObjectCalls {
     fun ptrcallNoArgsRetVariantScalar(methodBind: MemorySegment, instance: MemorySegment): Any? =
         callWithVariantArgs(methodBind, instance, emptyList())
 
+    fun ptrcallWithStringNameArgRetVariantScalarRetained(
+        methodBind: MemorySegment,
+        instance: MemorySegment,
+        name: String,
+    ): Any? {
+        Arena.ofConfined().use { arena ->
+            val arr = arena.allocate(ADDRESS, 1)
+            arr.setAtIndex(ADDRESS, 0, GodotStrings.makeStringName(name))
+            val ret = arena.allocate(BuiltinTypes.VARIANT_SIZE, 8L)
+            try {
+                objectMethodBindPtrcall.invoke(methodBind, instance, arr, ret)
+                val value = BuiltinTypes.readVariantScalar(ret, arena)
+                if (value is GodotObject && ptrcallWithStringArgRetBool(isClassBindForRetain, value.handle, "RefCounted")) {
+                    ptrcallNoArgsRetBool(refCountedReferenceBind, value.handle)
+                }
+                return value
+            } finally {
+                BuiltinTypes.destroyVariant(ret)
+            }
+        }
+    }
+
     fun ptrcallWithStringNameArgRetVariantScalar(
         methodBind: MemorySegment,
         instance: MemorySegment,
@@ -1244,6 +1266,13 @@ object ObjectCalls {
         boolArg: Boolean,
     ): NodePath =
         NodePath(callWithVariantArgs(methodBind, instance, listOf(objectArg, boolArg)) as? String ?: "")
+
+    private val isClassBindForRetain by lazy {
+        getMethodBind("Object", "is_class", 3927539163L)
+    }
+    private val refCountedReferenceBind by lazy {
+        getMethodBind("RefCounted", "reference", 2240911060L)
+    }
 }
 
 // Debug-gated self-test (called from the C scene-init self-test): validates the full

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -80,6 +80,14 @@ object ObjectCalls {
         getMethodBind("Object", "notification", 4023243586L)
     }
 
+    private val isClassBindForRetain by lazy {
+        getMethodBind("Object", "is_class", 3927539163L)
+    }
+
+    private val refCountedReferenceBind by lazy {
+        getMethodBind("RefCounted", "reference", 2240911060L)
+    }
+
     private class PtrcallScratch {
         private val arena = Arena.ofAuto()
         val args1: MemorySegment = arena.allocate(ADDRESS, 1)
@@ -2619,6 +2627,28 @@ object ObjectCalls {
     ): Any? {
         Arena.ofConfined().use { arena ->
             return readVariantReturn(methodBind, instance, MemorySegment.NULL, arena)
+        }
+    }
+
+    fun ptrcallWithStringNameArgRetVariantScalarRetained(
+        methodBind: MemorySegment,
+        instance: MemorySegment,
+        name: String,
+    ): Any? {
+        Arena.ofConfined().use { arena ->
+            val arr = arena.allocate(ADDRESS, 1)
+            arr.setAtIndex(ADDRESS, 0, GodotStrings.makeStringName(name))
+            val ret = arena.allocate(BuiltinTypes.VARIANT_SIZE, 8L)
+            try {
+                objectMethodBindPtrcall.invoke(methodBind, instance, arr, ret)
+                val value = BuiltinTypes.readVariantScalar(ret, arena)
+                if (value is GodotObject && ptrcallWithStringArgRetBool(isClassBindForRetain, value.handle, "RefCounted")) {
+                    ptrcallNoArgsRetBool(refCountedReferenceBind, value.handle)
+                }
+                return value
+            } finally {
+                BuiltinTypes.destroyVariant(ret)
+            }
         }
     }
 

--- a/src/main/kotlin/net/multigesture/kanama/api/ClassDB.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ClassDB.kt
@@ -89,7 +89,7 @@ object ClassDB {
      * Generated from Godot docs: ClassDB.instantiate
      */
     fun instantiate(classValue: String): Any? {
-        return ObjectCalls.ptrcallWithStringNameArgRetVariantScalar(instantiateBind, singleton, classValue)
+        return ObjectCalls.ptrcallWithStringNameArgRetVariantScalarRetained(instantiateBind, singleton, classValue)
     }
 
     /**


### PR DESCRIPTION
When using `ClassDB.instantiate` the returned instance is freed after return. Which makes this function nearly useless.
This PR changes so, if the returned instance is a `RefCounted` instance, we increment it's counter.

**I think this is not the 100% correct solution**, as now the references are not decremented automatically, resulting in a memory leak. Maybe the object should be wrapped in a `RefCounted` Kotlin instance, and maybe for this code, it would be better to live in the `BuiltinTypes.variantToScalar` function.
I still learning about the codebase, so I am mostly opening this PR to share my findings, and ask for help guiding me in the right direction fixing it correctly.

I made an MVP project showcasing the issue:
[Kanama Initiation Bug.zip](https://github.com/user-attachments/files/29972849/Kanama.Initiation.Bug.zip)
<details><summary>How to test</summary>

1. Open Godot from terminal (too see logs if Godot would crash)
2. Open the project and setup Kanama with Source checkout.
3. Build the runtime lib (with the current master HEAD being at: 22099f2d48c84b99d5dea21726b68f948ec38a14)
4. Run the `Test` button on the root Node (`KtTest`, the button is exported from a tool script)
5. See that the Terrain does not get texture (in my real project, Godot crashed at that point, but could not reproduce the crash in MVP)
6. Retest the same thing with this PR changes. (It should get the texture)
> Note: Also there is a `GdTest` node, with the same script just in GDScript for validating purposes.
> Note 2: There is a `Reset test` button to, it just resets the state back to the defaults.

</details>

I had a hard time figuring what the issue was, as when this occurred it made Godot crash at native functions.
So I had to go through Terrain3D, Godot and Kanama call chain to pinpoint the culprit.