### PR TITLE
Document ClassDB script-class behaviour + pin GDScript parity (task 41)

### DIFF
--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -368,3 +368,13 @@ declaration exists so shared game code compiles, but calling it throws at
 runtime. Construct script-backed resources on desktop/Android, or guard the call
 by platform. Its sibling `kotlinScriptInstance<T>()` (resolving the Kotlin
 instance of an existing resource) is supported on all three backends.
+
+**Not `ClassDB.instantiate`**: `ClassDB.instantiate("Weapon")` returns `null`
+(with `Cannot get class 'Weapon'`) for a custom resource class, even though
+`ClassDB.can_instantiate("Weapon")` returns `true`. This is **upstream Godot
+behaviour, not a Kanama limitation** — script global classes (GDScript, C#, and
+Kanama alike) live in the script server, not the engine `ClassDB` registry, so
+`ClassDB.instantiate` cannot construct them and `can_instantiate` answers from a
+different lookup. Construct with `newScriptInstance<T>()` from Kotlin, or from
+GDScript attach the loaded script to a base resource:
+`var r = Resource.new(); r.set_script(load("res://Weapon.kt"))`.

--- a/example_project/ProbeGlobalRes.gd
+++ b/example_project/ProbeGlobalRes.gd
@@ -1,0 +1,3 @@
+class_name ProbeGlobalRes
+extends Resource
+@export var payload: String = "default"

--- a/example_project/ProbeGlobalRes.gd.uid
+++ b/example_project/ProbeGlobalRes.gd.uid
@@ -1,0 +1,1 @@
+uid://sp0gkdfd0qtq

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -68,6 +68,7 @@ func _ready() -> void:
 		_kanama_dictionary_export_smoke(properties)
 		_kanama_dictionary_malformed_smoke()
 		_kanama_dictionary_nullable_value_smoke()
+		_kanama_classdb_script_class_smoke()
 		var replace_smoke_scene = $ScriptNode.replace_smoke_scene()
 		print("[kanama:gd] kt script replace_smoke_scene = ", replace_smoke_scene)
 		if not replace_smoke_scene:
@@ -330,6 +331,28 @@ func _kanama_dictionary_malformed_smoke() -> void:
 # Dictionary: a null value keeps its key (unlike a non-null value map, which cannot hold null and
 # drops). Round-trips through the write path too (null -> nil Variant). A wrong-typed value also
 # becomes null rather than dropping, since the key can now hold it.
+func _kanama_classdb_script_class_smoke() -> void:
+	# task 41 — ClassDB honesty for script global classes. `ClassDB.instantiate` only builds
+	# engine classes, so a script `@GlobalClass` (GDScript, C#, or Kanama) returns null +
+	# "Cannot get class" while `can_instantiate` returns true. This is upstream Godot behaviour:
+	# assert Kanama's SmokeResource matches a plain GDScript global class (ProbeGlobalRes), so a
+	# future divergence is caught. Construct script resources with `newScriptInstance<T>()` from
+	# Kotlin, or the base-Resource + set_script recipe below from GDScript — not ClassDB.
+	var kanama_can := ClassDB.can_instantiate("SmokeResource")
+	var kanama_instantiate_null := ClassDB.instantiate("SmokeResource") == null
+	var gdscript_can := ClassDB.can_instantiate("ProbeGlobalRes")
+	var gdscript_instantiate_null := ClassDB.instantiate("ProbeGlobalRes") == null
+	# Supported GDScript-side construction: attach the loaded Kanama script to a base Resource.
+	var built = ClassDB.instantiate("Resource")
+	built.set_script(load("res://SmokeResource.kt"))
+	var recipe_works = built != null and built.get_script() != null
+	print("[kanama:gd] kt script classdb_parity kanama_can=", kanama_can,
+		" kanama_instantiate_null=", kanama_instantiate_null, " gdscript_can=", gdscript_can,
+		" gdscript_instantiate_null=", gdscript_instantiate_null, " recipe_works=", recipe_works)
+	if not (kanama_can and kanama_instantiate_null and gdscript_can \
+			and gdscript_instantiate_null and recipe_works):
+		push_error("Kanama ClassDB script-class parity failed")
+
 func _kanama_dictionary_nullable_value_smoke() -> void:
 	$ScriptNode.smoke_nullable_scalar_map = {"a": null, "b": 2}
 	var got = $ScriptNode.smoke_nullable_scalar_map

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -135,6 +135,10 @@ check "kt script dictionary malformed survived=true wrong_key_empty=true wrong_v
 # issue #40 review — nullable scalar Map value (Map<String, Long?>) preserves a null value's key
 # (C# parity), and a wrong-typed value nulls rather than dropping. Round-trips through the write path.
 check "kt script dictionary nullable_value null_preserved=true wrong_nulled=true"
+# task 41 — a Kanama @GlobalClass script resource matches a plain GDScript global class for the
+# ClassDB pair (can_instantiate=true, instantiate=null: script classes aren't engine classes),
+# and the supported base-Resource + set_script construction recipe works.
+check "kt script classdb_parity kanama_can=true kanama_instantiate_null=true gdscript_can=true gdscript_instantiate_null=true recipe_works=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"


### PR DESCRIPTION
## What

Closes the remaining open piece of task 41 (issue #38). The other two deliverables already shipped — `newScriptInstance<T>()` (#44, the construction path; `c-sharp-compat.md` "Runtime custom resources" already SUPPORTED) and the mutate→save→reload round-trip (ResourceForge smoke). This handles the third: T-bond's `ClassDB` observation.

## Finding: not a Kanama bug

`ClassDB.can_instantiate("CustomResource")` → `true` but `ClassDB.instantiate("CustomResource")` → `null` + "Cannot get class". Reproduced side-by-side against a plain GDScript `class_name` resource — **identical behaviour**:

| class | `can_instantiate` | `instantiate` |
|---|---|---|
| GDScript `class_name` (`ProbeGlobalRes`) | `true` | `null` + "Cannot get class" |
| Kanama `@GlobalClass` (`SmokeResource`) | `true` | `null` + "Cannot get class" |

Upstream Godot: script global classes live in the script server, not the engine `ClassDB` registry, so `ClassDB.instantiate` structurally can't construct them. Kanama has exact parity with GDScript — no fix needed.

## Change

- `_kanama_classdb_script_class_smoke` pins Kanama↔GDScript parity for the pair, plus that the `Resource.new()`+`set_script` construction recipe works. Added `ProbeGlobalRes.gd` (a GDScript global class) as the parity fixture.
- Docs note in the custom-resources section: construct via `newScriptInstance<T>()` (Kotlin) or `Resource.new()`+`set_script` (GDScript), **not** `ClassDB.instantiate`.

No behaviour change → no CHANGELOG entry. Full `local_ci` **PASS** (macOS arm64, Godot 4.7-stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)