### PR TITLE
Fix hot_reload_smoke mktemp template poisoning re-runs on macOS

### DIFF
--- a/scripts/hot_reload_smoke.sh
+++ b/scripts/hot_reload_smoke.sh
@@ -23,7 +23,12 @@ case "$(uname -s)" in
     ;;
 esac
 
-BACKUP="$(mktemp /tmp/kanama_hello_backup.XXXXXX.kt)"
+# The template's X's must be trailing: BSD/macOS mktemp does not randomize
+# XXXXXX when a suffix follows it (e.g. a ".kt"), so a suffixed template yields
+# a fixed literal path that collides between concurrent runs and is left behind
+# by an interrupted run, poisoning every later run with "File exists". The
+# backup is only cp'd back and removed, so it needs no extension.
+BACKUP="$(mktemp /tmp/kanama_hello_backup.XXXXXX)"
 cp "$SCRIPT_FILE" "$BACKUP"
 
 restore() {


### PR DESCRIPTION
## Summary

`scripts/hot_reload_smoke.sh` created its script backup with:

```sh
BACKUP="$(mktemp /tmp/kanama_hello_backup.XXXXXX.kt)"
```

On macOS/BSD `mktemp`, only a **trailing** run of `X`s is randomized. The `.kt`
suffix after `XXXXXX` defeats substitution, so `mktemp` produces the fixed
literal path `/tmp/kanama_hello_backup.XXXXXX.kt` instead of a unique file. That
has two failure modes:

- two concurrent smoke runs collide on the same path; and
- any interrupted run (a crash, or the smoke being killed) leaves the literal
  file behind, so every later run fails at `mktemp` with `File exists` — a
  spurious hot-reload gate failure unrelated to the change under test.

This was previously mis-attributed to a "shared temp file owned by another
task"; the real cause is the non-trailing `mktemp` template.

## Fix

Drop the extension so the `X`s are trailing and `mktemp` randomizes on both BSD
and GNU. The backup is only `cp`'d back to the script and then removed, so it
needs no `.kt`.

## Verification

- Repeated `mktemp /tmp/kanama_hello_backup.XXXXXX` calls now yield distinct
  paths with no collision.
- `bash -n` clean. No functional change to the smoke: Godot only ever loads the
  real `HelloScript.kt`, never the backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)