### PR TITLE
Fix iOS bunnymark probe double-package compile break (task 58)

### DIFF
--- a/scripts/ios_visual_smoke.sh
+++ b/scripts/ios_visual_smoke.sh
@@ -982,7 +982,11 @@ elif [[ "$kanama_bunnymark_probe" -eq 1 ]]; then
   mkdir -p "$project_dir/kotlin-src" "$project_dir/images"
   cp "$bunnymark_demo_dir/images/godot_bunny.png" "$project_dir/images/godot_bunny.png"
   cp "$bunnymark_demo_dir/kotlin-src/BunnymarkV1SpritesKanama.kt" "$project_dir/kotlin-src/BunnymarkV1SpritesKanama.kt"
-  perl -0pi -e 's/\A/package net.multigesture.kanama.iosbunnymark\n\n/' \
+  # Replace the demo's own leading `package …` (the demo source declares
+  # `package net.multigesture.kanama.demos.bunnymark`) with the iOS package the generated .tscn
+  # and iOS registration expect — do NOT prepend, or two package declarations become a syntax
+  # error. The optional group also handles a demo source that carries no package line.
+  perl -0pi -e 's/\A(\s*package[^\n]*\n)?/package net.multigesture.kanama.iosbunnymark\n\n/' \
     "$project_dir/kotlin-src/BunnymarkV1SpritesKanama.kt"
   perl -0pi -e 's/(private var bunnyTexture: Texture2D\? = null\n)/$1    private var frame = 0\n/' \
     "$project_dir/kotlin-src/BunnymarkV1SpritesKanama.kt"


### PR DESCRIPTION
## What

`ios_visual_smoke.sh --kanama-bunnymark-probe` copied the demo's `BunnymarkV1SpritesKanama.kt` and **prepended** `package net.multigesture.kanama.iosbunnymark`. The demo source already declares `package net.multigesture.kanama.demos.bunnymark`, so the file ended with **two package declarations** → Kotlin/Native syntax error at compile, before install/launch. (Found while device-testing task 55.)

## Fix

Replace the leading `package …` line instead of prepending a second one (the optional group also handles a source with no package). Only the bunnymark probe used the `\A` prepend — the other demo probes generate self-contained scripts inline and are unaffected.

## Verified on iPhone 15 Pro

- The script compiles into the iOS Kotlin/Native runtime (`** BUILD SUCCEEDED **`, no double-package error).
- The run passes with the loader log **and** the bunnymark probe assertion captured on-device:
  ```
  [ios_visual_smoke] Kanama iOS loader log detected in stderr
  [ios_visual_smoke] Bunnymark add/process/finish/signal logs detected
  [ios_visual_smoke] OK
  ```
  — the per-demo assertion that task 55 (#76) enabled on the physical path.

`bash -n` clean; change is confined to `scripts/ios_visual_smoke.sh` (one perl substitution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)