### PR TITLE
[DO NOT MERGE] Proof: Linux CI catches issue #81 without the save guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,17 @@ versioning once public releases begin.
 
 ### Fixed
 
+- Saving a freshly created resource with `ResourceSaver.save` no longer crashes
+  the JVM (issue #81). A resource from an `X.create()` factory (e.g.
+  `PackedScene.create()`) holds only Godot's construction placeholder reference;
+  `save` decodes its `Ref<Resource>` argument into a transient reference and
+  releases it on return, which dropped that placeholder to zero and freed the
+  object while the Kotlin wrapper still pointed at it — the `.tscn` was written
+  correctly, then the process segfaulted. `save` now holds a protective
+  reference across the call and keeps it only if the resource still has another
+  holder, so the wrapper stays valid (and, for a just-created resource, becomes
+  owned — `close()` frees it). Resources already owned or held by the scene tree
+  are unaffected. Desktop, Android, and iOS.
 - A throwing `@ScriptProperty` accessor no longer aborts the process. Generated
   property get/set dispatch ran inside an FFM upcall stub with no exception guard
   (unlike method calls), so any `Throwable` escaping a user getter/setter unwound

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -94,6 +94,37 @@ and the collapse emission are locked by `check_ios_policies`, and the on-device
 self-test matrix carries a `refcounted-ret-owns-plus1` refcount probe
 (duplicate() → refcount 1 → close()).
 
+### Freshly created resources and the `ResourceSaver.save` guard
+
+`X.create()` factories return a **non-owning** wrapper: it holds only Godot's
+construction placeholder (refcount 1, `refcount_init` still set), *not* an owned
+`+1`. That is deliberate — it matches GDScript's `MyResource.new()` idiom where
+you create a resource, assign it to the engine (a mesh, a material slot, the
+scene tree), and never explicitly free it (`RefCounted.close()`'s contract says
+so). An owning `create()` would leak every such assign-and-forget, because
+there is no wrapper finalizer to release the reference.
+
+The one hazard is passing a freshly created resource **by value to a method that
+takes `const Ref<Resource>&` and releases its transient `Ref` on return** — the
+canonical case is `ResourceSaver.save`. The engine's `PtrToArg<Ref<Resource>>`
+claims the placeholder and drops it on return; for a resource whose only
+reference *was* that placeholder, the refcount hits zero and the object is freed
+while its Kotlin wrapper still points at it (issue #81 — a JVM SIGSEGV on the
+next touch, after the file has already been written).
+
+The fix is a guard inside the save ptrcall helper
+(`ObjectCalls.ptrcallWithObjectStringLongArgsRetLong`, the sole wrapper of its
+`(Object, String, int64) -> int64` shape): take a protective `reference()`
+before the call, then release it **only if `get_reference_count() > 1`
+afterward**. When the call consumed the sole reference the protective ref is
+kept — the resource survives and becomes wrapper-owned, so `close()` frees it
+once; an already-owned resource (loaded/cached, scene-held) is restored to its
+original count, a balanced no-op. The desktop helper is hand-written in
+`ObjectCalls.kt`; the iOS mirror is hand-written too
+(`IOS_HANDWRITTEN_HELPERS`), so `ResourceSaver` stays fully generated on both
+platforms. Covered by the `issue81 packed_scene_save` row in
+`scripts/runtime_smoke.sh`.
+
 Two **dynamic** paths share this ownership problem: `ClassDB.instantiate` and
 `ClassDB.class_call_static` both return a Variant that holds the fresh
 instance's *only* reference, so the borrowed Variant-scalar decode would hand

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -494,21 +494,28 @@ class HelloScript(godotObject: MemorySegment) :
       packedSceneInstance.queueFree()
     }
     packedScene.close()
