### PR TITLE
docs: state CI coverage boundary (build-time + desktop, not on-device)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,14 @@ that the in-editor runtime smoke does not exercise, so a passing runtime smoke
 alone is not sufficient. It also compiles the generated code for every exported
 property shape, so run it after widening any accepted `@ScriptProperty` type.
 
+CI coverage is **build-time + desktop runtime only**. The PR gate compiles every
+platform (desktop, the Android runtime AAR, the iOS device xcframework) and runs
+the desktop/Linux runtime smokes — which also exercise the runtime Android shares
+via PanamaPort. It does **not** run on-device: the Android R8-minified runtime
+gate (the task-42 PanamaPort-under-R8 class) and the iOS device runtime are
+deliberate **local device gates**. A green PR means it builds everywhere and the
+desktop runtime behaves — not that it is device-safe on mobile.
+
 Before a release tag, prefer an isolated clone gate:
 
 ```sh


### PR DESCRIPTION
One-line-ish note in AGENTS.md so a green PR is not misread as device-safe: CI compiles every platform + runs the desktop/Linux runtime smokes; Android R8-minified runtime and iOS device runtime stay as local device gates.

Also a live check of the path-gating from #46 — this is a docs-only change, so the `android` / `ios` jobs should **skip** (only `local-ci (linux)` + `docs` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)