### PR TITLE
Scope the newScriptInstance force-real override to the specific owner (task 56)

### DIFF
--- a/example_project/ReentrantForgeProbe.kt
+++ b/example_project/ReentrantForgeProbe.kt
@@ -1,0 +1,23 @@
+package net.multigesture.kanama.example
+
+import java.lang.foreign.MemorySegment
+import net.multigesture.kanama.annotations.GlobalClass
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.ResourceLoader
+
+// Task 56 fixture (outer). A non-@Tool resource created via newScriptInstance(). Its
+// constructor runs inside the programmatic-create window, and there it reentrantly
+// instantiates reentrant_inner.tscn — whose root carries the non-@Tool
+// ReentrantPlaceholderProbe. That inner node is a *different* owner, so it must NOT inherit
+// this resource's force-real override. Emits reentered=true so the smoke can confirm the
+// reentrant instantiation actually happened (otherwise the absent inner marker would be a
+// false pass).
+@ScriptClass(attachTo = "Resource")
+@GlobalClass
+class ReentrantForgeProbe(val godotObject: MemorySegment) {
+  init {
+    val node = ResourceLoader.loadPackedScene("res://reentrant_inner.tscn")?.instantiate()
+    System.err.println("[kanama:kt] ReentrantForgeProbe reentered=${node != null}")
+    node?.queueFree()
+  }
+}

--- a/example_project/ReentrantForgeProbe.kt.uid
+++ b/example_project/ReentrantForgeProbe.kt.uid
@@ -1,0 +1,1 @@
+uid://cmwsaqslqvype

--- a/example_project/ReentrantPlaceholderProbe.kt
+++ b/example_project/ReentrantPlaceholderProbe.kt
@@ -1,0 +1,17 @@
+package net.multigesture.kanama.example
+
+import java.lang.foreign.MemorySegment
+import net.multigesture.kanama.annotations.ScriptClass
+
+// Task 56 fixture (inner). A non-@Tool node script whose CONSTRUCTOR prints a marker.
+// A placeholder instance never invokes the factory, so the constructor — and its marker —
+// runs only when the instance is built for real. When this node is instantiated reentrantly
+// *during* another script's newScriptInstance() create window, per-owner scoping must still
+// hand it a placeholder (marker ABSENT). The pre-fix thread-wide flag forced it real (marker
+// PRESENT); that regression is what tool_smoke's check_absent guards.
+@ScriptClass(attachTo = "Node")
+class ReentrantPlaceholderProbe(val godotObject: MemorySegment) {
+  init {
+    System.err.println("[kanama:kt] ReentrantPlaceholderProbe CONSTRUCTED")
+  }
+}

--- a/example_project/ReentrantPlaceholderProbe.kt.uid
+++ b/example_project/ReentrantPlaceholderProbe.kt.uid
@@ -1,0 +1,1 @@
+uid://cfmj7gjff8peu

--- a/example_project/ResourceForgeSmoke.kt
+++ b/example_project/ResourceForgeSmoke.kt
@@ -4,6 +4,7 @@ import java.lang.foreign.MemorySegment
 import net.multigesture.kanama.annotations.OnReady
 import net.multigesture.kanama.annotations.ScriptClass
 import net.multigesture.kanama.annotations.Tool
+import net.multigesture.kanama.api.Engine
 import net.multigesture.kanama.api.FileAccess
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.ManualGodotLifetimeApi
@@ -69,6 +70,17 @@ class ResourceForgeSmoke(godotObject: MemorySegment) : KanamaScript<Node>(godotO
         "[kanama:kt] ResourceForgeSmoke live=$live save_error=$saveError " +
           "script_ref=$scriptRef payload_saved=$payloadSaved reload_ok=$reloadOk"
       )
+    }
+
+    // task 56: per-owner scoping of the force-real override. Creating ReentrantForgeProbe
+    // reentrantly instantiates a *different* non-@Tool script during its construction; that
+    // inner script must still get an editor placeholder (see the two markers asserted in
+    // tool_smoke). The force-real override must apply only to the resource under creation.
+    // Editor-only: the placeholder-vs-real distinction exists solely in the editor, so this
+    // adds no coverage in game mode — and skipping it there keeps runtime_smoke leak-free
+    // (the reentrant scene instance would otherwise outlive the one-frame --quit run).
+    if (Engine.isEditorHint()) {
+      newScriptInstance<ReentrantForgeProbe>().use {}
     }
   }
 }

--- a/example_project/reentrant_inner.tscn
+++ b/example_project/reentrant_inner.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://ReentrantPlaceholderProbe.kt" id="1"]
+
+[node name="ReentrantInner" type="Node"]
+script = ExtResource("1")

--- a/scripts/tool_smoke.sh
+++ b/scripts/tool_smoke.sh
@@ -79,5 +79,12 @@ check_absent "Cannot ptrcall nil constructor"
 # is reliably populated.
 check "ResourceForgeSmoke live=true save_error=0"
 check_absent "ResourceForgeSmoke create_failed"
+# task 56 — the force-real override for newScriptInstance() must be scoped to the specific
+# owner being created, not thread-wide. ReentrantForgeProbe's construction (inside the create
+# window) reentrantly instantiates a *different* non-@Tool script; reentered=true proves that
+# reentrant instantiation ran, and the inner CONSTRUCTED marker must stay ABSENT because that
+# inner owner still gets an editor placeholder. Pre-fix (thread-wide flag) the marker fired.
+check "ReentrantForgeProbe reentered=true"
+check_absent "ReentrantPlaceholderProbe CONSTRUCTED"
 
 echo "[tool_smoke] PASS"

