### PR TITLE
Node.setOwner(null): contextual object-parameter nullability (task 52a, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ versioning once public releases begin.
   `T::class.qualifiedName` still matches the registered template under obfuscation;
   device-validated on Pixel 7).
 
+### Fixed
+
+- `Node.setOwner(null)` now compiles and clears the owner through the typed
+  wrapper (issue #60). Godot uses a null owner to clear it (the engine itself
+  calls `child->set_owner(nullptr)` while replacing nodes), but the generator
+  emitted a non-null `Node` parameter, so the only way to pass null was the
+  dynamic `call("set_owner", null)`. Object-parameter nullability is now decided
+  by one contextual policy (consumed by both the type renderer and the
+  marshalling so they cannot drift): explicitly `meta: "required"` parameters
+  stay non-null; Resource/RefCounted-derived stay nullable (legacy); and an
+  audited `(class, method, arg)` override admits null for a specific ordinary
+  object — seeded with `Node.set_owner(owner)`, each entry citing the pinned 4.7
+  source. Generated `Node.owner` is now a writable `Node?` property, and the
+  desktop hand-shaped `Node` exposes the same. (Tightening the 65 explicitly
+  `required` resource parameters to non-null is a separate, source-breaking
+  follow-up.)
+
 ### Changed
 
 - Desktop/Android `Resource` now extends `RefCounted`, restoring Godot's real

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -317,6 +317,28 @@ class HelloScript(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, 
 		val pendingSetAmount = pendingSetProbe.get("amount") as? Long ?: -1L
 		pendingSetProbe.queueFree()
 		defaultProbeScript?.close()
+		// task 52a / issue #60 — Node.setOwner accepts null through the TYPED wrapper (not
+		// call("set_owner", null)), and null clears the owner. Also exercises the writable
+		// `owner: Node?` property. owner must be an ancestor, so parent owns child.
+		run {
+			val ownerParent = Node(ObjectCalls.constructObject("Node"))
+			val ownerChild = Node(ObjectCalls.constructObject("Node"))
+			self.addChild(ownerParent)
+			ownerParent.addChild(ownerChild)
+			ownerChild.setOwner(ownerParent)
+			val ownerSet = ownerChild.getOwner() != null
+			ownerChild.setOwner(null)
+			val ownerCleared = ownerChild.getOwner() == null
+			ownerChild.owner = ownerParent
+			val propSet = ownerChild.owner != null
+			ownerChild.owner = null
+			val propCleared = ownerChild.owner == null
+			ownerParent.queueFree()
+			System.err.println(
+				"[kanama:kt] task52a setOwner set=$ownerSet cleared=$ownerCleared " +
+					"prop_set=$propSet prop_cleared=$propCleared",
+			)
+		}
 		val scriptUid = ResourceSaver.getResourceIdForPath("res://HelloScript.kt")
 		val fileExists = FileAccess.fileExists("res://HelloScript.kt")
 		val fileSize = FileAccess.getSize("res://HelloScript.kt")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Node.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Node.kt
@@ -29,9 +29,11 @@ open class Node(handle: MemorySegment) : GodotObject(handle) {
         @JvmName("setSceneFilePathProperty")
         set(value) = setSceneFilePath(value)
 
-    val owner: Node?
+    var owner: Node?
         @JvmName("ownerProperty")
         get() = getOwner()
+        @JvmName("setOwnerProperty")
+        set(value) = setOwner(value)
 
     val multiplayer: MultiplayerAPI?
         @JvmName("multiplayerProperty")
@@ -207,8 +209,8 @@ open class Node(handle: MemorySegment) : GodotObject(handle) {
         return ObjectCalls.ptrcallNoArgsRetStringNameList(getGroupsBind, handle)
     }
 
-    fun setOwner(owner: Node) {
-        ObjectCalls.ptrcallWithObjectArgs(setOwnerBind, handle, listOf(owner.handle))
+    fun setOwner(owner: Node?) {
+        ObjectCalls.ptrcallWithObjectArgs(setOwnerBind, handle, listOf(owner?.handle ?: MemorySegment.NULL))
     }
 
     fun getOwner(): Node? {

--- a/scripts/audit_generator_object_policy.py
+++ b/scripts/audit_generator_object_policy.py
@@ -240,6 +240,8 @@ def main() -> int:
                         ),
                     )
 
+    errors.extend(check_object_param_nullability_policy(api_classes))
+
     if errors:
         print("[generator_object_policy] FAIL", file=sys.stderr)
         for error in errors:
@@ -248,6 +250,51 @@ def main() -> int:
 
     print("[generator_object_policy] PASS")
     return 0
+
+
+def _arg_meta(api_classes: dict, class_name: str, method_name: str, arg_name: str) -> str | None:
+    cls = api_classes.get(class_name)
+    if cls is None:
+        return None
+    for method in cls.methods.get(method_name, []):
+        if arg_name in method.argument_names:
+            return method.argument_metas[method.argument_names.index(arg_name)]
+    return None
+
+
+def check_object_param_nullability_policy(api_classes: dict) -> list[str]:
+    """Task 52a — prove the contextual object-parameter nullability policy and validate the override
+    table. Removing a policy branch, or leaving a stale/colliding override, fails here."""
+    from generate_api_wrapper import NULLABLE_OBJECT_PARAM_OVERRIDES, object_param_is_nullable
+
+    errs: list[str] = []
+
+    # Override table: every entry must resolve to a current Object argument that is NOT meta:required
+    # (an override must never admit null for a parameter Godot marks required — a refresh that adds
+    # `required` to an old override must fail here for human review).
+    for class_name, method_name, arg_name in NULLABLE_OBJECT_PARAM_OVERRIDES:
+        meta = _arg_meta(api_classes, class_name, method_name, arg_name)
+        if meta is None:
+            errs.append(f"stale NULLABLE_OBJECT_PARAM_OVERRIDES entry: {(class_name, method_name, arg_name)} not found in the API")
+        elif meta == "required":
+            errs.append(f"NULLABLE_OBJECT_PARAM_OVERRIDES entry {(class_name, method_name, arg_name)} collides with meta:required")
+
+    # The four canonical cases (Node = non-resource object; Texture2D = Resource-derived):
+    cases = [
+        # (class, method, arg, type, meta, expected_nullable, why)
+        ("Node", "set_owner", "owner", "Node", "", True, "audited override -> nullable"),
+        ("Node", "add_child", "node", "Node", "required", False, "required ordinary Object -> non-null"),
+        ("TextureRect", "set_texture", "texture", "Texture2D", "", True, "unmarked Resource -> nullable (legacy)"),
+        # 52a is non-breaking: a required Resource-like param STAYS nullable here; 52b tightens it to
+        # non-null by moving the `required` check above the resource-like line.
+        ("CanvasItem", "draw_texture", "texture", "Texture2D", "required", True, "required Resource -> still nullable in 52a"),
+    ]
+    for class_name, method_name, arg_name, type_name, meta, expected, why in cases:
+        actual = object_param_is_nullable(class_name, method_name, arg_name, type_name, meta, api_classes)
+        if actual != expected:
+            errs.append(f"object_param_is_nullable({class_name}.{method_name}.{arg_name}) = {actual}, expected {expected} ({why})")
+
+    return errs
 
 
 if __name__ == "__main__":

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -408,6 +408,16 @@ KOTLIN_DEFAULT_EXPRESSION_OVERRIDES = {
     ("Node3D", "look_at", "up"): "Vector3.UP",
     ("Node3D", "look_at_from_position", "up"): "Vector3.UP",
 }
+# (class, method, argument) object parameters that accept Kotlin `null` even though they are not
+# Resource/RefCounted-derived (which are nullable by legacy policy) and are not marked
+# `meta: "required"`. Each entry must cite the pinned Godot 4.7-stable source where null is a valid,
+# handled value. Task 52a (issue #60).
+#   Node.set_owner(null): Godot cleans up the previous owner then returns when p_owner is null, and
+#   the engine itself calls child->set_owner(nullptr) while replacing nodes.
+#   scene/main/node.cpp#L2271-L2280 and #L3243-L3249 (4.7-stable).
+NULLABLE_OBJECT_PARAM_OVERRIDES = {
+    ("Node", "set_owner", "owner"),
+}
 CUSTOM_MEMBER_SECTIONS = {
     "AnimationMixer": """
     fun setParameter(path: String, value: Any?) {
@@ -1697,11 +1707,73 @@ def kotlin_return_type(
     return kotlin_type(logical_type, type_name, wrapper_classes, api_classes)
 
 
-def object_arg_expression(name: str, type_name: str, api_classes: dict[str, ApiClass]) -> str:
-    return f"{name}?.requireOpenHandle() ?: MemorySegment.NULL" if is_resource_like(type_name, api_classes) else f"{name}.handle"
+def object_param_is_nullable(
+    class_name: str,
+    method_name: str,
+    arg_name: str,
+    type_name: str,
+    arg_meta: str,
+    api_classes: dict[str, ApiClass],
+) -> bool:
+    """Whether a generated Object parameter should be Kotlin-nullable (accept `null`).
+
+    Single decision point, consumed by both the type renderer and the marshalling so they cannot
+    drift. Order matters:
+
+      1. resource-like (Resource/RefCounted-derived) -> nullable (existing legacy policy).
+      2. `meta: "required"` -> non-null. Godot's RequiredParam marker; an audited override cannot
+         beat it (a Godot upgrade marking an old override required must stop admitting null).
+      3. exact (class, method, arg) in NULLABLE_OBJECT_PARAM_OVERRIDES -> nullable (audited source).
+      4. otherwise -> non-null (conservative legacy default).
+
+    Task 52a is intentionally non-breaking: resource-like stays nullable regardless of `required`.
+    Task 52b tightens by moving the `required` check ABOVE the resource-like line, turning the 65
+    explicitly-required resource-like parameters non-null (its own source-breaking change).
+    """
+    if is_resource_like(type_name, api_classes):
+        return True
+    if arg_meta == "required":
+        return False
+    return (class_name, method_name, arg_name) in NULLABLE_OBJECT_PARAM_OVERRIDES
+
+
+def kotlin_parameter_type(
+    class_name: str,
+    method_name: str,
+    arg_name: str,
+    arg_meta: str,
+    logical_type: str,
+    type_name: str,
+    wrapper_classes: set[str],
+    api_classes: dict[str, ApiClass],
+) -> str:
+    """Parameter type with method/argument context. Object params consult [object_param_is_nullable];
+    all other kinds fall back to the context-free [kotlin_type]. Marshalling uses the same decision."""
+    base = kotlin_type(logical_type, type_name, wrapper_classes, api_classes)
+    if logical_type != "Object":
+        return base
+    non_null = base[:-1] if base.endswith("?") else base
+    nullable = object_param_is_nullable(class_name, method_name, arg_name, type_name, arg_meta, api_classes)
+    return f"{non_null}?" if nullable else non_null
+
+
+def object_arg_expression(
+    name: str,
+    type_name: str,
+    is_nullable: bool,
+    api_classes: dict[str, ApiClass],
+) -> str:
+    """Marshal an Object parameter to its MemorySegment handle. [is_nullable] is the decision from
+    [object_param_is_nullable] so the type and the marshalling stay in lockstep. Resource-like keeps
+    the closed-handle check via requireOpenHandle()."""
+    resource_like = is_resource_like(type_name, api_classes)
+    if resource_like:
+        return f"{name}?.requireOpenHandle() ?: MemorySegment.NULL" if is_nullable else f"{name}.requireOpenHandle()"
+    return f"{name}?.handle ?: MemorySegment.NULL" if is_nullable else f"{name}.handle"
 
 
 def call_argument_expressions(
+    class_name: str,
     method: ApiMethod,
     object_types: set[str],
     api_classes: dict[str, ApiClass],
@@ -1709,9 +1781,19 @@ def call_argument_expressions(
 ) -> list[str]:
     names = names or [arg_name(name, index) for index, name in enumerate(method.argument_names)]
     expressions: list[str] = []
-    for name, type_name, logical_kind in zip(names, method.argument_types, method.logical_arg_kinds(object_types), strict=True):
+    for name, raw_name, type_name, arg_meta, logical_kind in zip(
+        names,
+        method.argument_names,
+        method.argument_types,
+        method.argument_metas,
+        method.logical_arg_kinds(object_types),
+        strict=True,
+    ):
         if logical_kind == "Object":
-            expressions.append(object_arg_expression(name, type_name, api_classes))
+            is_nullable = object_param_is_nullable(
+                class_name, method.name, raw_name, type_name, arg_meta, api_classes
+            )
+            expressions.append(object_arg_expression(name, type_name, is_nullable, api_classes))
         elif logical_kind == "Callable":
             expressions.extend([f"{name}.target.handle", f"{name}.method"])
         elif logical_kind == "Signal":
@@ -1789,11 +1871,12 @@ def render_method(
         for index, name in enumerate(method.argument_names)
     ]
     param_texts = []
-    for name, raw_name, kind, type_name, default_value in zip(
+    for name, raw_name, kind, type_name, arg_meta, default_value in zip(
         param_names,
         method.argument_names,
         logical_args,
         method.argument_types,
+        method.argument_metas,
         method.argument_defaults,
         strict=True,
     ):
@@ -1801,12 +1884,14 @@ def render_method(
         default_expression = KOTLIN_DEFAULT_EXPRESSION_OVERRIDES.get(
             (class_name, method.name, raw_name),
         ) or kotlin_default_expression(default_value, kind)
-        type_text = kotlin_type(kind, type_name, wrapper_classes, api_classes)
+        type_text = kotlin_parameter_type(
+            class_name, method.name, raw_name, arg_meta, kind, type_name, wrapper_classes, api_classes
+        )
         param_texts.append(
             f"{name}: {type_text} = {default_expression}" if default_expression is not None else f"{name}: {type_text}",
         )
     params = ", ".join(param_texts)
-    call_args = call_argument_expressions(method, object_types, api_classes, param_names)
+    call_args = call_argument_expressions(class_name, method, object_types, api_classes, param_names)
     return_array_element = typed_object_array_element_any(method.logical_return_kind(object_types))
     if return_array_element and shape.function not in DIRECT_TYPED_OBJECT_LIST_HELPERS:
         return_wrapper = api_object_wrapper_type(return_array_element, wrapper_classes)
@@ -1873,11 +1958,12 @@ def render_vararg_method(
         for index, name in enumerate(method.argument_names)
     ]
     fixed_params = []
-    for name, raw_name, kind, type_name, default_value in zip(
+    for name, raw_name, kind, type_name, arg_meta, default_value in zip(
         param_names,
         method.argument_names,
         logical_args,
         method.argument_types,
+        method.argument_metas,
         method.argument_defaults,
         strict=True,
     ):
@@ -1885,7 +1971,9 @@ def render_vararg_method(
         default_expression = KOTLIN_DEFAULT_EXPRESSION_OVERRIDES.get(
             (class_name, method.name, raw_name),
         ) or kotlin_default_expression(default_value, kind)
-        type_text = kotlin_type(kind, type_name, wrapper_classes, api_classes)
+        type_text = kotlin_parameter_type(
+            class_name, method.name, raw_name, arg_meta, kind, type_name, wrapper_classes, api_classes
+        )
         fixed_params.append(
             f"{name}: {type_text} = {default_expression}" if default_expression is not None else f"{name}: {type_text}",
         )
@@ -1950,6 +2038,7 @@ def first_method(cls: ApiClass, name: str) -> ApiMethod | None:
 
 
 def property_setter_type(
+    class_name: str,
     setter_method: ApiMethod,
     object_types: set[str],
     wrapper_classes: set[str],
@@ -1962,7 +2051,15 @@ def property_setter_type(
     if setter_method.logical_return_kind(object_types) != "void":
         return None
     setter_kind = setter_method.logical_arg_kinds(object_types)[0]
-    return kotlin_type(
+    # Route through the same contextual policy the method renderer uses, so a nullable Object setter
+    # (e.g. Node.set_owner(owner: Node?)) yields a nullable property type — otherwise render_property
+    # sees a Node? getter and a Node setter, the types mismatch, and it suppresses the setter (the
+    # property becomes read-only). Task 52a.
+    return kotlin_parameter_type(
+        class_name,
+        setter_method.name,
+        setter_method.argument_names[0],
+        setter_method.argument_metas[0],
         setter_kind,
         setter_method.argument_types[0],
         wrapper_classes,
@@ -2010,7 +2107,7 @@ def render_property(
     if setter and setter in emitted_methods:
         setter_method = first_method(cls, setter)
         setter_type = (
-            property_setter_type(setter_method, object_types, wrapper_classes, api_classes)
+            property_setter_type(cls.name, setter_method, object_types, wrapper_classes, api_classes)
             if setter_method is not None
             else None
         )

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -115,6 +115,9 @@ check "kt script accessor containment tscn_rejected=true baseline=true set_rejec
 # task 51 — Resource extends RefCounted, so setMeta/getMeta (GodotObject surface) work on a
 # Resource directly (no asObject() hop). set_get=51 proves the inherited meta round-trips.
 check "task51 resource meta set_get=51 has=true"
+# task 52a / issue #60 — Node.setOwner(null) clears the owner through the typed wrapper
+# (and the writable owner: Node? property). Reverting to a non-null setOwner fails to compile.
+check "task52a setOwner set=true cleared=true prop_set=true prop_cleared=true"
 # MutableList export (preserves mutability in the setter): ARRAY + PROPERTY_HINT_TYPE_STRING,
 # set/get round-trip for a mutable typed list.
 check "kt script mutable list export type=true hint=true hint_string=true roundtrip=true"

--- a/src/main/kotlin/net/multigesture/kanama/api/Node.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Node.kt
@@ -423,9 +423,23 @@ open class Node(handle: MemorySegment) : GodotObject(handle) {
      *
      * Generated from Godot docs: Node.set_owner
      */
-    fun setOwner(owner: Node) {
-        ObjectCalls.ptrcallWithObjectArgs(setOwnerBind, handle, listOf(owner.handle))
+    fun setOwner(owner: Node?) {
+        // Godot's Node::set_owner cleans up the previous owner and returns when p_owner is null, so
+        // null clears the owner (the engine itself calls child->set_owner(nullptr) while replacing
+        // nodes). Marshal null as MemorySegment.NULL. Task 52a / issue #60; audited in
+        // NULLABLE_OBJECT_PARAM_OVERRIDES in scripts/generate_api_wrapper.py.
+        ObjectCalls.ptrcallWithObjectArgs(setOwnerBind, handle, listOf(owner?.handle ?: MemorySegment.NULL))
     }
+
+    /**
+     * The owner of this node, or `null` to clear it. Honest hand-shaped mirror of the generated
+     * `var owner: Node?` property the reparented iOS wrapper now emits (task 52a).
+     */
+    var owner: Node?
+        @JvmName("ownerProperty")
+        get() = getOwner()
+        @JvmName("setOwnerProperty")
+        set(value) = setOwner(value)
 
     /**
      * The owner of this node. The owner must be an ancestor of this node. When packing the owner node


### PR DESCRIPTION
## What & why

Closes the user-reported [#60](https://github.com/falcon4ever/kanama/issues/60): `Node.setOwner(null)` didn't compile through the typed wrapper. Godot uses a null owner to clear it (`Node::set_owner` returns when `p_owner` is null; the engine itself calls `child->set_owner(nullptr)` while replacing nodes), but the generator emitted `setOwner(owner: Node)` non-null, so the only way to pass null was the dynamic `call("set_owner", null)`.

## Change

One **contextual object-parameter nullability policy**, consumed by both the type renderer and the marshalling so they cannot drift:

- `object_param_is_nullable(class, method, arg, type, meta)`: Resource/RefCounted-derived → nullable (legacy); `meta: "required"` → non-null (an override cannot beat it); audited `(class, method, arg)` override → nullable; else non-null.
- `kotlin_parameter_type()` wraps it for Object params; `render_method`, `render_vararg_method`, **and** `property_setter_type` route through it (so the generated `owner` property is a **writable `Node?`**, not read-only); `call_argument_expressions` marshals null as `MemorySegment.NULL`.
- `NULLABLE_OBJECT_PARAM_OVERRIDES` seeded with `("Node", "set_owner", "owner")`, citing `scene/main/node.cpp` (4.7-stable).

**Non-breaking (52a):** resource-like params stay nullable regardless of `required`. **52b** will tighten the 65 explicitly-`required` resource params to non-null (its own source-breaking change).

**Adoption:** desktop `Node.kt` is `DESKTOP_HANDSHAPED`, so `setOwner` + a writable `owner: Node?` (with `@JvmName` to avoid the accessor JVM clash) were added by hand; iOS `Node` regenerated in full context.

## Validation

- Generator policy audit proves the four cases (nullable Node override, required Node, nullable Resource, required Resource) and validates the override table (resolves + not `required`).
- Runtime probe: `setOwner(parent)` then `setOwner(null)` clears the owner, plus the `owner` property both ways — `set=true cleared=true prop_set=true prop_cleared=true`.
- Full `local_ci` PASS; drift gate PASS (desktop=988, ios=1013); `compileKotlinIosArm64` OK. No device run — this is a NULL in an existing object-pointer slot, not a new ABI shape.

## AI assistance

Implemented and validated with Claude Opus 4.8.