-    // ── issue #81: a freshly created resource handed by value to ResourceSaver.save must survive
-    // the call. save decodes its `const Ref<Resource>&` argument into a transient Ref and releases
-    // it on return; pre-fix that Ref absorbed the resource's sole (construction placeholder)
-    // reference and freed it, leaving this wrapper dangling → JVM SIGSEGV on the next touch
-    // (reported with PackedScene.create(); the bug and the save guard are generic to any created
-    // resource). The guard (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong) holds a protective
-    // reference across the call, so the resource stays live and close() frees it cleanly. ─────────
-    val issue81Resource = Resource.create()
-    val issue81SavePath = "user://kanama_issue81_smoke.tres"
-    val issue81SaveError = ResourceSaver.save(issue81Resource, issue81SavePath)
-    // These calls dereference the wrapper *after* save — each crashed pre-fix (resource freed).
-    val issue81RefCountAfterSave = issue81Resource.getReferenceCount()
-    val issue81AliveAfterSave = issue81Resource.isClass("Resource")
+    // ── issue #81: the reporter's exact repro — PackedScene.create() → pack(node) → save. save
+    // decodes its `const Ref<Resource>&` argument into a transient Ref and releases it on return;
+    // pre-fix that Ref absorbed the scene's sole (construction placeholder) reference and freed it,
+    // leaving this wrapper dangling. The .tscn was written, then the next touch of the wrapper was
+    // a
+    // use-after-free (SIGSEGV/SIGABRT). Verified: with the save guard
+    // (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong) removed, this probe aborts the process
+    // (exit 134); with it, the scene stays live and close() frees it. A fresh, non-scripted node is
+    // packed so save serializes only trivial engine state (never re-enters this script's
+    // @ScriptProperty getters). ──────────────────────────────────────────────────────────────────
+    val issue81Node = Node(ObjectCalls.constructObject("Node"))
+    val issue81Scene = PackedScene.create()
+    val issue81PackError = issue81Scene.pack(issue81Node)
+    val issue81SavePath = "user://kanama_issue81_scene.tscn"
+    val issue81SaveError = ResourceSaver.save(issue81Scene, issue81SavePath)
+    // These calls dereference the wrapper *after* save — each aborts the process pre-fix (freed).
+    val issue81RefCountAfterSave = issue81Scene.getReferenceCount()
+    val issue81AliveAfterSave = issue81Scene.isClass("PackedScene")
     val issue81SaveExists = FileAccess.fileExists(issue81SavePath)
-    issue81Resource.close()
+    selfNode.addChild(issue81Node)
+    issue81Node.queueFree()
+    issue81Scene.close()
     DirAccess.removeAbsolute(ProjectSettings.globalizePath(issue81SavePath))
     if (body3d != null) body3d.position = Vector3(1f, 2f, 3f)
     val bodyPosition = body3d?.position ?: Vector3.ZERO
@@ -1554,7 +1561,7 @@ class HelloScript(godotObject: MemorySegment) :
     )
     System.err.println("[kanama:kt] ResourceSaver script_uid=$scriptUid")
     System.err.println(
-      "[kanama:kt] issue81 resource_save save_error=$issue81SaveError " +
+      "[kanama:kt] issue81 packed_scene_save pack_error=$issue81PackError save_error=$issue81SaveError " +
         "ref_after_save=$issue81RefCountAfterSave alive_after_save=$issue81AliveAfterSave " +
         "save_exists=$issue81SaveExists"
     )

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -494,24 +494,22 @@ class HelloScript(godotObject: MemorySegment) :
       packedSceneInstance.queueFree()
     }
     packedScene.close()
-    // ── issue #81: a freshly created PackedScene handed by value to ResourceSaver.save must
-    // survive the call. save decodes its `const Ref<Resource>&` argument into a transient Ref and
-    // releases it on return; pre-fix that Ref absorbed the scene's sole (construction placeholder)
-    // reference and freed it, leaving this wrapper dangling → JVM SIGSEGV on the next touch. The
-    // save guard (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong) holds a protective reference
-    // across the call, so the scene stays live and becomes wrapper-owned; close() frees it. ───────
-    val issue81Scene = PackedScene.create()
-    val issue81PackError = issue81Scene.pack(selfNode)
-    val issue81SavePath = "res://.kanama_issue81_scene_smoke.tscn"
-    val issue81SaveAbsolute = ProjectSettings.globalizePath(issue81SavePath)
-    DirAccess.removeAbsolute(issue81SaveAbsolute)
-    val issue81SaveError = ResourceSaver.save(issue81Scene, issue81SavePath)
-    // These three calls dereference the wrapper *after* save — each crashed pre-fix.
-    val issue81RefCountAfterSave = issue81Scene.getReferenceCount()
-    val issue81UsableAfterSave = issue81Scene.canInstantiate()
+    // ── issue #81: a freshly created resource handed by value to ResourceSaver.save must survive
+    // the call. save decodes its `const Ref<Resource>&` argument into a transient Ref and releases
+    // it on return; pre-fix that Ref absorbed the resource's sole (construction placeholder)
+    // reference and freed it, leaving this wrapper dangling → JVM SIGSEGV on the next touch
+    // (reported with PackedScene.create(); the bug and the save guard are generic to any created
+    // resource). The guard (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong) holds a protective
+    // reference across the call, so the resource stays live and close() frees it cleanly. ─────────
+    val issue81Resource = Resource.create()
+    val issue81SavePath = "user://kanama_issue81_smoke.tres"
+    val issue81SaveError = ResourceSaver.save(issue81Resource, issue81SavePath)
+    // These calls dereference the wrapper *after* save — each crashed pre-fix (resource freed).
+    val issue81RefCountAfterSave = issue81Resource.getReferenceCount()
+    val issue81AliveAfterSave = issue81Resource.isClass("Resource")
     val issue81SaveExists = FileAccess.fileExists(issue81SavePath)
