### PR TITLE
Fix TPS multiplayer bugs: iOS @ScriptProperty replication, signal-callable crash, lifecycle re-enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ versioning once public releases begin.
 
 ### Added
 
+- Fixed iOS lambda signal callbacks dropping non-object scalar arguments.
+  Emitted `bool`, `int`, and `float` Variants now reach Kotlin with their
+  original values, matching desktop and Android; this fixes integer peer IDs
+  from multiplayer signals such as `peer_connected` arriving as `null`.
+- Fixed script lifecycle notifications re-enabling `_process` and
+  `_physics_process` after user code disabled them in `_ready` or
+  `_enter_tree`. Authority-gated multiplayer input scripts now remain disabled
+  on non-authoritative peers instead of letting one device drive multiple
+  players.
+- Fixed iOS value-type `@ScriptProperty` fields being write-only. `Vector2`,
+  `Vector3`, `String`, `NodePath`, and `List<String>` are now readable by the
+  engine (`Object.get`), matching desktop/Android — the iOS bridge previously
+  emitted a reader only for properties with a scalar setter, so these types
+  were settable from scene data but read back as `nil`. That silently broke
+  `MultiplayerSynchronizer` replication of value-type properties on the
+  authority peer (e.g. a `Vector2` movement vector never reaching the host, so
+  a client could not move or shoot). A codegen parity guard now flags any
+  future set-only data property.
+- Fixed iOS lambda/bound signal `Callable`s not being auto-disconnected when
+  their receiver is freed. The receiver's `ObjectID` is now recorded so Godot
+  disconnects the connection on free, instead of later firing the signal into a
+  freed object — a use-after-free crash on the client when a multiplayer host
+  ended the game.
 - iOS `@Export` / `@ScriptProperty` conversion parity: Kotlin `Int`/`Float`
   fields now narrow correctly from Godot's 64-bit Variant slots, scalar enum
   ordinals clamp and resolve to entries, and `List<Enum>` arrays map each

--- a/example_project/ProcessDisableSmoke.kt
+++ b/example_project/ProcessDisableSmoke.kt
@@ -1,0 +1,25 @@
+package net.multigesture.kanama.example
+
+import net.multigesture.kanama.annotations.OnProcess
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.GD
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.Node
+import java.lang.foreign.MemorySegment
+
+@ScriptClass(attachTo = "Node")
+class ProcessDisableSmoke(godotObject: MemorySegment) :
+    KanamaScript<Node>(godotObject, ::Node) {
+
+    @OnReady
+    fun ready() {
+        self.setProcess(false)
+        GD.print("ProcessDisableSmoke ready processing=${self.isProcessing()}")
+    }
+
+    @OnProcess
+    fun process(delta: Double) {
+        GD.print("ProcessDisableSmoke unexpected process delta_nonnegative=${delta >= 0.0}")
+    }
+}

--- a/example_project/ProcessDisableSmoke.kt.uid
+++ b/example_project/ProcessDisableSmoke.kt.uid
@@ -1,0 +1,1 @@
+uid://cls5j7svmgjaf

--- a/example_project/main.tscn
+++ b/example_project/main.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://cejvnas4d07ll" path="res://HelloScript.kt" id="2"]
 [ext_resource type="PackedScene" path="res://InstancedMesh.tscn" id="3"]
 [ext_resource type="Script" path="res://NonToolScript.kt" id="4"]
+[ext_resource type="Script" path="res://ProcessDisableSmoke.kt" id="5"]
 
 [node name="Node" type="Node" unique_id=1909033900]
 script = ExtResource("1")
@@ -84,5 +85,8 @@ target_path = NodePath("../SceneTarget3D")
 
 [node name="NonToolScriptNode" type="Node" parent="." unique_id=193847562]
 script = ExtResource("4")
+
+[node name="ProcessDisableSmoke" type="Node" parent="."]
+script = ExtResource("5")
 
 [node name="NonToolHelloKanama" type="NonToolHelloKanama" parent="." unique_id=512983746]

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
@@ -7,8 +7,12 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.binding.runtime.* // generated ObjectCalls.* extension helpers
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.CName
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.LongVar
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
@@ -1260,25 +1264,38 @@ internal object IosCallableRegistry {
     }
 }
 
