### PR TITLE
test(ios): @ScriptProperty get/set parity contract + gate JVM tests in CI (task 46)

### DIFF
--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -9,4 +9,10 @@ kotlin {
 dependencies {
     implementation(project(":annotations"))
     implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/IosScriptPropertyParityTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/IosScriptPropertyParityTest.kt
@@ -1,0 +1,116 @@
+package net.multigesture.kanama.processor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Task 46 — cross-backend @ScriptProperty get/set capability parity.
+ *
+ * The JVM backend (`ScriptBridge`) reads and writes every supported @ScriptProperty type through one
+ * generic path, so it is uniformly readable + settable. The iOS backend hand-rolls per-type codegen,
+ * so it can silently diverge — which is exactly how value/data types shipped **write-only** (settable
+ * from scene data but read back as nil), silently breaking `MultiplayerSynchronizer` replication (the
+ * 2026-07-16 "iPhone can't walk/shoot" bug).
+ *
+ * This locks the contract as a fast, device-free unit test: for every *data* type the iOS emitter
+ * supports, it must be both settable AND readable (matching the JVM's uniform capability). Object /
+ * custom-script refs are the one documented exemption (a cross-peer handle is meaningless to
+ * replicate). The codegen guard already fails the build on a violation; this test is the same rule
+ * exercised over an explicit type fixture, so a regression is caught in the JVM test suite too.
+ */
+class IosScriptPropertyParityTest {
+
+    private fun scalarProp(name: String, type: TypeMapping) =
+        ScriptPropertyModel(kotlinName = name, godotName = name, type = type, isMutable = true)
+
+    private fun stringListProp(name: String) =
+        ScriptPropertyModel(
+            kotlinName = name, godotName = name, type = TypeMapping.ARRAY,
+            isMutable = true, arrayElementString = true,
+        )
+
+    private fun objectProp(name: String) =
+        ScriptPropertyModel(
+            kotlinName = name, godotName = name, type = TypeMapping.OBJECT,
+            isMutable = true, objectWrapperFqName = "net.multigesture.kanama.api.Node",
+        )
+
+    private class Result(val source: String, val errors: List<String>) {
+        // The generated bridge's getProperty is a `when (propertyIndex)`; slice it from its declaration
+        // to the next `override fun` so field reads outside it don't produce false positives.
+        val getPropertyBlock: String = run {
+            val start = source.indexOf("override fun getProperty(")
+            if (start < 0) "" else {
+                val next = source.indexOf("override fun ", start + 20)
+                source.substring(start, if (next < 0) source.length else next)
+            }
+        }
+        fun readable(kotlinName: String) = getPropertyBlock.contains("script.$kotlinName")
+    }
+
+    private fun emit(vararg props: ScriptPropertyModel): Result {
+        val errors = mutableListOf<String>()
+        val model = ScriptModel(
+            simpleName = "ParityFixture",
+            fqName = "net.multigesture.kanama.test.ParityFixture",
+            attachTo = "Node",
+            isTool = false,
+            isGlobalClass = false,
+            properties = props.toList(),
+            toolButtons = emptyList(),
+            virtuals = emptyList(),
+            methods = emptyList(),
+            signals = emptyList(),
+        )
+        val source = IosScriptCodeEmitter(
+            listOf(IosScriptInput(model, "res://ParityFixture.kt")),
+            error = { errors += it },
+        ).registrySource()
+        return Result(source, errors)
+    }
+
+    @Test
+    fun everySettableDataTypeIsAlsoReadable() {
+        val r = emit(
+            scalarProp("motion", TypeMapping.VECTOR2),
+            scalarProp("shootTarget", TypeMapping.VECTOR3),
+            scalarProp("label", TypeMapping.STRING),
+            scalarProp("view", TypeMapping.NODE_PATH),
+            stringListProp("tags"),
+            // scalars (never at risk, but part of the contract)
+            scalarProp("count", TypeMapping.INT),
+            scalarProp("speed", TypeMapping.FLOAT),
+            scalarProp("armed", TypeMapping.BOOL),
+        )
+
+        // The parity guard (as the emitter's hard-error callback) must not fire: no write-only data.
+        assertTrue(
+            r.errors.isEmpty(),
+            "iOS @ScriptProperty parity guard flagged write-only data type(s): ${r.errors}",
+        )
+
+        // Each data type is engine-readable (has a getProperty branch) — the exact property the iOS
+        // multiplayer bug lost. Reverting a getProperty fix drops the read and fails this.
+        for (name in listOf("motion", "shootTarget", "label", "view", "tags")) {
+            assertTrue(r.readable(name), "data @ScriptProperty '$name' is write-only on iOS (no getProperty branch)")
+        }
+    }
+
+    @Test
+    fun objectRefsAreExemptWriteOnlyNoError() {
+        val r = emit(objectProp("crosshair"))
+        // Object refs are settable (owner handle) but intentionally not engine-readable — replicating
+        // a cross-peer handle is meaningless. This must NOT be flagged as a parity violation.
+        assertTrue(r.errors.isEmpty(), "object-ref @ScriptProperty wrongly flagged: ${r.errors}")
+        assertFalse(r.readable("crosshair"), "object refs are not expected to be engine-readable")
+    }
+
+    @Test
+    fun listStringIsReadableViaGetProperty() {
+        val r = emit(stringListProp("names"))
+        assertEquals(emptyList(), r.errors)
+        assertTrue(r.readable("names"), "List<String> @ScriptProperty must be engine-readable")
+    }
+}

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -113,6 +113,12 @@ if [[ -z "$kanama_version" ]]; then
 fi
 ensure_gdextension_header "${godot_bins[0]}"
 
+# JVM unit tests across all modules (runtime :test + KSP processor :processor:test). These were not
+# previously gated — the iOS @ScriptProperty get/set parity contract (task 46) lives here, along with
+# the existing type tests.
+echo "[local_ci] JVM unit tests"
+"$ROOT_DIR/gradlew" -p "$ROOT_DIR" test
+
 echo "[local_ci] public docs local-path guard"
 if git -C "$ROOT_DIR" grep -nE '(/Users/[[:alnum:]_.-]+|/home/[[:alnum:]_.-]+|lmuller)' -- \
   README.md docs CONTRIBUTING.md templates example_project; then


### PR DESCRIPTION
## Why

Task 46 (cross-backend parity), following the #49 review. The iOS backend hand-rolls per-type `@ScriptProperty` codegen, so it can silently diverge from the JVM backend's uniform get/set capability — exactly how value/data types shipped **write-only** and broke multiplayer replication.

## Change

- **Parity contract test** (`processor/src/test`): runs the iOS emitter over a fixture of every data type (Vector2/Vector3/String/NodePath/`List<String>` + scalars + an object ref) and asserts:
  - the parity guard emits **zero errors** (no write-only data types),
  - each data type appears in the generated `getProperty` block (engine-readable),
  - object refs are the documented exemption (settable, not readable).
- **Gates JVM tests in CI**: `local_ci.sh` didn't run `gradlew test` at all, so unit tests (this one *and* the pre-existing type tests) weren't enforced on PRs. Added a `gradlew test` step, so a regression in the emitter's get/set logic now fails the merge gate — not just the codegen guard.

## Verification

- 3/3 parity tests pass; full `gradlew test` green.
- Complements the hard-error codegen guard (#52): the guard fails the *build*; this fails the *test suite* over an explicit type fixture, and it's the seam the broader table-driven / cross-backend-diff work in task 46 builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)