### PR TITLE
Add support for creating resources from Kotlin side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added
+
+- Create script-backed custom resources from Kotlin with `newScriptInstance<T>()`
+  — the equivalent of GDScript's `MyResource.new()` (issue #38). `T` must be a
+  `@ScriptClass(attachTo = "Resource")` `@GlobalClass`. It returns an
+  `OwnedScriptResource<T>` holding the live `instance` and its owning `resource`;
+  `close()`/`use { }` releases the owning reference (the factory takes one, like
+  `.new()`, so the resource survives a `ResourceSaver.save`). Construction is
+  exception-safe (a failed attach never leaks the reference) and the loaded
+  script wrapper is released after attach. **Deferred on iOS** (compile-compatible
+  stub that throws at runtime) — supported on desktop and Android.
+
 ### Changed
 
 - Desktop/Android `Resource` now extends `RefCounted`, restoring Godot's real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ versioning once public releases begin.
   `.new()`, so the resource survives a `ResourceSaver.save`). Construction is
   exception-safe (a failed attach never leaks the reference) and the loaded
   script wrapper is released after attach. **Deferred on iOS** (compile-compatible
-  stub that throws at runtime) — supported on desktop and Android.
+  stub that throws at runtime) — supported on desktop and Android, including
+  R8-minified Android release (the `@ScriptClass` annotation is now `BINARY`-retained
+  and consumer keep rules preserve `@ScriptClass` class names, so
+  `T::class.qualifiedName` still matches the registered template under obfuscation;
+  device-validated on Pixel 7).
 
 ### Changed
 

--- a/android/godot-plugin/plugin/consumer-rules.pro
+++ b/android/godot-plugin/plugin/consumer-rules.pro
@@ -65,3 +65,14 @@
 # PanamaPort references desktop-only / hidden symbols on code paths it does not
 # take on Android; keep R8 from turning those into app warnings.
 -dontwarn com.v7878.**
+
+# newScriptInstance<T>() resolves the @ScriptClass template by T::class.qualifiedName, which must
+# match the KSP-registered key (the original name, baked into the kept generated registrar). R8
+# obfuscation renames game @ScriptClass classes, so the runtime name diverges and newScriptInstance
+# fails in minified release with "is not a registered @ScriptClass" (confirmed on Pixel 7, 2026-07-20).
+# Keep @ScriptClass class names AND their Kotlin metadata so qualifiedName stays stable; members and
+# non-@ScriptClass game classes remain freely obfuscatable.
+-keepnames @net.multigesture.kanama.annotations.ScriptClass class *
+# Preserve Kotlin metadata on kept @ScriptClass classes so T::class.qualifiedName resolves to the
+# original name at runtime (the value KSP registered as the template key).
+-keepkotlinmetadata

