### PR TITLE
Fix non-compiling iOS codegen for MutableList @ScriptProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Fixed
+
+- iOS: a `MutableList<T>` `@ScriptProperty` no longer generates non-compiling
+  Kotlin/Native. The iOS registrar's list-property setters decode into an
+  immutable `List`, which is not assignable to a `MutableList` field
+  (`Assignment type mismatch: List<String> vs MutableList<String>`), so an iOS
+  build of any script with a mutable-list export failed to compile. The setters
+  now append `.toMutableList()` for mutable properties, mirroring the desktop
+  emitter — which had handled this all along, while the iOS emitter dropped the
+  mutability flag entirely. Covers the string-list, engine-wrapper-list,
+  `@ScriptClass`-element-list, and enum-list arms. Immutable `List<T>` is
+  unchanged.
+
 ### Changed
 
 - `scripts/local_ci.sh` failures are now self-announcing. A failing stage prints a

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/IosScriptCodeEmitter.kt
@@ -114,6 +114,12 @@ internal data class IosProperty(
     // FQ enum element type for List<Enum> properties. The C/runtime path delivers the Array's
     // integer cells separately from object arrays; the generated bridge maps ordinals to entries.
     val arrayElementEnumFqName: String = "",
+    // True when the property is declared `MutableList<T>` rather than `List<T>`. The list decode
+    // helpers all produce an immutable `List` (map/mapNotNull/the delivered String list), so a
+    // mutable property needs a `.toMutableList()` suffix or the generated assignment fails to
+    // compile on Kotlin/Native (`List<T>` is not assignable to `MutableList<T>`). Mirrors the
+    // desktop emitter's `.toMutableList()` on `p.isMutable`.
+    val isMutable: Boolean = false,
 )
 
 internal data class IosSignal(
@@ -322,11 +328,11 @@ internal class IosScriptCodeEmitter(
                         // delivered owner handle resolves to its live Kotlin script instance, mirroring
                         // the single-object node_paths case. Stray unresolved handles are dropped.
                         property.isList && property.arrayElementCustomScriptFqName.isNotEmpty() -> {
-                            builder.appendLine("        $index -> { script.${property.kotlinName} = values.toList().mapNotNull { owner -> net.multigesture.kanama.ios.iosScriptInstanceForOwner(owner) as? ${property.arrayElementCustomScriptFqName} }; true }")
+                            builder.appendLine("        $index -> { script.${property.kotlinName} = values.toList().mapNotNull { owner -> net.multigesture.kanama.ios.iosScriptInstanceForOwner(owner) as? ${property.arrayElementCustomScriptFqName} }${property.mutableSuffix()}; true }")
                         }
                         // Array of an engine wrapper type: wrap each handle directly.
                         property.isList && property.listElementClassName.isNotEmpty() -> {
-                            builder.appendLine("        $index -> { script.${property.kotlinName} = values.map { owner: Long -> net.multigesture.kanama.api.${property.listElementClassName}(java.lang.foreign.MemorySegment.ofAddress(owner)) }; true }")
+                            builder.appendLine("        $index -> { script.${property.kotlinName} = values.map { owner: Long -> net.multigesture.kanama.api.${property.listElementClassName}(java.lang.foreign.MemorySegment.ofAddress(owner)) }${property.mutableSuffix()}; true }")
                         }
                     }
                 }
