### PR TITLE
Tighten required Resource/RefCounted object params to non-null (task 52b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ versioning once public releases begin.
 
 ### Changed
 
+- **Source-breaking:** object parameters that Godot 4.7 explicitly marks
+  `meta: "required"` are now generated as **non-null**, including the 65
+  Resource/RefCounted-derived required arguments that were previously nullable.
+  For example `ResourceSaver.save(resource: Resource, …)`,
+  `CanvasItem.drawTexture(texture: Texture2D, …)`, and the required-shape
+  arguments on `Control`, `InputMap`, `PhysicsServer2D/3D`,
+  `PhysicsDirectSpaceState2D/3D`, `Shape2D`, `CollisionObject2D/3D`, `OS`, and
+  `Input` no longer accept `null` and marshal via `requireOpenHandle()` without a
+  safe-call. This narrows public signatures: a call site passing `null` (or a
+  nullable value without a null-check) to one of these now fails to compile —
+  which is the honest contract, since the engine rejects null there. Unmarked
+  legacy Resource parameters stay nullable, and the audited
+  `NULLABLE_OBJECT_PARAM_OVERRIDES` (e.g. `Node.set_owner`) keep their null. The
+  policy (`required` wins over resource ancestry) is centralized in the generator
+  and locked by `audit_generator_object_policy.py`.
+
 - Desktop/Android `Resource` now extends `RefCounted`, restoring Godot's real
   `Object > RefCounted > Resource` chain (which iOS already had). Previously
   `Resource` was its own wrapper root that re-implemented the refcount lifetime

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CanvasItem.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CanvasItem.kt
@@ -250,28 +250,28 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
         ObjectCalls.ptrcallWithVector2TwoDoubleColorBoolDoubleBoolArgs(drawEllipseBind, handle, position, major, minor, color, filled, width, antialiased)
     }
 
-    fun drawTexture(texture: Texture2D?, position: Vector2, modulate: Color) {
-        ObjectCalls.ptrcallWithObjectVector2AndColorArgs(drawTextureBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, position, modulate)
+    fun drawTexture(texture: Texture2D, position: Vector2, modulate: Color) {
+        ObjectCalls.ptrcallWithObjectVector2AndColorArgs(drawTextureBind, handle, texture.requireOpenHandle(), position, modulate)
     }
 
-    fun drawTextureRect(texture: Texture2D?, rect: Rect2, tile: Boolean, modulate: Color, transpose: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectRect2BoolColorBoolArgs(drawTextureRectBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, tile, modulate, transpose)
+    fun drawTextureRect(texture: Texture2D, rect: Rect2, tile: Boolean, modulate: Color, transpose: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectRect2BoolColorBoolArgs(drawTextureRectBind, handle, texture.requireOpenHandle(), rect, tile, modulate, transpose)
     }
 
-    fun drawTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color, transpose: Boolean = false, clipUv: Boolean = true) {
-        ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(drawTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate, transpose, clipUv)
+    fun drawTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color, transpose: Boolean = false, clipUv: Boolean = true) {
+        ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(drawTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate, transpose, clipUv)
     }
 
-    fun drawMsdfTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color, outline: Double = 0.0, pixelRange: Double = 4.0, scale: Double = 1.0) {
-        ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(drawMsdfTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate, outline, pixelRange, scale)
+    fun drawMsdfTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color, outline: Double = 0.0, pixelRange: Double = 4.0, scale: Double = 1.0) {
+        ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(drawMsdfTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate, outline, pixelRange, scale)
     }
 
-    fun drawLcdTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color) {
-        ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(drawLcdTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate)
+    fun drawLcdTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color) {
+        ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(drawLcdTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate)
     }
 