--- a/annotations/src/main/kotlin/net/multigesture/kanama/annotations/Annotations.kt
+++ b/annotations/src/main/kotlin/net/multigesture/kanama/annotations/Annotations.kt
@@ -394,7 +394,11 @@ annotation class OverrideVirtual
  *   `KanamaScript._get_instance_base_type`.
  */
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
+// BINARY (not SOURCE) so the marker survives into the class file: R8/ProGuard consumer rules keep
+// @ScriptClass class names by this annotation, which newScriptInstance<T>() needs (it resolves the
+// template by T::class.qualifiedName, and obfuscation would otherwise break that lookup in minified
+// release). KSP reads it from source regardless of retention, and nothing reads it via reflection.
+@Retention(AnnotationRetention.BINARY)
 annotation class ScriptClass(val attachTo: String = "Node")
 
 /**

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -326,10 +326,36 @@ class WeaponForge(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, 
 `Resource.fromHandle` is a non-owning view over the same engine object; do
 not `close()` it — the script instance still uses that handle.
 
-The instance you save must be engine-created: loaded from a `.tres`, assigned
-through an inspector slot, or instantiated by the editor. Calling a script
-class constructor yourself — `Weapon(someOtherObject.godotObject)` — does not
-create a new `Weapon` resource; it only wraps an existing handle in a Kotlin
-view, and passing another object's handle (a node's, for example) produces a
-view of the wrong object. Programmatic creation of new script-backed
-resources from Kotlin is not supported yet.
+Calling a script class constructor yourself —
+`Weapon(someOtherObject.godotObject)` — does **not** create a new `Weapon`
+resource; it only wraps an existing handle in a Kotlin view, and passing another
+object's handle (a node's, for example) produces a view of the wrong object.
+
+## Creating Custom Resources from Kotlin
+
+To mint a brand-new resource from code (the equivalent of GDScript's
+`Weapon.new()` or C#'s `new Weapon()`), use `newScriptInstance<T>()`:
+
+```kotlin
+val weapon = newScriptInstance<Weapon>()
+weapon.damage = 25
+weapon.displayName = "Excalibur"
+ResourceSaver.save(Resource.fromHandle(weapon.godotObject), "res://excalibur.tres")
+```
+
+It constructs a fresh engine `Resource`, attaches the Kanama script, and returns
+the live Kotlin instance. It works at runtime and from `@Tool` editor code (a real
+instance is built even though the resource class itself is not `@Tool`).
+
+Requirements: `T` must be a `@ScriptClass(attachTo = "Resource")` class, and it
+must be `@GlobalClass` with a matching file name (`Weapon.kt`) so its `res://`
+path is discoverable for saving — the same constraint the global class list
+already imposes.
+
+Ownership mirrors GDScript `.new()`: the returned resource comes back with one
+owning reference, so it survives the `ResourceSaver.save` call above (which wraps
+it in a transient `Ref<>` internally). Lifetime is manual — assign it to an
+exported `Resource` slot or save it to keep it; an instance that is created and
+never stored persists until process shutdown. As above, pass
+`Resource.fromHandle(weapon.godotObject)` (a non-owning view) to
+`Resource`-typed APIs such as `ResourceSaver.save`; do not `close()` it.

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -334,13 +334,15 @@ object's handle (a node's, for example) produces a view of the wrong object.
 ## Creating Custom Resources from Kotlin
 
 To mint a brand-new resource from code (the equivalent of GDScript's
-`Weapon.new()` or C#'s `new Weapon()`), use `newScriptInstance<T>()`:
+`Weapon.new()` or C#'s `new Weapon()`), use `newScriptInstance<T>()`. It returns
+an `OwnedScriptResource<T>` holding the live `instance` and its owning `resource`:
 
 ```kotlin
-val weapon = newScriptInstance<Weapon>()
-weapon.damage = 25
-weapon.displayName = "Excalibur"
-ResourceSaver.save(Resource.fromHandle(weapon.godotObject), "res://excalibur.tres")
+newScriptInstance<Weapon>().use { owned ->
+    owned.instance.damage = 25
+    owned.instance.displayName = "Excalibur"
+    ResourceSaver.save(owned.resource, "res://excalibur.tres")
+}
 ```
 
 It constructs a fresh engine `Resource`, attaches the Kanama script, and returns
@@ -354,8 +356,15 @@ already imposes.
 
 Ownership mirrors GDScript `.new()`: the returned resource comes back with one
 owning reference, so it survives the `ResourceSaver.save` call above (which wraps
-it in a transient `Ref<>` internally). Lifetime is manual — assign it to an
-exported `Resource` slot or save it to keep it; an instance that is created and
-never stored persists until process shutdown. As above, pass
-`Resource.fromHandle(weapon.godotObject)` (a non-owning view) to
-`Resource`-typed APIs such as `ResourceSaver.save`; do not `close()` it.
+it in a transient `Ref<>` internally). **Release that reference** with
+`owned.close()` — or `use { }` as above — once you are done, unless you have
+handed ownership on by assigning `owned.resource` into a node/scene or an
+exported `Resource` slot (then the engine keeps it alive). Pass `owned.resource`
+directly to `Resource`-typed APIs such as `ResourceSaver.save`; there is no
+`Resource.fromHandle` view to manage.
+
+**iOS**: `newScriptInstance` is **deferred on iOS** (Kotlin/Native) — the
+declaration exists so shared game code compiles, but calling it throws at
+runtime. Construct script-backed resources on desktop/Android, or guard the call
+by platform. Its sibling `kotlinScriptInstance<T>()` (resolving the Kotlin
+instance of an existing resource) is supported on all three backends.

--- a/docs/reference/c-sharp-compat.md
+++ b/docs/reference/c-sharp-compat.md
@@ -71,7 +71,7 @@ Legend: `SUPPORTED` means validated in smoke tests or real demo ports.
 | Custom signal declarations | SUPPORTED | `@Signal` metadata and generated `*Signals` emit helpers are available. |
 | Godot signal connections | SUPPORTED | Use `object.signal(Name.Signals.foo).connect(...)` and generated method-name constants. |
 | Lambda signal callbacks | PARTIAL | Zero to three emitted arguments are supported through generated dispatcher methods used by Kanama's signal connection helpers. |
-| Runtime custom resources | SUPPORTED | Create a Godot `Resource`, attach a loaded Kanama script, then resolve `kotlinScriptInstance<T>()`. |
+| Runtime custom resources | SUPPORTED | `newScriptInstance<T>()` creates a script-backed `Resource` from Kotlin (GDScript `.new()` parity); or create a Godot `Resource`, attach a loaded Kanama script, then resolve `kotlinScriptInstance<T>()`. |
 | Inspector exports | PARTIAL | Scalars (including `Int`/`Float` narrow slots), strings, enums, enum lists, `NodePath`, groups/subgroups, common object/resource wrappers, typed node references, and selected arrays are supported across desktop, Android, and iOS. Flags and broader resource arrays remain intentionally conservative. |
 | Coroutines | SUPPORTED | `KanamaScope`, Godot main-thread dispatch, `awaitNextFrame`, `SceneTree.delaySeconds`, and signal awaits are available. |
 

--- a/example_project/ResourceForgeSmoke.kt
+++ b/example_project/ResourceForgeSmoke.kt
@@ -1,0 +1,55 @@
+package net.multigesture.kanama.example
+
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.annotations.Tool
+import net.multigesture.kanama.api.FileAccess
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.ManualGodotLifetimeApi
+import net.multigesture.kanama.api.Node
+import net.multigesture.kanama.api.Resource
+import net.multigesture.kanama.api.ResourceSaver
+import net.multigesture.kanama.api.newScriptInstance
+import java.lang.foreign.MemorySegment
+
+// issue #38 — programmatic creation of a script-backed custom resource from Kotlin.
+// @Tool so _ready fires in the editor as well as at runtime; the editor run exercises
+// the force-real path (a non-@Tool resource script would otherwise be instantiated as
+// an inert placeholder, and `newScriptInstance<SmokeResource>()` would fail to cast).
+@ScriptClass(attachTo = "Node")
+@Tool
+class ResourceForgeSmoke(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, ::Node) {
+
+    @OnReady
+    @OptIn(ManualGodotLifetimeApi::class)
+    fun ready() {
+        val path = "user://forged_smoke.tres"
+        val created = try {
+            newScriptInstance<SmokeResource>()
+        } catch (e: Throwable) {
+            System.err.println("[kanama:kt] ResourceForgeSmoke create_failed=${e.message}")
+            return
+        }
+        created.payload = "forged"
+        created.customIntValue = 7
+        val live = created.payload == "forged" && created.customIntValue == 7L
+
+        // Owned like GDScript .new(): the created resource survives this save, which
+        // wraps it in a transient Ref<> internally.
+        val saveError = ResourceSaver.save(Resource.fromHandle(created.godotObject), path)
+
+        // Read the .tres back from disk to prove the script reference and the property
+        // value serialized (leak-free: no reloaded engine object to manage).
+        val text = if (saveError == 0L) FileAccess.getFileAsString(path) else ""
+        val scriptRef = text.contains("SmokeResource.kt")
+        val payloadSaved = text.contains("forged")
+
+        System.err.println(
+            "[kanama:kt] ResourceForgeSmoke live=$live save_error=$saveError " +
+                "script_ref=$scriptRef payload_saved=$payloadSaved",
+        )
+
+        // Manual lifetime: release the owning reference so the smoke process exits clean.
+        Resource.fromHandle(created.godotObject).close()
+    }
+}

--- a/example_project/ResourceForgeSmoke.kt
+++ b/example_project/ResourceForgeSmoke.kt
@@ -7,8 +7,9 @@ import net.multigesture.kanama.api.FileAccess
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.ManualGodotLifetimeApi
 import net.multigesture.kanama.api.Node
-import net.multigesture.kanama.api.Resource
+import net.multigesture.kanama.api.ResourceLoader
 import net.multigesture.kanama.api.ResourceSaver
+import net.multigesture.kanama.api.kotlinScriptInstance
 import net.multigesture.kanama.api.newScriptInstance
 import java.lang.foreign.MemorySegment
 
@@ -24,32 +25,49 @@ class ResourceForgeSmoke(godotObject: MemorySegment) : KanamaScript<Node>(godotO
     @OptIn(ManualGodotLifetimeApi::class)
     fun ready() {
         val path = "user://forged_smoke.tres"
-        val created = try {
+        val owned = try {
             newScriptInstance<SmokeResource>()
         } catch (e: Throwable) {
             System.err.println("[kanama:kt] ResourceForgeSmoke create_failed=${e.message}")
             return
         }
-        created.payload = "forged"
-        created.customIntValue = 7
-        val live = created.payload == "forged" && created.customIntValue == 7L
+        // `use { }` releases the owning reference on the way out — the supported release path.
+        // No `Resource.fromHandle(...).close()` on a view the docs say is non-owning.
+        owned.use { handle ->
+            val res = handle.instance
+            res.payload = "forged"
+            res.customIntValue = 7
+            val live = res.payload == "forged" && res.customIntValue == 7L
 
-        // Owned like GDScript .new(): the created resource survives this save, which
-        // wraps it in a transient Ref<> internally.
-        val saveError = ResourceSaver.save(Resource.fromHandle(created.godotObject), path)
+            // Owned like GDScript .new(): survives this save (our +1 outlives the transient Ref<>
+            // the save wraps it in). `handle.resource` is the supported owning Resource.
+            val saveError = ResourceSaver.save(handle.resource, path)
 
-        // Read the .tres back from disk to prove the script reference and the property
-        // value serialized (leak-free: no reloaded engine object to manage).
-        val text = if (saveError == 0L) FileAccess.getFileAsString(path) else ""
-        val scriptRef = text.contains("SmokeResource.kt")
-        val payloadSaved = text.contains("forged")
+            // Text-level proof the script reference and payload serialized.
+            val text = if (saveError == 0L) FileAccess.getFileAsString(path) else ""
+            val scriptRef = text.contains("SmokeResource.kt")
+            val payloadSaved = text.contains("forged")
 
-        System.err.println(
-            "[kanama:kt] ResourceForgeSmoke live=$live save_error=$saveError " +
-                "script_ref=$scriptRef payload_saved=$payloadSaved",
-        )
+            // Real reload round-trip: load the .tres back (cache-ignore) and resolve the live Kanama
+            // instance — proving Godot can deserialize it into a working resource, not just that
+            // text was written. `Resource` is now a `GodotObject` (task 51), so `kotlinScriptInstance`
+            // resolves directly off the reloaded wrapper, which `use { }` then releases.
+            var reloadPayload = ""
+            var reloadInt = -1L
+            if (saveError == 0L) {
+                ResourceLoader.load(path, cacheMode = ResourceLoader.CACHE_MODE_IGNORE)?.use { reloaded ->
+                    reloaded.kotlinScriptInstance<SmokeResource>()?.let { r ->
+                        reloadPayload = r.payload
+                        reloadInt = r.customIntValue
+                    }
+                }
+            }
+            val reloadOk = reloadPayload == "forged" && reloadInt == 7L
 
-        // Manual lifetime: release the owning reference so the smoke process exits clean.
-        Resource.fromHandle(created.godotObject).close()
+            System.err.println(
+                "[kanama:kt] ResourceForgeSmoke live=$live save_error=$saveError " +
+                    "script_ref=$scriptRef payload_saved=$payloadSaved reload_ok=$reloadOk",
+            )
+        }
     }
 }

--- a/example_project/ResourceForgeSmoke.kt.uid
+++ b/example_project/ResourceForgeSmoke.kt.uid
@@ -1,0 +1,1 @@
+uid://cc2cm5vk1affd

--- a/example_project/main.tscn
+++ b/example_project/main.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" path="res://InstancedMesh.tscn" id="3"]
 [ext_resource type="Script" path="res://NonToolScript.kt" id="4"]
 [ext_resource type="Script" path="res://ProcessDisableSmoke.kt" id="5"]
+[ext_resource type="Script" path="res://ResourceForgeSmoke.kt" id="6"]
 
 [node name="Node" type="Node" unique_id=1909033900]
 script = ExtResource("1")
@@ -94,3 +95,6 @@ script = ExtResource("4")
 script = ExtResource("5")
 
 [node name="NonToolHelloKanama" type="NonToolHelloKanama" parent="." unique_id=512983746]
+
+[node name="ResourceForgeSmokeNode" type="Node" parent="." unique_id=771122334]
+script = ExtResource("6")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ScriptResources.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ScriptResources.kt
@@ -1,0 +1,30 @@
+package net.multigesture.kanama.api
+
+/**
+ * iOS mirror of the desktop/Android [OwnedScriptResource]. Present so shared game code that
+ * references the type compiles for the iOS (Kotlin/Native) backend; construction of the resource
+ * only happens on desktop/Android (see [newScriptInstance]).
+ */
+class OwnedScriptResource<out T> @PublishedApi internal constructor(
+    val instance: T,
+    val resource: Resource,
+) : AutoCloseable {
+    override fun close() {
+        resource.close()
+    }
+}
+
+/**
+ * Creating a script-backed resource from Kotlin is **deferred on iOS**.
+ *
+ * This declaration exists so shared game code calling `newScriptInstance<T>()` compiles for the
+ * iOS backend (its sibling `kotlinScriptInstance<T>()` is already mirrored); it throws at runtime.
+ * The construction path (constructObject + setScript + owned retain) lives in the desktop/Android
+ * `KanamaScript` runtime and has not been ported to the iOS C shim yet. Guard the call by platform,
+ * or build the resource on desktop/Android. Mirrors the enum / dictionary-property iOS deferrals.
+ */
+inline fun <reified T : Any> newScriptInstance(): OwnedScriptResource<T> =
+    throw NotImplementedError(
+        "newScriptInstance() is not supported on iOS yet — it works on desktop and Android. " +
+            "Guard the call by platform, or construct the resource on those backends.",
+    )

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -92,8 +92,12 @@ check "SelfSmoke self_class=Node3D same_object=true"
 # at runtime: the instance is live, saves (owned reference survives the transient Ref<>
 # inside ResourceSaver.save), and the saved .tres references the SmokeResource.kt script
 # and stores the "forged" payload. The probe releases its owned reference, so no leak.