-@OptIn(ExperimentalNativeApi::class)
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
 @CName("kanama_ios_runtime_dispatch_callable")
 fun kanamaIosRuntimeDispatchCallable(
     callbackId: Long,
     argumentCount: Int,
-    arg0: Long,
-    arg1: Long,
-    arg2: Long,
-    arg3: Long,
+    argumentTypes: CPointer<IntVar>?,
+    argumentValues: CPointer<LongVar>?,
 ) {
-    val handles = longArrayOf(arg0, arg1, arg2, arg3)
-    val count = argumentCount.coerceIn(0, handles.size)
+    val count = argumentCount.coerceIn(0, MAX_CALLABLE_ARGUMENTS)
     val args = ArrayList<Any?>(count)
     for (i in 0 until count) {
-        val handle = handles[i]
-        args.add(if (handle != 0L) GodotObject(handle) else null)
+        val type = argumentTypes?.get(i) ?: VT_NIL
+        val value = argumentValues?.get(i) ?: 0L
+        args.add(
+            when (type) {
+                VT_BOOL -> value != 0L
+                VT_INT -> value
+                VT_FLOAT -> Double.fromBits(value)
+                VT_OBJECT -> if (value != 0L) GodotObject(value) else null
+                else -> null
+            },
+        )
     }
     IosCallableRegistry.dispatch(callbackId, args)
 }
+
+private const val MAX_CALLABLE_ARGUMENTS = 4
+private const val VT_NIL = 0
+private const val VT_BOOL = 1
+private const val VT_INT = 2
+private const val VT_FLOAT = 3
+private const val VT_OBJECT = 24
 
 @OptIn(ExperimentalNativeApi::class)
 @CName("kanama_ios_runtime_release_callable")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
