### PR TITLE
docs: refresh mobile support status in agent-facing files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,15 @@ release shape.
 - Godot baseline: Godot `4.7 stable` (re-pin only on stable releases; bumps
   follow `docs/contributing/godot-upgrade.md`).
 - Desktop runtime/build JDK: JDK `25+`.
-- Mobile is experimental, device-validated: Android passed the Pixel 7 debug
-  matrix, R8-minified release APK, and Vulkan/Mobile renderer smoke; iOS passed
-  the full ten-step device gate on iPhone 12 and iPhone 15 Pro. Promotion to
-  Supported is gated on the release-support decision (§7 mobile promotion bar) in the internal task repo.
+- Mobile is Supported (4.7 stable), promoted from Experimental 2026-07-14 once
+  the §7 mobile promotion bar went green. Android is device-validated across
+  four models (Pixel 7, Moto g 5G 2023, Galaxy S10+, Pixel 3 XL): debug
+  validated to Android 9, but **release builds require Android 13+**. iOS is
+  device-validated on iPhone 12 and iPhone 15 Pro. Carried caveats: packaged
+  mobile addons are runtime-only (compiling project scripts needs the Kanama
+  checkout), the Android release path depends on the JitPack PanamaPort fork,
+  and there is no mobile hot reload. See
+  `docs/reference/version-support.md` for the full claims and validation dates.
 - Release artifacts use two shapes: desktop kits for new projects and store
   add-ons for existing projects. See `docs/exporting/desktop.md`.
 
@@ -222,10 +227,11 @@ Run local CI and demo smoke checks before changing support claims.
 
 ### Android Work
 
-Keep Android wording experimental unless the matching APK/emulator or device
-smoke path has passed. Use the Gradle AAR workflow documented in
-`docs/exporting/android.md`; do not infer Android support from desktop package
-success.
+Android is Supported (4.7 stable), but never widen a support claim past what
+the matching APK/emulator or device smoke path has actually validated — the
+release floor (Android 13+) and the runtime-only addon caveat both still hold.
+Use the Gradle AAR workflow documented in `docs/exporting/android.md`; do not
+infer Android support from desktop package success.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,11 +157,12 @@ The demos repository exposes:
 
 ## Android Port Notes
 
-Android support is experimental but device-validated on Godot 4.7 stable: the
-Pixel 7 debug demo matrix, an R8-minified release APK (via Kanama's PanamaPort
-fork), and the nine-demo Vulkan/Mobile renderer smoke have all passed. It is
-still not a polished phone-ready target; the remaining promotion criteria are
-in `docs/internals/release-support-decision.md` §7.
+Android is Supported on Godot 4.7 stable (promoted from Experimental
+2026-07-14): the Pixel 7 debug demo matrix, an R8-minified release APK (via
+Kanama's PanamaPort fork), and the nine-demo Vulkan/Mobile renderer smoke have
+all passed, alongside debug breadth on three more models. Note that release
+builds require Android 13+ and packaged addons are runtime-only; see
+`docs/reference/version-support.md` for the full support claim.
 
 Known constraints:
 - Android uses ART, so the GDExtension library must attach to the existing VM


### PR DESCRIPTION
`AGENTS.md` and `CONTRIBUTING.md` still described mobile as Experimental with promotion pending, but Android and iOS were promoted to **Supported (4.7 stable)** on 2026-07-14 — `README.md`, `CHANGELOG.md`, and `docs/reference/version-support.md` already reflect that. These three spots drifted because the promotion landed in the user-facing docs but not the agent-facing ones.

## Changes

- **`AGENTS.md` (Current Baseline)** — replaced the "Mobile is experimental / promotion gated on §7" bullet with the actual outcome: four Android models validated, iPhone 12 + 15 Pro on iOS. Kept the caveats that change what a reader does (release builds require Android 13+, packaged mobile addons are runtime-only, no mobile hot reload) and deferred the full claims to `version-support.md` rather than duplicating the table — AGENTS.md is meant to stay a short map.
- **`CONTRIBUTING.md` (Android Port Notes)** — same fix. This one also pointed at `docs/internals/release-support-decision.md` §7 for "remaining promotion criteria", which no longer exist now that the bar is green, so that pointer is dropped.
- **`AGENTS.md` (Android Work)** — this is a guidance rule for agents, not a status claim, so the intent is preserved: don't widen a claim past what the smoke path actually validated, with the release floor and runtime-only caveat as the live examples.

## Validation

Docs-only, no runtime surface. The `local_ci.sh` public-docs local-path guard passes; no `docs/` files touched, so the mkdocs strict build is unaffected.

## Note

No gate cross-checks support-status wording — `check_godot_version_pin.py` covers version pins only, and `AGENTS.md` asks a human to confirm the section against README/version-support/CHANGELOG by hand. If mobile status shifts again it will likely drift the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)