### PR TITLE
Fix sync_kdoc types/ wrapping to match ktfmt (unbreak the staleness check)

### DIFF
--- a/scripts/sync_kdoc_from_godot_docs.py
+++ b/scripts/sync_kdoc_from_godot_docs.py
@@ -146,13 +146,24 @@ def load_godot_docs(docs_dir: Path, class_name: str) -> GodotClassDocs | None:
     )
 
 
-def kdoc_block(indent: str, description: str, source: str) -> list[str]:
+def kdoc_block(indent: str, description: str, source: str, *, ktfmt_width: bool = False) -> list[str]:
     lines = [f"{indent}/**\n"]
     words = description.split(" ")
     current = ""
+    # api/ wrappers keep the historical fixed 96-char content width: they are excluded from
+    # ktfmt and byte-compared against generate_api_wrapper.py, so their wrapping must not move.
+    # types/ value-type wrappers ARE ktfmt-formatted, so wrap them to the emitted line's 100-col
+    # budget — the width ktfmt (googleStyle) reflows to. A fixed content width ignored the
+    # indented ` * ` prefix and emitted 101-char lines that ktfmt re-wrapped, leaving sync_kdoc
+    # --check and ktfmtCheck permanently fighting over that one column.
+    def fits(candidate: str) -> bool:
+        if ktfmt_width:
+            return len(indent) + len(" * ") + len(candidate) <= 100
+        return len(candidate) <= 96
+
     for word in words:
         candidate = word if not current else f"{current} {word}"
-        if len(candidate) > 96 and current:
+        if not fits(candidate) and current:
             lines.append(f"{indent} * {current}\n")
             current = word
         else:
@@ -311,7 +322,7 @@ def collect_builtin_replacements(path: Path, docs: GodotClassDocs) -> tuple[list
                 Replacement(
                     start=find_class_replacement_start(lines, index),
                     end=insert_at,
-                    lines=kdoc_block(class_match.group(1), description, docs.class_name),
+                    lines=kdoc_block(class_match.group(1), description, docs.class_name, ktfmt_width=True),
                 ),
             )
             continue
@@ -328,7 +339,7 @@ def collect_builtin_replacements(path: Path, docs: GodotClassDocs) -> tuple[list
                     Replacement(
                         start=replace_start if replace_start is not None else insert_at,
                         end=insert_at,
-                        lines=kdoc_block(fun_match.group(1), description, f"{docs.class_name}.{godot_name}"),
+                        lines=kdoc_block(fun_match.group(1), description, f"{docs.class_name}.{godot_name}", ktfmt_width=True),
                     ),
                 )
                 documented_functions += 1
@@ -351,7 +362,7 @@ def collect_builtin_replacements(path: Path, docs: GodotClassDocs) -> tuple[list
             Replacement(
                 start=replace_start if replace_start is not None else insert_at,
                 end=insert_at,
-                lines=kdoc_block(property_match.group(1), description, source),
+                lines=kdoc_block(property_match.group(1), description, source, ktfmt_width=True),
             ),
         )
         documented_members += 1


### PR DESCRIPTION
## What

Fixes the `wrapper KDoc staleness check` local gate, which went red after the ktfmt rollout (#69). **No wrapper content changes** — the value-type docs were already correctly wrapped; only `sync_kdoc`'s checker expectation was wrong.

## Root cause

`sync_kdoc_from_godot_docs.py` wrapped generated KDoc content at a fixed **96 chars regardless of indent**. For the ktfmt-formatted value-type wrappers under `types/`, a 2-space-indented member doc becomes `   * ` (5-char prefix) + 96 = **101 chars** — which ktfmt (googleStyle, 100 cols) then re-wraps. So the committed files were correct, but the checker's regenerated expectation never matched them, leaving `sync_kdoc --check` and `ktfmtCheck` permanently fighting over one column. The ktfmt merge surfaced a latent off-by-one.

## Fix

Make the `types/` path wrap to the emitted line's 100-column budget (`indent + " * " + content ≤ 100`), matching ktfmt exactly. The `api/` path is **unchanged** — those wrappers are excluded from ktfmt and byte-compared against `generate_api_wrapper.py`, so their 96-char wrapping must not move.

## Verification (local, with a Godot 4.7-stable `doc/classes` checkout)

- `sync_kdoc --write --scope types` → **changed_files=0** (no content churn)
- `sync_kdoc --check` (scope=all) → **changed_files=0** ✅
- `./gradlew ktfmtCheck` → **BUILD SUCCESSFUL** ✅
- `check_wrapper_generator.py` → **PASS** (api/ drift gate untouched)
- Only `scripts/sync_kdoc_from_godot_docs.py` changes.

Note: this stage is skipped on CI (runners have no Godot docs checkout), so this is a local-DX fix — it doesn't alter CI behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)