-check "ResourceForgeSmoke live=true save_error=0 script_ref=true payload_saved=true"
+check "ResourceForgeSmoke live=true save_error=0 script_ref=true payload_saved=true reload_ok=true"
 check_absent "ResourceForgeSmoke create_failed"
+# PR #44 review — the owning reference must be released via the supported path (OwnedScriptResource
+# .close()/use), not leaked. Reverting to the bare-T return + Resource.fromHandle().close() (or
+# dropping the use{}) reintroduces a per-call Resource leak that Godot reports on shutdown.
+check_absent "Leaked instance: Resource:"
 check "kt script export groups group=true subgroup=true"
 # task 32 — custom enum exports: INT + PROPERTY_HINT_ENUM metadata, ordinal
 # round-trip via set/get, tscn-stored int deserialized into the enum slot, and

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -88,6 +88,12 @@ check_absent "Leaked instance: AudioStreamWAV"
 check_absent "Leaked instance: BoxMesh"
 check_absent "Leaked instance: BoxShape3D"
 check "SelfSmoke self_class=Node3D same_object=true"
+# issue #38 — newScriptInstance() creates a script-backed custom resource from Kotlin
+# at runtime: the instance is live, saves (owned reference survives the transient Ref<>
+# inside ResourceSaver.save), and the saved .tres references the SmokeResource.kt script
+# and stores the "forged" payload. The probe releases its owned reference, so no leak.
+check "ResourceForgeSmoke live=true save_error=0 script_ref=true payload_saved=true"
+check_absent "ResourceForgeSmoke create_failed"
 check "kt script export groups group=true subgroup=true"
 # task 32 — custom enum exports: INT + PROPERTY_HINT_ENUM metadata, ordinal
 # round-trip via set/get, tscn-stored int deserialized into the enum slot, and

