### PR TITLE
Fix redirect order dropping the log dump in the in-process hot-reload smoke

### DIFF
--- a/scripts/hot_reload_in_process_smoke.sh
+++ b/scripts/hot_reload_in_process_smoke.sh
@@ -51,7 +51,10 @@ set_marker() {
 smoke_fail() {
   local kind="$1" pattern="$2"
   echo "[hot_reload_in_process_smoke] $kind: $pattern" >&2
-  tail -n 160 "$LOG_FILE" 2>/dev/null >&2 || true
+  # Redirect order matters: `>&2` first duplicates the real stderr, then `2>/dev/null`
+  # silences tail's own errors when the log does not exist yet. Reversing them points
+  # stdout at /dev/null and silently drops the whole dump.
+  tail -n 160 "$LOG_FILE" >&2 2>/dev/null || true
   echo >&2
   echo "[hot_reload_in_process_smoke] FAIL -- $kind: $pattern" >&2
   echo "[hot_reload_in_process_smoke] full log: $LOG_FILE" >&2


### PR DESCRIPTION
## What & why

Regression from #62, found today while reading an actual crash log.

`hot_reload_in_process_smoke.sh` guarded its log dump with `2>/dev/null` (the log may not exist yet when Godot dies early). Combined with the new `>&2`, the order came out wrong:

```sh
tail -n 160 "$LOG_FILE" 2>/dev/null >&2   # stdout -> /dev/null
```

`>&2` duplicates whatever fd2 **currently** points at — and fd2 had just been sent to `/dev/null`. So the entire 160-line dump was discarded. That is the exact opposite of what #62 was for.

Demonstration:

```console
$ bash -c 'tail -n 5 /tmp/t.txt 2>/dev/null >&2' 2>&1
             # nothing
$ bash -c 'tail -n 5 /tmp/t.txt >&2 2>/dev/null' 2>&1
line1
line2
line3
```

## How it surfaced

A captured hot-reload crash was **5 lines** where it should have been ~165. The failure banner and log path were there (so the run was still diagnosable, which is why it did not look broken), but the log content was gone.

Only this one script is affected — it is the only one that combines `2>/dev/null` with the redirect to stderr.

## Fix

`>&2 2>/dev/null` — duplicate the real stderr first, then silence `tail`'s own errors. Comment added, since the ordering is easy to reintroduce.

## Testing

Same failure path, same fake 300-line log: **163 lines captured**, was 5. `bash -n` clean.

## AI assistance

Found and fixed with Claude Opus 4.8.