### PR TITLE
Pin the object-valued typed-Map nil-drop contract (task 49 item 1)

### DIFF
--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -340,9 +340,19 @@ func _kanama_dictionary_nullable_value_smoke() -> void:
 	var wrong_value = $ScriptNode.smoke_nullable_scalar_map
 	var wrong_nulled = wrong_value.has("c") and wrong_value["c"] == null
 	$ScriptNode.smoke_nullable_scalar_map = {}
+	# Object-valued map (Map<Long, SmokeResource>, non-null value): a nil value DROPS the key.
+	# Kotlin cannot hold null in a non-null SmokeResource field, and nullable object-map values
+	# (Map<K, Resource?>) are rejected at build, so drop is the intended C#-consistent contract
+	# — task 49 item 1 pins it here rather than leaving it incidental.
+	var region_res = ClassDB.instantiate("Resource")
+	region_res.set_script(load("res://SmokeResource.kt"))
+	$ScriptNode.smoke_region_map = {10: region_res, 20: null}
+	var region_got = $ScriptNode.smoke_region_map
+	var object_null_dropped = region_got.has(10) and not region_got.has(20)
+	$ScriptNode.smoke_region_map = {}
 	print("[kanama:gd] kt script dictionary nullable_value null_preserved=", null_preserved,
-		" wrong_nulled=", wrong_nulled)
-	if not (null_preserved and wrong_nulled):
+		" wrong_nulled=", wrong_nulled, " object_null_dropped=", object_null_dropped)
+	if not (null_preserved and wrong_nulled and object_null_dropped):
 		push_error("Kanama dictionary nullable-value handling failed")
 
 # task 29 — virtual-return families. Calling an @OverrideVirtual method by name on a

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -134,7 +134,7 @@ check "kt script dictionary export scalar_type=true tscn_scalar_map=true scalar_
 check "kt script dictionary malformed survived=true wrong_key_empty=true wrong_value_dropped=true wrong_vector_key_dropped=true"
 # issue #40 review — nullable scalar Map value (Map<String, Long?>) preserves a null value's key
 # (C# parity), and a wrong-typed value nulls rather than dropping. Round-trips through the write path.
-check "kt script dictionary nullable_value null_preserved=true wrong_nulled=true"
+check "kt script dictionary nullable_value null_preserved=true wrong_nulled=true object_null_dropped=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"


### PR DESCRIPTION
## What

Closes the last rough edge from the typed `Map<K, V>` export PR (#43): the object-valued nil-drop was **intentional but only incidentally asserted**. This pins it — no behaviour change.

## Contract (already documented, now tested)

- `Map<K, V?>` (nullable scalar/value/enum) → key **kept with `null`** (C#-parity). *Already tested.*
- `Map<K, V>` (non-null) → nil entry **dropped** (Kotlin can't hold `null`).
- Nullable **object** map values (`Map<K, Resource?>`) → **rejected at build** (KSP).

So an object-valued map (`Map<Long, SmokeResource>`, always non-null) drops a nil value — the C#-consistent behaviour, unasserted until now.

## Change

The `nullable_value` smoke now sets `Map<Long, SmokeResource> = {10: res, 20: null}` and asserts `object_null_dropped` (key 10 survives, key 20 dropped); `runtime_smoke` checks it. Docs (`properties-resources.md`, lines 165–176) already spell out the drop-vs-preserve contract, so no doc change is needed. Item 2 (emitter keyword de-dup) already landed in #68.

## Verification

Full `local_ci` **PASS** (macOS arm64, Godot 4.7-stable), including the dictionary/mutable smoke probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)