--- a/src/main/kotlin/binding/KanamaScript.kt
+++ b/src/main/kotlin/binding/KanamaScript.kt
@@ -83,21 +83,33 @@ class KanamaScript(
     private val templatesByName = LinkedHashMap<String, KanamaScriptTemplate>()
     private val globalNameToTemplate = LinkedHashMap<String, KanamaScriptTemplate>()
 
-    // Depth counter set while [instantiateResourceScript] drives Object.set_script.
-    // Godot runs _instance_create synchronously on the calling thread, so a
-    // thread-local reliably scopes the whole attach. When > 0, callInstanceCreate
+    // Owners currently being programmatically created (by [instantiateResourceScript]
+    // driving Object.set_script), keyed by owner Object* address → nesting depth.
+    // Godot runs _instance_create synchronously on the calling thread, so a thread-local
+    // reliably scopes the whole attach. When an owner is present, callInstanceCreate
     // builds the real instance even in the editor for a non-@Tool script, so that
     // programmatic creation returns a live Kotlin object rather than a placeholder.
-    private val programmaticCreate = ThreadLocal.withInitial { 0 }
+    //
+    // Keyed by owner (not a thread-wide flag) so a reentrant instantiation of a
+    // *different* script during the attach — e.g. a scene load triggered from a resource
+    // constructor — is NOT force-realized; only the specific owner under construction is.
+    // A depth count (not a boolean) so a script whose constructor legitimately re-enters
+    // for the same owner still survives the nesting.
+    private val programmaticCreateOwners = ThreadLocal.withInitial { HashMap<Long, Int>() }
 
-    private inline fun <R> withProgrammaticCreate(body: () -> R): R {
-      programmaticCreate.set(programmaticCreate.get() + 1)
+    private inline fun <R> withProgrammaticCreate(ownerAddress: Long, body: () -> R): R {
+      val owners = programmaticCreateOwners.get()
+      owners[ownerAddress] = (owners[ownerAddress] ?: 0) + 1
       try {
         return body()
       } finally {
-        programmaticCreate.set(programmaticCreate.get() - 1)
+        val depth = (owners[ownerAddress] ?: 1) - 1
+        if (depth <= 0) owners.remove(ownerAddress) else owners[ownerAddress] = depth
       }
     }
+
+    private fun isProgrammaticCreateOwner(ownerAddress: Long): Boolean =
+      (programmaticCreateOwners.get()[ownerAddress] ?: 0) > 0
 
     data class KanamaScriptTemplate(
       val instanceBaseType: String,
@@ -690,7 +702,7 @@ class KanamaScript(
       net.multigesture.kanama.api.RefCounted.retainHandle(baseHandle)
       var success = false
       try {
-        withProgrammaticCreate {
+        withProgrammaticCreate(baseHandle.address()) {
           net.multigesture.kanama.api.GodotObject(baseHandle).setScript(resolved.script)
         }
         val instance =
@@ -1336,11 +1348,18 @@ class KanamaScript(
       // `if (Engine.isEditorHint()) return` boilerplate every script
       // would otherwise need.
       val script = ObjectRegistry.get(instance.address()) as? KanamaScript
+      // Owner this instance is being created for (double-indirect: args[0] is a type-ptr
+      // → the Object* value), matching callCreateInternal's decode. The force-real
+      // override applies only when *this* owner is the one under programmatic creation, so
+      // a different script instantiated reentrantly on the same thread still gets its
+      // editor placeholder.
+      val forObjectTypePtr = args.reinterpret(8).get(ADDRESS, 0)
+      val forObject = forObjectTypePtr.reinterpret(8).get(ADDRESS, 0)
       val skipForEditor =
         script != null &&
           !script.isTool &&
           net.multigesture.kanama.api.Engine.isEditorHint() &&
-          programmaticCreate.get() == 0
+          !isProgrammaticCreateOwner(forObject.address())
       callCreateInternal(instance, args, rRet, allowPlaceholder = skipForEditor)
     }
 


### PR DESCRIPTION
## What

Closes the editor-only reentrancy edge deferred from PR #44 (`newScriptInstance`). The "force a real instance instead of an editor placeholder" override was **thread-wide**, so a *different* non-`@Tool` script instantiated reentrantly on the same thread during a programmatic create (e.g. a scene load from a resource constructor) was also forced real — bypassing the editor placeholder it should get.

## Fix

Key the override on the **owner being created** instead of a thread-wide counter:
- `programmaticCreate` (a `ThreadLocal<Int>`) → `programmaticCreateOwners`, a `ThreadLocal<HashMap<Long,Int>>` mapping owner `Object*` address → nesting depth.
- `callInstanceCreate` decodes the owner from `args` (same double-indirect as `callCreateInternal`) and forces real **only** when that owner is the one under programmatic creation; any other reentrant instantiation falls through to normal editor-placeholder behaviour.
- The depth count preserves the existing reentrancy handling for the *same* owner.

## Fixture (full editor exit-gate)

`ReentrantForgeProbe` (created via `newScriptInstance`) reentrantly instantiates `reentrant_inner.tscn`, whose root carries the non-`@Tool` `ReentrantPlaceholderProbe`. The inner's constructor marker fires only if it was built real (placeholder skips the factory). `tool_smoke` asserts `reentered=true` **and** the inner marker **absent**. The driver is `Engine.isEditorHint()`-gated — the placeholder-vs-real distinction is editor-only, and gating keeps `runtime_smoke` leak-free.

## Verification

- `tool_smoke` **PASS** — `reentered=true`, inner `CONSTRUCTED` absent (stays placeholder).
- **Negative control** — reverting only the src fix (keeping the fixture) makes the inner forced real → `tool_smoke` **FAILS**, proving the fixture catches the regression.
- Full `local_ci` **PASS** (macOS arm64, Godot 4.7-stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)