### PR TITLE
fix(ios): stop lifecycle notifications re-enabling _process on the host (iOS twin of #50)

### DIFF
--- a/docs/reference/c-sharp-compat.md
+++ b/docs/reference/c-sharp-compat.md
@@ -49,7 +49,7 @@ Legend: `SUPPORTED` means validated in smoke tests or real demo ports.
 | Core singletons and utilities | SUPPORTED | `GD`, `Mathf`, `Input`, `OS`, `Engine`, `Time`, `ProjectSettings`, `DisplayServer`, and related helpers are available. |
 | 2D/3D gameplay APIs | PARTIAL | Broad promoted coverage exists, and real demo ports exercise common movement, physics, animation, particles, UI, audio, files, scenes, resources, and tween use cases. Use the coverage reports for exact wrapper availability. |
 | Dynamic fallback | PARTIAL | `GodotObject.call(...)`, `signal(...)`, and typed object wrappers cover mixed GDScript/Kanama edges. Prefer typed wrappers when available. |
-| Networking/multiplayer parity | PARTIAL | Some wrappers are promoted, but Kanama does not yet claim C#-style multiplayer workflow parity. |
+| Networking/multiplayer parity | SUPPORTED | The core multiplayer workflow — `ENetMultiplayerPeer` host/join, `@Rpc` calls, and `MultiplayerSynchronizer` `@ScriptProperty` replication — is validated end-to-end in the TPS demo across desktop, Android, and iOS, with each platform in the host role (clients see each other move/shoot over LAN and control only their own player). Less-common multiplayer APIs follow the general wrapper-coverage path. |
 
 ## Data And Marshalling
 

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -7610,7 +7610,12 @@ static void kanama_ios_script_instance_notification(
     GDExtensionBool reversed
 ) {
     (void)reversed;
-    if (what == KANAMA_IOS_NOTIFICATION_ENTER_TREE || what == KANAMA_IOS_NOTIFICATION_READY) {
+    // Configure processing ONCE, on ENTER_TREE (which fires before the script's _ready). Re-running
+    // it on READY would override a script's setProcess(false)/setProcessInput(false) made in _ready
+    // or _enter_tree — including authority-gated multiplayer input synchronizers, which then run on
+    // every peer and let an iOS host drive other players' inputs. iOS mirror of the JVM
+    // ScriptBridge.siNotification fix.
+    if (what == KANAMA_IOS_NOTIFICATION_ENTER_TREE) {
         KanamaIosScriptInstance *instance = kanama_ios_script_instance_data(data);
         kanama_ios_script_instance_configure_lifecycle_processing(instance);
     }


### PR DESCRIPTION
## Summary

iOS-only follow-up to the multiplayer fixes in #50. The JVM lifecycle fix there
(`ScriptBridge.siNotification` no longer re-enables `_process` after user code disables it in
`_ready`) had an **exact untouched twin in the iOS backend**. It only surfaces when an **iPhone
hosts** a multiplayer session — every earlier test had iOS as the client, where the bug is benign.

## Root cause

`kanama_ios_script_instance_notification` re-ran `configure_lifecycle_processing` on **both**
`ENTER_TREE` and `READY`. A script's `setProcess(false)` in `_ready` (e.g. an authority-gated
`MultiplayerSynchronizer` input script on a non-authoritative peer) was overridden one notification
later. So an iOS host ran **every** player's input synchronizer and drove all players (observed:
iOS host + Android/desktop client → the iOS host controlled both players).

## Fix

`configure_lifecycle_processing` is only ever called from this notification on iOS (unlike the JVM
path, which configures at instance creation), and `ENTER_TREE` fires **before** the script's `_ready`.
So configure once on `ENTER_TREE` and drop the `READY` re-config — `_ready`'s `setProcess(false)` is
then preserved.

## Validation (on-device)

- **iPhone hosts + Android joins**: iPhone now controls only its own player (was: both). ✅
- Re-confirmed the other host cells (unchanged, JVM path): desktop-host and Android-host each control
  only their own player with an iOS client. The full cross-platform host matrix now passes.

## Regression

The clean automated regression is a cross-backend `ProcessDisableSmoke` (run the same "disable
`_process` in `_ready`, assert it never fires" probe on JVM **and** iOS). The existing iOS smoke
script can't host it (its `@OnProcess` must fire for other checks), so it needs a dedicated scene
probe — tracked in **kanama-tasks/46** (cross-backend parity), which now explicitly covers this
lifecycle case. The broader rule captured there: a fix in one backend's script-instance/notification
path must land + be tested in the other backend's parallel path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
