### PR TITLE
fix(ios): make @ScriptProperty get/set parity guard a hard build error (closes #49 finding 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ versioning once public releases begin.
 
 ### Added
 
+- iOS `@ScriptProperty` codegen now **fails the build** (was a warning) when a *data* property is
+  settable by the engine but not readable (a write-only get/set asymmetry). This is the exact class
+  that silently shipped write-only value types and broke multiplayer replication; a new settable data
+  type must gain a `getProperty`/`encodeIosReturn` path before it can compile. Object/custom-script
+  refs remain intentionally exempt.
 - Fixed iOS lambda signal callbacks dropping non-object scalar arguments.
   Emitted `bool`, `int`, and `float` Variants now reach Kotlin with their
   original values, matching desktop and Android; this fixes integer peer IDs

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -143,6 +143,10 @@ internal data class IosScript(
 internal class IosScriptCodeEmitter(
     inputs: List<IosScriptInput>,
     private val warn: (String) -> Unit = {},
+    // Fails the KSP round (build error). Used for defects that must not ship, e.g. a data-type
+    // @ScriptProperty the engine can set but not read back — the exact get/set asymmetry that shipped
+    // write-only value types in the iOS backend and broke multiplayer replication on device.
+    private val error: (String) -> Unit = {},
 ) {
     // Sort by resourcePath to match the old task's `.sortedBy { it.resourcePath }`.
     private val scripts: List<IosScript> =
@@ -711,12 +715,15 @@ internal class IosScriptCodeEmitter(
         // handle across peers is meaningless and the inspector edits them via the node picker, not
         // get(). With Vector2/Vector3/String/NodePath and List<String> now readable this stays silent
         // in a healthy codebase and only trips if a new data type is added set-only (or one regresses).
+        // This is a hard build ERROR, not a warning: a warning is exactly what let the original
+        // write-only asymmetry ship unnoticed. A new settable data type must gain a getProperty path
+        // (or be explicitly excluded here) before it can compile.
         val engineReadableData = scalarGetExpression.isNotEmpty() || (isList && arrayElementString)
         val engineSettableDataType = valueTypeClassName.isNotEmpty() ||
             (!isObject && !isList && godotClassName == "String") ||
             (isList && arrayElementString)
         if (engineSettableDataType && !engineReadableData) {
-            warn(
+            error(
                 "[kanama-ios] $className.$kotlinName ($type) — data @ScriptProperty is write-only on " +
                     "iOS: settable from scene data / Object.set, but the engine reads it back as nil " +
                     "(no getProperty path). MultiplayerSynchronizer replication and the inspector cannot " +

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -840,7 +840,11 @@ class KanamaProcessor(
         // via -Pkanama…=false → the KSP option below. Default stays resource until the gate passes.
         val asResource = env.options["kanamaIosRegistryAsResource"]?.toBoolean() ?: true
         val extension = if (asResource) "kt.txt" else "kt"
-        val emitter = IosScriptCodeEmitter(iosScripts) { env.logger.warn("[kanama:ksp] $it") }
+        val emitter = IosScriptCodeEmitter(
+            iosScripts,
+            warn = { env.logger.warn("[kanama:ksp] $it") },
+            error = { env.logger.error("[kanama:ksp] $it") },
+        )
         val deps = Dependencies(aggregating = true, *scriptAggregatorSources.toTypedArray())
 
         fun write(packageName: String, fileName: String, content: String) {


### PR DESCRIPTION
## Why

Second-opinion review of #49 surfaced two findings:
- **Finding 1** — value/data `@ScriptProperty` were write-only (broke iOS multiplayer replication). **Already fixed + merged in #50**, device-validated.
- **Finding 2** — the asymmetry was *invisible*: the emitter parity guard was only a **warning**, which is what let it ship. This PR closes Finding 2.

## Change

The get/set parity guard (a *data* `@ScriptProperty` that's settable but not readable) now calls `env.logger.error` — a **hard KSP build failure** — instead of a warning. A new settable data type must gain a `getProperty`/`encodeIosReturn` path (or be explicitly exempted) before it can compile. Object/custom-script refs stay exempt by design (a cross-peer handle is meaningless to replicate).

## Safety / verification

- Logic unchanged — only `warn` → `error`.
- **Verified silent on the current codebase**: 0 guard hits across full KSP runs over `IosSmokeScript` (Vector2/Vector3/String/NodePath/`List<String>` — all 10 props). So no valid project breaks, and it confirms Finding 1 left **zero** remaining landmines.
- Processor compiles; CHANGELOG noted.

First slice of kanama-tasks/46 (the remaining cross-backend capability parity test is still tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)