### PR TITLE
Reparent desktop/Android Resource onto RefCounted (task 51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Changed
+
+- Desktop/Android `Resource` now extends `RefCounted`, restoring Godot's real
+  `Object > RefCounted > Resource` chain (which iOS already had). Previously
+  `Resource` was its own wrapper root that re-implemented the refcount lifetime
+  and hid `GodotObject`'s surface, so `setMeta`/`getMeta`/`connect`/
+  `callDeferred` were unreachable from every `Resource` subclass without an
+  `asObject()` hop. They are now callable directly. The duplicated refcount
+  policy is gone — `Resource` inherits one implementation from `RefCounted` —
+  and the inheritance audit enforces the parent rather than whitelisting
+  `Resource` as a root. `asObject()` is kept as a compatibility alias. No
+  intended behaviour change to resource lifetime; purely a surface gain.
+
 ### Fixed
 
 - iOS: a `MutableList<T>` `@ScriptProperty` no longer generates non-compiling

--- a/docs/contributing/api-coverage.md
+++ b/docs/contributing/api-coverage.md
@@ -28,7 +28,7 @@ These numbers count only checked-in Kotlin API wrappers. Class coverage may incl
 Rows marked `inherited only` are promoted wrappers whose Godot class declares no own methods in `extension_api.json`; behavior comes from their parent wrapper.
 
 - Classes: 1036 / 1036 `████████████` 100.0%
-- Methods: 15373 / 15385 `████████████` 99.9% (callable methods; engine virtuals excluded — see below)
+- Methods: 15374 / 15385 `████████████` 99.9% (callable methods; engine virtuals excluded — see below)
 
 ### Per-Platform Class Sets
 
@@ -45,7 +45,7 @@ Every platform tree is held to `check_full_drift_gate` (committed == fresh regen
 
 | Area | Classes | Class Coverage | Methods | Method Coverage |
 | --- | ---: | --- | ---: | --- |
-| Core | 226/226 | `████████████` 100.0% | 2962/2970 | `████████████` 99.7% |
+| Core | 226/226 | `████████████` 100.0% | 2963/2970 | `████████████` 99.8% |
 | Scene | 26/26 | `████████████` 100.0% | 923/923 | `████████████` 100.0% |
 | Resources | 306/306 | `████████████` 100.0% | 2886/2891 | `████████████` 99.8% |
 | Input | 20/20 | `████████████` 100.0% | 238/238 | `████████████` 100.0% |
@@ -733,7 +733,7 @@ These notes summarize wrapper feedback from real ports. They are contextual sign
 | `RayCast2D` | 2D | 28/28 | `████████` 100.0% |
 | `RayCast3D` | 3D | 35/35 | `████████` 100.0% |
 | `RectangleShape2D` | 2D | 2/2 | `████████` 100.0% |
-| `RefCounted` | Core | 2/4 | `████░░░░` 50.0% |
+| `RefCounted` | Core | 3/4 | `██████░░` 75.0% |
 | `ReferenceRect` | UI | 6/6 | `████████` 100.0% |
 | `ReflectionProbe` | 3D | 30/30 | `████████` 100.0% |
 | `RegEx` | Core | 10/10 | `████████` 100.0% |

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -228,6 +228,18 @@ class HelloScript(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, 
 			smokeScene = PackedScene.create()
 		}
 		GD.print("Hello from Kanama script")
+		// task 51 — Resource now extends RefCounted (Godot's real Object > RefCounted > Resource
+		// chain, as iOS already did), so GodotObject's surface (setMeta/getMeta/…) is reachable on
+		// any Resource. The former split root hid it — T-bond's chat report. Prove setMeta round-trips
+		// directly on a Resource (no asObject() hop) and that the refcount lifetime still closes clean.
+		run {
+			val res = Resource.create()
+			res.setMeta("kanama_t51", 51L)
+			val metaBack = (res.getMeta("kanama_t51") as? Number)?.toLong() ?: -1L
+			val hasMeta = res.hasMeta("kanama_t51")
+			res.close()
+			System.err.println("[kanama:kt] task51 resource meta set_get=$metaBack has=$hasMeta")
+		}
 		val mathLerp = Mathf.lerp(2.0, 4.0, 0.25)
 		val mathClamp = Mathf.clamp(12L, 0L, 10L)
 		val mathWrap = Mathf.wrap(11L, 0L, 10L)

--- a/scripts/audit_api_wrapper_inheritance.py
+++ b/scripts/audit_api_wrapper_inheritance.py
@@ -25,8 +25,12 @@ CLASS_RE = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 
+# Root wrappers that legitimately extend a hand base rather than their Godot parent's wrapper.
+# `Resource` was removed (task 51): it now extends `RefCounted`, matching Godot's real
+# `Object > RefCounted > Resource` chain (as iOS already did), so the audit enforces that parent
+# instead of whitelisting it as a root.
 ROOT_WRAPPER_BASES = {"GodotObject", "AutoCloseable"}
-ROOT_CLASSES = {"Object", "RefCounted", "Resource"}
+ROOT_CLASSES = {"Object", "RefCounted"}
 
 
 def allowed_bases(class_name: str, api_classes: dict) -> set[str]:

--- a/scripts/check_wrapper_generator.py
+++ b/scripts/check_wrapper_generator.py
@@ -26,11 +26,16 @@ IOS_API_DIR = ROOT / "ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api
 # it here. Non-API files (GodotObject, GD, DirAccessHandle, ...) are auto-excluded (not in the API).
 DESKTOP_HANDSHAPED = frozenset({
     # hand-authored static facades / lifetime & handle policy the generator does not emit
-    "DirAccess", "FileAccess", "RefCounted", "Resource",
+    "DirAccess", "FileAccess", "RefCounted",
     # generated base + hand ergonomic helpers / aliases / custom defaults
     "AnimationPlayer", "Button", "LineEdit", "Light3D", "Range", "Slider", "Viewport",
     "Node", "Node3D", "TabBar",
-    # hand factory/downcast helpers (`create` / `from*` / `node`) not emitted by desktop generator
+    # hand factory/downcast helpers (`create` / `from*` / `node`) not emitted by desktop generator.
+    # `Resource` now extends `RefCounted` (task 51) — its refcount lifetime is inherited, not
+    # hand-written; it stays exempt only for its `create`/`fromObject`/`asObject` helpers, the same
+    # reason its factory-helper siblings below are here. (ROOT_CLASSES in the inheritance audit was
+    # retired for it, so the `: RefCounted` parent is now enforced there.)
+    "Resource",
     "ArrayMesh", "AudioStreamPlayer", "BaseMaterial3D", "BoxMesh", "BoxShape3D", "ButtonGroup",
     "Camera3D", "ConfigFile", "ENetMultiplayerPeer", "EditorExportPlatform", "Font",
     "InputEventKey", "InputEventMouseButton", "InputEventMouseMotion", "LightmapGI", "Material",

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -102,6 +102,9 @@ check "kt script enum list export type=true hint=true hint_string=true tscn=true
 # rejected (previous value survives), a failed get yields null, and the property recovers.
 # Removing the containment makes Godot exit 134 before printing this line at all.
 check "kt script accessor containment tscn_rejected=true baseline=true set_rejected=true set_recovered=true get_contained=true get_recovered=true"
+# task 51 — Resource extends RefCounted, so setMeta/getMeta (GodotObject surface) work on a
+# Resource directly (no asObject() hop). set_get=51 proves the inherited meta round-trips.
+check "task51 resource meta set_get=51 has=true"
 # MutableList export (preserves mutability in the setter): ARRAY + PROPERTY_HINT_TYPE_STRING,
 # set/get round-trip for a mutable typed list.
 check "kt script mutable list export type=true hint=true hint_string=true roundtrip=true"

--- a/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
@@ -35,6 +35,19 @@ open class RefCounted internal constructor(
     }
 
     /**
+     * Takes a `+1` reference on the underlying object for a Kotlin wrapper that outlives the call
+     * that produced it (e.g. a resource read out of a typed Array/Dictionary, or a script resource
+     * retained by `ScriptBridge`). Balanced by [close]. Lifted here from the former standalone
+     * `Resource` root so both `RefCounted` and `Resource` share one lifetime policy.
+     */
+    internal fun retainForKotlinWrapper(): MemorySegment {
+        checkOpen()
+        ObjectCalls.ptrcallNoArgsRetBool(referenceBind, handle)
+        wrapperReferenceReleased = false
+        return handle
+    }
+
+    /**
      * Releases this Kotlin wrapper's reference to the underlying Godot object.
      *
      * This is a low-level lifetime operation. Do not use it as general gameplay
@@ -56,6 +69,8 @@ open class RefCounted internal constructor(
     companion object {
         private const val NOARGS_LONG_HASH = 3905245786L
         private const val UNREFERENCE_HASH = 2240911060L
+        // reference() shares unreference()'s hash: both are bool()-signatured no-arg RefCounted methods.
+        private const val REFERENCE_HASH = 2240911060L
 
         private val getReferenceCountBind by lazy {
             ObjectCalls.getMethodBind("RefCounted", "get_reference_count", NOARGS_LONG_HASH)
@@ -63,6 +78,10 @@ open class RefCounted internal constructor(
 
         private val unreferenceBind by lazy {
             ObjectCalls.getMethodBind("RefCounted", "unreference", UNREFERENCE_HASH)
+        }
+
+        private val referenceBind by lazy {
+            ObjectCalls.getMethodBind("RefCounted", "reference", REFERENCE_HASH)
         }
 
         internal fun releaseHandle(handle: MemorySegment) {

--- a/src/main/kotlin/net/multigesture/kanama/api/Resource.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Resource.kt
@@ -10,14 +10,8 @@ import java.lang.foreign.MemorySegment
  * Generated from Godot docs: Resource
  */
 open class Resource internal constructor(
-    internal val handle: MemorySegment,
-) : AutoCloseable {
-
-    protected var closed = false
-    private var wrapperReferenceReleased = false
-
-    val isNull: Boolean
-        get() = handle.address() == 0L
+    handle: MemorySegment,
+) : RefCounted(handle) {
 
     /**
      * The unique path to this resource. If it has been saved to disk, the value will be its filepath.
@@ -294,58 +288,16 @@ open class Resource internal constructor(
         return wrap(ObjectCalls.ptrcallWithLongArgRetObject(duplicateDeepBind, handle, mode))
     }
 
-    fun getReferenceCount(): Long {
-        checkOpen()
-        return ObjectCalls.ptrcallNoArgsRetInt(getReferenceCountBind, handle).toLong()
-    }
-
-    fun isClass(className: String): Boolean {
-        checkOpen()
-        return ObjectCalls.ptrcallWithStringArgRetBool(isClassBind, handle, className)
-    }
-
     /**
      * Returns a non-owning Object wrapper for this resource.
+     *
+     * Retained for source compatibility: `Resource` now inherits `GodotObject`'s surface directly
+     * (`setMeta`/`connect`/`callDeferred`/…), so this is largely a convenience alias for callers
+     * that already hold one (e.g. `docs/contributing/demo-porting-rules.md`).
      */
     fun asObject(): GodotObject {
         checkOpen()
         return GodotObject(handle)
-    }
-
-    internal fun requireOpenHandle(): MemorySegment {
-        checkOpen()
-        return handle
-    }
-
-    internal fun retainForKotlinWrapper(): MemorySegment {
-        checkOpen()
-        ObjectCalls.ptrcallNoArgsRetBool(referenceBind, handle)
-        wrapperReferenceReleased = false
-        return handle
-    }
-
-    /**
-     * Releases this Kotlin wrapper's reference to the underlying Godot resource.
-     *
-     * This is a low-level lifetime operation. Do not use it as general gameplay
-     * cleanup for live Godot-owned resources such as meshes, materials,
-     * `PackedScene`s, textures, animations, audio streams, or any resource assigned
-     * into a node or scene.
-     */
-    @ManualGodotLifetimeApi
-    override open fun close() {
-        if (closed || wrapperReferenceReleased || isNull) return
-        wrapperReferenceReleased = true
-        val shouldDestroy = ObjectCalls.ptrcallNoArgsRetBool(unreferenceBind, handle)
-        if (shouldDestroy) {
-            closed = true
-            ObjectCalls.destroyObject(handle)
-        }
-    }
-
-    protected fun checkOpen() {
-        check(!closed) { "Resource handle is closed" }
-        check(!isNull) { "Resource handle is null" }
     }
 
     object Signals {
@@ -382,10 +334,6 @@ open class Resource internal constructor(
         private const val NOARGS_VOID_HASH = 3218959716L
         private const val DUPLICATE_HASH = 482882304L
         private const val DUPLICATE_DEEP_HASH = 905779109L
-        private const val GET_REFERENCE_COUNT_HASH = 3905245786L
-        private const val IS_CLASS_HASH = 3927539163L
-        private const val UNREFERENCE_HASH = 2240911060L
-        private const val REFERENCE_HASH = 2240911060L
 
         private val getPathBind by lazy {
             ObjectCalls.getMethodBind("Resource", "get_path", GET_PATH_HASH)
@@ -469,22 +417,6 @@ open class Resource internal constructor(
 
         private val duplicateDeepBind by lazy {
             ObjectCalls.getMethodBind("Resource", "duplicate_deep", DUPLICATE_DEEP_HASH)
-        }
-
-        private val getReferenceCountBind by lazy {
-            ObjectCalls.getMethodBind("RefCounted", "get_reference_count", GET_REFERENCE_COUNT_HASH)
-        }
-
-        private val isClassBind by lazy {
-            ObjectCalls.getMethodBind("Object", "is_class", IS_CLASS_HASH)
-        }
-
-        private val unreferenceBind by lazy {
-            ObjectCalls.getMethodBind("RefCounted", "unreference", UNREFERENCE_HASH)
-        }
-
-        private val referenceBind by lazy {
-            ObjectCalls.getMethodBind("RefCounted", "reference", REFERENCE_HASH)
         }
 
         internal fun wrap(handle: MemorySegment): Resource? =


### PR DESCRIPTION
## What & why

T-bond reported (chat) that `Resource` lacks `set_meta` and reimplements the whole RefCounted interface. Root cause: desktop/Android `Resource` was its own wrapper root (`: AutoCloseable`) instead of extending `RefCounted`, breaking Godot's real `Object > RefCounted > Resource` chain — **which iOS already had**. So `GodotObject`'s surface (`setMeta`/`getMeta`/`connect`/`callDeferred`) was unreachable from every `Resource` subclass without an `asObject()` hop, and the refcount lifetime was copy-pasted.

## Change

`Resource` now `extends RefCounted`:

- **`Resource.kt`**: `: RefCounted(handle)`; dropped the shadowing `handle` field, the dead NULL-handle machinery (`isNull` + guards — zero external consumers), and the duplicated lifetime (`getReferenceCount`/`isClass`/`requireOpenHandle`/`retainForKotlinWrapper`/`close`/`checkOpen` + their binds/hashes). All inherited now.
- **`RefCounted.kt`**: lifted `retainForKotlinWrapper()` + a `referenceBind` up, so the **one** retain policy is shared (the typed-array/Map resource reads in `BuiltinTypes` and `ScriptBridge.retainScriptResource` go through it).
- **inheritance audit**: retired `Resource` from `ROOT_CLASSES`, so the `: RefCounted` parent is now **enforced**, not whitelisted.
- **drift gate**: `Resource` stays in `DESKTOP_HANDSHAPED`, but now for its `create`/`fromObject`/`asObject` factory helpers (same reason as its ~30 siblings), not a hand-written lifetime. Retiring it fully needs the generator to emit those helpers — a shared feature, out of scope here.
- `api-coverage.md` regenerated (`RefCounted` 2/4 → 3/4, gained `reference`).

`asObject()` kept as a compatibility alias. **No intended lifetime behaviour change** — purely a surface gain.

## Validation (all three platforms)

- **Desktop**: full `local_ci` PASS; inheritance / drift / singleton-refcount audits PASS; `setMeta` round-trips directly on a `Resource` (`runtime_smoke`: `task51 resource meta set_get=51 has=true`); leak count **identical to main** (6 = pre-existing shutdown noise) → no refcount regression.
- **iOS**: `compileKotlinIosArm64` OK (iOS `Resource` already `: RefCounted`, unchanged).
- **Android**: device-validated on **Pixel 7** (setMeta round-trip on a `Resource`).

## AI assistance

Implemented and validated with Claude Opus 4.8.