### PR TITLE
docs: refresh post-promotion staleness (nav labels + C# parity)

### DIFF
--- a/docs/reference/c-sharp-compat.md
+++ b/docs/reference/c-sharp-compat.md
@@ -26,7 +26,7 @@ Legend: `SUPPORTED` means validated in smoke tests or real demo ports.
 | Register new Godot classes | SUPPORTED | `@RegisterClass` registers permanent ClassDB types. |
 | Lifecycle callbacks | SUPPORTED | `@OnReady`, `@OnProcess`, `@OnPhysicsProcess`, `@OnEnterTree`, `@OnExitTree`. |
 | Tool scripts | SUPPORTED | `@Tool` works for both `@ScriptClass` and `@RegisterClass`. |
-| Global classes | PARTIAL | `@GlobalClass`/`@ClassName` work for typed inspector-facing classes; broader editor UI validation is still ongoing. |
+| Global classes | SUPPORTED | `@GlobalClass`/`@ClassName` register in the editor's global class list: the class appears in the Create New Resource dialog and its `.tres` instances match typed export slots (GUI-validated, [#39](https://github.com/falcon4ever/kanama/issues/39)). One constraint: the file must be named after the class. |
 | Hot reload | PARTIAL | Build + scene reload is the reliable workflow; in-place live-node replacement still has edge cases. |
 
 ## Editor And Build Workflow
@@ -81,7 +81,7 @@ Legend: `SUPPORTED` means validated in smoke tests or real demo ports.
 | Kotlin script object is separate from the Godot node | Keeps JVM script lifetime, Godot object lifetime, hot reload, and editor placeholders explicit. Use `KanamaScript<T>.self` for the attached node/resource. |
 | Lower-camel Kotlin API only | Matches Kotlin style and avoids maintaining duplicate C#-style aliases. |
 | Explicit install paths | Desktop kits cover new packaged projects, store addons cover existing packaged projects, and source checkouts remain the development path for unreleased Kanama changes. |
-| Desktop-first runtime | Kanama embeds a normal JVM in a desktop Godot process. Android (Supported on 4.7 stable) runs through ART and PanamaPort; web export is not planned. |
+| Desktop-first runtime | Kanama embeds a normal JVM in a desktop Godot process. Android and iOS are both Supported on 4.7 stable (Android through ART and PanamaPort; iOS through a Kotlin/Native `.xcframework`, no on-device JVM); web export is not planned. |
 
 ## Coverage References
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,8 +51,8 @@ nav:
       - Kotlin Style: game-dev/style-guide.md
   - Exporting:
       - Desktop and Packaging: exporting/desktop.md
-      - Android Experimental: exporting/android.md
-      - iOS Experimental: exporting/ios.md
+      - Android: exporting/android.md
+      - iOS: exporting/ios.md
   - Reference:
       - Version Support: reference/version-support.md
       - C# Comparison: reference/c-sharp-compat.md


### PR DESCRIPTION
## What

Small documentation freshness pass, catching a few spots the mobile-promotion sweep (2026-07-14) missed.

- **mkdocs nav**: drop "Experimental" from the Android/iOS nav labels — both were promoted to Supported (4.7 stable) on 2026-07-14; the page bodies were already updated but the nav labels lagged.
- **c-sharp-compat**: Global classes `PARTIAL` → `SUPPORTED` — task 37 landed `@GlobalClass` editor registration and it was GUI-validated ([#39](https://github.com/falcon4ever/kanama/issues/39)).
- **c-sharp-compat**: the desktop-first "Intentional Differences" row now names iOS as Supported alongside Android.

## Why

Docs-only; no code, no runtime, no generator changes. Removes stale "experimental"/"partial" wording that under-claims the current Supported state.

## Validation

`mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)