### PR TITLE
ci: run iOS xcframework lane on C-shim (ios/) changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,10 @@ jobs:
           fi
           changed="$(git diff --name-only '${{ github.event.pull_request.base.sha }}'...HEAD)"
           echo "changed files:"; echo "$changed"
-          if printf '%s\n' "$changed" | grep -qE '^(src/|processor/|annotations/|ios-runtime/|android/|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/ci\.yml)'; then
+          # `ios/` (the C shim + headers) and `gdextension/` (the bundled interface header the shim
+          # includes) must trigger the mobile lanes — a change to `ios/bootstrap/kanama_ios_shim.c`
+          # otherwise skipped the iOS xcframework build (only `ios-runtime/` was matched).
+          if printf '%s\n' "$changed" | grep -qE '^(src/|processor/|annotations/|ios/|ios-runtime/|gdextension/|android/|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/ci\.yml)'; then
             echo "mobile=true" >> "$GITHUB_OUTPUT"
           else
             echo "mobile=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

PR #51 changed `ios/bootstrap/kanama_ios_shim.c` but the **iOS xcframework build lane SKIPPED** — the change-detection filter in `ci.yml` matched `ios-runtime/` but not `ios/` (the C shim + headers) or `gdextension/` (the interface header the shim includes). So C-shim changes weren't compiled in CI and relied on manual on-device builds.

## Change

Add `ios/` and `gdextension/` to the mobile-change filter regex, so a shim/header change sets `mobile=true` and runs the iOS (and Android) build lanes.

This PR itself exercises it: touching `.github/workflows/ci.yml` is already in the filter, so the mobile lanes run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)