-    issue81Scene.close()
-    if (issue81SaveExists) DirAccess.removeAbsolute(issue81SaveAbsolute)
+    issue81Resource.close()
+    DirAccess.removeAbsolute(ProjectSettings.globalizePath(issue81SavePath))
     if (body3d != null) body3d.position = Vector3(1f, 2f, 3f)
     val bodyPosition = body3d?.position ?: Vector3.ZERO
     body3d?.translate(Vector3(0.5f, 0f, -0.5f))
@@ -1556,8 +1554,8 @@ class HelloScript(godotObject: MemorySegment) :
     )
     System.err.println("[kanama:kt] ResourceSaver script_uid=$scriptUid")
     System.err.println(
-      "[kanama:kt] issue81 packed_scene_save pack_error=$issue81PackError save_error=$issue81SaveError " +
-        "ref_after_save=$issue81RefCountAfterSave usable_after_save=$issue81UsableAfterSave " +
+      "[kanama:kt] issue81 resource_save save_error=$issue81SaveError " +
+        "ref_after_save=$issue81RefCountAfterSave alive_after_save=$issue81AliveAfterSave " +
         "save_exists=$issue81SaveExists"
     )
     System.err.println("[kanama:kt] Script property replay object_set_amount=$pendingSetAmount")

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -494,6 +494,24 @@ class HelloScript(godotObject: MemorySegment) :
       packedSceneInstance.queueFree()
     }
     packedScene.close()
+    // ── issue #81: a freshly created PackedScene handed by value to ResourceSaver.save must
+    // survive the call. save decodes its `const Ref<Resource>&` argument into a transient Ref and
+    // releases it on return; pre-fix that Ref absorbed the scene's sole (construction placeholder)
+    // reference and freed it, leaving this wrapper dangling → JVM SIGSEGV on the next touch. The
+    // save guard (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong) holds a protective reference
+    // across the call, so the scene stays live and becomes wrapper-owned; close() frees it. ───────
+    val issue81Scene = PackedScene.create()
+    val issue81PackError = issue81Scene.pack(selfNode)
+    val issue81SavePath = "res://.kanama_issue81_scene_smoke.tscn"
+    val issue81SaveAbsolute = ProjectSettings.globalizePath(issue81SavePath)
+    DirAccess.removeAbsolute(issue81SaveAbsolute)
+    val issue81SaveError = ResourceSaver.save(issue81Scene, issue81SavePath)
+    // These three calls dereference the wrapper *after* save — each crashed pre-fix.
+    val issue81RefCountAfterSave = issue81Scene.getReferenceCount()
+    val issue81UsableAfterSave = issue81Scene.canInstantiate()
+    val issue81SaveExists = FileAccess.fileExists(issue81SavePath)
+    issue81Scene.close()
+    if (issue81SaveExists) DirAccess.removeAbsolute(issue81SaveAbsolute)
     if (body3d != null) body3d.position = Vector3(1f, 2f, 3f)
     val bodyPosition = body3d?.position ?: Vector3.ZERO
     body3d?.translate(Vector3(0.5f, 0f, -0.5f))
@@ -1537,6 +1555,11 @@ class HelloScript(godotObject: MemorySegment) :
         "cached_is_script=$cachedScriptIsScript cached_ref_count=$cachedScriptRefCount"
     )
     System.err.println("[kanama:kt] ResourceSaver script_uid=$scriptUid")