@@ -340,7 +346,7 @@ internal class IosScriptCodeEmitter(
                 script.properties.forEachIndexed { index, property ->
                     if (property.arrayElementEnumFqName.isNotEmpty()) {
                         val fq = property.arrayElementEnumFqName
-                        builder.appendLine("        $index -> { script.${property.kotlinName} = values.map { i -> $fq.entries[i.toInt().coerceIn(0, $fq.entries.lastIndex)] }; true }")
+                        builder.appendLine("        $index -> { script.${property.kotlinName} = values.map { i -> $fq.entries[i.toInt().coerceIn(0, $fq.entries.lastIndex)] }${property.mutableSuffix()}; true }")
                     }
                 }
                 builder.appendLine("        else -> false")
@@ -352,7 +358,7 @@ internal class IosScriptCodeEmitter(
                 builder.appendLine("    override fun setPropertyStringArray(propertyIndex: Int, values: List<String>): Boolean = when (propertyIndex) {")
                 script.properties.forEachIndexed { index, property ->
                     if (property.isList && property.listElementIsString) {
-                        builder.appendLine("        $index -> { script.${property.kotlinName} = values; true }")
+                        builder.appendLine("        $index -> { script.${property.kotlinName} = values${property.mutableSuffix()}; true }")
                     }
                 }
                 builder.appendLine("        else -> false")
@@ -647,6 +653,11 @@ internal class IosScriptCodeEmitter(
         return if (a.type in iosCallArgTypes) "$cell as ${a.type.kotlinType}" else null
     }
 
+    // List decode helpers (map/mapNotNull/the delivered String list) all yield an immutable
+    // `List`. A `MutableList<T>` property therefore needs this suffix, or the generated assignment
+    // fails to compile on Kotlin/Native. Mirrors the desktop emitter's `.toMutableList()`.
+    private fun IosProperty.mutableSuffix(): String = if (isMutable) ".toMutableList()" else ""
+
     private fun ScriptPropertyModel.toIosProperty(className: String): IosProperty {
         val isList = type == TypeMapping.ARRAY
         val isObject = objectWrapperFqName != null
@@ -755,6 +766,7 @@ internal class IosScriptCodeEmitter(
             scalarSetExpression = scalarSetExpression,
             scalarGetExpression = scalarGetExpression,
             arrayElementEnumFqName = if (isList) arrayElementEnumFqName.orEmpty() else "",
+            isMutable = isMutable,
         )
     }
 

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/IosScriptPropertyParityTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/IosScriptPropertyParityTest.kt
@@ -25,10 +25,10 @@ class IosScriptPropertyParityTest {
     private fun scalarProp(name: String, type: TypeMapping) =
         ScriptPropertyModel(kotlinName = name, godotName = name, type = type, isMutable = true)
 
-    private fun stringListProp(name: String) =
+    private fun stringListProp(name: String, mutable: Boolean = true) =
         ScriptPropertyModel(
             kotlinName = name, godotName = name, type = TypeMapping.ARRAY,
-            isMutable = true, arrayElementString = true,
+            isMutable = mutable, arrayElementString = true,
         )
 
     private fun objectProp(name: String) =
@@ -48,6 +48,16 @@ class IosScriptPropertyParityTest {
             }
         }
         fun readable(kotlinName: String) = getPropertyBlock.contains("script.$kotlinName")
+        // The generated set-side assignment for a list property (`script.<name> = <decode>…`).
+        // Returns the tail after the `=` up to the trailing `; true }` so mutability-suffix
+        // assertions don't depend on the exact decode expression.
+        fun setterRhs(kotlinName: String): String {
+            val marker = "script.$kotlinName = "
+            val at = source.indexOf(marker)
+            if (at < 0) return ""
+            val end = source.indexOf("; true }", at)
+            return source.substring(at + marker.length, if (end < 0) source.length else end)
+        }
     }
 
     private fun emit(vararg props: ScriptPropertyModel): Result {
@@ -112,5 +122,36 @@ class IosScriptPropertyParityTest {
         val r = emit(stringListProp("names"))
         assertEquals(emptyList(), r.errors)
         assertTrue(r.readable("names"), "List<String> @ScriptProperty must be engine-readable")
+    }
+
+    /**
+     * A `MutableList<T>` @ScriptProperty must decode with a `.toMutableList()` suffix: the list
+     * decode helpers all yield an immutable `List`, which is not assignable to a `MutableList`
+     * field on Kotlin/Native (compile-verified: `Assignment type mismatch: List<String> vs
+     * MutableList<String>`). Without the suffix the generated iOS registrar does not compile.
+     * The desktop emitter has done this for `p.isMutable` all along; the iOS emitter dropped
+     * `isMutable` entirely until this was threaded through. Reverting the suffix fails this test.
+     */
+    @Test
+    fun mutableListPropertyDecodesWithToMutableListSuffix() {
+        val r = emit(stringListProp("mutableTags", mutable = true))
+        assertEquals(emptyList(), r.errors)
+        assertTrue(
+            r.setterRhs("mutableTags").contains(".toMutableList()"),
+            "MutableList<String> @ScriptProperty must decode with .toMutableList() " +
+                "(actual: '${r.setterRhs("mutableTags")}')",
+        )
+    }
+
+    /** The mirror: an immutable `List<T>` must NOT gain the suffix (it would silently rewrap). */
+    @Test
+    fun immutableListPropertyHasNoToMutableListSuffix() {
+        val r = emit(stringListProp("readonlyTags", mutable = false))
+        assertEquals(emptyList(), r.errors)
+        assertFalse(
+            r.setterRhs("readonlyTags").contains(".toMutableList()"),
+            "immutable List<String> @ScriptProperty must not gain a .toMutableList() suffix " +
+                "(actual: '${r.setterRhs("readonlyTags")}')",
+        )
     }
 }


### PR DESCRIPTION
## What & why

A `MutableList<T>` `@ScriptProperty` generated **non-compiling Kotlin/Native** on iOS. The iOS registrar's list-property setters decode into an immutable `List`, then assign it to the user's declared field:

```
Assignment type mismatch: actual type is 'List<String>', but 'MutableList<String>' was expected.
```

Root cause: the iOS emitter dropped the mutability flag entirely — `isMutable` never reached `IosProperty`. The **desktop** emitter has appended `.toMutableList()` for `p.isMutable` all along; iOS never did. This threads `isMutable` through and adds the suffix to all four list-setter arms (String list, engine-wrapper list, `@ScriptClass`-element list, enum list). Immutable `List<T>` is unchanged.

Found as a split-out during the PR #43 review (the `MutableMap` sibling defect). Pre-existing on `main`.

## Verification

- **Compile-proved on the real iosArm64 toolchain**, not by inspection: a throwaway with the emitted shape failed `compileKotlinIosArm64` with the mismatch above; appending `.toMutableList()` compiled clean.
- **Regression test** in `IosScriptPropertyParityTest` pins both directions (mutable gains the suffix, immutable does not), and is **negative-verified** — neutering `mutableSuffix()` fails the mutable assertion at the exact line; restoring it passes.
- Full `local_ci.sh` **PASS** (Godot 4.7.stable, macOS arm64).

## AI assistance

Investigated, implemented, and verified with Claude Opus 4.8.