@@ -342,7 +342,10 @@ class GodotSignal internal constructor(
         callback: (List<Any?>) -> Unit,
     ): SignalConnection {
         val callbackId = IosCallableRegistry.register(callback)
-        val result = IosGodot.objectConnectCallable(owner.handle.address(), name, callbackId, flags)
+        // Pass the receiver (target) so the Callable is bound to its ObjectID and Godot auto-disconnects
+        // it when the receiver is freed. Previously target was ignored, leaving an object-less Callable
+        // that survived the receiver's free and fired into freed memory on later emissions.
+        val result = IosGodot.objectConnectCallable(owner.handle.address(), name, target.handle.address(), callbackId, flags)
         if (result != 0L) {
             // connect failed; Godot freed the callable (which released the entry),
             // but release defensively in case it never reached the trampoline path.
@@ -1169,8 +1172,8 @@ internal object IosGodot {
     fun objectDisconnect(sourceObject: Long, signalName: String, targetObject: Long, method: String): Int =
         kanama_ios_godot_object_disconnect(sourceObject, signalName, targetObject, method)
 
-    fun objectConnectCallable(sourceObject: Long, signalName: String, callbackId: Long, flags: Long): Long =
-        kanama_ios_godot_object_connect_callable(sourceObject, signalName, callbackId, flags)
+    fun objectConnectCallable(sourceObject: Long, signalName: String, targetObject: Long, callbackId: Long, flags: Long): Long =
+        kanama_ios_godot_object_connect_callable(sourceObject, signalName, targetObject, callbackId, flags)
 
     fun objectDisconnectCallable(sourceObject: Long, signalName: String, callbackId: Long): Int =
         kanama_ios_godot_object_disconnect_callable(sourceObject, signalName, callbackId)

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -1928,6 +1928,21 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
         ObjectCalls.getMethodBind("Object", "emit_signal", 4047867050L), lamEmitter, listOf("kanamaLambda"))
     check("lambda-callable(connect fires once, disconnect stops it)", lamFiredOnce == 1 && lamFires == 1)
 
+    // Lambda Callable scalar-argument delivery. MultiplayerAPI.peer_connected emits the peer id
+    // as a Variant int; use a self-contained user signal to exercise that same C trampoline path.
+    var lamIntArg: Any? = null
+    val lamIntId = IosCallableRegistry.register { args -> lamIntArg = args.firstOrNull() }
+    ObjectCalls.callWithVariantArgs(
+        ObjectCalls.getMethodBind("Object", "add_user_signal", 85656714L), lamEmitter, listOf("kanamaLambdaInt"))
+    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambdaInt", lamIntId, 0L)
+    ObjectCalls.callWithVariantArgs(
+        ObjectCalls.getMethodBind("Object", "emit_signal", 4047867050L),
+        lamEmitter,
+        listOf("kanamaLambdaInt", 4_294_967_001L),
+    )
+    check("lambda-callable(int argument delivered)", lamIntArg == 4_294_967_001L)
+    IosGodot.objectDisconnectCallable(lamEmitter.address(), "kanamaLambdaInt", lamIntId)
+
     // Typed Array[StringName] return (Phase 2.7g). add_to_group("kgrp") then get_groups() == ["kgrp"]
     // — exercises ptrcallNoArgsRetStringNameList (Array size/get + StringName->utf8 blob). Plain Node.
     val grpNode = ObjectCalls.constructObject("Node")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -1919,7 +1919,7 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     val lamEmitter = ObjectCalls.constructObject("Node")
     ObjectCalls.callWithVariantArgs(
         ObjectCalls.getMethodBind("Object", "add_user_signal", 85656714L), lamEmitter, listOf("kanamaLambda"))
-    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambda", lamId, 0L)
+    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambda", lamEmitter.address(), lamId, 0L)
     ObjectCalls.callWithVariantArgs(
         ObjectCalls.getMethodBind("Object", "emit_signal", 4047867050L), lamEmitter, listOf("kanamaLambda"))
     val lamFiredOnce = lamFires
@@ -1934,7 +1934,7 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     val lamIntId = IosCallableRegistry.register { args -> lamIntArg = args.firstOrNull() }
     ObjectCalls.callWithVariantArgs(
         ObjectCalls.getMethodBind("Object", "add_user_signal", 85656714L), lamEmitter, listOf("kanamaLambdaInt"))
-    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambdaInt", lamIntId, 0L)
+    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambdaInt", lamEmitter.address(), lamIntId, 0L)
     ObjectCalls.callWithVariantArgs(
         ObjectCalls.getMethodBind("Object", "emit_signal", 4047867050L),
         lamEmitter,
@@ -1942,6 +1942,22 @@ fun kanamaIosRuntimeObjectCallsSelfTest() {
     )
     check("lambda-callable(int argument delivered)", lamIntArg == 4_294_967_001L)
     IosGodot.objectDisconnectCallable(lamEmitter.address(), "kanamaLambdaInt", lamIntId)
+
+    // Auto-disconnect on receiver free: a lambda Callable connected with a receiver must be
+    // disconnected by Godot when that receiver is freed, so a later emission neither fires it nor
+    // touches freed memory. Regression for the iOS host-disconnect crash — the Callable was created
+    // with object_id=0, so Godot could not associate it with its receiver and never disconnected it;
+    // when the freed receiver's script later ran on emit it was a use-after-free (__cxa_pure_virtual).
+    var lamFreeFires = 0
+    val lamFreeReceiver = ObjectCalls.constructObject("Node")
+    val lamFreeId = IosCallableRegistry.register { lamFreeFires++ }
+    ObjectCalls.callWithVariantArgs(
+        ObjectCalls.getMethodBind("Object", "add_user_signal", 85656714L), lamEmitter, listOf("kanamaLambdaFree"))
+    IosGodot.objectConnectCallable(lamEmitter.address(), "kanamaLambdaFree", lamFreeReceiver.address(), lamFreeId, 0L)
+    ObjectCalls.destroyObject(lamFreeReceiver) // free the receiver; Godot must auto-disconnect the bound Callable
+    ObjectCalls.callWithVariantArgs(
+        ObjectCalls.getMethodBind("Object", "emit_signal", 4047867050L), lamEmitter, listOf("kanamaLambdaFree"))
+    check("lambda-callable(auto-disconnect on receiver free)", lamFreeFires == 0)
 
     // Typed Array[StringName] return (Phase 2.7g). add_to_group("kgrp") then get_groups() == ["kgrp"]
     // — exercises ptrcallNoArgsRetStringNameList (Array size/get + StringName->utf8 blob). Plain Node.

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
@@ -995,6 +995,13 @@ private fun encodeIosReturn(value: Any?, retTag: CPointer<IntVar>?, retBuf: CPoi
             retBuf.reinterpret<CPointerVar<ByteVar>>()[0] = ptr
             retTag[0] = IOS_PT_STRING
         }
+        // NodePath ships its path string like a String; the C pt_return_to_variant NODE_PATH case
+        // builds a Godot NodePath from it. Makes NodePath @ScriptProperty readable (get parity).
+        is NodePath -> {
+            val ptr = IosReturnStringScratch.encode(value.path)
+            retBuf.reinterpret<CPointerVar<ByteVar>>()[0] = ptr
+            retTag[0] = IOS_PT_NODE_PATH
+        }
         // task 29 — fixed-element packed-array returns: ship a {count, data} desc + flat element
         // buffer via a reused scratch; the C side rebuilds the matching Packed*Array from it.
         is ByteArray -> {

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -164,10 +164,8 @@ extern void kanama_ios_runtime_script_instance_free(int64_t instance_handle);
 extern void kanama_ios_runtime_dispatch_callable(
     int64_t callback_id,
     int32_t argument_count,
-    int64_t arg0,
-    int64_t arg1,
-    int64_t arg2,
-    int64_t arg3
+    const int32_t *argument_types,
+    const int64_t *argument_values
 );
 extern void kanama_ios_runtime_release_callable(int64_t callback_id);
 extern void kanama_ios_runtime_objectcalls_selftest(void);
@@ -7104,9 +7102,9 @@ static GDExtensionObjectPtr kanama_ios_variant_to_object(GDExtensionConstVariant
 
 // Custom-Callable trampoline: invoked by Godot when a signal connected via
 // kanama_ios_godot_object_connect_callable fires. Forwards to the Kotlin
-// callback registry keyed by callable_userdata (the callback id). Object-typed
-// signal arguments are passed through as handles (up to 4); other types arrive
-// as 0 and surface as null on the Kotlin side.
+// callback registry keyed by callable_userdata (the callback id). Scalar signal
+// arguments are passed as Variant type tags plus int64 payloads (up to 4).
+// Unsupported Variant types surface as null.
 static void kanama_ios_callable_trampoline(
     void *callable_userdata,
     const GDExtensionConstVariantPtr *p_args,
@@ -7115,17 +7113,48 @@ static void kanama_ios_callable_trampoline(
     GDExtensionCallError *r_error
 ) {
     int64_t callback_id = (int64_t)(intptr_t)callable_userdata;
-    int64_t handles[4] = { 0, 0, 0, 0 };
+    int32_t argument_types[4] = { 0, 0, 0, 0 };
+    int64_t argument_values[4] = { 0, 0, 0, 0 };
     int n = (int)p_argument_count;
     if (n > 4) {
         n = 4;
     }
     for (int i = 0; i < n; i++) {
-        handles[i] = (int64_t)(intptr_t)kanama_ios_variant_to_object(p_args[i]);
+        int32_t type = g_variant_get_type != NULL
+            ? (int32_t)g_variant_get_type(p_args[i])
+            : KANAMA_IOS_VARIANT_TYPE_NIL;
+        argument_types[i] = type;
+        switch (type) {
+            case KANAMA_IOS_VARIANT_TYPE_BOOL: {
+                uint8_t value = 0;
+                if (g_variant_to_bool != NULL) {
+                    g_variant_to_bool(&value, (GDExtensionVariantPtr)p_args[i]);
+                }
+                argument_values[i] = value != 0 ? 1 : 0;
+                break;
+            }
+            case KANAMA_IOS_VARIANT_TYPE_INT:
+                if (g_variant_to_int != NULL) {
+                    g_variant_to_int(&argument_values[i], (GDExtensionVariantPtr)p_args[i]);
+                }
+                break;
+            case KANAMA_IOS_VARIANT_TYPE_FLOAT: {
+                double value = 0.0;
+                if (g_variant_to_float != NULL) {
+                    g_variant_to_float(&value, (GDExtensionVariantPtr)p_args[i]);
+                }
+                memcpy(&argument_values[i], &value, sizeof(value));
+                break;
+            }
+            case KANAMA_IOS_VARIANT_TYPE_OBJECT:
+                argument_values[i] = (int64_t)(intptr_t)kanama_ios_variant_to_object(p_args[i]);
+                break;
+            default:
+                break;
+        }
     }
     kanama_ios_runtime_dispatch_callable(
-        callback_id, (int32_t)p_argument_count,
-        handles[0], handles[1], handles[2], handles[3]);
+        callback_id, (int32_t)p_argument_count, argument_types, argument_values);
     if (r_return != NULL) {
         kanama_ios_init_nil_variant((GDExtensionUninitializedVariantPtr)r_return);
     }

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -251,6 +251,7 @@ static int g_kanama_ios_audio_session_configured = 0;
 static GDExtensionInterfaceGetProcAddress g_get_proc_address = NULL;
 static GDExtensionClassLibraryPtr g_library = NULL;
 static GDExtensionInterfaceCallableCustomCreate2 g_callable_custom_create2 = NULL;
+static GDExtensionInterfaceObjectGetInstanceId g_object_get_instance_id = NULL;
 
 static GDExtensionInterfaceStringNameNewWithUtf8Chars g_string_name_new = NULL;
 static GDExtensionInterfaceStringNewWithUtf8Chars g_string_new = NULL;
@@ -872,6 +873,10 @@ static int kanama_ios_resolve_godot_api(void) {
     // Optional: lambda/bound signal callbacks need this. Not added to the required
     // resolution check below so older runtimes still load; connect_callable NULL-checks it.
     g_callable_custom_create2 = (GDExtensionInterfaceCallableCustomCreate2)kanama_ios_lookup("callable_custom_create2");
+    // Needed so lambda/bound signal Callables report their receiver's ObjectID; Godot uses it to
+    // auto-disconnect the connection when that object is freed. Without it (object_id=0) a freed
+    // receiver's signal fires into a stale Callable -> use-after-free (iOS host-disconnect crash).
+    g_object_get_instance_id = (GDExtensionInterfaceObjectGetInstanceId)kanama_ios_lookup("object_get_instance_id");
     g_variant_new_nil = (GDExtensionInterfaceVariantNewNil)kanama_ios_lookup("variant_new_nil");
     g_global_get_singleton = (GDExtensionInterfaceGlobalGetSingleton)kanama_ios_lookup(
         "global_get_singleton"
@@ -7185,6 +7190,7 @@ static void kanama_ios_callable_free(void *callable_userdata) {
 int64_t kanama_ios_godot_object_connect_callable(
     int64_t object,
     const char *signal_name,
+    int64_t target_object,
     int64_t callback_id,
     int64_t flags
 ) {
@@ -7202,7 +7208,12 @@ int64_t kanama_ios_godot_object_connect_callable(
     memset(&info, 0, sizeof(info));
     info.callable_userdata = (void *)(intptr_t)callback_id;
     info.token = g_library;
-    info.object_id = 0;
+    // Bind the Callable to its receiver's ObjectID so Godot auto-disconnects the connection when the
+    // receiver is freed (e.g. a Menu freed on scene change). object_id does NOT affect Callable hash
+    // or equality (Godot uses call_func+userdata), so the explicit-disconnect path still matches.
+    info.object_id = (target_object != 0 && g_object_get_instance_id != NULL)
+        ? g_object_get_instance_id((GDExtensionConstObjectPtr)(intptr_t)target_object)
+        : 0;
     info.call_func = kanama_ios_callable_trampoline;
     info.free_func = kanama_ios_callable_free;
     uint8_t callable_value[24];

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -5240,6 +5240,18 @@ static void kanama_ios_pt_return_to_variant(int32_t tag, const void *ret_buf, ui
         kanama_ios_destroy_string(&cell);
         return;
     }
+    // NodePath returns ship a char* pointer in ret_buf (the string can exceed the fixed buffer),
+    // exactly like PT_STRING above. The generic pt_arg_to_variant path can't handle this: it treats
+    // its `p` as the string bytes directly (the arg convention), so NODE_PATH must dereference here.
+    if (tag == KANAMA_IOS_PT_NODE_PATH) {
+        const char *s = (ret_buf != NULL) ? *(const char *const *)ret_buf : NULL;
+        uint64_t cell = 0;
+        memset(out_variant, 0, 24);
+        kanama_ios_init_node_path(&cell, (s != NULL) ? s : "");
+        g_variant_from_node_path(out_variant, &cell);
+        kanama_ios_destroy_node_path(&cell);
+        return;
+    }
     if (tag == KANAMA_IOS_PT_PACKED_STRING_ARRAY) {
         const uint8_t *blob = (ret_buf != NULL) ? *(const uint8_t *const *)ret_buf : NULL;
         memset(out_variant, 0, 24);

--- a/ios/include/kanama_ios.h
+++ b/ios/include/kanama_ios.h
@@ -466,6 +466,7 @@ int64_t kanama_ios_godot_object_connect(
 int64_t kanama_ios_godot_object_connect_callable(
     int64_t object,
     const char *signal_name,
+    int64_t target_object,
     int64_t callback_id,
     int64_t flags
 );

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -238,7 +238,8 @@ internal class IosScriptCodeEmitter(
             builder.appendLine("        else -> false")
             builder.appendLine("    }")
             val readableProperties = script.properties.filter {
-                it.scalarGetExpression.isNotEmpty() || it.arrayElementEnumFqName.isNotEmpty()
+                it.scalarGetExpression.isNotEmpty() || it.arrayElementEnumFqName.isNotEmpty() ||
+                    it.listElementIsString
             }
             if (readableProperties.isNotEmpty()) {
                 builder.appendLine()
@@ -247,6 +248,10 @@ internal class IosScriptCodeEmitter(
                     when {
                         property.arrayElementEnumFqName.isNotEmpty() ->
                             builder.appendLine("        $index -> script.${property.kotlinName}.map { it.ordinal.toLong() }")
+                        // List<String>: encodeIosReturn ships it as a PackedStringArray; without this
+                        // branch a String-list @ScriptProperty is read back as nil (write-only).
+                        property.listElementIsString ->
+                            builder.appendLine("        $index -> script.${property.kotlinName}")
                         property.scalarGetExpression.isNotEmpty() ->
                             builder.appendLine("        $index -> ${property.scalarGetExpression}")
                     }
@@ -688,7 +693,35 @@ internal class IosScriptCodeEmitter(
             isObject || isList || customScript.isNotEmpty() -> ""
             enumFqName != null -> "script.$kotlinName.ordinal.toLong()"
             scalarSetExpression.isNotEmpty() -> "script.$kotlinName"
+            // Types that write through a dedicated set path (Vector2/Vector3/NodePath via
+            // setPropertyValue, String via setPropertyString) have an empty scalarSetExpression — but
+            // they are still *readable*: encodeIosReturn and the C pt_return_to_variant path handle
+            // all of them. Without a getProperty branch the engine reads them back as nil, which
+            // silently breaks MultiplayerSynchronizer replication of value-type @ScriptProperty (e.g.
+            // a Vector2 `motion` or Vector3 `shoot_target`) on the authority peer — the value never
+            // leaves the sending device. (String/NodePath have the identical defect; folded in here.)
+            type == TypeMapping.VECTOR2 || type == TypeMapping.VECTOR3 ||
+                type == TypeMapping.NODE_PATH || type == TypeMapping.STRING -> "script.$kotlinName"
             else -> ""
+        }
+        // Get/set parity guard: a *data* @ScriptProperty the engine can set but not read back is
+        // write-only on iOS — the engine gets nil, silently breaking MultiplayerSynchronizer
+        // replication and inspector reads (exactly how the Vector2 `motion` / Vector3 `shoot_target`
+        // bug hid). Object and custom-script refs are intentionally excluded: replicating an object
+        // handle across peers is meaningless and the inspector edits them via the node picker, not
+        // get(). With Vector2/Vector3/String/NodePath and List<String> now readable this stays silent
+        // in a healthy codebase and only trips if a new data type is added set-only (or one regresses).
+        val engineReadableData = scalarGetExpression.isNotEmpty() || (isList && arrayElementString)
+        val engineSettableDataType = valueTypeClassName.isNotEmpty() ||
+            (!isObject && !isList && godotClassName == "String") ||
+            (isList && arrayElementString)
+        if (engineSettableDataType && !engineReadableData) {
+            warn(
+                "[kanama-ios] $className.$kotlinName ($type) — data @ScriptProperty is write-only on " +
+                    "iOS: settable from scene data / Object.set, but the engine reads it back as nil " +
+                    "(no getProperty path). MultiplayerSynchronizer replication and the inspector cannot " +
+                    "get() this property. Add an encodeIosReturn case + a getProperty branch to fix.",
+            )
         }
         val godotVariantType = when {
             isObject -> 24 // OBJECT

--- a/scripts/ios_visual_smoke.sh
+++ b/scripts/ios_visual_smoke.sh
@@ -595,6 +595,7 @@ import net.multigesture.kanama.api.Mathf
 import net.multigesture.kanama.api.RefCounted
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Vector2
+import net.multigesture.kanama.types.Vector3
 
 enum class IosSmokeMode { EASY, NORMAL, HARD }
 
@@ -614,6 +615,26 @@ class IosSmokeScript(godotObject: MemorySegment) : KanamaScript<Label>(godotObje
 
     @ScriptProperty
     var smokeModes: List<IosSmokeMode> = emptyList()
+
+    // Value-type @ScriptProperty read-back coverage. These are set through the engine and read
+    // back through Object.get() below, which forces the engine to call the ScriptInstance getter —
+    // the exact path MultiplayerSynchronizer uses on the authority peer. Before the getProperty
+    // value-type fix these were write-only (read back as nil), silently breaking replication of a
+    // Vector2 `motion` / Vector3 `shoot_target`.
+    @ScriptProperty
+    var probeMotion: Vector2 = Vector2.ZERO
+
+    @ScriptProperty
+    var probeShootTarget: Vector3 = Vector3.ZERO
+
+    @ScriptProperty
+    var probeName: String = ""
+
+    @ScriptProperty
+    var probeView: NodePath = NodePath.EMPTY
+
+    @ScriptProperty
+    var probeTags: List<String> = emptyList()
 
     private var processedFrames = 0
     private var sawUnhandledInput = false
@@ -693,6 +714,31 @@ class IosSmokeScript(godotObject: MemorySegment) : KanamaScript<Label>(godotObje
             "[kanama][ios][kn] task39 property engine get " +
                 "float=${engineFloat == 2.5} int=${engineInt == 7L} enum=${engineEnum == 0L} " +
                 "enumListRequested=true",
+        )
+        // Data @ScriptProperty get parity: assign the Kotlin fields directly, then read each back
+        // through Object.get so the engine calls the ScriptInstance getter — the path
+        // MultiplayerSynchronizer uses on the authority peer. Whole-number vector components are exact
+        // in float32, so the round trip is bit-exact. Before the getProperty data-type fixes these
+        // read back as nil. Object.get decodes Vector2/Vector3/String/NodePath on iOS; the List<String>
+        // read exercises the getProperty + PackedStringArray encode path (Object.get can't decode a
+        // packed array back, so it is not asserted here — the emitter parity guard + the cross-backend
+        // parity check cover List<String> regressions).
+        probeMotion = Vector2(3.0, 4.0)
+        probeShootTarget = Vector3(5.0, 6.0, 7.0)
+        probeName = "kanama"
+        probeView = NodePath("../Background")
+        probeTags = listOf("alpha", "beta")
+        val engineMotion = self.get("probe_motion")
+        val engineShootTarget = self.get("probe_shoot_target")
+        val engineName = self.get("probe_name")
+        val engineView = self.get("probe_view")
+        self.get("probe_tags") // exercises the List<String> getProperty + PackedStringArray encode path
+        println(
+            "[kanama][ios][kn] datatype property engine get " +
+                "vector2=${engineMotion == Vector2(3.0, 4.0)} " +
+                "vector3=${engineShootTarget == Vector3(5.0, 6.0, 7.0)} " +
+                "string=${engineName == "kanama"} " +
+                "nodepath=${(engineView as? String) == "../Background"}",
         )
         val propertyConversionsOk =
             initialPropertyConversions && roundTripPropertyConversions && engineScalarReadsOk
@@ -2472,6 +2518,15 @@ if [[ "$physical_device" -eq 0 && "$kanama_user_script_probe" -eq 1 ]]; then
     echo "[ios_visual_smoke] task 39 narrow/enum property conversions delivered and round-tripped"
   else
     echo "[ios_visual_smoke] task 39 property conversion probe failed" >&2
+    exit 1
+  fi
+  # Data @ScriptProperty get parity: Vector2/Vector3/String/NodePath read back through the engine
+  # getter (the path MultiplayerSynchronizer uses on the authority peer). Regression for the
+  # write-only data-type getProperty bug that broke iOS multiplayer movement/shooting.
+  if rg -q 'datatype property engine get vector2=true vector3=true string=true nodepath=true' "$stderr_log" "$stdout_log"; then
+    echo "[ios_visual_smoke] data @ScriptProperty get parity (Vector2/Vector3/String/NodePath) round-tripped"
+  else
+    echo "[ios_visual_smoke] data @ScriptProperty get parity probe failed" >&2
     exit 1
   fi
   # Phase 3.3: an arg-bearing virtual dispatched through the generic callV path.

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -133,6 +133,11 @@ check "InstancedMesh raw_class=MeshInstance3D is_class_match=true typed_lookup=t
 # under Engine.is_editor_hint()).
 check "NonToolScript\\._ready fired"
 check "NonToolScript\\._process fired"
+# Disabling processing in @OnReady must survive later ScriptInstance lifecycle
+# notifications. Re-enabling here makes authority-gated multiplayer inputs run on
+# every peer and lets one device control multiple players.
+check "ProcessDisableSmoke ready processing=false"
+check_absent "ProcessDisableSmoke unexpected process"
 # Non-tool @RegisterClass must run in game mode too — runtime gating only
 # applies to editor instances.
 check "NonToolHelloKanama\\._ready fired"

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -235,9 +235,6 @@ object ScriptBridge {
     private const val PROPERTY_USAGE_GROUP = 64
     private const val PROPERTY_USAGE_CATEGORY = 128
     private const val PROPERTY_USAGE_SUBGROUP = 256
-    private const val NOTIFICATION_ENTER_TREE = 10
-    private const val NOTIFICATION_READY = 13
-
     private val physicsProcessNameValue by lazy { GodotStrings.stringNameStorage("_physics_process") }
     private val processNameValue by lazy { GodotStrings.stringNameStorage("_process") }
     private val processDeltaScratch = ThreadLocal.withInitial {
@@ -554,10 +551,10 @@ object ScriptBridge {
     // --- Notification ---
 
     @JvmStatic
-    fun siNotification(data: MemorySegment, what: Int, reversed: Byte) {
-        if (what == NOTIFICATION_ENTER_TREE || what == NOTIFICATION_READY) {
-            si(data)?.let(::configureLifecycleProcessing)
-        }
+    fun siNotification(_data: MemorySegment, _what: Int, _reversed: Byte) {
+        // Processing is enabled once when the script instance is created. Re-enabling it from
+        // ENTER_TREE or READY notifications would override a script's setProcess(false) or
+        // setPhysicsProcess(false), including authority-gated multiplayer input scripts.
     }
 
     // --- Method arg count ---


### PR DESCRIPTION
## Summary

Fixes four multiplayer bugs (plus a class of latent iOS `@ScriptProperty` write-only bugs) found
while device-testing the `tps-demo-kanama` port across desktop / Android (Pixel 7) / iOS (iPhone 15
Pro). Three are iOS-only; one is in the shared JVM runtime (desktop + Android). All are validated
on-device. No demo/gameplay changes — the port stays literal to the upstream GDScript.

## Bugs fixed

**1 — Lifecycle re-enabled `_process` after user code disabled it** (shared JVM runtime; desktop +
Android). `ScriptBridge.siNotification` re-ran processing config on `ENTER_TREE`/`READY`, overriding a
script's `setProcess(false)` in `_ready`. In multiplayer this made a host run every peer's
authority-gated input synchronizer → one device drove all players. Fix: `siNotification` no longer
re-enables processing. Regression: `ProcessDisableSmoke` + `runtime_smoke.sh` assert processing stays
off. *Latent on desktop too; single-player never disables processing in `_ready`.*

**2 — iOS signal scalar args arrived `null`** (iOS only). The callable trampoline passed all args as
object handles, so `peer_connected(int id)` wrapped the id as a bogus object → crash on connect. Fix:
typed arg arrays decoded per Variant type. Regression: an int over a user signal (`>2³²`, proves no
truncation).

**3 — iOS value-type `@ScriptProperty` were write-only → client can't move/shoot** (iOS only). The
KSP emitter only generated an engine *reader* (`getProperty`) for properties with a scalar *setter*;
value types write through a separate path, so `Vector2 motion` / `Vector3 shoot_target` had no reader
and `Object.get` returned `nil`. `MultiplayerSynchronizer` serializes on the authority by calling
`get(...)`, so the iPhone sent zeros — no walk, no shoot. Jump worked because it's an `@Rpc`, not a
replicated property. Fix: emit `getProperty` for the value/data types the runtime can encode. **Also
folded in the same-class landmines found in review: `String`, `NodePath`, `List<String>`** (object
refs stay write-only by design — a cross-peer handle is meaningless to replicate).

**4 — iOS crash when the host ends the game** (iOS only). iOS lambda/bound signal `Callable`s were
created with `object_id = 0` and the receiver passed to `Signal.connect(target, …)` was ignored, so
Godot couldn't auto-disconnect the connection when the receiver (Menu) was freed on scene change. On
host-quit the stale connection fired into the freed Menu → `set_text` on a dead `Button` →
`__cxa_pure_virtual` / `SIGABRT`. Fix: thread the receiver through and set `object_id` to its instance
id (verified against Godot source that `object_id` affects neither Callable hash nor equality, so the
explicit-disconnect path is unchanged). Regression: a receiver-bound lambda must not fire after the
receiver is freed.

## Prevention

- **Emitter parity guard**: warns at codegen for any *data-type* `@ScriptProperty` that is settable
  but not readable — turns this whole class into a build signal instead of a device session.
- Follow-up tasks filed (kanama-tasks 46/47): a cross-backend capability parity check (escalate the
  guard to a hard KSP error + assert iOS matches the JVM property capabilities) and a replication-
  shaped loopback smoke.

## Validation (on-device, iPhone 15 Pro + Pixel 7, desktop host)

- Bug 1: Android host controls only its own player.
- Bug 3: iPhone client **walks and shoots**.
- Bug 4: iPhone client **does not crash** when the host ends the game.
- iOS runtime self-test: `OBJECTCALLS 116/0`, `PTRCALL 70/0` (includes the new auto-disconnect check).
- `runtime_smoke.sh` PASS (desktop, Bug 1 regression).

## Not included (by decision)

The client sitting in the level ("limbo") when the host quits mid-game is a **pre-existing upstream
demo gap** (`tps-demo/level/level.gd` only handles `peer_disconnected`), kept literal to upstream. Bug
4 removes only the *crash*, bringing iOS to desktop/Android parity.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