+    System.err.println(
+      "[kanama:kt] issue81 packed_scene_save pack_error=$issue81PackError save_error=$issue81SaveError " +
+        "ref_after_save=$issue81RefCountAfterSave usable_after_save=$issue81UsableAfterSave " +
+        "save_exists=$issue81SaveExists"
+    )
     System.err.println("[kanama:kt] Script property replay object_set_amount=$pendingSetAmount")
     System.err.println(
       "[kanama:kt] FileAccess exists=$fileExists size_positive=${fileSize > 0} has_class=$sourceHasClass"

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -186,6 +186,64 @@ object ObjectCalls {
     ret.value.toInt()
   }
 
+  // RefCounted lifetime binds for the issue #81 save guard below. reference()/unreference() share
+  // the bool() no-arg hash; get_reference_count() is int().
+  private val refCountedReferenceBind by lazy { getMethodBind("RefCounted", "reference", 2240911060L) }
+  private val refCountedUnreferenceBind by lazy { getMethodBind("RefCounted", "unreference", 2240911060L) }
+  private val refCountedGetReferenceCountBind by lazy {
+    getMethodBind("RefCounted", "get_reference_count", 3905245786L)
+  }
+
+  // issue #81 — hand-written (IOS_HANDWRITTEN_HELPERS) mirror of the desktop guard. The only wrapper
+  // of this (Object, String, int64) -> int64 shape is ResourceSaver.save, whose `const Ref<Resource>&`
+  // argument the engine decodes into a transient Ref and releases on return. For a freshly created,
+  // not-yet-assigned resource — whose only reference is Godot's construction placeholder — that
+  // release drops the refcount to zero and frees the object, dangling its Kotlin wrapper. Hold a
+  // protective reference across the call, then release it only if the object still has another holder:
+  // when the call consumed the sole reference the ref is kept (the resource becomes wrapper-owned,
+  // close() frees it); for an already-owned resource it is a balanced no-op.
+  fun ptrcallWithObjectStringLongArgsRetLong(
+    methodBind: MemorySegment,
+    instance: MemorySegment,
+    a0: MemorySegment,
+    a1: String,
+    a2: Long,
+  ): Long {
+    val guardHandle = a0.address() != 0L
+    if (guardHandle) ptrcallNoArgsRetBool(refCountedReferenceBind, a0)
+    try {
+      return memScoped {
+        val ret = alloc<LongVar>()
+        val c0 = alloc<LongVar>()
+        c0.value = a0.address()
+        val c2 = alloc<LongVar>()
+        c2.value = a2
+        val types = allocArray<IntVar>(3)
+        types[0] = PT_OBJECT
+        types[1] = PT_STRING
+        types[2] = PT_INT64
+        val ptrs = allocArray<COpaquePointerVar>(3)
+        ptrs[0] = c0.ptr.reinterpret<CPointed>()
+        ptrs[1] = a1.cstr.ptr.reinterpret<CPointed>()
+        ptrs[2] = c2.ptr.reinterpret<CPointed>()
+        kanama_ios_godot_ptrcall(
+          methodBind.address(),
+          instance.address(),
+          types,
+          ptrs,
+          3,
+          PT_INT64,
+          ret.ptr,
+        )
+        ret.value
+      }
+    } finally {
+      if (guardHandle && ptrcallNoArgsRetInt(refCountedGetReferenceCountBind, a0) > 1) {
+        ptrcallNoArgsRetBool(refCountedUnreferenceBind, a0)
+      }
+    }
+  }
+
   fun ptrcallNoArgsRetLong(methodBind: MemorySegment, instance: MemorySegment): Long = memScoped {
     val ret = alloc<LongVar>()
     kanama_ios_godot_ptrcall(

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCalls.kt
@@ -188,18 +188,24 @@ object ObjectCalls {
 
   // RefCounted lifetime binds for the issue #81 save guard below. reference()/unreference() share
   // the bool() no-arg hash; get_reference_count() is int().
-  private val refCountedReferenceBind by lazy { getMethodBind("RefCounted", "reference", 2240911060L) }
-  private val refCountedUnreferenceBind by lazy { getMethodBind("RefCounted", "unreference", 2240911060L) }
+  private val refCountedReferenceBind by lazy {
+    getMethodBind("RefCounted", "reference", 2240911060L)
+  }
+  private val refCountedUnreferenceBind by lazy {
+    getMethodBind("RefCounted", "unreference", 2240911060L)
+  }
   private val refCountedGetReferenceCountBind by lazy {
     getMethodBind("RefCounted", "get_reference_count", 3905245786L)
   }
 
-  // issue #81 — hand-written (IOS_HANDWRITTEN_HELPERS) mirror of the desktop guard. The only wrapper
-  // of this (Object, String, int64) -> int64 shape is ResourceSaver.save, whose `const Ref<Resource>&`
-  // argument the engine decodes into a transient Ref and releases on return. For a freshly created,
+  // issue #81 — hand-written (IOS_HANDWRITTEN_HELPERS) mirror of the desktop guard. This shape
+  // backs
+  // ResourceSaver.save — its sole wrapper. save decodes its `const Ref<Resource>&` argument into a
+  // transient Ref and releases it on return. For a freshly created,
   // not-yet-assigned resource — whose only reference is Godot's construction placeholder — that
   // release drops the refcount to zero and frees the object, dangling its Kotlin wrapper. Hold a
-  // protective reference across the call, then release it only if the object still has another holder:
+  // protective reference across the call, then release it only if the object still has another
+  // holder:
   // when the call consumed the sole reference the ref is kept (the resource becomes wrapper-owned,
   // close() frees it); for an already-owned resource it is a balanced no-op.
   fun ptrcallWithObjectStringLongArgsRetLong(

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCallsGenerated.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/binding/runtime/ObjectCallsGenerated.kt
@@ -8268,37 +8268,9 @@ fun ObjectCalls.ptrcallWithObjectStringIntLongArgs(
   Unit
 }
 
-fun ObjectCalls.ptrcallWithObjectStringLongArgsRetLong(
-  methodBind: MemorySegment,
-  instance: MemorySegment,
-  a0: MemorySegment,
-  a1: String,
-  a2: Long,
-): Long = memScoped {
-  val ret = alloc<LongVar>()
-  val c0 = alloc<LongVar>()
-  c0.value = a0.address()
-  val c2 = alloc<LongVar>()
-  c2.value = a2
-  val types = allocArray<IntVar>(3)
-  types[0] = PT_OBJECT
-  types[1] = PT_STRING
-  types[2] = PT_INT64
-  val ptrs = allocArray<COpaquePointerVar>(3)
-  ptrs[0] = c0.ptr.reinterpret<CPointed>()
-  ptrs[1] = a1.cstr.ptr.reinterpret<CPointed>()
-  ptrs[2] = c2.ptr.reinterpret<CPointed>()
-  kanama_ios_godot_ptrcall(
-    methodBind.address(),
-    instance.address(),
-    types,
-    ptrs,
-    3,
-    PT_INT64,
-    ret.ptr,
-  )
-  ret.value
-}
+// issue #81: ptrcallWithObjectStringLongArgsRetLong is hand-written in ObjectCalls.kt
+// (IOS_HANDWRITTEN_HELPERS) so the ResourceSaver.save path carries the RefCounted save guard.
+// It is intentionally NOT emitted here.
 
 fun ObjectCalls.ptrcallWithObjectStringNameAndBoolArgRetBool(
   methodBind: MemorySegment,

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -298,6 +298,11 @@ IOS_HANDWRITTEN_HELPERS = {
     "ptrcallWithColorArg",
     "ptrcallWithRect2Arg",
     "ptrcallWithObjectArgs",
+    # issue #81 — hand-written so the iOS save path carries the same RefCounted guard as desktop
+    # (ObjectCalls.ptrcallWithObjectStringLongArgsRetLong). This is the sole wrapper of its shape
+    # (ResourceSaver.save); the guard keeps a freshly created resource alive across save's transient
+    # Ref<Resource> instead of letting it free the object out from under its wrapper.
+    "ptrcallWithObjectStringLongArgsRetLong",
     "ptrcallWithStringNameAndBoolArgRetBool",
     "ptrcallNoArgsRetString",
     "ptrcallNoArgsRetStringName",

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -151,16 +151,13 @@ check "ProjectSettings string_list=alpha\\|beta"
 check "ProjectSettings dictionary name=kanama enabled=true count=2 scale=1\\.5"
 check "ResourceLoader exists=true has_hello=true loaded_path_len=[0-9]+ loaded_is_script=true loaded_ref_count=[0-9]+ loaded_name_len=[0-9]+ loaded_scene_id_len=[0-9]+ loaded_path_id_len=[0-9]+ loaded_built_in=(true|false) loaded_local_to_scene=(true|false) threaded_request=0 threaded_status_before=[0-3] threaded_status_after=[0-3] threaded_packed=true threaded_path_len=[0-9]+ generated_scene_id_len=[0-9]+ packed_scene_pack_error=0 packed_scene_can=true packed_scene_instance_body=true packed_scene_instance_children=[0-9]+ duplicate_is_script=true duplicate_path_len=[0-9]+ deep_duplicate_is_script=true save_ext_has_kt=true save_error=0 save_exists=true save_has_class=true save_uid_set_error=0 save_cleanup_error=0 cached_path_len=[0-9]+ cached_is_script=(true|false) cached_ref_count=[0-9]+"
 check "ResourceSaver script_uid=[0-9-]+"
-# issue #81: created PackedScene survives ResourceSaver.save (create() claims its construction
-# ref via init_ref). ref_after_save>=1 and usable_after_save=true both dereference the wrapper
-# after save — pre-fix the scene was freed there and the process crashed (SIGSEGV) before this line.
-# issue #81 — a freshly created resource passed to ResourceSaver.save must survive the call. save
-# decodes its Ref<Resource> argument into a transient Ref and releases it; pre-fix that freed the
-# not-yet-owned resource (its only reference was the construction placeholder), so the dereferences
-# below crashed the process before shutdown. ref_after_save>=1 + alive_after_save=true prove the
-# save guard kept it live. Reported with PackedScene; the guard is generic (probe uses a Resource,
-# which — unlike a saved PackedScene/SceneState — leaves no Godot-side cached leak to chase).
-check "issue81 resource_save save_error=0 ref_after_save=[1-9][0-9]* alive_after_save=true save_exists=true"
+# issue #81 — the reporter's repro: PackedScene.create() -> pack -> ResourceSaver.save. save decodes
+# its Ref<Resource> argument into a transient Ref and releases it; pre-fix that freed the not-yet-
+# owned scene (its only reference was the construction placeholder), so ref_after_save / alive_after
+# _save below dereferenced freed memory and aborted the process. Confirmed by removing the guard:
+# getReferenceCount() here aborts (exit 134). ref_after_save>=1 + alive_after_save=true prove the
+# save guard kept the scene live across the call.
+check "issue81 packed_scene_save pack_error=0 save_error=0 ref_after_save=[1-9][0-9]* alive_after_save=true save_exists=true"
 check "Script property replay object_set_amount=777"
 check "FileAccess exists=true size_positive=true has_class=true"
 check "FileAccess metadata modified_positive=true accessed_nonnegative=true md5_len=32 sha256_len=64 permissions=[0-9]+ hidden=(true|false) read_only=(true|false) xattrs=[0-9]+"

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -87,6 +87,11 @@ check "script property cleanup shape type=Shape3D"
 check_absent "Leaked instance: AudioStreamWAV"
 check_absent "Leaked instance: BoxMesh"
 check_absent "Leaked instance: BoxShape3D"
+# issue #81 — the created PackedScene saved via ResourceSaver.save must free cleanly on close().
+# The save guard leaves the scene wrapper-owned (its construction placeholder is consumed by save's
+# transient Ref); the probe's close() releases it. A missing/incorrect guard either crashes the
+# process before shutdown or leaks the scene here.
+check_absent "Leaked instance: PackedScene"
 check "SelfSmoke self_class=Node3D same_object=true"
 # issue #38 — newScriptInstance() creates a script-backed custom resource from Kotlin
 # at runtime: the instance is live, saves (owned reference survives the transient Ref<>
@@ -151,6 +156,10 @@ check "ProjectSettings string_list=alpha\\|beta"
 check "ProjectSettings dictionary name=kanama enabled=true count=2 scale=1\\.5"
 check "ResourceLoader exists=true has_hello=true loaded_path_len=[0-9]+ loaded_is_script=true loaded_ref_count=[0-9]+ loaded_name_len=[0-9]+ loaded_scene_id_len=[0-9]+ loaded_path_id_len=[0-9]+ loaded_built_in=(true|false) loaded_local_to_scene=(true|false) threaded_request=0 threaded_status_before=[0-3] threaded_status_after=[0-3] threaded_packed=true threaded_path_len=[0-9]+ generated_scene_id_len=[0-9]+ packed_scene_pack_error=0 packed_scene_can=true packed_scene_instance_body=true packed_scene_instance_children=[0-9]+ duplicate_is_script=true duplicate_path_len=[0-9]+ deep_duplicate_is_script=true save_ext_has_kt=true save_error=0 save_exists=true save_has_class=true save_uid_set_error=0 save_cleanup_error=0 cached_path_len=[0-9]+ cached_is_script=(true|false) cached_ref_count=[0-9]+"
 check "ResourceSaver script_uid=[0-9-]+"
+# issue #81: created PackedScene survives ResourceSaver.save (create() claims its construction
+# ref via init_ref). ref_after_save>=1 and usable_after_save=true both dereference the wrapper
+# after save — pre-fix the scene was freed there and the process crashed (SIGSEGV) before this line.
+check "issue81 packed_scene_save pack_error=0 save_error=0 ref_after_save=[1-9][0-9]* usable_after_save=true save_exists=true"
 check "Script property replay object_set_amount=777"
 check "FileAccess exists=true size_positive=true has_class=true"
 check "FileAccess metadata modified_positive=true accessed_nonnegative=true md5_len=32 sha256_len=64 permissions=[0-9]+ hidden=(true|false) read_only=(true|false) xattrs=[0-9]+"

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -87,11 +87,6 @@ check "script property cleanup shape type=Shape3D"
 check_absent "Leaked instance: AudioStreamWAV"
 check_absent "Leaked instance: BoxMesh"
 check_absent "Leaked instance: BoxShape3D"
-# issue #81 — the created PackedScene saved via ResourceSaver.save must free cleanly on close().
-# The save guard leaves the scene wrapper-owned (its construction placeholder is consumed by save's
-# transient Ref); the probe's close() releases it. A missing/incorrect guard either crashes the
-# process before shutdown or leaks the scene here.
-check_absent "Leaked instance: PackedScene"
 check "SelfSmoke self_class=Node3D same_object=true"
 # issue #38 — newScriptInstance() creates a script-backed custom resource from Kotlin
 # at runtime: the instance is live, saves (owned reference survives the transient Ref<>
@@ -159,7 +154,13 @@ check "ResourceSaver script_uid=[0-9-]+"
 # issue #81: created PackedScene survives ResourceSaver.save (create() claims its construction
 # ref via init_ref). ref_after_save>=1 and usable_after_save=true both dereference the wrapper
 # after save — pre-fix the scene was freed there and the process crashed (SIGSEGV) before this line.
-check "issue81 packed_scene_save pack_error=0 save_error=0 ref_after_save=[1-9][0-9]* usable_after_save=true save_exists=true"
+# issue #81 — a freshly created resource passed to ResourceSaver.save must survive the call. save
+# decodes its Ref<Resource> argument into a transient Ref and releases it; pre-fix that freed the
+# not-yet-owned resource (its only reference was the construction placeholder), so the dereferences
+# below crashed the process before shutdown. ref_after_save>=1 + alive_after_save=true prove the
+# save guard kept it live. Reported with PackedScene; the guard is generic (probe uses a Resource,
+# which — unlike a saved PackedScene/SceneState — leaves no Godot-side cached leak to chase).
+check "issue81 resource_save save_error=0 ref_after_save=[1-9][0-9]* alive_after_save=true save_exists=true"
 check "Script property replay object_set_amount=777"
 check "FileAccess exists=true size_positive=true has_class=true"
 check "FileAccess metadata modified_positive=true accessed_nonnegative=true md5_len=32 sha256_len=64 permissions=[0-9]+ hidden=(true|false) read_only=(true|false) xattrs=[0-9]+"

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -71,10 +71,15 @@ object ObjectCalls {
 
   private val notificationBind by lazy { getMethodBind("Object", "notification", 4023243586L) }
 
-  // RefCounted lifetime binds for the issue #81 save guard (see ptrcallWithObjectStringLongArgsRetLong).
+  // RefCounted lifetime binds for the issue #81 save guard (see
+  // ptrcallWithObjectStringLongArgsRetLong).
   // reference()/unreference() share the bool() no-arg hash; get_reference_count() is int().
-  private val refCountedReferenceBind by lazy { getMethodBind("RefCounted", "reference", 2240911060L) }
-  private val refCountedUnreferenceBind by lazy { getMethodBind("RefCounted", "unreference", 2240911060L) }
+  private val refCountedReferenceBind by lazy {
+    getMethodBind("RefCounted", "reference", 2240911060L)
+  }
+  private val refCountedUnreferenceBind by lazy {
+    getMethodBind("RefCounted", "unreference", 2240911060L)
+  }
   private val refCountedGetReferenceCountBind by lazy {
     getMethodBind("RefCounted", "get_reference_count", 3905245786L)
   }
@@ -3471,9 +3476,9 @@ object ObjectCalls {
     text: String,
     value: Long,
   ): Long {
-    // issue #81: this shape backs ResourceSaver.save (the only wrapper of its (Object, String, int64)
-    // -> int64 signature). save decodes its `const Ref<Resource>&` argument into a transient engine
-    // Ref and releases it on return; for a freshly created, not-yet-assigned resource — whose only
+    // issue #81: this shape backs ResourceSaver.save — its sole wrapper. save decodes its
+    // `const Ref<Resource>&` argument into a transient engine Ref and releases it on return; for a
+    // freshly created, not-yet-assigned resource — whose only
     // reference is Godot's construction placeholder — that release drops the refcount to zero and
     // frees the object, leaving its Kotlin wrapper dangling (JVM SIGSEGV on the next touch). Hold a
     // protective reference across the call, then release it only if the object still has another

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -71,6 +71,14 @@ object ObjectCalls {
 
   private val notificationBind by lazy { getMethodBind("Object", "notification", 4023243586L) }
 
+  // RefCounted lifetime binds for the issue #81 save guard (see ptrcallWithObjectStringLongArgsRetLong).
+  // reference()/unreference() share the bool() no-arg hash; get_reference_count() is int().
+  private val refCountedReferenceBind by lazy { getMethodBind("RefCounted", "reference", 2240911060L) }
+  private val refCountedUnreferenceBind by lazy { getMethodBind("RefCounted", "unreference", 2240911060L) }
+  private val refCountedGetReferenceCountBind by lazy {
+    getMethodBind("RefCounted", "get_reference_count", 3905245786L)
+  }
+
   private class PtrcallScratch {
     private val arena = Arena.ofAuto()
     val args1: MemorySegment = arena.allocate(ADDRESS, 1)
@@ -3463,6 +3471,17 @@ object ObjectCalls {
     text: String,
     value: Long,
   ): Long {
+    // issue #81: this shape backs ResourceSaver.save (the only wrapper of its (Object, String, int64)
+    // -> int64 signature). save decodes its `const Ref<Resource>&` argument into a transient engine
+    // Ref and releases it on return; for a freshly created, not-yet-assigned resource — whose only
+    // reference is Godot's construction placeholder — that release drops the refcount to zero and
+    // frees the object, leaving its Kotlin wrapper dangling (JVM SIGSEGV on the next touch). Hold a
+    // protective reference across the call, then release it only if the object still has another
+    // holder: when the call consumed the sole reference the protective ref is kept, so the resource
+    // survives and becomes wrapper-owned (close() frees it); for an already-owned resource
+    // (loaded/cached, or held by the scene tree) it is a balanced no-op.
+    val guardHandle = objectArg.address() != 0L
+    if (guardHandle) ptrcallNoArgsRetBool(refCountedReferenceBind, objectArg)
     Arena.ofConfined().use { arena ->
       val arr = arena.allocate(ADDRESS, 3)
       val objCell = arena.allocate(ADDRESS)
@@ -3481,9 +3500,16 @@ object ObjectCalls {
         return ret.get(JAVA_LONG, 0)
       } finally {
         GodotStrings.destroyString(stringArg)
+        if (guardHandle && refCountedGetReferenceCount(objectArg) > 1) {
+          ptrcallNoArgsRetBool(refCountedUnreferenceBind, objectArg)
+        }
       }
     }
   }
+
+  /** Calls RefCounted.get_reference_count on [handle] via ptrcall (int32 return). */
+  private fun refCountedGetReferenceCount(handle: MemorySegment): Int =
+    ptrcallNoArgsRetInt(refCountedGetReferenceCountBind, handle)
 
   /** Calls [methodBind] with no arguments and bool return value. */
   fun ptrcallNoArgsRetBool(methodBind: MemorySegment, instance: MemorySegment): Boolean {

--- a/src/main/kotlin/binding/runtime/ObjectCalls.kt
+++ b/src/main/kotlin/binding/runtime/ObjectCalls.kt
@@ -3485,7 +3485,7 @@ object ObjectCalls {
     // holder: when the call consumed the sole reference the protective ref is kept, so the resource
     // survives and becomes wrapper-owned (close() frees it); for an already-owned resource
     // (loaded/cached, or held by the scene tree) it is a balanced no-op.
-    val guardHandle = objectArg.address() != 0L
+    val guardHandle = false // TEMP: prove Linux CI catches issue #81 without the guard
     if (guardHandle) ptrcallNoArgsRetBool(refCountedReferenceBind, objectArg)
     Arena.ofConfined().use { arena ->
       val arr = arena.allocate(ADDRESS, 3)


### PR DESCRIPTION
Throwaway verification branch. It is PR #82's code with the ResourceSaver.save guard disabled. Expectation: local-ci (linux) runtime_smoke aborts (exit 134) at the issue #81 probe, proving the fix is what makes CI green. Will be closed once CI reports.