### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Thanks for contributing to Kanama! Fill in the sections and delete these comments. -->
+
+## What & why
+
+<!-- What does this change, and why? Link the issue it addresses. -->
+Closes #
+
+## Checklist
+
+- [ ] Ran `scripts/local_ci.sh <godot>` to green — the full gate, not just the in-editor smoke (see `AGENTS.md` → Validation).
+- [ ] Up to date with the latest `main` (branch protection also enforces this at merge time).
+- [ ] If this touches ABI / memory-ownership code (`src/main/kotlin/binding/`, `processor/`, retain/release, marshalling), I've called it out below so it gets a careful review.
+- [ ] Updated docs / CHANGELOG if behavior changed, and bumped any paired constants I touched (see `AGENTS.md` → synchronized invariants).
+
+## Testing
+
+<!-- How did you verify this? Which platforms did you build/run — desktop / Android / iOS? -->
+
+## AI assistance
+
+<!-- Good practice (and required for a future Asset Store listing): disclose if AI tools were used to write this change. -->


### PR DESCRIPTION
Prefills every PR with a What/why + checklist + testing + AI-disclosure prompt. Nudges the high-value self-checks (run `local_ci`, sync with `main`, flag ABI/ownership changes, bump paired constants) that CI + review then enforce.

It is a nudge, not a gate — CI and branch protection remain the enforcement. Docs-only, so the mobile lanes should path-skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)