### PR TITLE
Contain exceptions in generated @ScriptProperty set/get (task 50)

### DIFF
--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -144,6 +144,36 @@ class HelloScript(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, 
 	@ScriptProperty
 	var smokeResources: List<SmokeResource> = emptyList()
 
+	// task 50 — user accessors that throw. Without containment in ScriptBridge's
+	// siSet/siGet these exceptions escape an FFM upcall stub and abort the whole
+	// process; with it, the engine sees a rejected write or a null read and keeps
+	// running. Kept as two separate properties on purpose: the generated dispatchSet
+	// reads the *old* value (for owned-resource cleanup) before assigning, so a
+	// property whose getter throws also becomes unwritable — combining both throws on
+	// one property wedges it permanently and tests nothing useful.
+	@ScriptProperty
+	var smokeThrowingSetter: Long = 0
+		set(value) {
+			check(value != 666L) { "kanama smoke: deliberate property-set failure" }
+			field = value
+		}
+
+	// Armed via smokeArmGetterThrow() rather than a sentinel value, so the getter can be
+	// disarmed without a write (a write would trip the same throwing getter — see above).
+	private var smokeGetterThrowArmed: Boolean = false
+
+	@ScriptProperty
+	var smokeThrowingGetter: Long = 5
+		get() {
+			check(!smokeGetterThrowArmed) { "kanama smoke: deliberate property-get failure" }
+			return field
+		}
+
+	@RegisterFunction
+	fun smokeArmGetterThrow(armed: Boolean) {
+		smokeGetterThrowArmed = armed
+	}
+
 	@ToolButton(text = "Reset Health", icon = "Reload")
 	fun resetHealth() {
 		health = 99

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -63,6 +63,7 @@ func _ready() -> void:
 			push_error("Kanama script export group/subgroup metadata missing")
 		_kanama_enum_export_smoke(properties)
 		_kanama_enum_list_export_smoke(properties)
+		_kanama_accessor_containment_smoke()
 		var replace_smoke_scene = $ScriptNode.replace_smoke_scene()
 		print("[kanama:gd] kt script replace_smoke_scene = ", replace_smoke_scene)
 		if not replace_smoke_scene:
@@ -149,6 +150,35 @@ func _kanama_enum_list_export_smoke(properties: Array) -> void:
 		" nullfill=", nullfill == [1, 0])
 	if not (list_type and list_hint and list_hint_string and tscn_value == [2, 0] and roundtrip == [0, 1] and clamped == [2, 0] and nullfill == [1, 0]):
 		push_error("Kanama enum-list export metadata or round-trip failed")
+
+# task 50 — a throwing user accessor must not abort the process. Without containment in
+# ScriptBridge.siSet/siGet the exception escapes an FFM upcall stub and kills Godot
+# (exit 134). With it: a failed set is rejected and the previous value survives, a failed
+# get yields null, and the property recovers afterwards. Reaching the print at all is
+# itself part of the assertion — an uncontained throw never gets here.
+func _kanama_accessor_containment_smoke() -> void:
+	$ScriptNode.smoke_throwing_setter = 42
+	var baseline = $ScriptNode.smoke_throwing_setter == 42
+	# Setter throws on 666: the write must be rejected, the previous value must survive,
+	# and the process must stay alive.
+	$ScriptNode.smoke_throwing_setter = 666
+	var set_rejected = $ScriptNode.smoke_throwing_setter == 42
+	# ...and the property still takes valid writes afterwards.
+	$ScriptNode.smoke_throwing_setter = 7
+	var set_recovered = $ScriptNode.smoke_throwing_setter == 7
+	# Getter throws while armed: the read must yield null rather than aborting the caller
+	# (returning "property missing" here would raise a GDScript error and halt this func).
+	$ScriptNode.smoke_arm_getter_throw(true)
+	var get_contained = $ScriptNode.smoke_throwing_getter == null
+	$ScriptNode.smoke_arm_getter_throw(false)
+	var get_recovered = $ScriptNode.smoke_throwing_getter == 5
+	print("[kanama:gd] kt script accessor containment baseline=", baseline,
+		" set_rejected=", set_rejected,
+		" set_recovered=", set_recovered,
+		" get_contained=", get_contained,
+		" get_recovered=", get_recovered)
+	if not (baseline and set_rejected and set_recovered and get_contained and get_recovered):
+		push_error("Kanama script-property accessor containment failed")
 
 # task 29 — virtual-return families. Calling an @OverrideVirtual method by name on a
 # script-attached host routes through the script instance dispatch (the same path the

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -157,6 +157,11 @@ func _kanama_enum_list_export_smoke(properties: Array) -> void:
 # get yields null, and the property recovers afterwards. Reaching the print at all is
 # itself part of the assertion — an uncontained throw never gets here.
 func _kanama_accessor_containment_smoke() -> void:
+	# main.tscn stores 666 for this property, which the setter rejects. Scene-load property
+	# application goes through siSet, so containment must leave the Kotlin default (0) intact
+	# rather than aborting the process — the stale-.tscn case, where a scene holds a value the
+	# current script no longer accepts.
+	var tscn_rejected = $ScriptNode.smoke_throwing_setter == 0
 	$ScriptNode.smoke_throwing_setter = 42
 	var baseline = $ScriptNode.smoke_throwing_setter == 42
 	# Setter throws on 666: the write must be rejected, the previous value must survive,
@@ -172,12 +177,13 @@ func _kanama_accessor_containment_smoke() -> void:
 	var get_contained = $ScriptNode.smoke_throwing_getter == null
 	$ScriptNode.smoke_arm_getter_throw(false)
 	var get_recovered = $ScriptNode.smoke_throwing_getter == 5
-	print("[kanama:gd] kt script accessor containment baseline=", baseline,
+	print("[kanama:gd] kt script accessor containment tscn_rejected=", tscn_rejected,
+		" baseline=", baseline,
 		" set_rejected=", set_rejected,
 		" set_recovered=", set_recovered,
 		" get_contained=", get_contained,
 		" get_recovered=", get_recovered)
-	if not (baseline and set_rejected and set_recovered and get_contained and get_recovered):
+	if not (tscn_rejected and baseline and set_rejected and set_recovered and get_contained and get_recovered):
 		push_error("Kanama script-property accessor containment failed")
 
 # task 29 — virtual-return families. Calling an @OverrideVirtual method by name on a

--- a/example_project/main.tscn
+++ b/example_project/main.tscn
@@ -81,6 +81,7 @@ script = ExtResource("2")
 label = "from_tscn"
 smoke_difficulty = 2
 smoke_joints = [2, 0]
+smoke_throwing_setter = 666
 target_path = NodePath("../SceneTarget3D")
 
 [node name="NonToolScriptNode" type="Node" parent="." unique_id=193847562]

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -318,10 +318,11 @@ if ! rg -q 'val kt = SelfSmoke\(godotObject\)' "$self_smoke_registrar"; then
   echo "[local_ci] generated self-smoke registrar does not construct the KanamaScript base-class example" >&2
   exit 1
 fi
-# 15 = the example HelloScript's exported properties incl. metadata/tool-button
-# entries, the task-32 enum export (smoke_difficulty), and the task-38 enum-list
-# export (smoke_joints). Bump when the example gains/loses an exported property.
-if ! rg -q 'propertyCount = 15' "$hello_script_registrar"; then
+# 17 = the example HelloScript's exported properties incl. metadata/tool-button
+# entries, the task-32 enum export (smoke_difficulty), the task-38 enum-list
+# export (smoke_joints), and the task-50 throwing-accessor containment fixture
+# (smoke_throwing_setter, smoke_throwing_getter). Bump when the example gains/loses one.
+if ! rg -q 'propertyCount = 17' "$hello_script_registrar"; then
   echo "[local_ci] generated script-property list count does not include metadata/tool-button entries" >&2
   exit 1
 fi

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -89,6 +89,11 @@ check "kt script enum export type=true hint=true hint_string=true tscn=true roun
 # ordinal-array round-trip via set/get, tscn deserialize, per-element clamp, and
 # inspector Add-Element null-fill defaulting to the first entry.
 check "kt script enum list export type=true hint=true hint_string=true tscn=true roundtrip=true clamp=true nullfill=true"
+# task 50 — a throwing user @ScriptProperty accessor must be contained by ScriptBridge's
+# siSet/siGet rather than escaping the FFM upcall and aborting the process. A failed set is
+# rejected (previous value survives), a failed get yields null, and the property recovers.
+# Removing the containment makes Godot exit 134 before printing this line at all.
+check "kt script accessor containment baseline=true set_rejected=true set_recovered=true get_contained=true get_recovered=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"
@@ -197,8 +202,8 @@ check "DisplayServer input mouse=-?[0-9]+,-?[0-9]+ buttons=[0-9]+ keyboard_name_
 check "DisplayServer passive clipboard=(true|false) image=(true|false) clipboard_len=[0-9]+ primary_len=[0-9]+ cursor=[0-9]+ mouse_mode=[0-9]+ keyboard_focus=-?[0-9]+ swap_cancel=(true|false) additional_outputs=(true|false) hardware_keyboard=(true|false) window_transparency=(true|false) dpi=[0-9]+ max_scale=[0-9.]+ ime_selection=-?[0-9]+,-?[0-9]+ ime_text_len=[0-9]+ tablet_drivers=[0-9]+ tablet_current_len=[0-9]+ tablet_first_len=[0-9]+"
 check "DisplayServer tts speaking=(true|false) paused=(true|false) voices=[0-9]+ vk_height=[0-9]+ active_popup=-?[0-9]+ window_instance=-?[0-9]+ window_screen=-?[0-9]+ can_draw=(true|false) focused=(true|false) maximize_allowed=(true|false) max_dbl=(true|false) min_dbl=(true|false)"
 check "DisplayServer accessibility screen_reader=-?[0-9]+ contrast=-?[0-9]+ reduce_animation=-?[0-9]+ reduce_transparency=-?[0-9]+ window_max=-?[0-9]+,-?[0-9]+ window_min=-?[0-9]+,-?[0-9]+ window_pos=-?[0-9]+,-?[0-9]+ window_pos_decorated=-?[0-9]+,-?[0-9]+ window_size=-?[0-9]+,-?[0-9]+ window_size_decorated=-?[0-9]+,-?[0-9]+"
-check "kt script methods size = 9"
-check "kt script properties size = 15"
+check "kt script methods size = 10"
+check "kt script properties size = 17"
 check "kt script signals size = 1"
 check "kt script replace_smoke_scene = true"
 check "kt script rpc config ok = true"

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -93,7 +93,7 @@ check "kt script enum list export type=true hint=true hint_string=true tscn=true
 # siSet/siGet rather than escaping the FFM upcall and aborting the process. A failed set is
 # rejected (previous value survives), a failed get yields null, and the property recovers.
 # Removing the containment makes Godot exit 134 before printing this line at all.
-check "kt script accessor containment baseline=true set_rejected=true set_recovered=true get_contained=true get_recovered=true"
+check "kt script accessor containment tscn_rejected=true baseline=true set_rejected=true set_recovered=true get_contained=true get_recovered=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -429,10 +429,18 @@ object ScriptBridge {
     ) {
         // This handler runs inside the catch that exists to stop an exception from escaping an
         // FFM upcall, so it must never throw itself — a throw here defeats the containment
-        // exactly when it is needed. Two guards: `t.javaClass.name` (plain Java reflection)
-        // instead of `t::class.qualifiedName`, because Kotlin KClass reflection is the kind of
-        // thing that degrades under R8 on Android; and runCatching around the whole body, so
-        // even a surprise (a user toString(), a closed stderr) cannot escape.
+        // exactly when it is needed. Hence `t.javaClass.name` (plain Java reflection) rather
+        // than `t::class.qualifiedName`, which is the kind of Kotlin reflection that degrades
+        // under R8 on Android, and runCatching around the detail below.
+        //
+        // The minimal line goes out FIRST and separately. On an R8-minified Android device the
+        // detailed line was silently lost, which left a contained failure completely invisible:
+        // the property write just did nothing, with no exception and no log. Swallowing the
+        // diagnostic is a bad trade for not crashing, so the cheap reflection-free line must
+        // not be able to ride down with the detailed one.
+        runCatching {
+            System.err.println("[kanama:kt] script property $op failed (property=0x${nameLong.toString(16)})")
+        }
         runCatching {
             val script = instance?.script
             val scriptName = script?.globalName?.takeIf { it.isNotEmpty() }
@@ -445,6 +453,13 @@ object ScriptBridge {
                     "${t.javaClass.name}: ${t.message}",
             )
             t.printStackTrace(System.err)
+        }.onFailure { inner ->
+            // Name what defeated the detailed log instead of hiding it — this is the only way
+            // to find out why the Android detail line disappeared, since the failure is by
+            // construction unobservable otherwise.
+            runCatching {
+                System.err.println("[kanama:kt] script property $op detail log failed: ${inner.javaClass.name}: ${inner.message}")
+            }
         }
     }
 

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -427,17 +427,25 @@ object ScriptBridge {
         nameLong: Long,
         t: Throwable,
     ) {
-        val script = instance?.script
-        val scriptName = script?.globalName?.takeIf { it.isNotEmpty() }
-            ?: script?.kotlinClassName?.takeIf { it.isNotEmpty() }
-            ?: instance?.kotlinObject?.javaClass?.name
-            ?: "<unknown>"
-        System.err.println(
-            "[kanama:kt] script property $op failed script=$scriptName " +
-                "property=0x${nameLong.toString(16)} instance=0x${data.address().toString(16)}: " +
-                "${t::class.qualifiedName}: ${t.message}",
-        )
-        t.printStackTrace(System.err)
+        // This handler runs inside the catch that exists to stop an exception from escaping an
+        // FFM upcall, so it must never throw itself — a throw here defeats the containment
+        // exactly when it is needed. Two guards: `t.javaClass.name` (plain Java reflection)
+        // instead of `t::class.qualifiedName`, because Kotlin KClass reflection is the kind of
+        // thing that degrades under R8 on Android; and runCatching around the whole body, so
+        // even a surprise (a user toString(), a closed stderr) cannot escape.
+        runCatching {
+            val script = instance?.script
+            val scriptName = script?.globalName?.takeIf { it.isNotEmpty() }
+                ?: script?.kotlinClassName?.takeIf { it.isNotEmpty() }
+                ?: instance?.kotlinObject?.javaClass?.name
+                ?: "<unknown>"
+            System.err.println(
+                "[kanama:kt] script property $op failed script=$scriptName " +
+                    "property=0x${nameLong.toString(16)} instance=0x${data.address().toString(16)}: " +
+                    "${t.javaClass.name}: ${t.message}",
+            )
+            t.printStackTrace(System.err)
+        }
     }
 
     private fun formatScriptCallContext(

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -269,7 +269,21 @@ object ScriptBridge {
     fun siSet(data: MemorySegment, name: MemorySegment, value: MemorySegment): Byte {
         val nameLong = name.reinterpret(8).get(JAVA_LONG, 0)
         val si = si(data) ?: return 0
-        if (si.dispatchSet(nameLong, value)) return 1
+        val handled = try {
+            si.dispatchSet(nameLong, value)
+        } catch (t: Throwable) {
+            // Generated property dispatch runs inside an FFM upcall stub, so an escaping
+            // exception unwinds through native frames and aborts the JVM — taking Godot
+            // with it — instead of surfacing as an engine error. Contain it the way
+            // siCall does (task 50). Reachable from any user accessor that throws, not
+            // just a decode failure in generated code.
+            // Return 1, not 0: the property IS ours and is in the property list, so the
+            // honest report is "owned, write rejected, previous value kept". Returning 0
+            // would tell the engine this script has no such property.
+            logScriptPropertyFailure("set", si, data, nameLong, t)
+            return 1
+        }
+        if (handled) return 1
         val values = si.placeholderPropertyValues ?: return 0
         if (!si.hasProperty(nameLong)) return 0
         values.put(nameLong, BuiltinTypes.copyVariant(value))?.close()
@@ -280,7 +294,23 @@ object ScriptBridge {
     fun siGet(data: MemorySegment, name: MemorySegment, ret: MemorySegment): Byte {
         val nameLong = name.reinterpret(8).get(JAVA_LONG, 0)
         val si = si(data) ?: return 0
-        if (si.dispatchGet(nameLong, ret)) return 1
+        val handled = try {
+            si.dispatchGet(nameLong, ret)
+        } catch (t: Throwable) {
+            // See siSet for why containment is required here at all. Returning 0 looks like
+            // the safe choice but is worse in practice: it makes the engine treat the
+            // property as *nonexistent*, so GDScript raises "Invalid access to property"
+            // and aborts the calling function — one throwing getter then breaks unrelated
+            // control flow (verified: it halted the smoke mid-probe). Instead initialize
+            // [ret] to nil and report success, so the caller simply reads `null`.
+            // Safe because the generated getter evaluates the Kotlin property *before*
+            // writing [ret], so a throwing accessor leaves [ret] untouched — nil-init here
+            // cannot clobber a partially constructed Variant.
+            logScriptPropertyFailure("get", si, data, nameLong, t)
+            BuiltinTypes.initNilVariant(ret)
+            return 1
+        }
+        if (handled) return 1
         val values = si.placeholderPropertyValues ?: return 0
         val storedValue = values[nameLong]
         if (storedValue != null) {
@@ -382,6 +412,32 @@ object ScriptBridge {
                 rError.reinterpret(12).set(JAVA_INT, 0, 1)
             }
         }
+    }
+
+    /**
+     * Log a contained exception from a generated property accessor (task 50). Mirrors the
+     * siCall failure log: containment means the engine sees a rejected write or an absent
+     * value rather than a crash, so this stderr record is the only signal the developer
+     * gets that their accessor threw.
+     */
+    private fun logScriptPropertyFailure(
+        op: String,
+        instance: KanamaScriptInstance?,
+        data: MemorySegment,
+        nameLong: Long,
+        t: Throwable,
+    ) {
+        val script = instance?.script
+        val scriptName = script?.globalName?.takeIf { it.isNotEmpty() }
+            ?: script?.kotlinClassName?.takeIf { it.isNotEmpty() }
+            ?: instance?.kotlinObject?.javaClass?.name
+            ?: "<unknown>"
+        System.err.println(
+            "[kanama:kt] script property $op failed script=$scriptName " +
+                "property=0x${nameLong.toString(16)} instance=0x${data.address().toString(16)}: " +
+                "${t::class.qualifiedName}: ${t.message}",
+        )
+        t.printStackTrace(System.err)
     }
 
     private fun formatScriptCallContext(

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -542,7 +542,16 @@ object ScriptBridge {
                 val namePtr = list.get(ADDRESS, i.toLong() * propInfoSize + propNameOff)
                 val nameLong = namePtr.reinterpret(8L).get(JAVA_LONG, 0L)
                 val variantBuf = a.allocate(VARIANT_SIZE, 8L)
-                if (si.dispatchGet(nameLong, variantBuf)) {
+                // Same containment contract as siGet (task 50): this is an upcall slot, so an
+                // exception escaping a user getter would abort the process. Skip just the one
+                // property — the rest of the state is still worth reporting to the engine.
+                val got = try {
+                    si.dispatchGet(nameLong, variantBuf)
+                } catch (t: Throwable) {
+                    logScriptPropertyFailure("get(state)", si, data, nameLong, t)
+                    false
+                }
+                if (got) {
                     try {
                         callAdd.invoke(namePtr, variantBuf, userData)
                     } finally {
@@ -594,6 +603,11 @@ object ScriptBridge {
                             "applied=$applied value=${value?.let { it::class.qualifiedName } ?: "null"}"
                     )
                 }
+            } catch (t: Throwable) {
+                // Scene-stored property replay runs during instance creation, which is itself an
+                // upcall — so contain like siSet (task 50). The property keeps its Kotlin default
+                // and the remaining replayed properties still get applied.
+                logScriptPropertyFailure("set(replay)", scriptInstance, scriptInstance.ownerObject, nameLong, t)
             } finally {
                 BuiltinTypes.destroyVariant(variant)
             }


### PR DESCRIPTION
## Problem

`ScriptBridge.siSet`/`siGet` ran generated property dispatch with no exception guard, unlike `siCall`. That dispatch executes inside an FFM upcall stub, so **any escaping exception unwound through native frames and aborted the JVM** — taking Godot with it (exit 134 + `hs_err` dump) instead of surfacing as an engine error.

This is reachable from **any user accessor that throws**, not just a decode failure in generated code, so every exported property shape was one unchecked exception away from a process abort. It had never fired only because all other generated reads are fail-soft *by convention* (`variantReadExpr` uses `as?` + typed fallback, `readVariantLongList` zero-defaults, `readDictionaryScalars` drops) — an invariant nothing enforced.

Found by an independent review of #43, which reached the hole via hard casts in the typed-Map read. That PR's casts are its own fix; **this is the maintainer-side root cause**, and it applies on Android too via the shared JVM runtime.

## Fix

Contain `Throwable` in both entry points, logging via a new `logScriptPropertyFailure` that mirrors the `siCall` failure log. The two sides deliberately differ:

- **`siSet` returns 1** — the property is ours and is in the property list, so "owned, write rejected, previous value kept" is the honest report. Returning 0 would tell the engine the script has no such property.
- **`siGet` nil-initializes `ret` and returns 1.** Returning 0 looks safer but makes the engine treat the property as *nonexistent*: GDScript raises `Invalid access to property` and aborts the **calling function**, so one throwing getter breaks unrelated control flow. This was settled as "return 0" during design and then **falsified by testing** — it halted the smoke mid-probe. Nil-init is safe because the generated getter evaluates the Kotlin property *before* writing `ret`, so a throwing accessor leaves `ret` untouched.

## Gate

`smokeThrowingSetter` / `smokeThrowingGetter` + `smokeArmGetterThrow()` in `HelloScript`, asserted in `runtime_smoke.sh`.

Kept as **two** properties on purpose: the generated `dispatchSet` reads the old value for owned-resource cleanup before assigning, so a property whose *getter* throws also becomes unwritable. Combining both throws on one property wedges it permanently and tests nothing — the fixture comment records this so it isn't "simplified" back.

## Verification

- `runtime_smoke.sh` PASS, `local_ci.sh` PASS (macOS, Godot 4.7-stable).
- **Negative test:** bypassing `siSet` containment reproduces `Unrecoverable uncaught exception ... VM will now exit` + SIGBUS and fails the smoke — the gate pins the behavior rather than merely passing beside it.
- Count pins bumped in both required places: `properties size` 15→17, `methods size` 9→10 (`runtime_smoke.sh`), `propertyCount` 15→17 (`local_ci.sh`).

Desktop runtime only — no on-device validation in this PR.

## Deferred

The per-shape malformed-input matrix from task 50. Its value dropped once containment landed (containment is type-agnostic); what it would still guard is that each *decode path* is individually fail-soft, which overlaps what #43 is fixing. Better revisited after that lands than built twice.

**Incidental finding, not addressed here:** `cleanupPropertyExpr` emits an old-value read even for scalar properties where cleanup is a no-op — a pointless getter call on every set, and the mechanism behind the wedge above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)