### PR TITLE
ci: add PR merge gate + CODEOWNERS + contributor guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS — auto-requests @falcon4ever on PRs touching ABI-sensitive and
+# infrastructure paths. Pair with a branch-protection rule on `main` that
+# requires review from Code Owners, so these paths cannot merge without a
+# maintainer audit — enforcing the "do not widen ABI-sensitive types" rule in
+# AGENTS.md mechanically instead of by vigilance.
+#
+# Later matches win; the broad default stays first. While @falcon4ever is the
+# sole owner, `*` already routes every PR here — the specific entries below
+# document the danger zones and keep maintainer review required on them even
+# after other collaborators are added.
+
+# Default owner for everything.
+*                                                       @falcon4ever
+
+# --- FFM / Panama ABI + memory-ownership surface (marshalling, retain/release) ---
+/src/main/kotlin/binding/                               @falcon4ever
+/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt  @falcon4ever
+
+# --- KSP processor: type resolution, code emitters, serialized script model ---
+/processor/                                             @falcon4ever
+
+# --- Generators, audits, and the CI gate scripts (the source of truth) ---
+/scripts/                                               @falcon4ever
+
+# --- GDExtension ABI header + build/version single-source pins ---
+/gdextension/                                           @falcon4ever
+/build.gradle.kts                                       @falcon4ever
+/gradle.properties                                      @falcon4ever
+
+# --- Repo automation and the guardrails themselves ---
+/.github/                                               @falcon4ever

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: ci
+
+# Pull-request merge gate. Runs the same local_ci.sh gate a maintainer runs by
+# hand, so a contributor's "smoke passes" claim is never load-bearing — CI decides.
+#
+# Free on GitHub-hosted standard runners for public repos. Fork PRs run with a
+# read-only token and no secret access (pull_request, not pull_request_target);
+# keep the repo setting "Require approval for first-time contributors" enabled so
+# an outside PR's first run needs a maintainer click.
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Dash form of kanamaGodotVersion in gradle.properties (the single-source pin, F4).
+  GODOT_VERSION: 4.7-stable
+
+jobs:
+  gate:
+    name: local-ci (linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Install CLI dependencies
+        shell: bash
+        run: |
+          # local_ci.sh and the smoke scripts shell out to ripgrep (`rg`), which
+          # is not preinstalled on ubuntu-24.04 runners.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
+
+      - name: Cache Godot binary
+        id: godot-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/godot
+          key: godot-${{ env.GODOT_VERSION }}-linux-x86_64
+
+      - name: Download Godot
+        if: steps.godot-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/godot"
+          godot_zip="$(mktemp)"
+          curl -fL -o "$godot_zip" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q "$godot_zip" -d "$HOME/godot"
+          rm -f "$godot_zip"
+
+      - name: Run local CI gate
+        shell: bash
+        run: |
+          godot_bin="$HOME/godot/Godot_v${GODOT_VERSION}_linux.x86_64"
+          chmod +x "$godot_bin"
+          # --skip-docs: mkdocs strict runs in the dedicated `docs` job below.
+          # The native bootstrap build (CMake + gcc, preinstalled on ubuntu) is
+          # kept in for parity; add --skip-bootstrap for faster PR turnaround.
+          scripts/local_ci.sh --skip-docs "$godot_bin"
+
+  docs:
+    name: docs (mkdocs strict)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install docs dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build docs (strict)
+        run: mkdocs build --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,13 @@ generated wrappers and focused policy fixes over ad hoc hand wrappers.
 - Keep Gradle coordinates, docs snippets, badges, changelog headings, package
   workflow variables, and companion demo defaults synchronized with the active
   release pass.
+- Some invariants are pinned in more than one file; changing one and not the
+  others is silent drift. Changing the example script's exported-property set
+  means updating the count in **both** `scripts/runtime_smoke.sh`
+  (`properties size = N`) and `scripts/local_ci.sh` (`propertyCount = N`).
+  Adding a field to the serialized script model (`ScriptModelJson`) means bumping
+  `SCRIPT_MODEL_SCHEMA_VERSION`. Before finishing, grep the repo for the old
+  value of any pinned constant you touched.
 - Do not widen ABI-sensitive types to make wrappers generate. Add exact helper
   shapes and audits first.
 - Prefer generated wrappers and focused policy fixes over ad hoc hand wrappers.
@@ -233,6 +240,12 @@ mkdocs build --strict
 ./gradlew jar
 ./scripts/local_ci.sh /absolute/path/to/godot-4.7-stable
 ```
+
+`local_ci.sh` is the definition of done for processor, runtime, and
+script-model changes: it runs the static registrar/count/generated-code checks
+that the in-editor runtime smoke does not exercise, so a passing runtime smoke
+alone is not sufficient. It also compiles the generated code for every exported
+property shape, so run it after widening any accepted `@ScriptProperty` type.
 
 Before a release tag, prefer an isolated clone gate:
 


### PR DESCRIPTION
Adds the first `pull_request`-triggered CI so our own PRs are validated automatically before merge. This is just the CI plumbing — whether to open the repo to outside contributions (and require review on their PRs) is a separate decision for later.

## What this adds
- **`.github/workflows/ci.yml`**
  - `gate` (ubuntu-24.04): JDK 25 + headless Godot 4.7-stable, runs `scripts/local_ci.sh --skip-docs` — the static registrar/count/compile checks plus the runtime, `@Tool`, and hot-reload smokes. Installs ripgrep (local_ci shells out to `rg`). Godot + Gradle cached.
  - `docs` (ubuntu-24.04): `mkdocs build --strict`.
  - `pull_request` trigger, `permissions: contents: read`, `timeout-minutes` + `concurrency: cancel-in-progress`.
- **`.github/CODEOWNERS`** — marks the ABI-sensitive surface (FFM `binding/`, `RefCounted`, `processor/`, generator+gate `scripts/`, `gdextension/`, version pins, `.github/`).
- **`AGENTS.md`** — records the synchronized-constant landmines (property count is pinned in both `runtime_smoke.sh` and `local_ci.sh`; `ScriptModelJson` field additions need a `SCRIPT_MODEL_SCHEMA_VERSION` bump) and states that a green `local_ci.sh` is the definition of done.

## Optional, later
Once these checks have run on `main`, branch protection can require them before merge. That, and any policy for outside PRs, is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)