-    fun drawStyleBox(styleBox: StyleBox?, rect: Rect2) {
-        ObjectCalls.ptrcallWithObjectAndRect2Arg(drawStyleBoxBind, handle, styleBox?.requireOpenHandle() ?: MemorySegment.NULL, rect)
+    fun drawStyleBox(styleBox: StyleBox, rect: Rect2) {
+        ObjectCalls.ptrcallWithObjectAndRect2Arg(drawStyleBoxBind, handle, styleBox.requireOpenHandle(), rect)
     }
 
     fun drawPrimitive(points: List<Vector2>, colors: List<Color>, uvs: List<Vector2>, texture: Texture2D?) {
@@ -286,36 +286,36 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
         ObjectCalls.ptrcallWithPackedVector2ListColorPackedVector2ListAndObjectArgs(drawColoredPolygonBind, handle, points, color, uvs, texture?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
-    fun drawString(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleArgs(drawStringBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, modulate, justificationFlags, direction, orientation, oversampling)
+    fun drawString(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleArgs(drawStringBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, modulate, justificationFlags, direction, orientation, oversampling)
     }
 
-    fun drawMultilineString(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(drawMultilineStringBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, maxLines, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
+    fun drawMultilineString(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(drawMultilineStringBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, maxLines, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
     }
 
-    fun drawStringOutline(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, size: Int = 1, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(drawStringOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, size, modulate, justificationFlags, direction, orientation, oversampling)
+    fun drawStringOutline(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, size: Int = 1, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(drawStringOutlineBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, size, modulate, justificationFlags, direction, orientation, oversampling)
     }
 
-    fun drawMultilineStringOutline(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, size: Int = 1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(drawMultilineStringOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, maxLines, size, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
+    fun drawMultilineStringOutline(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, size: Int = 1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(drawMultilineStringOutlineBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, maxLines, size, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
     }
 
-    fun drawChar(font: Font?, pos: Vector2, char: String, fontSize: Int = 16, modulate: Color, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(drawCharBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, char, fontSize, modulate, oversampling)
+    fun drawChar(font: Font, pos: Vector2, char: String, fontSize: Int = 16, modulate: Color, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(drawCharBind, handle, font.requireOpenHandle(), pos, char, fontSize, modulate, oversampling)
     }
 
-    fun drawCharOutline(font: Font?, pos: Vector2, char: String, fontSize: Int = 16, size: Int = -1, modulate: Color, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringTwoIntColorDoubleArgs(drawCharOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, char, fontSize, size, modulate, oversampling)
+    fun drawCharOutline(font: Font, pos: Vector2, char: String, fontSize: Int = 16, size: Int = -1, modulate: Color, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringTwoIntColorDoubleArgs(drawCharOutlineBind, handle, font.requireOpenHandle(), pos, char, fontSize, size, modulate, oversampling)
     }
 
-    fun drawMesh(mesh: Mesh?, texture: Texture2D?, transform: Transform2D, modulate: Color) {
-        ObjectCalls.ptrcallWithTwoObjectTransform2DColorArgs(drawMeshBind, handle, mesh?.requireOpenHandle() ?: MemorySegment.NULL, texture?.requireOpenHandle() ?: MemorySegment.NULL, transform, modulate)
+    fun drawMesh(mesh: Mesh, texture: Texture2D?, transform: Transform2D, modulate: Color) {
+        ObjectCalls.ptrcallWithTwoObjectTransform2DColorArgs(drawMeshBind, handle, mesh.requireOpenHandle(), texture?.requireOpenHandle() ?: MemorySegment.NULL, transform, modulate)
     }
 
-    fun drawMultimesh(multimesh: MultiMesh?, texture: Texture2D?) {
-        ObjectCalls.ptrcallWithTwoObjectArgs(drawMultimeshBind, handle, multimesh?.requireOpenHandle() ?: MemorySegment.NULL, texture?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun drawMultimesh(multimesh: MultiMesh, texture: Texture2D?) {
+        ObjectCalls.ptrcallWithTwoObjectArgs(drawMultimeshBind, handle, multimesh.requireOpenHandle(), texture?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     fun drawSetTransform(position: Vector2, rotation: Double = 0.0, scale: Vector2) {
@@ -426,8 +426,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
         return ObjectCalls.ptrcallWithVector2ArgRetVector2(makeCanvasPositionLocalBind, handle, viewportPoint)
     }
 
-    fun makeInputLocal(event: InputEvent?): InputEvent? {
-        return InputEvent.wrap(ObjectCalls.ptrcallWithObjectArgRetObject(makeInputLocalBind, handle, event?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun makeInputLocal(event: InputEvent): InputEvent? {
+        return InputEvent.wrap(ObjectCalls.ptrcallWithObjectArgRetObject(makeInputLocalBind, handle, event.requireOpenHandle()))
     }
 
     fun setVisibilityLayer(layer: Long) {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CollisionObject2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CollisionObject2D.kt
@@ -158,8 +158,8 @@ open class CollisionObject2D(handle: MemorySegment) : Node2D(handle) {
         ObjectCalls.ptrcallWithUInt32AndVector2Args(shapeOwnerSetOneWayCollisionDirectionBind, handle, ownerId, direction)
     }
 
-    fun shapeOwnerAddShape(ownerId: Long, shape: Shape2D?) {
-        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun shapeOwnerAddShape(ownerId: Long, shape: Shape2D) {
+        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape.requireOpenHandle())
     }
 
     fun shapeOwnerGetShapeCount(ownerId: Long): Int {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CollisionObject3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CollisionObject3D.kt
@@ -147,8 +147,8 @@ open class CollisionObject3D(handle: MemorySegment) : Node3D(handle) {
         return ObjectCalls.ptrcallWithUInt32ArgRetBool(isShapeOwnerDisabledBind, handle, ownerId)
     }
 
-    fun shapeOwnerAddShape(ownerId: Long, shape: Shape3D?) {
-        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun shapeOwnerAddShape(ownerId: Long, shape: Shape3D) {
+        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape.requireOpenHandle())
     }
 
     fun shapeOwnerGetShapeCount(ownerId: Long): Int {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Control.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Control.kt
@@ -637,16 +637,16 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
         ObjectCalls.ptrcallNoArgs(endBulkThemeOverrideBind, handle)
     }
 
-    fun addThemeIconOverride(name: String, texture: Texture2D?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeIconOverrideBind, handle, name, texture?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeIconOverride(name: String, texture: Texture2D) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeIconOverrideBind, handle, name, texture.requireOpenHandle())
     }
 
-    fun addThemeStyleboxOverride(name: String, stylebox: StyleBox?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeStyleboxOverrideBind, handle, name, stylebox?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeStyleboxOverride(name: String, stylebox: StyleBox) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeStyleboxOverrideBind, handle, name, stylebox.requireOpenHandle())
     }
 
-    fun addThemeFontOverride(name: String, font: Font?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeFontOverrideBind, handle, name, font?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeFontOverride(name: String, font: Font) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeFontOverrideBind, handle, name, font.requireOpenHandle())
     }
 
     fun addThemeFontSizeOverride(name: String, fontSize: Int) {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Input.kt
@@ -106,12 +106,12 @@ object Input {
         return ObjectCalls.ptrcallWithStringNameAndBoolArgRetBool(isActionJustReleasedBind, singleton, action, exactMatch)
     }
 
-    fun isActionJustPressedByEvent(action: String, event: InputEvent?, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustPressedByEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL, exactMatch)
+    fun isActionJustPressedByEvent(action: String, event: InputEvent, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustPressedByEventBind, singleton, action, event.requireOpenHandle(), exactMatch)
     }
 
-    fun isActionJustReleasedByEvent(action: String, event: InputEvent?, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustReleasedByEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL, exactMatch)
+    fun isActionJustReleasedByEvent(action: String, event: InputEvent, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustReleasedByEventBind, singleton, action, event.requireOpenHandle(), exactMatch)
     }
 
     fun getActionStrength(action: String, exactMatch: Boolean = false): Double {
@@ -326,8 +326,8 @@ object Input {
         ObjectCalls.ptrcallWithObjectLongAndVector2Arg(setCustomMouseCursorBind, singleton, image?.requireOpenHandle() ?: MemorySegment.NULL, shape, hotspot)
     }
 
-    fun parseInputEvent(event: InputEvent?) {
-        ObjectCalls.ptrcallWithObjectArgs(parseInputEventBind, singleton, listOf(event?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun parseInputEvent(event: InputEvent) {
+        ObjectCalls.ptrcallWithObjectArgs(parseInputEventBind, singleton, listOf(event.requireOpenHandle()))
     }
 
     fun setUseAccumulatedInput(enable: Boolean) {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/InputMap.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/InputMap.kt
@@ -36,24 +36,24 @@ object InputMap {
         return ObjectCalls.ptrcallWithStringNameArgRetDouble(actionGetDeadzoneBind, singleton, action)
     }
 
-    fun actionAddEvent(action: String, event: InputEvent?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionAddEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionAddEvent(action: String, event: InputEvent) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionAddEventBind, singleton, action, event.requireOpenHandle())
     }
 
-    fun actionHasEvent(action: String, event: InputEvent?): Boolean {
-        return ObjectCalls.ptrcallWithStringNameAndObjectArgRetBool(actionHasEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionHasEvent(action: String, event: InputEvent): Boolean {
+        return ObjectCalls.ptrcallWithStringNameAndObjectArgRetBool(actionHasEventBind, singleton, action, event.requireOpenHandle())
     }
 
-    fun actionEraseEvent(action: String, event: InputEvent?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionEraseEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionEraseEvent(action: String, event: InputEvent) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionEraseEventBind, singleton, action, event.requireOpenHandle())
     }
 
     fun actionEraseEvents(action: String) {
         ObjectCalls.ptrcallWithStringNameArg(actionEraseEventsBind, singleton, action)
     }
 
-    fun eventIsAction(event: InputEvent?, action: String, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(eventIsActionBind, singleton, event?.requireOpenHandle() ?: MemorySegment.NULL, action, exactMatch)
+    fun eventIsAction(event: InputEvent, action: String, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(eventIsActionBind, singleton, event.requireOpenHandle(), action, exactMatch)
     }
 
     fun loadFromProjectSettings() {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/OS.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/OS.kt
@@ -317,12 +317,12 @@ object OS {
         ObjectCalls.ptrcallNoArgs(revokeGrantedPermissionsBind, singleton)
     }
 
-    fun addLogger(logger: Logger?) {
-        ObjectCalls.ptrcallWithObjectArgs(addLoggerBind, singleton, listOf(logger?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun addLogger(logger: Logger) {
+        ObjectCalls.ptrcallWithObjectArgs(addLoggerBind, singleton, listOf(logger.requireOpenHandle()))
     }
 
-    fun removeLogger(logger: Logger?) {
-        ObjectCalls.ptrcallWithObjectArgs(removeLoggerBind, singleton, listOf(logger?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun removeLogger(logger: Logger) {
+        ObjectCalls.ptrcallWithObjectArgs(removeLoggerBind, singleton, listOf(logger.requireOpenHandle()))
     }
 
     fun fromHandle(handle: MemorySegment): OS? =

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsServer2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsServer2D.kt
@@ -451,8 +451,8 @@ object PhysicsServer2D {
         ObjectCalls.ptrcallWithRIDCallableArgs(bodySetStateSyncCallbackBind, singleton, body, callable.target.handle, callable.method)
     }
 
-    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters2D?, result: PhysicsTestMotionResult2D?): Boolean {
-        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters?.requireOpenHandle() ?: MemorySegment.NULL, result?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters2D, result: PhysicsTestMotionResult2D?): Boolean {
+        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters.requireOpenHandle(), result?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     fun bodyGetDirectState(body: RID): PhysicsDirectBodyState2D? {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsServer3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsServer3D.kt
@@ -533,8 +533,8 @@ object PhysicsServer3D {
         ObjectCalls.ptrcallWithRIDAndBoolArg(bodySetRayPickableBind, singleton, body, enable)
     }
 
-    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters3D?, result: PhysicsTestMotionResult3D?): Boolean {
-        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters?.requireOpenHandle() ?: MemorySegment.NULL, result?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters3D, result: PhysicsTestMotionResult3D?): Boolean {
+        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters.requireOpenHandle(), result?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     fun bodyGetDirectState(body: RID): PhysicsDirectBodyState3D? {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ResourceSaver.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ResourceSaver.kt
@@ -21,20 +21,20 @@ object ResourceSaver {
     const val FLAG_COMPRESS: Long = 32L
     const val FLAG_REPLACE_SUBRESOURCE_PATHS: Long = 64L
 
-    fun save(resource: Resource?, path: String = "", flags: Long = 0L): Long {
-        return ObjectCalls.ptrcallWithObjectStringLongArgsRetLong(saveBind, singleton, resource?.requireOpenHandle() ?: MemorySegment.NULL, path, flags)
+    fun save(resource: Resource, path: String = "", flags: Long = 0L): Long {
+        return ObjectCalls.ptrcallWithObjectStringLongArgsRetLong(saveBind, singleton, resource.requireOpenHandle(), path, flags)
     }
 
     fun setUid(resource: String, uid: Long): Long {
         return ObjectCalls.ptrcallWithStringAndLongArgRetLong(setUidBind, singleton, resource, uid)
     }
 
-    fun addResourceFormatSaver(formatSaver: ResourceFormatSaver?, atFront: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectAndBoolArg(addResourceFormatSaverBind, singleton, formatSaver?.requireOpenHandle() ?: MemorySegment.NULL, atFront)
+    fun addResourceFormatSaver(formatSaver: ResourceFormatSaver, atFront: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectAndBoolArg(addResourceFormatSaverBind, singleton, formatSaver.requireOpenHandle(), atFront)
     }
 
-    fun removeResourceFormatSaver(formatSaver: ResourceFormatSaver?) {
-        ObjectCalls.ptrcallWithObjectArgs(removeResourceFormatSaverBind, singleton, listOf(formatSaver?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun removeResourceFormatSaver(formatSaver: ResourceFormatSaver) {
+        ObjectCalls.ptrcallWithObjectArgs(removeResourceFormatSaverBind, singleton, listOf(formatSaver.requireOpenHandle()))
     }
 
     fun getResourceIdForPath(path: String, generate: Boolean = false): Long {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Shape2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Shape2D.kt
@@ -28,12 +28,12 @@ open class Shape2D(handle: MemorySegment) : Resource(handle) {
         return ObjectCalls.ptrcallNoArgsRetDouble(getCustomSolverBiasBind, handle)
     }
 
-    fun collide(localXform: Transform2D, withShape: Shape2D?, shapeXform: Transform2D): Boolean {
-        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(collideBind, handle, localXform, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform)
+    fun collide(localXform: Transform2D, withShape: Shape2D, shapeXform: Transform2D): Boolean {
+        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(collideBind, handle, localXform, withShape.requireOpenHandle(), shapeXform)
     }
 
-    fun collideWithMotion(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D?, shapeXform: Transform2D, shapeMotion: Vector2): Boolean {
-        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool(collideWithMotionBind, handle, localXform, localMotion, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform, shapeMotion)
+    fun collideWithMotion(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D, shapeXform: Transform2D, shapeMotion: Vector2): Boolean {
+        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool(collideWithMotionBind, handle, localXform, localMotion, withShape.requireOpenHandle(), shapeXform, shapeMotion)
     }
 
     fun draw(canvasItem: RID, color: Color) {

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Viewport.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Viewport.kt
@@ -465,12 +465,12 @@ open class Viewport(handle: MemorySegment) : Node(handle) {
         ObjectCalls.ptrcallWithStringArg(pushTextInputBind, handle, text)
     }
 
-    fun pushInput(event: InputEvent?, inLocalCoords: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectAndBoolArg(pushInputBind, handle, event?.requireOpenHandle() ?: MemorySegment.NULL, inLocalCoords)
+    fun pushInput(event: InputEvent, inLocalCoords: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectAndBoolArg(pushInputBind, handle, event.requireOpenHandle(), inLocalCoords)
     }
 
-    fun pushUnhandledInput(event: InputEvent?, inLocalCoords: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectAndBoolArg(pushUnhandledInputBind, handle, event?.requireOpenHandle() ?: MemorySegment.NULL, inLocalCoords)
+    fun pushUnhandledInput(event: InputEvent, inLocalCoords: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectAndBoolArg(pushUnhandledInputBind, handle, event.requireOpenHandle(), inLocalCoords)
     }
 
     fun notifyMouseEntered() {

--- a/scripts/audit_generator_object_policy.py
+++ b/scripts/audit_generator_object_policy.py
@@ -263,8 +263,8 @@ def _arg_meta(api_classes: dict, class_name: str, method_name: str, arg_name: st
 
 
 def check_object_param_nullability_policy(api_classes: dict) -> list[str]:
-    """Task 52a — prove the contextual object-parameter nullability policy and validate the override
-    table. Removing a policy branch, or leaving a stale/colliding override, fails here."""
+    """Task 52a/52b — prove the contextual object-parameter nullability policy and validate the
+    override table. Removing a policy branch, or leaving a stale/colliding override, fails here."""
     from generate_api_wrapper import NULLABLE_OBJECT_PARAM_OVERRIDES, object_param_is_nullable
 
     errs: list[str] = []
@@ -285,9 +285,9 @@ def check_object_param_nullability_policy(api_classes: dict) -> list[str]:
         ("Node", "set_owner", "owner", "Node", "", True, "audited override -> nullable"),
         ("Node", "add_child", "node", "Node", "required", False, "required ordinary Object -> non-null"),
         ("TextureRect", "set_texture", "texture", "Texture2D", "", True, "unmarked Resource -> nullable (legacy)"),
-        # 52a is non-breaking: a required Resource-like param STAYS nullable here; 52b tightens it to
-        # non-null by moving the `required` check above the resource-like line.
-        ("CanvasItem", "draw_texture", "texture", "Texture2D", "required", True, "required Resource -> still nullable in 52a"),
+        # 52b tightening: a required Resource-like param is now non-null (the `required` check sits
+        # above the resource-like line), calling requireOpenHandle() without a safe-call.
+        ("CanvasItem", "draw_texture", "texture", "Texture2D", "required", False, "required Resource -> non-null (52b)"),
     ]
     for class_name, method_name, arg_name, type_name, meta, expected, why in cases:
         actual = object_param_is_nullable(class_name, method_name, arg_name, type_name, meta, api_classes)

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -1720,20 +1720,22 @@ def object_param_is_nullable(
     Single decision point, consumed by both the type renderer and the marshalling so they cannot
     drift. Order matters:
 
-      1. resource-like (Resource/RefCounted-derived) -> nullable (existing legacy policy).
-      2. `meta: "required"` -> non-null. Godot's RequiredParam marker; an audited override cannot
-         beat it (a Godot upgrade marking an old override required must stop admitting null).
+      1. `meta: "required"` -> non-null. Godot's RequiredParam marker wins over everything,
+         including resource ancestry; an audited override cannot beat it (a Godot upgrade marking
+         an old override required must stop admitting null). This is the task-52b tightening.
+      2. resource-like (Resource/RefCounted-derived) -> nullable (existing legacy policy for
+         *unmarked* resource params).
       3. exact (class, method, arg) in NULLABLE_OBJECT_PARAM_OVERRIDES -> nullable (audited source).
       4. otherwise -> non-null (conservative legacy default).
 
-    Task 52a is intentionally non-breaking: resource-like stays nullable regardless of `required`.
-    Task 52b tightens by moving the `required` check ABOVE the resource-like line, turning the 65
-    explicitly-required resource-like parameters non-null (its own source-breaking change).
+    Task 52a kept resource-like nullable regardless of `required` (non-breaking). Task 52b moves
+    the `required` check ABOVE the resource-like line, turning the 65 explicitly-required
+    resource-like parameters non-null — a source-breaking narrowing of public signatures.
     """
-    if is_resource_like(type_name, api_classes):
-        return True
     if arg_meta == "required":
         return False
+    if is_resource_like(type_name, api_classes):
+        return True
     return (class_name, method_name, arg_name) in NULLABLE_OBJECT_PARAM_OVERRIDES
 
 

--- a/src/main/kotlin/net/multigesture/kanama/api/CanvasItem.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/CanvasItem.kt
@@ -586,8 +586,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_texture
      */
-    fun drawTexture(texture: Texture2D?, position: Vector2, modulate: Color) {
-        ObjectCalls.ptrcallWithObjectVector2AndColorArgs(drawTextureBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, position, modulate)
+    fun drawTexture(texture: Texture2D, position: Vector2, modulate: Color) {
+        ObjectCalls.ptrcallWithObjectVector2AndColorArgs(drawTextureBind, handle, texture.requireOpenHandle(), position, modulate)
     }
 
     /**
@@ -601,8 +601,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_texture_rect
      */
-    fun drawTextureRect(texture: Texture2D?, rect: Rect2, tile: Boolean, modulate: Color, transpose: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectRect2BoolColorBoolArgs(drawTextureRectBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, tile, modulate, transpose)
+    fun drawTextureRect(texture: Texture2D, rect: Rect2, tile: Boolean, modulate: Color, transpose: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectRect2BoolColorBoolArgs(drawTextureRectBind, handle, texture.requireOpenHandle(), rect, tile, modulate, transpose)
     }
 
     /**
@@ -616,8 +616,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_texture_rect_region
      */
-    fun drawTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color, transpose: Boolean = false, clipUv: Boolean = true) {
-        ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(drawTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate, transpose, clipUv)
+    fun drawTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color, transpose: Boolean = false, clipUv: Boolean = true) {
+        ObjectCalls.ptrcallWithObjectTwoRect2ColorTwoBoolArgs(drawTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate, transpose, clipUv)
     }
 
     /**
@@ -634,8 +634,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_msdf_texture_rect_region
      */
-    fun drawMsdfTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color, outline: Double = 0.0, pixelRange: Double = 4.0, scale: Double = 1.0) {
-        ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(drawMsdfTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate, outline, pixelRange, scale)
+    fun drawMsdfTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color, outline: Double = 0.0, pixelRange: Double = 4.0, scale: Double = 1.0) {
+        ObjectCalls.ptrcallWithObjectTwoRect2ColorThreeDoubleArgs(drawMsdfTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate, outline, pixelRange, scale)
     }
 
     /**
@@ -645,8 +645,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_lcd_texture_rect_region
      */
-    fun drawLcdTextureRectRegion(texture: Texture2D?, rect: Rect2, srcRect: Rect2, modulate: Color) {
-        ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(drawLcdTextureRectRegionBind, handle, texture?.requireOpenHandle() ?: MemorySegment.NULL, rect, srcRect, modulate)
+    fun drawLcdTextureRectRegion(texture: Texture2D, rect: Rect2, srcRect: Rect2, modulate: Color) {
+        ObjectCalls.ptrcallWithObjectTwoRect2AndColorArgs(drawLcdTextureRectRegionBind, handle, texture.requireOpenHandle(), rect, srcRect, modulate)
     }
 
     /**
@@ -658,8 +658,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_style_box
      */
-    fun drawStyleBox(styleBox: StyleBox?, rect: Rect2) {
-        ObjectCalls.ptrcallWithObjectAndRect2Arg(drawStyleBoxBind, handle, styleBox?.requireOpenHandle() ?: MemorySegment.NULL, rect)
+    fun drawStyleBox(styleBox: StyleBox, rect: Rect2) {
+        ObjectCalls.ptrcallWithObjectAndRect2Arg(drawStyleBoxBind, handle, styleBox.requireOpenHandle(), rect)
     }
 
     /**
@@ -723,8 +723,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_string
      */
-    fun drawString(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleArgs(drawStringBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, modulate, justificationFlags, direction, orientation, oversampling)
+    fun drawString(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleIntColorThreeLongDoubleArgs(drawStringBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, modulate, justificationFlags, direction, orientation, oversampling)
     }
 
     /**
@@ -736,8 +736,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_multiline_string
      */
-    fun drawMultilineString(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(drawMultilineStringBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, maxLines, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
+    fun drawMultilineString(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorFourLongDoubleArgs(drawMultilineStringBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, maxLines, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
     }
 
     /**
@@ -749,8 +749,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_string_outline
      */
-    fun drawStringOutline(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, size: Int = 1, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(drawStringOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, size, modulate, justificationFlags, direction, orientation, oversampling)
+    fun drawStringOutline(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, size: Int = 1, modulate: Color, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleTwoIntColorThreeLongDoubleArgs(drawStringOutlineBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, size, modulate, justificationFlags, direction, orientation, oversampling)
     }
 
     /**
@@ -762,8 +762,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_multiline_string_outline
      */
-    fun drawMultilineStringOutline(font: Font?, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, size: Int = 1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(drawMultilineStringOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, text, alignment, width, fontSize, maxLines, size, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
+    fun drawMultilineStringOutline(font: Font, pos: Vector2, text: String, alignment: Long = 0L, width: Double = -1.0, fontSize: Int = 16, maxLines: Int = -1, size: Int = 1, modulate: Color, brkFlags: Long = 3L, justificationFlags: Long = 3L, direction: Long = 0L, orientation: Long = 0L, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringLongDoubleThreeIntColorFourLongDoubleArgs(drawMultilineStringOutlineBind, handle, font.requireOpenHandle(), pos, text, alignment, width, fontSize, maxLines, size, modulate, brkFlags, justificationFlags, direction, orientation, oversampling)
     }
 
     /**
@@ -773,8 +773,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_char
      */
-    fun drawChar(font: Font?, pos: Vector2, char: String, fontSize: Int = 16, modulate: Color, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(drawCharBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, char, fontSize, modulate, oversampling)
+    fun drawChar(font: Font, pos: Vector2, char: String, fontSize: Int = 16, modulate: Color, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringIntColorDoubleArgs(drawCharBind, handle, font.requireOpenHandle(), pos, char, fontSize, modulate, oversampling)
     }
 
     /**
@@ -784,8 +784,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_char_outline
      */
-    fun drawCharOutline(font: Font?, pos: Vector2, char: String, fontSize: Int = 16, size: Int = -1, modulate: Color, oversampling: Double = 0.0) {
-        ObjectCalls.ptrcallWithObjectVector2StringTwoIntColorDoubleArgs(drawCharOutlineBind, handle, font?.requireOpenHandle() ?: MemorySegment.NULL, pos, char, fontSize, size, modulate, oversampling)
+    fun drawCharOutline(font: Font, pos: Vector2, char: String, fontSize: Int = 16, size: Int = -1, modulate: Color, oversampling: Double = 0.0) {
+        ObjectCalls.ptrcallWithObjectVector2StringTwoIntColorDoubleArgs(drawCharOutlineBind, handle, font.requireOpenHandle(), pos, char, fontSize, size, modulate, oversampling)
     }
 
     /**
@@ -798,8 +798,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_mesh
      */
-    fun drawMesh(mesh: Mesh?, texture: Texture2D?, transform: Transform2D, modulate: Color) {
-        ObjectCalls.ptrcallWithTwoObjectTransform2DColorArgs(drawMeshBind, handle, mesh?.requireOpenHandle() ?: MemorySegment.NULL, texture?.requireOpenHandle() ?: MemorySegment.NULL, transform, modulate)
+    fun drawMesh(mesh: Mesh, texture: Texture2D?, transform: Transform2D, modulate: Color) {
+        ObjectCalls.ptrcallWithTwoObjectTransform2DColorArgs(drawMeshBind, handle, mesh.requireOpenHandle(), texture?.requireOpenHandle() ?: MemorySegment.NULL, transform, modulate)
     }
 
     /**
@@ -811,8 +811,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.draw_multimesh
      */
-    fun drawMultimesh(multimesh: MultiMesh?, texture: Texture2D?) {
-        ObjectCalls.ptrcallWithTwoObjectArgs(drawMultimeshBind, handle, multimesh?.requireOpenHandle() ?: MemorySegment.NULL, texture?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun drawMultimesh(multimesh: MultiMesh, texture: Texture2D?) {
+        ObjectCalls.ptrcallWithTwoObjectArgs(drawMultimeshBind, handle, multimesh.requireOpenHandle(), texture?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     /**
@@ -1119,8 +1119,8 @@ open class CanvasItem(handle: MemorySegment) : Node(handle) {
      *
      * Generated from Godot docs: CanvasItem.make_input_local
      */
-    fun makeInputLocal(event: InputEvent?): InputEvent? {
-        return InputEvent.wrap(ObjectCalls.ptrcallWithObjectArgRetObject(makeInputLocalBind, handle, event?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun makeInputLocal(event: InputEvent): InputEvent? {
+        return InputEvent.wrap(ObjectCalls.ptrcallWithObjectArgRetObject(makeInputLocalBind, handle, event.requireOpenHandle()))
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/CollisionObject2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/CollisionObject2D.kt
@@ -343,8 +343,8 @@ open class CollisionObject2D(handle: MemorySegment) : Node2D(handle) {
      *
      * Generated from Godot docs: CollisionObject2D.shape_owner_add_shape
      */
-    fun shapeOwnerAddShape(ownerId: Long, shape: Shape2D?) {
-        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun shapeOwnerAddShape(ownerId: Long, shape: Shape2D) {
+        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape.requireOpenHandle())
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/CollisionObject3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/CollisionObject3D.kt
@@ -310,8 +310,8 @@ open class CollisionObject3D(handle: MemorySegment) : Node3D(handle) {
      *
      * Generated from Godot docs: CollisionObject3D.shape_owner_add_shape
      */
-    fun shapeOwnerAddShape(ownerId: Long, shape: Shape3D?) {
-        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun shapeOwnerAddShape(ownerId: Long, shape: Shape3D) {
+        ObjectCalls.ptrcallWithUInt32AndObjectArg(shapeOwnerAddShapeBind, handle, ownerId, shape.requireOpenHandle())
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/Control.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Control.kt
@@ -1292,8 +1292,8 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
      *
      * Generated from Godot docs: Control.add_theme_icon_override
      */
-    fun addThemeIconOverride(name: String, texture: Texture2D?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeIconOverrideBind, handle, name, texture?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeIconOverride(name: String, texture: Texture2D) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeIconOverrideBind, handle, name, texture.requireOpenHandle())
     }
 
     /**
@@ -1303,8 +1303,8 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
      *
      * Generated from Godot docs: Control.add_theme_stylebox_override
      */
-    fun addThemeStyleboxOverride(name: String, stylebox: StyleBox?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeStyleboxOverrideBind, handle, name, stylebox?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeStyleboxOverride(name: String, stylebox: StyleBox) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeStyleboxOverrideBind, handle, name, stylebox.requireOpenHandle())
     }
 
     /**
@@ -1314,8 +1314,8 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
      *
      * Generated from Godot docs: Control.add_theme_font_override
      */
-    fun addThemeFontOverride(name: String, font: Font?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeFontOverrideBind, handle, name, font?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun addThemeFontOverride(name: String, font: Font) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(addThemeFontOverrideBind, handle, name, font.requireOpenHandle())
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/Input.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Input.kt
@@ -228,8 +228,8 @@ object Input {
      * Generated from Godot docs: Input.is_action_just_pressed_by_event
      */
     @JvmStatic
-    fun isActionJustPressedByEvent(action: String, event: InputEvent?, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustPressedByEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL, exactMatch)
+    fun isActionJustPressedByEvent(action: String, event: InputEvent, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustPressedByEventBind, singleton, action, event.requireOpenHandle(), exactMatch)
     }
 
     /**
@@ -245,8 +245,8 @@ object Input {
      * Generated from Godot docs: Input.is_action_just_released_by_event
      */
     @JvmStatic
-    fun isActionJustReleasedByEvent(action: String, event: InputEvent?, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustReleasedByEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL, exactMatch)
+    fun isActionJustReleasedByEvent(action: String, event: InputEvent, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithStringNameObjectAndBoolArgRetBool(isActionJustReleasedByEventBind, singleton, action, event.requireOpenHandle(), exactMatch)
     }
 
     /**
@@ -1020,8 +1020,8 @@ object Input {
      * Generated from Godot docs: Input.parse_input_event
      */
     @JvmStatic
-    fun parseInputEvent(event: InputEvent?) {
-        ObjectCalls.ptrcallWithObjectArgs(parseInputEventBind, singleton, listOf(event?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun parseInputEvent(event: InputEvent) {
+        ObjectCalls.ptrcallWithObjectArgs(parseInputEventBind, singleton, listOf(event.requireOpenHandle()))
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/InputMap.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/InputMap.kt
@@ -90,8 +90,8 @@ object InputMap {
      * Generated from Godot docs: InputMap.action_add_event
      */
     @JvmStatic
-    fun actionAddEvent(action: String, event: InputEvent?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionAddEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionAddEvent(action: String, event: InputEvent) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionAddEventBind, singleton, action, event.requireOpenHandle())
     }
 
     /**
@@ -100,8 +100,8 @@ object InputMap {
      * Generated from Godot docs: InputMap.action_has_event
      */
     @JvmStatic
-    fun actionHasEvent(action: String, event: InputEvent?): Boolean {
-        return ObjectCalls.ptrcallWithStringNameAndObjectArgRetBool(actionHasEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionHasEvent(action: String, event: InputEvent): Boolean {
+        return ObjectCalls.ptrcallWithStringNameAndObjectArgRetBool(actionHasEventBind, singleton, action, event.requireOpenHandle())
     }
 
     /**
@@ -110,8 +110,8 @@ object InputMap {
      * Generated from Godot docs: InputMap.action_erase_event
      */
     @JvmStatic
-    fun actionEraseEvent(action: String, event: InputEvent?) {
-        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionEraseEventBind, singleton, action, event?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun actionEraseEvent(action: String, event: InputEvent) {
+        ObjectCalls.ptrcallWithStringNameAndObjectArg(actionEraseEventBind, singleton, action, event.requireOpenHandle())
     }
 
     /**
@@ -147,8 +147,8 @@ object InputMap {
      * Generated from Godot docs: InputMap.event_is_action
      */
     @JvmStatic
-    fun eventIsAction(event: InputEvent?, action: String, exactMatch: Boolean = false): Boolean {
-        return ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(eventIsActionBind, singleton, event?.requireOpenHandle() ?: MemorySegment.NULL, action, exactMatch)
+    fun eventIsAction(event: InputEvent, action: String, exactMatch: Boolean = false): Boolean {
+        return ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(eventIsActionBind, singleton, event.requireOpenHandle(), action, exactMatch)
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/OS.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/OS.kt
@@ -120,18 +120,17 @@ object OS {
         ObjectCalls.ptrcallNoArgs(closeMidiInputsBind, singleton)
     }
 
-    @JvmStatic
     /**
      * Displays a modal dialog box using the host platform's implementation. The engine execution is
      * blocked until the dialog is closed.
      *
      * Generated from Godot docs: OS.alert
      */
+    @JvmStatic
     fun alert(text: String, title: String = "Alert!") {
         ObjectCalls.ptrcallWithTwoStringArgs(alertBind, singleton, text, title)
     }
 
-    @JvmStatic
     /**
      * Crashes the engine (or the editor if called within a `@tool` script). See also `kill`. Note:
      * This method should only be used for testing the system's crash handler, not for any other
@@ -140,6 +139,7 @@ object OS {
      *
      * Generated from Godot docs: OS.crash
      */
+    @JvmStatic
     fun crash(message: String) {
         ObjectCalls.ptrcallWithStringArg(crashBind, singleton, message)
     }
@@ -375,7 +375,6 @@ object OS {
         return ObjectCalls.ptrcallNoArgsRetLong(getStderrTypeBind, singleton)
     }
 
-    @JvmStatic
     /**
      * Executes the given process in a blocking way. The file specified in `path` must exist and be
      * executable. The system path resolution will be used. The `arguments` are used in the given
@@ -391,6 +390,7 @@ object OS {
      *
      * Generated from Godot docs: OS.execute
      */
+    @JvmStatic
     fun execute(path: String, arguments: List<String>, output: List<Any?> = emptyList(), readStderr: Boolean = false, openConsole: Boolean = false): Int {
         return ObjectCalls.ptrcallWithStringPackedStringListArrayTwoBoolArgsRetInt(executeBind, singleton, path, arguments, output, readStderr, openConsole)
     }
@@ -468,7 +468,6 @@ object OS {
         return ObjectCalls.ptrcallWithStringAndPackedStringListArgRetLong(openWithProgramBind, singleton, programPath, paths)
     }
 
-    @JvmStatic
     /**
      * Kill (terminate) the process identified by the given process ID (`pid`), such as the ID returned
      * by `execute` in non-blocking mode. See also `crash`. Note: This method can also be used to kill
@@ -477,6 +476,7 @@ object OS {
      *
      * Generated from Godot docs: OS.kill
      */
+    @JvmStatic
     fun kill(pid: Int): Long {
         return ObjectCalls.ptrcallWithIntArgRetLong(killBind, singleton, pid)
     }
@@ -1207,8 +1207,8 @@ object OS {
      * Generated from Godot docs: OS.add_logger
      */
     @JvmStatic
-    fun addLogger(logger: Logger?) {
-        ObjectCalls.ptrcallWithObjectArgs(addLoggerBind, singleton, listOf(logger?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun addLogger(logger: Logger) {
+        ObjectCalls.ptrcallWithObjectArgs(addLoggerBind, singleton, listOf(logger.requireOpenHandle()))
     }
 
     /**
@@ -1217,8 +1217,8 @@ object OS {
      * Generated from Godot docs: OS.remove_logger
      */
     @JvmStatic
-    fun removeLogger(logger: Logger?) {
-        ObjectCalls.ptrcallWithObjectArgs(removeLoggerBind, singleton, listOf(logger?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun removeLogger(logger: Logger) {
+        ObjectCalls.ptrcallWithObjectArgs(removeLoggerBind, singleton, listOf(logger.requireOpenHandle()))
     }
 
     @JvmStatic

--- a/src/main/kotlin/net/multigesture/kanama/api/PhysicsDirectSpaceState2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/PhysicsDirectSpaceState2D.kt
@@ -22,8 +22,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.intersect_point
      */
-    fun intersectPoint(parameters: PhysicsPointQueryParameters2D?, maxResults: Int = 32): List<Map<String, Any?>> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectPointBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun intersectPoint(parameters: PhysicsPointQueryParameters2D, maxResults: Int = 32): List<Map<String, Any?>> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectPointBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -38,8 +38,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.intersect_ray
      */
-    fun intersectRay(parameters: PhysicsRayQueryParameters2D?): Map<String, Any?> {
-        return ObjectCalls.ptrcallWithObjectArgRetDictionary(intersectRayBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun intersectRay(parameters: PhysicsRayQueryParameters2D): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithObjectArgRetDictionary(intersectRayBind, handle, parameters.requireOpenHandle())
     }
 
     /**
@@ -52,8 +52,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.intersect_shape
      */
-    fun intersectShape(parameters: PhysicsShapeQueryParameters2D?, maxResults: Int = 32): List<Map<String, Any?>> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectShapeBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun intersectShape(parameters: PhysicsShapeQueryParameters2D, maxResults: Int = 32): List<Map<String, Any?>> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectShapeBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -68,8 +68,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.cast_motion
      */
-    fun castMotion(parameters: PhysicsShapeQueryParameters2D?): List<Float> {
-        return ObjectCalls.ptrcallWithObjectArgRetPackedFloat32List(castMotionBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun castMotion(parameters: PhysicsShapeQueryParameters2D): List<Float> {
+        return ObjectCalls.ptrcallWithObjectArgRetPackedFloat32List(castMotionBind, handle, parameters.requireOpenHandle())
     }
 
     /**
@@ -82,8 +82,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.collide_shape
      */
-    fun collideShape(parameters: PhysicsShapeQueryParameters2D?, maxResults: Int = 32): List<Vector2> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetVector2List(collideShapeBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun collideShape(parameters: PhysicsShapeQueryParameters2D, maxResults: Int = 32): List<Vector2> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetVector2List(collideShapeBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -98,8 +98,8 @@ open class PhysicsDirectSpaceState2D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState2D.get_rest_info
      */
-    fun getRestInfo(parameters: PhysicsShapeQueryParameters2D?): Map<String, Any?> {
-        return ObjectCalls.ptrcallWithObjectArgRetDictionary(getRestInfoBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun getRestInfo(parameters: PhysicsShapeQueryParameters2D): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithObjectArgRetDictionary(getRestInfoBind, handle, parameters.requireOpenHandle())
     }
 
     companion object {

--- a/src/main/kotlin/net/multigesture/kanama/api/PhysicsDirectSpaceState3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/PhysicsDirectSpaceState3D.kt
@@ -20,8 +20,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.intersect_point
      */
-    fun intersectPoint(parameters: PhysicsPointQueryParameters3D?, maxResults: Int = 32): List<Map<String, Any?>> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectPointBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun intersectPoint(parameters: PhysicsPointQueryParameters3D, maxResults: Int = 32): List<Map<String, Any?>> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectPointBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -37,8 +37,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.intersect_ray
      */
-    fun intersectRay(parameters: PhysicsRayQueryParameters3D?): Map<String, Any?> {
-        return ObjectCalls.ptrcallWithObjectArgRetDictionary(intersectRayBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun intersectRay(parameters: PhysicsRayQueryParameters3D): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithObjectArgRetDictionary(intersectRayBind, handle, parameters.requireOpenHandle())
     }
 
     /**
@@ -52,8 +52,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.intersect_shape
      */
-    fun intersectShape(parameters: PhysicsShapeQueryParameters3D?, maxResults: Int = 32): List<Map<String, Any?>> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectShapeBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun intersectShape(parameters: PhysicsShapeQueryParameters3D, maxResults: Int = 32): List<Map<String, Any?>> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetDictionaryList(intersectShapeBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -68,8 +68,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.cast_motion
      */
-    fun castMotion(parameters: PhysicsShapeQueryParameters3D?): List<Float> {
-        return ObjectCalls.ptrcallWithObjectArgRetPackedFloat32List(castMotionBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun castMotion(parameters: PhysicsShapeQueryParameters3D): List<Float> {
+        return ObjectCalls.ptrcallWithObjectArgRetPackedFloat32List(castMotionBind, handle, parameters.requireOpenHandle())
     }
 
     /**
@@ -83,8 +83,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.collide_shape
      */
-    fun collideShape(parameters: PhysicsShapeQueryParameters3D?, maxResults: Int = 32): List<Vector3> {
-        return ObjectCalls.ptrcallWithObjectAndIntArgRetVector3List(collideShapeBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL, maxResults)
+    fun collideShape(parameters: PhysicsShapeQueryParameters3D, maxResults: Int = 32): List<Vector3> {
+        return ObjectCalls.ptrcallWithObjectAndIntArgRetVector3List(collideShapeBind, handle, parameters.requireOpenHandle(), maxResults)
     }
 
     /**
@@ -100,8 +100,8 @@ open class PhysicsDirectSpaceState3D(handle: MemorySegment) : GodotObject(handle
      *
      * Generated from Godot docs: PhysicsDirectSpaceState3D.get_rest_info
      */
-    fun getRestInfo(parameters: PhysicsShapeQueryParameters3D?): Map<String, Any?> {
-        return ObjectCalls.ptrcallWithObjectArgRetDictionary(getRestInfoBind, handle, parameters?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun getRestInfo(parameters: PhysicsShapeQueryParameters3D): Map<String, Any?> {
+        return ObjectCalls.ptrcallWithObjectArgRetDictionary(getRestInfoBind, handle, parameters.requireOpenHandle())
     }
 
     companion object {

--- a/src/main/kotlin/net/multigesture/kanama/api/PhysicsServer2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/PhysicsServer2D.kt
@@ -1238,8 +1238,8 @@ object PhysicsServer2D {
      * Generated from Godot docs: PhysicsServer2D.body_test_motion
      */
     @JvmStatic
-    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters2D?, result: PhysicsTestMotionResult2D?): Boolean {
-        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters?.requireOpenHandle() ?: MemorySegment.NULL, result?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters2D, result: PhysicsTestMotionResult2D?): Boolean {
+        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters.requireOpenHandle(), result?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/PhysicsServer3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/PhysicsServer3D.kt
@@ -1272,8 +1272,8 @@ object PhysicsServer3D {
      * Generated from Godot docs: PhysicsServer3D.body_test_motion
      */
     @JvmStatic
-    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters3D?, result: PhysicsTestMotionResult3D?): Boolean {
-        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters?.requireOpenHandle() ?: MemorySegment.NULL, result?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun bodyTestMotion(body: RID, parameters: PhysicsTestMotionParameters3D, result: PhysicsTestMotionResult3D?): Boolean {
+        return ObjectCalls.ptrcallWithRIDAndTwoObjectArgsRetBool(bodyTestMotionBind, singleton, body, parameters.requireOpenHandle(), result?.requireOpenHandle() ?: MemorySegment.NULL)
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/ResourceSaver.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ResourceSaver.kt
@@ -22,7 +22,6 @@ object ResourceSaver {
     const val FLAG_COMPRESS: Long = 32L
     const val FLAG_REPLACE_SUBRESOURCE_PATHS: Long = 64L
 
-    @JvmStatic
     /**
      * Saves a resource to disk to the given path, using a `ResourceFormatSaver` that recognizes the
      * resource object. If `path` is empty, `ResourceSaver` will try to use `Resource.resource_path`.
@@ -32,8 +31,9 @@ object ResourceSaver {
      *
      * Generated from Godot docs: ResourceSaver.save
      */
-    fun save(resource: Resource?, path: String = "", flags: Long = 0L): Long {
-        return ObjectCalls.ptrcallWithObjectStringLongArgsRetLong(saveBind, singleton, resource?.requireOpenHandle() ?: MemorySegment.NULL, path, flags)
+    @JvmStatic
+    fun save(resource: Resource, path: String = "", flags: Long = 0L): Long {
+        return ObjectCalls.ptrcallWithObjectStringLongArgsRetLong(saveBind, singleton, resource.requireOpenHandle(), path, flags)
     }
 
     /**
@@ -54,8 +54,8 @@ object ResourceSaver {
      * Generated from Godot docs: ResourceSaver.get_recognized_extensions
      */
     @JvmStatic
-    fun getRecognizedExtensions(type: Resource?): List<String> {
-        return ObjectCalls.ptrcallWithObjectArgRetPackedStringList(getRecognizedExtensionsBind, singleton, type?.requireOpenHandle() ?: MemorySegment.NULL)
+    fun getRecognizedExtensions(type: Resource): List<String> {
+        return ObjectCalls.ptrcallWithObjectArgRetPackedStringList(getRecognizedExtensionsBind, singleton, type.requireOpenHandle())
     }
 
     /**
@@ -66,8 +66,8 @@ object ResourceSaver {
      * Generated from Godot docs: ResourceSaver.add_resource_format_saver
      */
     @JvmStatic
-    fun addResourceFormatSaver(formatSaver: ResourceFormatSaver?, atFront: Boolean = false) {
-        ObjectCalls.ptrcallWithObjectAndBoolArg(addResourceFormatSaverBind, singleton, formatSaver?.requireOpenHandle() ?: MemorySegment.NULL, atFront)
+    fun addResourceFormatSaver(formatSaver: ResourceFormatSaver, atFront: Boolean = false) {
+        ObjectCalls.ptrcallWithObjectAndBoolArg(addResourceFormatSaverBind, singleton, formatSaver.requireOpenHandle(), atFront)
     }
 
     /**
@@ -76,8 +76,8 @@ object ResourceSaver {
      * Generated from Godot docs: ResourceSaver.remove_resource_format_saver
      */
     @JvmStatic
-    fun removeResourceFormatSaver(formatSaver: ResourceFormatSaver?) {
-        ObjectCalls.ptrcallWithObjectArgs(removeResourceFormatSaverBind, singleton, listOf(formatSaver?.requireOpenHandle() ?: MemorySegment.NULL))
+    fun removeResourceFormatSaver(formatSaver: ResourceFormatSaver) {
+        ObjectCalls.ptrcallWithObjectArgs(removeResourceFormatSaverBind, singleton, listOf(formatSaver.requireOpenHandle()))
     }
 
     /**

--- a/src/main/kotlin/net/multigesture/kanama/api/Shape2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Shape2D.kt
@@ -50,8 +50,8 @@ open class Shape2D(handle: MemorySegment) : Resource(handle) {
      *
      * Generated from Godot docs: Shape2D.collide
      */
-    fun collide(localXform: Transform2D, withShape: Shape2D?, shapeXform: Transform2D): Boolean {
-        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(collideBind, handle, localXform, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform)
+    fun collide(localXform: Transform2D, withShape: Shape2D, shapeXform: Transform2D): Boolean {
+        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetBool(collideBind, handle, localXform, withShape.requireOpenHandle(), shapeXform)
     }
 
     /**
@@ -63,8 +63,8 @@ open class Shape2D(handle: MemorySegment) : Resource(handle) {
      *
      * Generated from Godot docs: Shape2D.collide_with_motion
      */
-    fun collideWithMotion(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D?, shapeXform: Transform2D, shapeMotion: Vector2): Boolean {
-        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool(collideWithMotionBind, handle, localXform, localMotion, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform, shapeMotion)
+    fun collideWithMotion(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D, shapeXform: Transform2D, shapeMotion: Vector2): Boolean {
+        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetBool(collideWithMotionBind, handle, localXform, localMotion, withShape.requireOpenHandle(), shapeXform, shapeMotion)
     }
 
     /**
@@ -79,8 +79,8 @@ open class Shape2D(handle: MemorySegment) : Resource(handle) {
      *
      * Generated from Godot docs: Shape2D.collide_and_get_contacts
      */
-    fun collideAndGetContacts(localXform: Transform2D, withShape: Shape2D?, shapeXform: Transform2D): List<Vector2> {
-        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetPackedVector2List(collideAndGetContactsBind, handle, localXform, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform)
+    fun collideAndGetContacts(localXform: Transform2D, withShape: Shape2D, shapeXform: Transform2D): List<Vector2> {
+        return ObjectCalls.ptrcallWithTransform2DObjectTransform2DArgsRetPackedVector2List(collideAndGetContactsBind, handle, localXform, withShape.requireOpenHandle(), shapeXform)
     }
 
     /**
@@ -97,8 +97,8 @@ open class Shape2D(handle: MemorySegment) : Resource(handle) {
      *
      * Generated from Godot docs: Shape2D.collide_with_motion_and_get_contacts
      */
-    fun collideWithMotionAndGetContacts(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D?, shapeXform: Transform2D, shapeMotion: Vector2): List<Vector2> {
-        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetPackedVector2List(collideWithMotionAndGetContactsBind, handle, localXform, localMotion, withShape?.requireOpenHandle() ?: MemorySegment.NULL, shapeXform, shapeMotion)
+    fun collideWithMotionAndGetContacts(localXform: Transform2D, localMotion: Vector2, withShape: Shape2D, shapeXform: Transform2D, shapeMotion: Vector2): List<Vector2> {
+        return ObjectCalls.ptrcallWithTransform2DVector2ObjectTransform2DVector2ArgsRetPackedVector2List(collideWithMotionAndGetContactsBind, handle, localXform, localMotion, withShape.requireOpenHandle(), shapeXform, shapeMotion)
     }
 
     /**


### PR DESCRIPTION
## What

Completes task 52 (52a landed the policy in #66). **Source-breaking:** object parameters Godot 4.7 explicitly marks `meta: "required"` now generate **non-null**, including the 65 Resource/RefCounted-derived required arguments that were previously nullable.

52a intentionally kept resource-like params nullable regardless of `required` (non-breaking). 52b moves the `required` check **above** the resource-like line in `object_param_is_nullable` — a 2-line reorder — so e.g. `ResourceSaver.save(resource: Resource, …)` and `CanvasItem.drawTexture(texture: Texture2D, …)` no longer accept `null` and marshal via `requireOpenHandle()` without a safe-call. A call site passing `null` there now fails to compile, which is the honest contract (the engine rejects null).

## Scope

- Unmarked legacy Resource params **stay nullable**; the audited `NULLABLE_OBJECT_PARAM_OVERRIDES` (`Node.set_owner`) keep their null.
- Regenerated wrappers: 13 desktop + 12 iOS — `CanvasItem`, `Control`, `CollisionObject2D/3D`, `Input`, `InputMap`, `OS`, `PhysicsServer2D/3D`, `PhysicsDirectSpaceState2D/3D`, `ResourceSaver`, `Shape2D`, `Viewport`.
- Policy locked by the 4-case test in `audit_generator_object_policy.py` (required-Resource case now expects non-null).

## Verification

- `audit_generator_object_policy.py` PASS
- Drift gate PASS (desktop 988 + iOS 1013)
- `./gradlew jar` — no example-project callers break (all pass non-null)
- `compileKotlinIosArm64` clean
- Full `local_ci` PASS

## Notes

- **Companion demos** live in separate repos — this is source-breaking, so rebuild them if any pass `null` to a now-required param (rare in practice).
- **Follow-up (separate):** the ktfmt rollout (#69) left `ObjectCallsGenerated.kt` generated-but-not-ktfmt-excluded, so `upgrade_godot.sh`'s re-adopt needs a `ktfmtFormat` step (or exclude that file) to avoid tripping `ktfmtCheck` on a future Godot bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
