### PR TITLE
Fix intermittent native smoke crash during varcall initialization

### DIFF
--- a/scripts/hot_reload_in_process_smoke.sh
+++ b/scripts/hot_reload_in_process_smoke.sh
@@ -4,11 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_DIR="$ROOT_DIR/example_project"
 SCRIPT_FILE="$PROJECT_DIR/HelloScript.kt"
-LOG_FILE="${KANAMA_HOTRELOAD_IN_PROCESS_LOG:-/tmp/kanama_hot_reload_in_process.log}"
 
 if [[ $# -lt 1 ]]; then
   echo "usage: $0 /absolute/path/to/godot_binary"
   exit 2
+fi
+
+if [[ -n "${KANAMA_HOTRELOAD_IN_PROCESS_LOG:-}" ]]; then
+  LOG_FILE="$KANAMA_HOTRELOAD_IN_PROCESS_LOG"
+else
+  LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/kanama_hot_reload_in_process.XXXXXX.log")"
 fi
 
 GODOT_BIN="$1"
@@ -25,7 +30,9 @@ esac
 BACKUP="$(mktemp /tmp/kanama_hello_backup.XXXXXX.kt)"
 SIGNAL_FILE="$(mktemp /tmp/kanama_hot_reload_signal.XXXXXX)"
 STAGE_FILE="$(mktemp /tmp/kanama_hot_reload_stage.XXXXXX)"
-rm -f "$SIGNAL_FILE" "$STAGE_FILE" "$LOG_FILE"
+rm -f "$SIGNAL_FILE" "$STAGE_FILE"
+: >"$LOG_FILE"
+echo "[hot_reload_in_process_smoke] full log: $LOG_FILE"
 cp "$SCRIPT_FILE" "$BACKUP"
 
 GODOT_PID=""

--- a/src/main/kotlin/KanamaBinding.kt
+++ b/src/main/kotlin/KanamaBinding.kt
@@ -16,6 +16,7 @@ import net.multigesture.kanama.binding.KanamaScript
 import net.multigesture.kanama.binding.KanamaScriptLanguage
 import net.multigesture.kanama.binding.runtime.ClassDB
 import net.multigesture.kanama.binding.runtime.GodotStrings
+import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.ffi.GodotFFI
 
 /**
@@ -44,6 +45,7 @@ object KanamaBinding {
         "${version.major}.${version.minor}.${version.patch} (${version.string})"
     )
 
+    ObjectCalls.prewarmVarcallDowncall()
     installInitCallbacks(initPtr)
   }
 

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -156,6 +156,18 @@ object ObjectCalls {
     )
   }
 
+  /**
+   * Creates the six-argument varcall downcall stub while bootstrap is still running through JNI.
+   *
+   * On macOS/AArch64, asking HotSpot to generate this native-entry-point blob for the first time
+   * from inside an FFM upcall can race the thread-local JIT W^X transition. The first generic
+   * `Object.call` normally reaches that path from a script notification. Resolve the handle before
+   * Kanama installs its lifecycle upcalls so later calls only execute an existing blob.
+   */
+  internal fun prewarmVarcallDowncall() {
+    objectMethodBindCall.type()
+  }
+
   private val objectDestroy by lazy {
     GodotFFI.lookup("object_destroy", FunctionDescriptor.ofVoid(ADDRESS))
   }


### PR DESCRIPTION
## Summary

- preserve a unique full log for every in-process hot-reload smoke invocation
- initialize the generic varcall native adapter during JNI bootstrap
- ensure lifecycle callbacks never trigger first-time adapter creation from inside an FFM upcall

## Root cause

The first generic `GodotObject.call` lazily created the six-argument
`object_method_bind_call` adapter while execution was already inside a Godot-to-JVM
upcall. On macOS ARM64, the adapter-generation timing matched all preserved crash
reports. Prewarming the adapter before installing lifecycle callbacks moves that work
to the safe bootstrap path without changing the ABI, retrying, or adding a delay.

Instrumented ordering changed from the adapter first being generated at the historical
crash window inside a script notification to being generated before the first lifecycle
upcall was installed.

## Validation

- `./gradlew jar` — PASS
- `./gradlew ktfmtCheck` — PASS
- `./scripts/local_ci.sh <godot-4.7>` — PASS
- macOS ARM64 in-process hot-reload stress — 30/30 PASS
- Linux ARM64, Temurin 25.0.3+9, Godot 4.7 stable — 30/30 PASS

## Limitation

Reverting the fix restores the original lazy ordering, but the historical baseline
stopped reproducing the intermittent crash during bounded reruns. The original crash
reports remain the direct failure evidence; this PR does not claim that the negative
reproduction gate passed.