--- a/scripts/tool_smoke.sh
+++ b/scripts/tool_smoke.sh
@@ -72,5 +72,12 @@ check_absent "NonToolHelloKanama\\._ready fired"
 check_absent "Orphan StringName"
 check_absent "unclaimed string names"
 check_absent "Cannot ptrcall nil constructor"
+# issue #38 — newScriptInstance() must build a REAL script-backed resource even in
+# the editor (a non-@Tool resource class would otherwise instantiate as a placeholder
+# and the reified cast would fail). Assert creation + save succeed here; the on-disk
+# script-reference round-trip is asserted in runtime_smoke where the global class list
+# is reliably populated.
+check "ResourceForgeSmoke live=true save_error=0"
+check_absent "ResourceForgeSmoke create_failed"
 
 echo "[tool_smoke] PASS"

--- a/src/main/kotlin/binding/KanamaScript.kt
+++ b/src/main/kotlin/binding/KanamaScript.kt
@@ -88,6 +88,22 @@ class KanamaScript(
         private val templatesByName = LinkedHashMap<String, KanamaScriptTemplate>()
         private val globalNameToTemplate = LinkedHashMap<String, KanamaScriptTemplate>()
 
+        // Depth counter set while [instantiateResourceScript] drives Object.set_script.
+        // Godot runs _instance_create synchronously on the calling thread, so a
+        // thread-local reliably scopes the whole attach. When > 0, callInstanceCreate
+        // builds the real instance even in the editor for a non-@Tool script, so that
+        // programmatic creation returns a live Kotlin object rather than a placeholder.
+        private val programmaticCreate = ThreadLocal.withInitial { 0 }
+
+        private inline fun <R> withProgrammaticCreate(body: () -> R): R {
+            programmaticCreate.set(programmaticCreate.get() + 1)
+            try {
+                return body()
+            } finally {
+                programmaticCreate.set(programmaticCreate.get() - 1)
+            }
+        }
+
         data class KanamaScriptTemplate(
             val instanceBaseType: String,
             val isTool: Boolean,
@@ -570,6 +586,91 @@ class KanamaScript(
             val className = parseClassName(source) ?: return false
             return bindScriptToTemplate(script, className)
         }
+
+        /**
+         * Programmatically creates a brand-new script-backed resource from Kotlin.
+         *
+         * Backs the public [net.multigesture.kanama.api.newScriptInstance] helper.
+         * Constructs a fresh engine `Resource`, attaches the Kanama script registered
+         * for [fqName]/[simpleName], and returns the live Kotlin object. The resource
+         * is left with one owning reference (GDScript `.new()` parity) so it survives a
+         * later `ResourceSaver.save` which wraps it in a transient `Ref<>`.
+         *
+         * Currently restricted to `@ScriptClass(attachTo = "Resource")` classes.
+         */
+        fun instantiateResourceScript(fqName: String?, simpleName: String?): Any {
+            val requested = fqName ?: simpleName ?: "<unknown>"
+            val template = resolveTemplate(fqName, simpleName)
+                ?: error(
+                    "newScriptInstance: '$requested' is not a registered @ScriptClass. " +
+                        "Annotate it with @ScriptClass(attachTo = \"Resource\") and name the file <ClassName>.kt."
+                )
+            require(template.instanceBaseType == "Resource") {
+                "newScriptInstance: '${template.kotlinClassName}' attaches to '${template.instanceBaseType}', " +
+                    "but programmatic creation currently supports only @ScriptClass(attachTo = \"Resource\")."
+            }
+            val script = resolveScriptResource(template)
+                ?: error(
+                    "newScriptInstance: could not resolve the script resource for '${template.kotlinClassName}'. " +
+                        "Mark it @GlobalClass and name the file after the class so its res:// path is discoverable."
+                )
+            val baseHandle = ObjectCalls.constructObject("Resource")
+            withProgrammaticCreate {
+                net.multigesture.kanama.api.GodotObject(baseHandle).setScript(script)
+            }
+            // Own the fresh resource so it is not freed when a later save drops its
+            // transient Ref<> (mirrors the task-43 owned-return convention).
+            net.multigesture.kanama.api.RefCounted.retainHandle(baseHandle)
+            return ScriptBridge.kotlinObjectForOwner(baseHandle)
+                ?: error(
+                    "newScriptInstance: no script instance was created for '${template.kotlinClassName}'. " +
+                        "The script may have failed to attach."
+                )
+        }
+
+        private fun resolveTemplate(fqName: String?, simpleName: String?): KanamaScriptTemplate? =
+            synchronized(templatesByName) {
+                fqName?.let { templatesByName[it] } ?: simpleName?.let { templatesByName[it] }
+            }
+
+        /**
+         * Resolves the `Script` resource to attach for [template]. Prefers loading the
+         * on-disk `res://<Class>.kt` (via its global-class registry path) so the saved
+         * resource references the script as an `ExtResource` and reloads correctly;
+         * falls back to the registration-time script object when no path is known.
+         */
+        private fun resolveScriptResource(
+            template: KanamaScriptTemplate,
+        ): net.multigesture.kanama.api.Resource? {
+            if (template.globalName.isNotEmpty()) {
+                globalClassPath(template.globalName)?.let { path ->
+                    net.multigesture.kanama.api.ResourceLoader.load(path)?.let { return it }
+                }
+            }
+            return registeredScriptObjectFor(template)
+                ?.let { net.multigesture.kanama.api.Resource.fromHandle(it) }
+        }
+
+        // Match the global-class entry by its res:// path rather than the "class" key:
+        // dictionary StringName values (the "class"/"base" fields) currently decode to
+        // null, while the "path" String decodes cleanly. A @GlobalClass script's file is
+        // required to be named after the class (<GlobalName>.kt), so the path suffix is a
+        // reliable, unique key.
+        private fun globalClassPath(globalName: String): String? {
+            val rootPath = "res://$globalName.kt"
+            val fileSuffix = "/$globalName.kt"
+            return net.multigesture.kanama.api.ProjectSettings.getGlobalClassList()
+                .mapNotNull { it["path"] as? String }
+                .firstOrNull { it == rootPath || it.endsWith(fileSuffix) }
+        }
+
+        private fun registeredScriptObjectFor(template: KanamaScriptTemplate): MemorySegment? =
+            synchronized(scriptCatalog) {
+                scriptCatalog.values.firstOrNull { meta ->
+                    meta.kotlinClassName == template.kotlinClassName ||
+                        (template.globalName.isNotEmpty() && meta.globalName == template.globalName)
+                }?.let { MemorySegment.ofAddress(it.objectAddress) }
+            }
 
         fun clearScriptTemplates() {
             synchronized(templatesByName) {
@@ -1108,7 +1209,8 @@ class KanamaScript(
             // would otherwise need.
             val script = ObjectRegistry.get(instance.address()) as? KanamaScript
             val skipForEditor = script != null && !script.isTool &&
-                net.multigesture.kanama.api.Engine.isEditorHint()
+                net.multigesture.kanama.api.Engine.isEditorHint() &&
+                programmaticCreate.get() == 0
             callCreateInternal(instance, args, rRet, allowPlaceholder = skipForEditor)
         }
 

--- a/src/main/kotlin/binding/KanamaScript.kt
+++ b/src/main/kotlin/binding/KanamaScript.kt
@@ -598,7 +598,10 @@ class KanamaScript(
          *
          * Currently restricted to `@ScriptClass(attachTo = "Resource")` classes.
          */
-        fun instantiateResourceScript(fqName: String?, simpleName: String?): Any {
+        fun instantiateResourceScript(
+            fqName: String?,
+            simpleName: String?,
+        ): Pair<Any, net.multigesture.kanama.api.Resource> {
             val requested = fqName ?: simpleName ?: "<unknown>"
             val template = resolveTemplate(fqName, simpleName)
                 ?: error(
@@ -609,23 +612,35 @@ class KanamaScript(
                 "newScriptInstance: '${template.kotlinClassName}' attaches to '${template.instanceBaseType}', " +
                     "but programmatic creation currently supports only @ScriptClass(attachTo = \"Resource\")."
             }
-            val script = resolveScriptResource(template)
+            val resolved = resolveScriptResource(template)
                 ?: error(
                     "newScriptInstance: could not resolve the script resource for '${template.kotlinClassName}'. " +
                         "Mark it @GlobalClass and name the file after the class so its res:// path is discoverable."
                 )
             val baseHandle = ObjectCalls.constructObject("Resource")
-            withProgrammaticCreate {
-                net.multigesture.kanama.api.GodotObject(baseHandle).setScript(script)
-            }
-            // Own the fresh resource so it is not freed when a later save drops its
-            // transient Ref<> (mirrors the task-43 owned-return convention).
+            // Own the fresh resource immediately (before attach) so the +1 is released on any error
+            // path, not just success — mirrors the task-43 owned-return convention. Balanced by the
+            // returned Resource's close() on the happy path, or releaseHandle in finally otherwise.
             net.multigesture.kanama.api.RefCounted.retainHandle(baseHandle)
-            return ScriptBridge.kotlinObjectForOwner(baseHandle)
-                ?: error(
-                    "newScriptInstance: no script instance was created for '${template.kotlinClassName}'. " +
-                        "The script may have failed to attach."
-                )
+            var success = false
+            try {
+                withProgrammaticCreate {
+                    net.multigesture.kanama.api.GodotObject(baseHandle).setScript(resolved.script)
+                }
+                val instance = ScriptBridge.kotlinObjectForOwner(baseHandle)
+                    ?: error(
+                        "newScriptInstance: no script instance was created for '${template.kotlinClassName}'. " +
+                            "The script may have failed to attach."
+                    )
+                success = true
+                return instance to net.multigesture.kanama.api.Resource.fromHandle(baseHandle)
+            } finally {
+                // The loaded script wrapper is our transient +1 — the base resource holds its own
+                // reference via setScript, so release ours (the borrowed fallback stays untouched).
+                if (resolved.owned) resolved.script.close()
+                // On failure, drop the owning +1 we took above so a bad construction never leaks.
+                if (!success) net.multigesture.kanama.api.RefCounted.releaseHandle(baseHandle)
+            }
         }
 
         private fun resolveTemplate(fqName: String?, simpleName: String?): KanamaScriptTemplate? =
@@ -639,16 +654,26 @@ class KanamaScript(
          * resource references the script as an `ExtResource` and reloads correctly;
          * falls back to the registration-time script object when no path is known.
          */
-        private fun resolveScriptResource(
-            template: KanamaScriptTemplate,
-        ): net.multigesture.kanama.api.Resource? {
+        /**
+         * A resolved script resource plus whether the caller owns it. The `ResourceLoader.load`
+         * path returns a `+1` owning wrapper that must be closed once attached; the registration
+         * fallback is a borrowed `fromHandle` view that must NOT be closed.
+         */
+        private class ResolvedScript(
+            val script: net.multigesture.kanama.api.Resource,
+            val owned: Boolean,
+        )
+
+        private fun resolveScriptResource(template: KanamaScriptTemplate): ResolvedScript? {
             if (template.globalName.isNotEmpty()) {
                 globalClassPath(template.globalName)?.let { path ->
-                    net.multigesture.kanama.api.ResourceLoader.load(path)?.let { return it }
+                    net.multigesture.kanama.api.ResourceLoader.load(path)?.let {
+                        return ResolvedScript(it, owned = true)
+                    }
                 }
             }
             return registeredScriptObjectFor(template)
-                ?.let { net.multigesture.kanama.api.Resource.fromHandle(it) }
+                ?.let { ResolvedScript(net.multigesture.kanama.api.Resource.fromHandle(it), owned = false) }
         }
 
         // Match the global-class entry by its res:// path rather than the "class" key:

--- a/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
@@ -84,6 +84,18 @@ open class RefCounted internal constructor(
             ObjectCalls.getMethodBind("RefCounted", "reference", REFERENCE_HASH)
         }
 
+        /**
+         * Takes one owning reference on [handle] (RefCounted.reference), keeping the
+         * object alive independently of any transient `Ref<>` the engine may create
+         * (e.g. inside `ResourceSaver.save`). Mirrors the owned-return convention used
+         * for freshly instantiated RefCounted values. Returns true when this was the
+         * first reference (refcount went 0 -> 1).
+         */
+        internal fun retainHandle(handle: MemorySegment): Boolean {
+            if (handle.address() == 0L) return false
+            return ObjectCalls.ptrcallNoArgsRetBool(referenceBind, handle)
+        }
+
         internal fun releaseHandle(handle: MemorySegment) {
             if (handle.address() != 0L) {
                 if (ObjectCalls.ptrcallNoArgsRetBool(unreferenceBind, handle)) {

--- a/src/main/kotlin/net/multigesture/kanama/api/ScriptResources.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ScriptResources.kt
@@ -3,31 +3,66 @@ package net.multigesture.kanama.api
 import net.multigesture.kanama.binding.KanamaScript
 
 /**
- * Creates a brand-new, engine-backed script resource of type [T] purely from Kotlin.
+ * An owning handle to a resource script created with [newScriptInstance].
  *
- * [T] must be a custom resource declared with `@ScriptClass(attachTo = "Resource")`
- * (and, for its `res://` path to be discoverable, `@GlobalClass` with a matching
- * file name). This is the programmatic equivalent of GDScript's `MyResource.new()`
- * or C#'s `new MyResource()` — it constructs a fresh engine `Resource`, attaches the
- * Kanama script, and returns the live Kotlin instance:
+ * Holds the live Kotlin script [instance] and the owning [resource] wrapper. The factory takes
+ * one reference on the fresh resource (like GDScript `.new()`), so it survives a
+ * `ResourceSaver.save(resource, ...)`. **Release that reference** by [close]ing this handle (or
+ * wrapping the call in `use { }`) once you are done — unless you have handed ownership on by
+ * assigning the resource into a node/scene or an exported `Resource` slot, in which case the
+ * engine keeps it alive and closing is unnecessary.
+ *
+ * This replaces the previous bare-`T` return, which left the owning reference unreleasable
+ * through any supported API (the only exit was closing a `Resource.fromHandle` view, which
+ * contradicts that view's non-owning contract).
+ */
+class OwnedScriptResource<out T> @PublishedApi internal constructor(
+    /** The live Kotlin script instance — your `@ScriptClass(attachTo = "Resource")` type. */
+    val instance: T,
+    /** The owning `Resource`. Save it, assign it into a slot, or [close] this handle to release. */
+    val resource: Resource,
+) : AutoCloseable {
+    override fun close() = resource.close()
+}
+
+/**
+ * Creates a brand-new, engine-backed script resource of type [T] purely from Kotlin — the
+ * programmatic equivalent of GDScript's `MyResource.new()` or C#'s `new MyResource()`.
+ *
+ * [T] must be a custom resource declared with `@ScriptClass(attachTo = "Resource")` (and, for
+ * its `res://` path to be discoverable, `@GlobalClass` with a matching file name). Returns an
+ * [OwnedScriptResource] holding the live [instance][OwnedScriptResource.instance] and its owning
+ * [resource][OwnedScriptResource.resource]:
  *
  * ```kotlin
- * val weapon = newScriptInstance<Weapon>()
- * weapon.damage = 25
- * ResourceSaver.save(Resource.fromHandle(weapon.godotObject), "res://weapon.tres")
+ * newScriptInstance<Weapon>().use { owned ->
+ *     owned.instance.damage = 25
+ *     ResourceSaver.save(owned.resource, "res://weapon.tres")
+ * }
  * ```
  *
- * Ownership: the returned resource comes back with one owning reference (like
- * `.new()`), so it stays valid across a `ResourceSaver.save`. Lifetime is manual —
- * keep it by assigning it to an exported `Resource` slot / saving it, or it will
- * persist until process shutdown. Use [Resource.fromHandle] for the non-owning view
- * that `ResourceSaver`/`Resource`-typed APIs expect.
+ * Ownership: the returned resource comes back with one owning reference (like `.new()`), so it
+ * stays valid across a `ResourceSaver.save`. Release it with [OwnedScriptResource.close] / `use`,
+ * or hand ownership on by assigning it into a node/scene or an exported `Resource` slot.
  *
- * Works at runtime and from `@Tool` editor code (the real instance is built even for
- * a non-`@Tool` resource class). Throws [IllegalStateException]/[IllegalArgumentException]
- * with a descriptive message if [T] is not a registered resource script class.
+ * Works at runtime and from `@Tool` editor code (the real instance is built even for a
+ * non-`@Tool` resource class). Throws [IllegalStateException]/[IllegalArgumentException] with a
+ * descriptive message if [T] is not a registered resource script class.
  */
-inline fun <reified T : Any> newScriptInstance(): T {
-    @Suppress("UNCHECKED_CAST")
-    return KanamaScript.instantiateResourceScript(T::class.qualifiedName, T::class.simpleName) as T
+inline fun <reified T : Any> newScriptInstance(): OwnedScriptResource<T> {
+    val (instance, resource) =
+        KanamaScript.instantiateResourceScript(T::class.qualifiedName, T::class.simpleName)
+    if (instance !is T) {
+        // The created instance is a different @ScriptClass than requested — the template lookup
+        // falls back from fully-qualified to simple name, so two classes sharing a simple name in
+        // different packages can resolve to the wrong one. Release the owning reference and fail
+        // with a clear message instead of a bare ClassCastException.
+        resource.close()
+        error(
+            "newScriptInstance<${T::class.simpleName}>: created a '${instance::class.qualifiedName}', " +
+                "not '${T::class.qualifiedName}'. Two @ScriptClass types may share the simple name " +
+                "'${T::class.simpleName}' in different packages — give them distinct class names.",
+        )
+    }
+    return OwnedScriptResource(instance, resource)
 }

--- a/src/main/kotlin/net/multigesture/kanama/api/ScriptResources.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ScriptResources.kt
@@ -1,0 +1,33 @@
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.binding.KanamaScript
+
+/**
+ * Creates a brand-new, engine-backed script resource of type [T] purely from Kotlin.
+ *
+ * [T] must be a custom resource declared with `@ScriptClass(attachTo = "Resource")`
+ * (and, for its `res://` path to be discoverable, `@GlobalClass` with a matching
+ * file name). This is the programmatic equivalent of GDScript's `MyResource.new()`
+ * or C#'s `new MyResource()` — it constructs a fresh engine `Resource`, attaches the
+ * Kanama script, and returns the live Kotlin instance:
+ *
+ * ```kotlin
+ * val weapon = newScriptInstance<Weapon>()
+ * weapon.damage = 25
+ * ResourceSaver.save(Resource.fromHandle(weapon.godotObject), "res://weapon.tres")
+ * ```
+ *
+ * Ownership: the returned resource comes back with one owning reference (like
+ * `.new()`), so it stays valid across a `ResourceSaver.save`. Lifetime is manual —
+ * keep it by assigning it to an exported `Resource` slot / saving it, or it will
+ * persist until process shutdown. Use [Resource.fromHandle] for the non-owning view
+ * that `ResourceSaver`/`Resource`-typed APIs expect.
+ *
+ * Works at runtime and from `@Tool` editor code (the real instance is built even for
+ * a non-`@Tool` resource class). Throws [IllegalStateException]/[IllegalArgumentException]
+ * with a descriptive message if [T] is not a registered resource script class.
+ */
+inline fun <reified T : Any> newScriptInstance(): T {
+    @Suppress("UNCHECKED_CAST")
+    return KanamaScript.instantiateResourceScript(T::class.qualifiedName, T::class.simpleName) as T
+}


### PR DESCRIPTION
Add easier support for creating resources from Kotlin side.
See [note](https://github.com/falcon4ever/kanama/issues/38#issuecomment-4949505283):
> Creating a brand-new script-backed resource purely from Kotlin isn't supported yet — I'm treating that as a separate ergonomics feature to design properly.

It seems it was "supported" but not exposed cleanly for the user.
Code was generated and tested with Opus 4.8 and manually.

This resource was created and filled with data fully from Kotlin:
<img width="2952" height="1377" alt="image" src="https://github.com/user-attachments/assets/85b9906d-00cd-4349-bda5-9854881e303d" />
