### PR TITLE
Make kanama_tools GDScript warning-clean for the Asset Store (task 45a)

### DIFF
--- a/example_project/addons/kanama_tools/kotlin_syntax_highlighter.gd
+++ b/example_project/addons/kanama_tools/kotlin_syntax_highlighter.gd
@@ -211,7 +211,7 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
         if _is_identifier_start(ch):
             var end := _consume_identifier(text, i)
             var word := text.substr(i, end - i)
-            var color := _color_for_identifier(word, text, end)
+            var color: Variant = _color_for_identifier(word, text, end)
             if color != null:
                 _set_color(result, i, color)
                 _set_color(result, end, _text_color)


### PR DESCRIPTION
## What

Task 45a — the codeable Asset Store submission prep. Investigating it revealed most of the prep was **already in place**, so this is a one-line fix:

- ✅ **JDK-25 editor preflight** already exists (`_run_java_preflight` — detects `libjvm` via `JAVA_HOME`/fallbacks, shows a clear *"Install a JDK 25+ … set JAVA_HOME"* dialog). Verified working.
- ✅ **LICENSE/README** already shipped in the store addon (`packageStoreAddon` → `addons/kanama` + `addons/kanama_tools`).
- ⚠️ **GDScript warnings** — one real warning found and fixed here.

## The fix

`kotlin_syntax_highlighter.gd:214` used `var color := _color_for_identifier(...)`, inferring the type from the function's `Variant` return (INFERRED_DECLARATION warning). Godot excludes addon scripts from warnings by default so it never surfaced in-project, but the Asset Store requires the plugin be warning-clean. Declared `color` explicitly as `Variant` (semantically identical — the function returns a `Color` or `null`).

## Verification

- With `debug/gdscript/warnings/exclude_addons=false`, `plugin.gd` + `kotlin_syntax_highlighter.gd` now emit **zero** warnings, and the plugin loads (preflight runs: `Java runtime preflight ok`).
- `tool_smoke` **PASS** (plugin/highlighter still functions).

Docs already cover the preflight (`editor-workflow.md`, `desktop.md`, `release-kit.md`), so no docs change. **45b** (the actual store listing/upload) remains maintainer-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)