### PR TITLE
android_smoke: assert a script instance constructs, not just binds (task 54)

### DIFF
--- a/scripts/android_smoke.sh
+++ b/scripts/android_smoke.sh
@@ -234,6 +234,12 @@ check_log "Initializing Godot plugin KanamaAndroid"
 check_log "registered KanamaScriptLanguage"
 check_log "registered KanamaResourceFormatLoader for \\.kt"
 check_log "ResourceFormatLoader\\._load bound kotlinClass="
+# task 54 — assert a script instance actually CONSTRUCTED, not merely that the loader bound the
+# class above. A regression that resolves the class but produces no live instance passes the bind
+# check but fails this. (The desktop hot-reload smoke asserts `placeholder=false`; that field is
+# editor-only and never appears here — the Android smoke runs the game, where every construct is a
+# real, non-placeholder instance, so the construct line itself is the equivalent proof.)
+check_log "KanamaScript\\.construct kotlinClass="
 check_log "OnGodotMainLoopStarted"
 
 # Renderer assertion: the override must have actually initialized on device.


### PR DESCRIPTION
## What & why

`android_smoke.sh` asserted the loader **bound** the Kotlin class (`ResourceFormatLoader._load bound kotlinClass=`) but nothing that a real instance actually **constructed** — a regression that binds the class but produces no live instance passed the gate. This adds `check_log "KanamaScript.construct kotlinClass="`.

The desktop hot-reload smoke asserts `placeholder=false`; that field is **editor-only** and never appears in the Android smoke, which runs the **game** (not the editor) where every construct is a real, non-placeholder instance. So the construct line itself is the equivalent proof, and a `check_absent "placeholder=true"` would be a misleading no-op — omitted deliberately.

## Validation

Pixel 7 (Starter-Kit-Match3): the new check matches real on-device construction (`KanamaScript.construct kotlinClass=…Particles/Audio/…`); `android_smoke` **PASS**. (This script runs in the device flow, not `local_ci`, so CI here only builds.)

## AI assistance

Implemented and validated with Claude Opus 4.8.