### PR TITLE
Add Experimental Kotlin/Wasm Web export workflow (Task 57f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ versioning once public releases begin.
 
 ### Added
 
+- **Web backend promoted to Experimental (Kotlin/Wasm preview)** on Godot 4.7
+  stable. A reproducible source-checkout export workflow (`buildWebScripts` /
+  `exportWeb`) turns the two validated demos (Starter-Kit-Match3, Bunnymark) into
+  self-contained, cache-busted, HTTP-servable Web exports with a release payload
+  report and a versioned export-smoke harness (`scripts/web_export_smoke.sh`).
+  Both demos pass the automated smoke in Chrome (the CI gate) and Firefox; in
+  Safari, Bunnymark passes automatically and Match3 is verified by hand. Adds the
+  [Web export guide](exporting/web.md). Still **not a Supported target**:
+  single-thread Compatibility renderer only, no packaged addon, two-demo corpus.
+
 - Create script-backed custom resources from Kotlin with `newScriptInstance<T>()`
   — the equivalent of GDScript's `MyResource.new()` (issue #38). `T` must be a
   `@ScriptClass(attachTo = "Resource")` `@GlobalClass`. It returns an

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ project scripts needs the Kanama checkout), and there is no mobile hot reload â€
 see the [iOS export guide](docs/exporting/ios.md) and
 [Version Support](docs/reference/version-support.md).
 
-A **Kotlin/Wasm Web backend is in development**. It runs Bunnymark and Match3
-as production Godot Web exports across Chrome, Firefox, and Safari through a
-generated proxy and a versioned JavaScript bridge, with no on-device JVM. There
-is **no supported packaged export workflow yet** â€” it is not a Supported target
-and there is no user-facing export guide. See
+A **Kotlin/Wasm Web backend is Experimental (preview)**. It runs Bunnymark and
+Match3 as production Godot Web exports across Chrome, Firefox, and Safari through
+a generated proxy and a versioned JavaScript bridge, with no on-device JVM. It is
+**not a Supported target**: single-thread Compatibility renderer only, a
+source-checkout export (no packaged addon), and a two-demo corpus. See the
+[Web export guide](docs/exporting/web.md) and
 [Web Internals](docs/contributing/web-internals.md) for the architecture.
 
 See [Version Support](docs/reference/version-support.md) for the current test matrix and

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -1,9 +1,10 @@
 # Web Internals
 
-This page records the current Web implementation path. Web is **In development**
-on the Godot 4.7 stable baseline — not a Supported target, with no packaged
-export workflow and no user-facing export guide yet. The API/build flow is less
-settled than desktop, Android, or iOS.
+This page records the current Web implementation path. Web is **Experimental
+(Kotlin/Wasm preview)** on the Godot 4.7 stable baseline — not a Supported target,
+with a source-checkout export workflow (no packaged addon) and a user-facing
+[export guide](../exporting/web.md). The API/build flow is less settled than
+desktop, Android, or iOS.
 
 ## Where Web Sits Relative to the Other Backends
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -2,13 +2,20 @@
 
 ## Current Status
 
-The Web backend is **in development** on the Godot 4.7 stable baseline. It
-compiles Kanama project scripts to **Kotlin/Wasm** and runs them against a Godot
-4.7 Web export through a generated per-call proxy and a versioned JavaScript
-bridge (protocol 6). It is **not a Supported target yet**: two demos are
+The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
+baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
+against a Godot 4.7 Web export through a generated per-call proxy and a versioned
+JavaScript bridge (protocol 6). It is **not a Supported target**: two demos are
 validated (Starter-Kit-Match3 and Bunnymark) as production Web exports, the
 renderer is single-thread Compatibility only, and the corpus/browser matrix is
 still growing.
+
+**Evidence.** Both demos pass the automated production export smoke in **Chrome**
+(the CI gate) and **Firefox**. In **Safari**, Bunnymark passes the automated gate
+and Match3 is verified running by hand (its runtime-selected swipe works and
+matches/collapses/refills); the automated SafariDriver gate cannot synthesize
+Match3's drag reliably, so that one cell is a manual local check — see Known
+Limitations.
 
 This page is the reproducible export workflow for those two validated demos. For
 the architecture — batching, snapshots, handle generations, the bridge protocol
@@ -170,6 +177,11 @@ rejection, console-error checks, and a protocol-version match.
 
 - Only **Starter-Kit-Match3** and **Bunnymark** are validated; the wider demo
   corpus and 3D are not yet on Web.
+- **Safari automated Match3 drag.** The Match3 export runs correctly in Safari by
+  hand, but SafariDriver's synthesized pointer drag does not reliably trigger the
+  swipe in the automated gate (coordinates and Godot picking are correct; the
+  drag-to-swipe is a WebDriver synthesis limitation). The automated Safari gate
+  covers Bunnymark; Safari Match3 is a manual local check.
 - Single-thread Compatibility renderer only; no threads, no cross-origin
   isolation.
 - No Web editor, no compiler, no hot reload, no Web GDExtension, and no TeaVM or

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -1,0 +1,180 @@
+# Web
+
+## Current Status
+
+The Web backend is **in development** on the Godot 4.7 stable baseline. It
+compiles Kanama project scripts to **Kotlin/Wasm** and runs them against a Godot
+4.7 Web export through a generated per-call proxy and a versioned JavaScript
+bridge (protocol 6). It is **not a Supported target yet**: two demos are
+validated (Starter-Kit-Match3 and Bunnymark) as production Web exports, the
+renderer is single-thread Compatibility only, and the corpus/browser matrix is
+still growing.
+
+This page is the reproducible export workflow for those two validated demos. For
+the architecture — batching, snapshots, handle generations, the bridge protocol
+— see [Web Internals](../contributing/web-internals.md).
+
+## How Web Differs
+
+Unlike desktop, Android, and iOS, the Web backend uses **no JVM and no
+FFM/PanamaPort path**. Project gameplay is ahead-of-time compiled to WebAssembly
+(Kotlin/Wasm, which depends on the WasmGC and exception-handling proposals, so it
+targets modern browsers). The Kanama Wasm module and Godot's own Emscripten/Wasm
+runtime are **separate modules** that cannot share a heap, so calls cross as
+typed commands over a JavaScript bridge rather than as direct FFI.
+
+## Requirements
+
+- **Godot 4.7 stable** editor binary (matching the pinned baseline).
+- The **`web_nothreads_release`** export template for that exact Godot version.
+  The single-thread template is required: the preview backend does not use
+  threads or cross-origin isolation.
+- A **modern browser** with WasmGC + exception handling (recent
+  Chrome/Firefox/Safari).
+- **Node.js** (only for the export-smoke harness, not for the export itself).
+- Reproducible builds currently require
+  `--no-daemon -Pkotlin.compiler.execution.strategy=in-process`; the Kotlin
+  daemon can exhaust memory on these builds while the in-process path is stable.
+
+## Web-Compatible Project Scripts
+
+A project's JVM/desktop scripts are **not** directly Wasm-compatible: they take a
+`java.lang.foreign.MemorySegment` script-constructor handle and may use JVM-only
+pointer APIs. The Web export therefore uses a Wasm-compatible source set kept
+next to the JVM sources at **`<project>/web/kotlin-src/`**:
+
+- the script constructor takes a neutral `GodotHandle` instead of
+  `MemorySegment`;
+- raw pointer identity (`handle.address()`) is replaced by `isSameInstance()`.
+
+The `web/` directory is the export's Kotlin script root, so files under
+`web/kotlin-src/` resolve to `res://kotlin-src/*.kt` and match the scene script
+attachments. (Single-sourcing JVM and Web scripts is planned future work.)
+
+## Build The Web Scripts
+
+`buildWebScripts` generates the GDScript proxy bundle (proxies + manifest +
+protocol descriptor) and collects the Kotlin/Wasm runtime a project attaches:
+
+```sh
+./gradlew --no-daemon -Pkotlin.compiler.execution.strategy=in-process \
+  :web-runtime:buildWebScripts
+```
+
+The bundle lands in `web-runtime/build/web-scripts/` with a
+`build-web-scripts.report.json` recording the protocol version, renderer, and
+files. No source maps are published.
+
+## Export A Demo
+
+`exportWeb` stages a disposable copy of the project, runs the Godot Web export,
+installs the Kotlin/Wasm runtime and bridge, cache-busts the entry scripts, and
+writes a self-contained served directory plus a release payload report. Point it
+at a **clean checkout** of the demo (never a shared working tree); the Web script
+root is auto-derived from `<project>/web`.
+
+Match3:
+
+```sh
+./gradlew --no-daemon -Pkotlin.compiler.execution.strategy=in-process \
+  :web-runtime:exportWeb \
+  -PkanamaWebDemo=match3 \
+  -PkanamaGodotExecutable=/absolute/path/to/godot \
+  -PkanamaWebTemplateRelease=/absolute/path/to/web_nothreads_release.zip \
+  -PkanamaWebMatch3ProjectDir=/absolute/path/to/checkout/Starter-Kit-Match3
+```
+
+Bunnymark (the validated 256-sprite V1Sprites variant):
+
+```sh
+./gradlew --no-daemon -Pkotlin.compiler.execution.strategy=in-process \
+  :web-runtime:exportWeb \
+  -PkanamaWebDemo=bunnymark \
+  -PkanamaWebBunnymarkVariant=BunnymarkV1Sprites \
+  -PkanamaGodotExecutable=/absolute/path/to/godot \
+  -PkanamaWebTemplateRelease=/absolute/path/to/web_nothreads_release.zip \
+  -PkanamaWebBunnymarkProjectDir=/absolute/path/to/checkout/Bunnymark
+```
+
+The export lands in `web-runtime/build/web-export/<demo>/`. It is self-contained
+— no workstation-absolute paths leak into the served HTML — and includes
+`kanama-web/export-report.json` listing every served file, its size, the total
+payload, the renderer, the thread setting, and the source-map policy.
+
+## Serve The Export
+
+The export must be served over HTTP (opening `index.html` from disk will not
+load the Wasm modules). Any static server works. The repository ships a minimal
+one that binds an ephemeral localhost port, sends the correct
+`application/wasm` MIME type, and sets `Cache-Control: no-store`:
+
+```sh
+python3 scripts/web/serve_export.py web-runtime/build/web-export/match3
+# prints PORT=<n>; open http://127.0.0.1:<n>/
+```
+
+## Run The Export Smoke
+
+`web_export_smoke.sh` serves an already-built export, drives the demo in a real
+browser through a full play + teardown sequence, validates the machine-readable
+result against a versioned schema, and proves the served tree was not mutated. A
+run is never green from page load alone.
+
+```sh
+scripts/web_export_smoke.sh \
+  --engine chrome \
+  --export-dir web-runtime/build/web-export/match3 \
+  --demo match3 \
+  --result /tmp/match3-chrome.json
+```
+
+**Chrome is the intended CI gate.** Firefox and Safari are explicit **local
+release gates** run before a promotion. Each gate asserts gameplay deltas,
+crossing budgets, handle/callback/scheduler teardown to baseline, stale-handle
+rejection, console-error checks, and a protocol-version match.
+
+## Browser Debugging
+
+- **Chrome** — the driver self-launches headless Chrome and drives it over the
+  DevTools Protocol. Godot's Compatibility renderer needs a WebGL context, which
+  in headless Chrome comes from ANGLE's SwiftShader software path
+  (`--enable-unsafe-swiftshader --use-angle=swiftshader`); do **not** pass
+  `--disable-gpu`, which disables it. It collects console/exception events.
+- **Firefox** — driven over WebDriver BiDi; console errors via
+  `log.entryAdded`.
+- **Safari** — driven over WebDriver. SafariDriver exposes no browser-log
+  endpoint, so the Safari gate asserts bridge callback/telemetry plus every
+  gameplay and teardown invariant, and needs device-pixel-ratio-aware pointer
+  coordinates.
+
+## Renderer And Thread Constraints
+
+- **Compatibility renderer only** (`rendering_method = gl_compatibility`). The
+  Forward+/Mobile renderers are not used for Web.
+- **Single thread.** The export uses the `web_nothreads` template and does not
+  require COOP/COEP cross-origin isolation, so it can be served from a plain
+  static host. Threaded Godot Web is out of scope for the preview.
+
+## Payload And Source Maps
+
+- The Kotlin gameplay Wasm is **content-hashed by the build** (its filename is
+  its hash), so it is cache-busted automatically when gameplay changes.
+- The two fixed-name entry scripts (`kanama-web-spike.js`,
+  `kanama-web-bridge.js`) are cache-busted with a content-derived `?v=<hash>`
+  query string stamped into `index.html`.
+- **No source maps ship** (webpack `sourceMaps = false`); both
+  `buildWebScripts` and `exportWeb` fail loudly if a `.map` file appears.
+- `kanama-web/export-report.json` reports the full payload for budget tracking.
+
+## Known Limitations
+
+- Only **Starter-Kit-Match3** and **Bunnymark** are validated; the wider demo
+  corpus and 3D are not yet on Web.
+- Single-thread Compatibility renderer only; no threads, no cross-origin
+  isolation.
+- No Web editor, no compiler, no hot reload, no Web GDExtension, and no TeaVM or
+  Kotlin/JS production path.
+- A packaged/addon install path (exporting without the Kanama checkout) is not
+  yet available; the current workflow is a source-checkout export.
+- Not a Supported target: no support claim, and the corpus/browser matrix and
+  budgets are still being hardened.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ ownership, signals, and wrapper coverage. For existing GDScript projects, use
 | Windows | Supported (4.7 stable) |
 | Android | Supported (4.7 stable); debug ≥ Android 9, release ≥ Android 13 (Pixel 7 / Moto g 5G / S10+ / Pixel 3 XL) |
 | iOS | Supported (4.7 stable, Kotlin/Native); device-validated iPhone 12 / 15 Pro |
-| Web | In development (Kotlin/Wasm backend; no supported export workflow yet) |
+| Web | Experimental (Kotlin/Wasm preview, 4.7 stable); source-checkout export, 2-demo corpus, not Supported |
 
 See [Version Support](reference/version-support.md) for exact Godot, JDK,
 smoke-test, and packaging boundaries.

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -13,7 +13,7 @@ page records the platforms and engine versions validated for it.
 | Linux x86_64 | Supported (4.7 stable) | Full local CI, native bootstrap preflight, strict docs, all 11 demo builds, the nine-demo desktop smoke matrix, TPS checked smoke, distribution packaging, and desktop-kit/store-addon install smokes passed on Ubuntu 25.04 with Godot `4.7.stable.official.5b4e0cb0f` and OpenJDK 25.0.2 (2026-07-13/14). The resource-loader/saver teardown fix is required. Packaged desktop exports remain a separate release-readiness track. |
 | Windows x86_64 | Supported (4.7 stable) | Full local revalidation on the 4.7 stable console binary (2026-07-13): demo audits, script builds, imports, the nine-demo desktop runtime smoke, the TPS smoke, and the packaged desktop-kit + store-addon install smokes all passed. Gradle commands that build the native bootstrap run from a VS 2022 developer environment (VsDevCmd); Git Bash runs the smoke scripts. |
 | iOS (Kotlin/Native backend) | Supported (4.7 stable) | Promoted from Experimental 2026-07-14 (§7 mobile promotion bar B1–B4 MET). The iOS backend runs full Kanama project scripts via a C shim + Kotlin/Native static `.xcframework`, using the same wrapper generator as desktop/Android (no JVM on device). Full device gate (9-demo matrix + fresh-project install path) passed on two models: **iPhone 12** (iOS 26.5, 2026-06-25; 0 guardrail failures) + **iPhone 15 Pro** (iOS 26.5, 2026-07-10, full-breadth wrapper runtime), both on 4.7 stable iOS templates. Packaged `.xcframework` addon is runtime-only (compiling project scripts needs the Kanama checkout; ~199.5 MB debug / ~87.6 MB release static `.a`). No mobile hot reload. One FPS Audio autoload follow-up + task-26 multiplayer UI polish tracked as non-blocking — see [exporting/ios.md](../exporting/ios.md). |
-| Web | In development (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs the Bunnymark and Match3 production exports in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge. **Not a Supported target: no packaged export workflow, no export guide, single-thread Compatibility renderer only.** See §Web below. |
+| Web | Experimental (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs the Bunnymark and Match3 production exports in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge, with a reproducible source-checkout export workflow ([guide](../exporting/web.md)). **Not a Supported target: source-checkout export only (no packaged addon), single-thread Compatibility renderer, 2-demo corpus.** See §Web below. |
 
 Validated support is only claimed after the matching smoke path passes.
 Use the
@@ -103,12 +103,14 @@ stays in sync with desktop/Android).
 
 ## Web
 
-Web is **In development** on the Godot 4.7 stable baseline. It is **not a
-Supported target**: the export workflow is an in-development preview (a
-source-checkout export of the two validated demos, no packaged addon), and there
-is no support claim. A user-facing export guide is at
-[Exporting → Web](../exporting/web.md). This supersedes the earlier note that
-ruled Web out entirely.
+Web is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable baseline. It
+is **not a Supported target**: it is a source-checkout export of the two validated
+demos (no packaged addon), single-thread Compatibility renderer only, and makes no
+support claim. A user-facing export guide is at
+[Exporting → Web](../exporting/web.md). The two demos pass the automated production
+export smoke in Chrome and Firefox; in Safari, Bunnymark passes automatically and
+Match3 is verified by hand (a SafariDriver drag-synthesis limitation, not a runtime
+defect). This supersedes the earlier note that ruled Web out entirely.
 
 Unlike desktop/Android/iOS, the Web backend does **not** use a JVM or an
 FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -104,9 +104,11 @@ stays in sync with desktop/Android).
 ## Web
 
 Web is **In development** on the Godot 4.7 stable baseline. It is **not a
-Supported target**: there is no packaged export workflow, no user-facing export
-guide, and no support claim. This supersedes the earlier note that ruled Web
-out entirely.
+Supported target**: the export workflow is an in-development preview (a
+source-checkout export of the two validated demos, no packaged addon), and there
+is no support claim. A user-facing export guide is at
+[Exporting → Web](../exporting/web.md). This supersedes the earlier note that
+ruled Web out entirely.
 
 Unlike desktop/Android/iOS, the Web backend does **not** use a JVM or an
 FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Desktop and Packaging: exporting/desktop.md
       - Android: exporting/android.md
       - iOS: exporting/ios.md
+      - Web: exporting/web.md
   - Reference:
       - Version Support: reference/version-support.md
       - C# Comparison: reference/c-sharp-compat.md

--- a/scripts/fixtures/web-fake-export/fake_driver.py
+++ b/scripts/fixtures/web-fake-export/fake_driver.py
@@ -69,6 +69,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--demo", required=True)
     parser.add_argument("--timeout", type=int, required=True)
     parser.add_argument("--source-checksum", required=True)
+    parser.add_argument("--export-dir", default=None)
     parser.add_argument("--browser-binary", default=None)
     parser.add_argument("--mode", default="success")
     parser.add_argument("--mutate-path", default=None)

--- a/scripts/fixtures/web-fake-export/fake_driver.py
+++ b/scripts/fixtures/web-fake-export/fake_driver.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Deterministic fake browser driver for the export-smoke scaffold self-test.
+
+This driver launches no browser. It accepts the same explicit flags a real
+driver does (``--url``, ``--result``, ``--demo``, ``--timeout``,
+``--source-checksum``, optional ``--browser-binary``) plus a ``--mode`` selector,
+and produces one of the outcomes the shell must handle. It exists only to prove
+the shell's mechanics; it never claims a real demo passed.
+
+Modes:
+  success          write a valid, passing result envelope; exit 0
+  fail             write a valid envelope with a failed assertion (pass=false); exit 0
+  malformed        write non-JSON to the result path; exit 0
+  schema-violation write JSON missing a required field; exit 0
+  wrong-checksum   write a passing envelope with a mismatched source checksum; exit 0
+  crash            write nothing and exit non-zero
+  timeout          sleep past the shell's deadline (never writes a result)
+  mutate           write into --mutate-path (in the served tree) then succeed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+
+def _envelope(demo: str, checksum: str, *, passing: bool) -> dict:
+    failed = 0 if passing else 1
+    checks = {"fakeStartup": True, "fakeGameplay": passing, "fakeTeardown": True}
+    passed = sum(1 for value in checks.values() if value)
+    total = len(checks)
+    return {
+        "schemaVersion": 1,
+        "demo": demo,
+        "protocolVersion": 6,
+        "pass": passing,
+        "durationMs": 12,
+        "artifact": {
+            "url": "http://127.0.0.1:0/",
+            "files": [
+                {"name": "index.html", "bytes": 512},
+                {"name": "kanama-web-fake.js", "bytes": 160},
+            ],
+            "totalBytes": 672,
+            "sourceTreeChecksum": checksum,
+        },
+        "browser": {"engine": "chrome", "name": "fake-fixture", "version": "0"},
+        "startup": {"loaded": True, "outcome": "ready", "durationMs": 5},
+        "assertions": {
+            "summary": {"total": total, "passed": passed, "failed": failed, "skipped": 0},
+            "checks": checks,
+        },
+        "crossings": {"total": 3},
+        "handles": {"liveAfterGameplay": 4, "liveAfterTeardown": 0, "staleRejected": 1},
+        "callbacks": {"pending": 0},
+        "connections": {"open": 0},
+        "scheduler": {"pendingCoroutines": 0},
+        "console": {"errors": [], "boundaryErrors": []},
+        "teardown": {"outcome": "clean", "ownerRegistriesToBaseline": True},
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--result", required=True)
+    parser.add_argument("--demo", required=True)
+    parser.add_argument("--timeout", type=int, required=True)
+    parser.add_argument("--source-checksum", required=True)
+    parser.add_argument("--browser-binary", default=None)
+    parser.add_argument("--mode", default="success")
+    parser.add_argument("--mutate-path", default=None)
+    args = parser.parse_args(argv)
+
+    if args.mode == "timeout":
+        # Sleep well past the shell's deadline; the shell must kill us.
+        time.sleep(args.timeout + 120)
+        return 0
+
+    if args.mode == "crash":
+        print("fake_driver: simulated browser crash", file=sys.stderr)
+        return 3
+
+    if args.mode == "malformed":
+        with open(args.result, "w", encoding="utf-8") as handle:
+            handle.write("this is not json{")
+        return 0
+
+    if args.mode == "schema-violation":
+        envelope = _envelope(args.demo, args.source_checksum, passing=True)
+        del envelope["handles"]  # drop a required top-level group
+        with open(args.result, "w", encoding="utf-8") as handle:
+            json.dump(envelope, handle)
+        return 0
+
+    if args.mode == "mutate":
+        if args.mutate_path:
+            with open(args.mutate_path, "a", encoding="utf-8") as handle:
+                handle.write("\n<!-- mutated by fake driver -->\n")
+        envelope = _envelope(args.demo, args.source_checksum, passing=True)
+        with open(args.result, "w", encoding="utf-8") as handle:
+            json.dump(envelope, handle)
+        return 0
+
+    passing = args.mode != "fail"
+    checksum = "deadbeef" if args.mode == "wrong-checksum" else args.source_checksum
+    envelope = _envelope(args.demo, checksum, passing=passing)
+    with open(args.result, "w", encoding="utf-8") as handle:
+        json.dump(envelope, handle, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/fixtures/web-fake-export/index.html
+++ b/scripts/fixtures/web-fake-export/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Kanama Web export-smoke fake fixture</title>
+<!--
+  A tiny STATIC stand-in for a real Web export, used only to exercise the
+  web_export_smoke.sh scaffold (arg parsing, port/process cleanup, timeout and
+  error capture, result-schema validation, source-tree immutability). It runs no
+  Kanama runtime and proves nothing about Bunnymark or Match3.
+-->
+<h1>Kanama Web export-smoke fake fixture</h1>
+<p>Static placeholder served by the scaffold self-test.</p>

--- a/scripts/fixtures/web-fake-export/kanama-web-fake.js
+++ b/scripts/fixtures/web-fake-export/kanama-web-fake.js
@@ -1,0 +1,3 @@
+// Static payload stand-in so the fake export lists more than one served file.
+// Not a runtime; the scaffold self-test never loads this as code.
+globalThis.KanamaWebFakeFixture = { note: "scaffold self-test payload only" };

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -75,15 +75,19 @@ ensure_gdextension_header() {
 
 usage() {
   cat <<'EOF'
-usage: scripts/local_ci.sh [--skip-docs] [--skip-bootstrap] /path/to/godot [more_godot_binaries...]
+usage: scripts/local_ci.sh [--skip-docs] [--skip-bootstrap] [--skip-web] /path/to/godot [more_godot_binaries...]
 
 Runs local CI-style checks:
   - Gradle build/sync
   - optional CMake bootstrap build
   - optional mkdocs strict build
+  - Web Kotlin/Wasm compile + fail-loud gameplay coverage gate + smoke scaffold
   - runtime smoke for each Godot binary
   - @Tool editor execution smoke for each Godot binary
   - hot-reload smoke for each Godot binary
+
+The heavy in-browser Web export smoke (a real Godot export driven in Chrome/
+Firefox/Safari) is a separate gate: scripts/web_export_smoke.sh.
 
 You can also provide one Godot binary with KANAMA_GODOT_BIN.
 EOF
@@ -91,6 +95,7 @@ EOF
 
 skip_docs=0
 skip_bootstrap=0
+skip_web=0
 godot_bins=()
 
 while [[ $# -gt 0 ]]; do
@@ -105,6 +110,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-bootstrap)
       skip_bootstrap=1
+      shift
+      ;;
+    --skip-web)
+      skip_web=1
       shift
       ;;
     --*)
@@ -522,6 +531,32 @@ if [[ $skip_docs -eq 0 ]]; then
   fi
 else
   echo "[local_ci] skipping docs build"
+fi
+
+if [[ $skip_web -eq 0 ]]; then
+  # Web bridge + driver static checks (fast, no browser).
+  if command -v node >/dev/null 2>&1; then
+    stage "web bridge + driver syntax"
+    node --check "$ROOT_DIR/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js"
+    for driver in "$ROOT_DIR"/scripts/web/drivers/*.mjs "$ROOT_DIR"/scripts/web/drivers/demos/*.mjs; do
+      [[ -e "$driver" ]] && node --check "$driver"
+    done
+  else
+    echo "[local_ci] node not found; skipping web driver syntax check"
+  fi
+
+  # Export-smoke scaffold self-test against the static fake fixture (no browser).
+  stage "web export-smoke scaffold self-test"
+  "$ROOT_DIR/scripts/web/scaffold_selftest.sh"
+
+  # Kotlin/Wasm compile + the fail-loud gameplay coverage gate. The Web build
+  # needs the in-process Kotlin compiler; the daemon can exhaust memory here.
+  stage "web Wasm compile + coverage gate"
+  "$ROOT_DIR/gradlew" -p "$ROOT_DIR" --no-daemon \
+    -Pkotlin.compiler.execution.strategy=in-process \
+    :web-runtime:compileKotlinWasmJs :web-runtime:generateWebGameplayCoverage
+else
+  echo "[local_ci] skipping web checks"
 fi
 
 for godot_bin in "${godot_bins[@]}"; do

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -23,7 +23,10 @@ import os from "node:os";
 import path from "node:path";
 
 import { runMatch3 } from "./demos/match3.mjs";
+import { runBunnymark } from "./demos/bunnymark.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
+
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark };
 
 function parseArgs(argv) {
   const args = {};
@@ -63,9 +66,9 @@ async function main() {
   const deadline = Date.now() + timeoutMs;
   const startedAt = Date.now();
 
-  if (args.demo !== "match3") {
-    // Bunnymark + the other demos are formalized in the Phase 3 follow-on.
-    throw new Error(`chrome_cdp: demo '${args.demo}' not yet formalized (Task 57f Phase 3)`);
+  const runDemo = DEMOS[args.demo];
+  if (!runDemo) {
+    throw new Error(`chrome_cdp: unknown demo '${args.demo}' (expected ${Object.keys(DEMOS).join("|")})`);
   }
 
   const chromeBinary = args["browser-binary"] ?? DEFAULT_CHROME;
@@ -220,7 +223,7 @@ async function main() {
 
     // Drive the demo. The demo module returns startup + assertion + lifecycle
     // facts; console/exception capture stays here where CDP delivers it.
-    const demoResult = await runMatch3({ url: args.url, call, evaluate, deadline });
+    const demoResult = await runDemo({ url: args.url, call, evaluate, deadline });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -1,0 +1,247 @@
+// chrome_cdp.mjs -- Chrome production Web export-smoke driver (Task 57f).
+//
+// Formalized from the Task-57 group-8 integration CDP driver. Unlike that
+// ad-hoc script (which assumed a Chrome already listening on a fixed port), this
+// driver OWNS its browser: it launches headless Chrome on an ephemeral remote
+// debugging port, drives the demo over CDP, emits the versioned v1 result
+// envelope (scripts/web/result_schema.py), and always tears the browser down.
+//
+// It is the intended CI gate. Firefox and Safari are separate local drivers.
+//
+// Args (all explicit; no workstation-absolute assumptions):
+//   --url <url>              served export URL (from the smoke shell)
+//   --result <path>          where to write the result envelope
+//   --demo <match3>          demo to drive (bunnymark: Phase 3 follow-on)
+//   --timeout <seconds>      overall driver budget
+//   --source-checksum <hex>  pre-run served-tree checksum to echo into artifact
+//   --export-dir <dir>       served export dir, for payload sizing
+//   --browser-binary <path>  Chrome binary (optional; falls back to macOS default)
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runMatch3 } from "./demos/match3.mjs";
+import { buildEnvelope, collectPayload } from "./envelope.mjs";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (!key.startsWith("--")) throw new Error(`unexpected driver argument: ${key}`);
+    args[key.slice(2)] = argv[i + 1];
+  }
+  for (const required of ["url", "result", "demo", "timeout", "source-checksum", "export-dir"]) {
+    if (!args[required]) throw new Error(`chrome_cdp: missing --${required}`);
+  }
+  return args;
+}
+
+const DEFAULT_CHROME =
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForDebugTarget(port, deadline) {
+  while (Date.now() < deadline) {
+    try {
+      const pages = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+      const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+      if (page) return page;
+    } catch {
+      // Chrome not listening yet.
+    }
+    await delay(150);
+  }
+  throw new Error("Chrome did not expose a CDP page target before the deadline");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const timeoutMs = Number(args.timeout) * 1000;
+  const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+
+  if (args.demo !== "match3") {
+    // Bunnymark + the other demos are formalized in the Phase 3 follow-on.
+    throw new Error(`chrome_cdp: demo '${args.demo}' not yet formalized (Task 57f Phase 3)`);
+  }
+
+  const chromeBinary = args["browser-binary"] ?? DEFAULT_CHROME;
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "kanama-chrome-"));
+  const debugPort = 0; // let Chrome choose; we read the chosen port from DevToolsActivePort
+
+  const chrome = spawn(
+    chromeBinary,
+    [
+      "--headless=new",
+      // Godot's Compatibility renderer needs a WebGL context. In headless Chrome
+      // that comes from ANGLE's SwiftShader software path, which recent Chrome
+      // gates behind an explicit opt-in; do NOT pass --disable-gpu (it kills it).
+      "--enable-unsafe-swiftshader",
+      "--use-angle=swiftshader",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-extensions",
+      "--hide-scrollbars",
+      "--force-device-scale-factor=1",
+      `--user-data-dir=${profileDir}`,
+      `--remote-debugging-port=${debugPort}`,
+      "--window-size=1280,900",
+      "about:blank",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  let socket = null;
+  const cleanup = () => {
+    try {
+      socket?.close();
+    } catch {
+      // ignore
+    }
+    if (!chrome.killed) chrome.kill("SIGKILL");
+    try {
+      fs.rmSync(profileDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  };
+  process.on("exit", cleanup);
+
+  try {
+    // Chrome writes the chosen debugging port to DevToolsActivePort in the
+    // profile dir; poll for it, then connect.
+    const portFile = path.join(profileDir, "DevToolsActivePort");
+    let port = null;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(portFile)) {
+        port = fs.readFileSync(portFile, "utf-8").split("\n")[0].trim();
+        if (port) break;
+      }
+      if (chrome.exitCode !== null) {
+        throw new Error(`Chrome exited early with code ${chrome.exitCode}`);
+      }
+      await delay(100);
+    }
+    if (!port) throw new Error("Chrome did not report a DevTools port");
+
+    const page = await waitForDebugTarget(port, deadline);
+
+    socket = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((resolve, reject) => {
+      socket.addEventListener("open", resolve, { once: true });
+      socket.addEventListener("error", reject, { once: true });
+    });
+
+    let nextId = 1;
+    const pendingCalls = new Map();
+    const consoleEvents = [];
+    socket.addEventListener("message", ({ data }) => {
+      const message = JSON.parse(data);
+      if (message.id) {
+        const callback = pendingCalls.get(message.id);
+        pendingCalls.delete(message.id);
+        if (message.error) callback.reject(new Error(JSON.stringify(message.error)));
+        else callback.resolve(message.result);
+        return;
+      }
+      if (message.method === "Runtime.exceptionThrown") {
+        consoleEvents.push({
+          type: "exception",
+          text:
+            message.params.exceptionDetails?.exception?.description ??
+            message.params.exceptionDetails?.text ??
+            "exception",
+        });
+      }
+      if (
+        message.method === "Runtime.consoleAPICalled" &&
+        message.params.type === "error"
+      ) {
+        consoleEvents.push({
+          type: "console.error",
+          text: message.params.args
+            .map((arg) => arg.value ?? arg.description ?? arg.type)
+            .join(" "),
+        });
+      }
+    });
+
+    // Per-call timeout: a CDP command whose response is dropped (e.g. a race
+    // with navigation destroying the execution context) must surface as an
+    // error, never hang the whole driver past the smoke budget.
+    const CALL_TIMEOUT_MS = 20_000;
+    const call = (method, params = {}) => {
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingCalls.delete(id);
+          reject(new Error(`CDP ${method} timed out after ${CALL_TIMEOUT_MS}ms`));
+        }, CALL_TIMEOUT_MS);
+        pendingCalls.set(id, {
+          resolve: (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          reject: (error) => {
+            clearTimeout(timer);
+            reject(error);
+          },
+        });
+        socket.send(JSON.stringify({ id, method, params }));
+      });
+    };
+    const evaluate = async (expression) => {
+      const result = await call("Runtime.evaluate", {
+        expression,
+        returnByValue: true,
+        awaitPromise: true,
+      });
+      if (result.exceptionDetails) {
+        throw new Error(
+          result.exceptionDetails.exception?.description ?? result.exceptionDetails.text,
+        );
+      }
+      return result.result.value;
+    };
+
+    await call("Runtime.enable");
+    await call("Page.enable");
+    await call("Network.enable");
+    await call("Network.setCacheDisabled", { cacheDisabled: true });
+    await call("Emulation.setDeviceMetricsOverride", {
+      width: 1280,
+      height: 900,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+
+    // Drive the demo. The demo module returns startup + assertion + lifecycle
+    // facts; console/exception capture stays here where CDP delivers it.
+    const demoResult = await runMatch3({ url: args.url, call, evaluate, deadline });
+
+    const browserVersion = await evaluate("navigator.userAgent");
+    const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);
+
+    const envelope = buildEnvelope({
+      demo: args.demo,
+      browser: { engine: "chrome", name: "Google Chrome", version: browserVersion },
+      payload,
+      durationMs: Date.now() - startedAt,
+      consoleEvents,
+      demoResult,
+    });
+
+    fs.writeFileSync(args.result, `${JSON.stringify(envelope, null, 2)}\n`);
+    cleanup();
+    process.exit(envelope.pass ? 0 : 1);
+  } catch (error) {
+    cleanup();
+    process.stderr.write(`chrome_cdp: ${error.stack ?? error}\n`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -221,9 +221,19 @@ async function main() {
       mobile: false,
     });
 
+    // Transport the demo modules use, independent of CDP specifics.
+    const navigate = (url) => call("Page.navigate", { url });
+    const pointer = async (press, release) => {
+      await call("Input.dispatchMouseEvent", { type: "mousePressed", x: press.x, y: press.y, button: "left", buttons: 1, clickCount: 1 });
+      await delay(100);
+      await call("Input.dispatchMouseEvent", { type: "mouseMoved", x: release.x, y: release.y, button: "none", buttons: 1 });
+      await delay(25);
+      await call("Input.dispatchMouseEvent", { type: "mouseReleased", x: release.x, y: release.y, button: "left", buttons: 0, clickCount: 1 });
+    };
+
     // Drive the demo. The demo module returns startup + assertion + lifecycle
     // facts; console/exception capture stays here where CDP delivers it.
-    const demoResult = await runDemo({ url: args.url, call, evaluate, deadline });
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/demos/bunnymark.mjs
+++ b/scripts/web/drivers/demos/bunnymark.mjs
@@ -21,11 +21,10 @@ const trace = (msg) => {
 const snapshot = (evaluate) =>
   evaluate("JSON.stringify(globalThis.KanamaWebBridge.bunnymarkSnapshot())").then(JSON.parse);
 
-export async function runBunnymark({ url, evaluate, deadline }) {
+export async function runBunnymark({ url, evaluate, navigate, deadline }) {
   const startupStart = Date.now();
   trace("navigate");
-  // The driver already navigated to about:blank; go to the served export.
-  await evaluate(`(() => { globalThis.location.href = ${JSON.stringify(`${url}?bunnymark=${Date.now()}`)}; return true; })()`);
+  await navigate(`${url}?bunnymark=${Date.now()}`);
 
   let ready = false;
   const readyDeadline = Math.min(deadline, Date.now() + 30_000);

--- a/scripts/web/drivers/demos/bunnymark.mjs
+++ b/scripts/web/drivers/demos/bunnymark.mjs
@@ -1,0 +1,163 @@
+// demos/bunnymark.mjs -- Bunnymark play + teardown assertions for the Web smoke.
+//
+// Ported from the validated Task-57 Firefox BiDi Bunnymark driver, decoupled
+// from any one browser: the caller injects `evaluate` (page expression -> value).
+// Bunnymark drives entirely through bridge method calls, so unlike Match3 it
+// needs no synthetic pointer input.
+//
+// It adds 256 sprites through one bounded position batch, measures a steady
+// window, removes/re-adds one sprite to advance a handle generation and prove a
+// stale handle is rejected, then finishes and asserts deterministic teardown to
+// zero live handles.
+
+const BUNNY_COUNT = 256;
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[bunnymark ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+const snapshot = (evaluate) =>
+  evaluate("JSON.stringify(globalThis.KanamaWebBridge.bunnymarkSnapshot())").then(JSON.parse);
+
+export async function runBunnymark({ url, evaluate, deadline }) {
+  const startupStart = Date.now();
+  trace("navigate");
+  // The driver already navigated to about:blank; go to the served export.
+  await evaluate(`(() => { globalThis.location.href = ${JSON.stringify(`${url}?bunnymark=${Date.now()}`)}; return true; })()`);
+
+  let ready = false;
+  const readyDeadline = Math.min(deadline, Date.now() + 30_000);
+  while (!ready && Date.now() < readyDeadline) {
+    try {
+      ready = Boolean(
+        await evaluate(
+          "globalThis.KanamaWebBridge?.firstHandle > 0 && globalThis.KanamaWebBridge?.resourceLoads === 1",
+        ),
+      );
+    } catch {
+      // page mid-navigation; retry
+    }
+    if (!ready) await delay(100);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm Bunnymark did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace("ready; adding bunnies");
+
+  await evaluate(`(() => {
+    const bridge = globalThis.KanamaWebBridge;
+    for (let i = 0; i < ${BUNNY_COUNT}; i += 1) bridge.callNoArgs(bridge.firstHandle, bridge.bunnymarkMethodId("add"));
+    return true;
+  })()`);
+  await delay(750);
+  await evaluate("globalThis.KanamaWebBridge.resetBunnymarkTimings(); true");
+
+  const windowStart = await snapshot(evaluate);
+  const target = windowStart.processCalls + 120;
+  while (Number(await evaluate("globalThis.KanamaWebBridge.processCalls")) < target) {
+    if (Date.now() > deadline) throw new Error("Bunnymark measurement window did not complete");
+    await delay(25);
+  }
+  const running = await snapshot(evaluate);
+  trace(`steady: adds=${running.addBunnyCalls} live=${running.liveBrowserHandles} batch=${running.maxPositionMutationBatch}`);
+
+  await evaluate(`globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.firstHandle, globalThis.KanamaWebBridge.bunnymarkMethodId("remove")); true`);
+  await delay(100);
+  const removed = await snapshot(evaluate);
+
+  await evaluate(`globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.firstHandle, globalThis.KanamaWebBridge.bunnymarkMethodId("add")); true`);
+  await delay(250);
+  const replaced = await snapshot(evaluate);
+
+  const staleHandleFailed = Boolean(
+    await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      try {
+        bridge.requireBrowserHandle(bridge.lastFreedObjectHandle, "Sprite2D");
+        return false;
+      } catch (error) {
+        return String(error).includes("Stale or wrong-kind");
+      }
+    })()`),
+  );
+
+  await evaluate(`globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.firstHandle, globalThis.KanamaWebBridge.bunnymarkMethodId("finish")); true`);
+  await delay(750);
+  const finished = await snapshot(evaluate);
+  trace(`finished: live=${finished.liveBrowserHandles} frees=${finished.objectFrees} signal=${finished.signalEmits}`);
+
+  const protocolVersion = Number(await evaluate("globalThis.KanamaWebBridge.results.protocolVersion"));
+  const processDelta = running.processCalls - windowStart.processCalls;
+  const crossingDelta = running.kotlinToGodotCalls - windowStart.kotlinToGodotCalls;
+
+  const checks = {
+    mode: running.mode === "bunnymark" && running.bunnymarkVariant === "BunnymarkV1Sprites",
+    ready: running.readyCount === 1 && running.handle > 0,
+    exactAdds: running.addBunnyCalls === BUNNY_COUNT,
+    exactConstruction:
+      running.objectConstructions === BUNNY_COUNT &&
+      running.liveBrowserHandles === BUNNY_COUNT + 1,
+    textureLoaded: running.resourceLoads === 1,
+    exactPositionBatch:
+      running.maxPositionMutationBatch === BUNNY_COUNT &&
+      running.lastPositionMutationBatch === BUNNY_COUNT,
+    boundedPhaseCrossings:
+      processDelta >= 20 && crossingDelta >= processDelta - 2 && crossingDelta <= processDelta + 2,
+    timingSamples: running.processTiming.count >= 120 && running.applyTiming.count >= 120,
+    fixedBuffer: running.commandBufferGrowths === 0,
+    removedAndFreed: removed.objectFrees === 1 && removed.liveBrowserHandles === BUNNY_COUNT,
+    generationAdvanced:
+      replaced.objectConstructions === BUNNY_COUNT + 1 &&
+      replaced.liveBrowserHandles === BUNNY_COUNT + 1 &&
+      replaced.objectHandleGenerationAdvanced === true &&
+      staleHandleFailed,
+    finishSignal:
+      finished.signalEmits === 1 &&
+      finished.lastSignalName === "benchmark_finished" &&
+      finished.lastSignalValue === BUNNY_COUNT,
+    deterministicTeardown:
+      finished.resourceReleases === 1 &&
+      finished.objectFrees === BUNNY_COUNT + 1 &&
+      finished.liveBrowserHandles === 0,
+  };
+
+  const boundaryErrors = [];
+  for (const [label, snap] of [["running", running], ["removed", removed], ["replaced", replaced], ["finished", finished]]) {
+    if (snap.callbackErrors !== 0) boundaryErrors.push(`${label}.callbackErrors=${snap.callbackErrors}`);
+  }
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready,
+      outcome: ready ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: running.liveBrowserHandles,
+      liveAfterTeardown: finished.liveBrowserHandles,
+      staleRejected: staleHandleFailed ? 1 : 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: running.kotlinToGodotCalls,
+      maxPositionMutationBatch: running.maxPositionMutationBatch,
+      processDelta,
+    },
+    callbacks: {
+      finishSignalEmits: finished.signalEmits,
+    },
+    connections: {
+      afterTeardownLiveHandles: finished.liveBrowserHandles,
+    },
+    scheduler: {
+      commandBufferGrowths: running.commandBufferGrowths,
+    },
+    teardown: {
+      outcome: checks.deterministicTeardown ? "clean" : "incomplete",
+      ownerRegistriesToBaseline: finished.liveBrowserHandles === 0,
+    },
+    boundaryErrors,
+  };
+}

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -115,7 +115,9 @@ function findLegalSwap(tileGrid) {
   return null;
 }
 
-async function drag(call, evaluate, { x, y, dx, dy }) {
+async function drag(pointer, evaluate, { x, y, dx, dy }) {
+  // Board -> CSS client-pixel geometry is browser-agnostic; each driver's
+  // pointer() handles the protocol (and any device-pixel-ratio adjustment).
   const geometry = await evaluate(`(() => {
     const canvas = document.querySelector("canvas");
     const rect = canvas.getBoundingClientRect();
@@ -130,17 +132,13 @@ async function drag(call, evaluate, { x, y, dx, dy }) {
       release: toClient(boardX + (${x} + ${dx}) * ${OFFSET}, boardY + (${y} + ${dy}) * ${OFFSET}),
     };
   })()`);
-  await call("Input.dispatchMouseEvent", { type: "mousePressed", x: geometry.press.x, y: geometry.press.y, button: "left", buttons: 1, clickCount: 1 });
-  await delay(100);
-  await call("Input.dispatchMouseEvent", { type: "mouseMoved", x: geometry.release.x, y: geometry.release.y, button: "none", buttons: 1 });
-  await delay(25);
-  await call("Input.dispatchMouseEvent", { type: "mouseReleased", x: geometry.release.x, y: geometry.release.y, button: "left", buttons: 0, clickCount: 1 });
+  await pointer(geometry.press, geometry.release);
   return geometry;
 }
 
-async function navigateAndSettle(call, evaluate, url, label) {
+async function navigateAndSettle(navigate, evaluate, url, label) {
   trace(`navigate ${label}`);
-  await call("Page.navigate", { url: `${url}?run=${label}&cache=${Date.now()}` });
+  await navigate(`${url}?run=${label}&cache=${Date.now()}`);
   const deadline = Date.now() + 30_000;
   let board = null;
   while (Date.now() < deadline) {
@@ -195,15 +193,15 @@ function teardownClean(t) {
   );
 }
 
-export async function runMatch3({ url, call, evaluate }) {
+export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const startupStart = Date.now();
-  const firstRun = await navigateAndSettle(call, evaluate, url, "first");
+  const firstRun = await navigateAndSettle(navigate, evaluate, url, "first");
   const startupDurationMs = Date.now() - startupStart;
 
   const legalSwap = findLegalSwap(firstRun.settled.tileGrid);
   if (!legalSwap) throw new Error("Settled Match3 board has no legal swap");
   const beforeSwap = await snapshot(evaluate);
-  await drag(call, evaluate, legalSwap);
+  await drag(pointer, evaluate, legalSwap);
   const afterSwap = await waitUntil(
     evaluate,
     (v) => v.tileFrees > beforeSwap.tileFrees && v.tileGrid.length === 64 &&
@@ -214,7 +212,7 @@ export async function runMatch3({ url, call, evaluate }) {
   matrixFrom(afterSwap.tileGrid);
 
   const firstTeardown = await teardownCurrentRun(evaluate);
-  const secondRun = await navigateAndSettle(call, evaluate, url, "restart");
+  const secondRun = await navigateAndSettle(navigate, evaluate, url, "restart");
   const secondTeardown = await teardownCurrentRun(evaluate);
 
   const tileFreeDelta = afterSwap.tileFrees - beforeSwap.tileFrees;

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -132,6 +132,7 @@ async function drag(pointer, evaluate, { x, y, dx, dy }) {
       release: toClient(boardX + (${x} + ${dx}) * ${OFFSET}, boardY + (${y} + ${dy}) * ${OFFSET}),
     };
   })()`);
+  trace(`drag swap=${JSON.stringify({ x, y, dx, dy })} press=${JSON.stringify(geometry.press)} release=${JSON.stringify(geometry.release)}`);
   await pointer(geometry.press, geometry.release);
   return geometry;
 }

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -1,0 +1,300 @@
+// demos/match3.mjs -- Match3 play + teardown assertions for the Web export smoke.
+//
+// Ported from the validated Task-57 group-8 integration driver, but decoupled
+// from any one browser: the caller injects `call` (CDP-style command) and
+// `evaluate` (page expression -> value). It returns the demoResult contract in
+// envelope.mjs: protocol, startup, checks, handles, crossings, callbacks,
+// connections, scheduler, teardown, boundaryErrors.
+//
+// A run is never green from page load alone: it plays a runtime-selected legal
+// swap, asserts match/collapse/refill + audiovisual feedback + bounded
+// crossings, then tears the scene down twice to baseline and proves stale
+// handles are rejected.
+
+const OFFSET = 68;
+const BOARD = 8;
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[match3 ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+const START = Date.now();
+
+async function snapshot(evaluate) {
+  return evaluate(`(() => {
+    const bridge = globalThis.KanamaWebBridge;
+    const classCount = (suffix) => {
+      const entry = Object.entries(bridge.match3ReadyByClass).find(([n]) => n.endsWith(suffix));
+      return entry?.[1] ?? 0;
+    };
+    const tileGrid = [...bridge.match3TileTypeByHandle.entries()].map(([handle, type]) => {
+      const position = bridge.match3NodePositions.get(handle);
+      return position
+        ? { handle, type, x: Math.round(position.x / ${OFFSET}), y: Math.round(position.y / ${OFFSET}) }
+        : { handle, type, x: null, y: null };
+    }).sort((l, r) => (l.y - r.y) || (l.x - r.x));
+    return {
+      protocol: bridge.results.protocolVersion,
+      mainHandle: bridge.match3MainHandle,
+      audioHandle: bridge.match3AudioHandle,
+      tileGrid,
+      tileReady: classCount(".Tile"),
+      particleReady: classCount(".Particles"),
+      tileFrees: bridge.match3TileScriptFrees,
+      particleFrees: bridge.match3ParticleFrees,
+      packedSceneInstantiations: bridge.match3PackedSceneInstantiations,
+      addChildCommands: bridge.match3AddChildCommands,
+      positionTweenTargets: bridge.match3PositionTweenTargets,
+      playCommands: bridge.match3AudioPlayCommands,
+      playersConstructed: bridge.match3AudioPlayersConstructed,
+      sceneTreeHandles: [...bridge.sceneTreeHandlesByOwner.entries()],
+      sceneTreeHandlesCreated: bridge.match3SceneTreeHandlesCreated,
+      sceneTreeHandleReuses: bridge.match3SceneTreeHandleReuses,
+      liveHandles: bridge.liveBrowserHandleCount,
+      callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+      pending: bridge.api.kanamaWebPendingCoroutineCount(),
+      jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+      tweensCreated: bridge.match3TweensCreated,
+      tweensReleased: bridge.match3TweensReleased,
+      callbackErrors: bridge.callbackErrors,
+      failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+    };
+  })()`);
+}
+
+async function waitUntil(evaluate, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let current = null;
+  while (Date.now() < deadline) {
+    current = await snapshot(evaluate);
+    if (predicate(current)) return current;
+    await delay(25);
+  }
+  return current;
+}
+
+function matrixFrom(tileGrid) {
+  const grid = Array.from({ length: BOARD }, () => Array(BOARD).fill(null));
+  for (const tile of tileGrid) {
+    if (Number.isInteger(tile.x) && Number.isInteger(tile.y) &&
+        tile.x >= 0 && tile.x < BOARD && tile.y >= 0 && tile.y < BOARD) {
+      if (grid[tile.x][tile.y] !== null) throw new Error(`Duplicate tile ${tile.x},${tile.y}`);
+      grid[tile.x][tile.y] = tile.type;
+    }
+  }
+  if (grid.some((col) => col.some((v) => v === null))) {
+    throw new Error(`Incomplete Match3 grid telemetry: ${JSON.stringify(tileGrid)}`);
+  }
+  return grid;
+}
+
+function hasMatch(grid) {
+  for (let y = 0; y < BOARD; y += 1)
+    for (let x = 0; x < BOARD - 2; x += 1)
+      if (grid[x][y] === grid[x + 1][y] && grid[x][y] === grid[x + 2][y]) return true;
+  for (let x = 0; x < BOARD; x += 1)
+    for (let y = 0; y < BOARD - 2; y += 1)
+      if (grid[x][y] === grid[x][y + 1] && grid[x][y] === grid[x][y + 2]) return true;
+  return false;
+}
+
+function findLegalSwap(tileGrid) {
+  const grid = matrixFrom(tileGrid);
+  if (hasMatch(grid)) throw new Error("Board was not settled before legal-swap search");
+  for (let y = 0; y < BOARD; y += 1)
+    for (let x = 0; x < BOARD; x += 1)
+      for (const [dx, dy] of [[1, 0], [0, 1]]) {
+        const ox = x + dx;
+        const oy = y + dy;
+        if (ox >= BOARD || oy >= BOARD) continue;
+        [grid[x][y], grid[ox][oy]] = [grid[ox][oy], grid[x][y]];
+        const legal = hasMatch(grid);
+        [grid[x][y], grid[ox][oy]] = [grid[ox][oy], grid[x][y]];
+        if (legal) return { x, y, dx, dy };
+      }
+  return null;
+}
+
+async function drag(call, evaluate, { x, y, dx, dy }) {
+  const geometry = await evaluate(`(() => {
+    const canvas = document.querySelector("canvas");
+    const rect = canvas.getBoundingClientRect();
+    const boardX = canvas.width / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
+    const boardY = canvas.height / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
+    const toClient = (gx, gy) => ({
+      x: rect.left + gx * rect.width / canvas.width,
+      y: rect.top + gy * rect.height / canvas.height,
+    });
+    return {
+      press: toClient(boardX + ${x} * ${OFFSET}, boardY + ${y} * ${OFFSET}),
+      release: toClient(boardX + (${x} + ${dx}) * ${OFFSET}, boardY + (${y} + ${dy}) * ${OFFSET}),
+    };
+  })()`);
+  await call("Input.dispatchMouseEvent", { type: "mousePressed", x: geometry.press.x, y: geometry.press.y, button: "left", buttons: 1, clickCount: 1 });
+  await delay(100);
+  await call("Input.dispatchMouseEvent", { type: "mouseMoved", x: geometry.release.x, y: geometry.release.y, button: "none", buttons: 1 });
+  await delay(25);
+  await call("Input.dispatchMouseEvent", { type: "mouseReleased", x: geometry.release.x, y: geometry.release.y, button: "left", buttons: 0, clickCount: 1 });
+  return geometry;
+}
+
+async function navigateAndSettle(call, evaluate, url, label) {
+  trace(`navigate ${label}`);
+  await call("Page.navigate", { url: `${url}?run=${label}&cache=${Date.now()}` });
+  const deadline = Date.now() + 30_000;
+  let board = null;
+  while (Date.now() < deadline) {
+    board = await evaluate("globalThis.KanamaWebMatch3Results ?? null");
+    if (board?.pass === true) break;
+    await delay(50);
+  }
+  if (board?.pass !== true) throw new Error(`Match3 ${label} board did not become ready`);
+  trace(`${label} board ready; settling`);
+  const settled = await waitUntil(
+    evaluate,
+    (v) => v.tileGrid.length === 64 && v.pending === 0 && v.jobs === 0 &&
+           v.callbacks === 12 && v.tweensCreated === v.tweensReleased,
+    30_000,
+  );
+  trace(`${label} settled: tiles=${settled.tileGrid.length} pending=${settled.pending} jobs=${settled.jobs} callbacks=${settled.callbacks} tweens=${settled.tweensCreated}/${settled.tweensReleased}`);
+  matrixFrom(settled.tileGrid);
+  return { board, settled };
+}
+
+async function teardownCurrentRun(evaluate) {
+  const beforeMain = await snapshot(evaluate);
+  const sceneTreeProbe = await evaluate(`globalThis.KanamaWebBridge.invoke(${beforeMain.mainHandle}, "g8_scene_tree", "g8_scene_tree", () => globalThis.KanamaWebBridge.api.kanamaWebMatch3Group8SceneTreeProbe(${beforeMain.mainHandle}), 0)`);
+  const sceneTreeHandle = await evaluate("globalThis.KanamaWebBridge.api.kanamaWebMatch3Group8SceneTreeHandle()");
+  const afterSceneTree = await snapshot(evaluate);
+  const mainTeardownResult = await evaluate(`globalThis.KanamaWebBridge.invoke(${beforeMain.mainHandle}, "g8_main_teardown", "g8_main_teardown", () => globalThis.KanamaWebBridge.api.kanamaWebMatch3Group8MainTeardownProbe(${beforeMain.mainHandle}), 0)`);
+  const afterMain = await waitUntil(
+    evaluate,
+    (v) => v.mainHandle === 0 && v.tileGrid.length === 0 && v.pending === 0 && v.jobs === 0 &&
+           v.tweensCreated === v.tweensReleased,
+    15_000,
+  );
+  const sceneTreeStaleProbe = await evaluate(`globalThis.KanamaWebBridge.api.kanamaWebMatch3Group8SceneTreeStaleProbe(${sceneTreeHandle})`);
+  const audioTeardownResult = await evaluate(`globalThis.KanamaWebBridge.invoke(${afterMain.audioHandle}, "g7_audio_teardown", "g7_audio_teardown", () => globalThis.KanamaWebBridge.api.kanamaWebMatch3Group7AudioOwnerTeardownProbe(${afterMain.audioHandle}), 0)`);
+  const afterAudio = await waitUntil(
+    evaluate,
+    (v) => v.audioHandle === 0 && v.liveHandles === 0 && v.callbacks === 0 && v.pending === 0 && v.jobs === 0,
+    15_000,
+  );
+  return { beforeMain, sceneTreeProbe, sceneTreeHandle, afterSceneTree, mainTeardownResult, afterMain, sceneTreeStaleProbe, audioTeardownResult, afterAudio };
+}
+
+function teardownClean(t) {
+  return (
+    t.sceneTreeProbe === 3 && t.sceneTreeHandle > 0 &&
+    t.afterSceneTree.sceneTreeHandles.length === 1 &&
+    t.mainTeardownResult === 1 && t.afterMain.mainHandle === 0 &&
+    t.afterMain.tileGrid.length === 0 && t.afterMain.sceneTreeHandles.length === 0 &&
+    t.sceneTreeStaleProbe === 1 && t.audioTeardownResult === 1 &&
+    t.afterAudio.audioHandle === 0 && t.afterAudio.liveHandles === 0 &&
+    t.afterAudio.callbacks === 0 && t.afterAudio.pending === 0 && t.afterAudio.jobs === 0
+  );
+}
+
+export async function runMatch3({ url, call, evaluate }) {
+  const startupStart = Date.now();
+  const firstRun = await navigateAndSettle(call, evaluate, url, "first");
+  const startupDurationMs = Date.now() - startupStart;
+
+  const legalSwap = findLegalSwap(firstRun.settled.tileGrid);
+  if (!legalSwap) throw new Error("Settled Match3 board has no legal swap");
+  const beforeSwap = await snapshot(evaluate);
+  await drag(call, evaluate, legalSwap);
+  const afterSwap = await waitUntil(
+    evaluate,
+    (v) => v.tileFrees > beforeSwap.tileFrees && v.tileGrid.length === 64 &&
+           v.pending === 0 && v.jobs === 0 && v.callbacks === 12 &&
+           v.tweensCreated === v.tweensReleased,
+    30_000,
+  );
+  matrixFrom(afterSwap.tileGrid);
+
+  const firstTeardown = await teardownCurrentRun(evaluate);
+  const secondRun = await navigateAndSettle(call, evaluate, url, "restart");
+  const secondTeardown = await teardownCurrentRun(evaluate);
+
+  const tileFreeDelta = afterSwap.tileFrees - beforeSwap.tileFrees;
+  const tileReadyDelta = afterSwap.tileReady - beforeSwap.tileReady;
+  const particleReadyDelta = afterSwap.particleReady - beforeSwap.particleReady;
+  const particleFreeDelta = afterSwap.particleFrees - beforeSwap.particleFrees;
+  const packedDelta = afterSwap.packedSceneInstantiations - beforeSwap.packedSceneInstantiations;
+  const addDelta = afterSwap.addChildCommands - beforeSwap.addChildCommands;
+  const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
+
+  const checks = {
+    protocol6: firstRun.settled.protocol === 6 && secondRun.settled.protocol === 6,
+    exactOriginalBoard:
+      firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
+      firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,
+    settledBoardHasNoExistingMatch: !hasMatch(matrixFrom(firstRun.settled.tileGrid)),
+    runtimeSelectedLegalSwap: legalSwap !== null,
+    matchCollapseRefillCompleted:
+      tileFreeDelta >= 3 && tileReadyDelta === tileFreeDelta &&
+      particleReadyDelta === tileFreeDelta && particleFreeDelta === particleReadyDelta &&
+      packedDelta === tileReadyDelta + particleReadyDelta && addDelta === packedDelta &&
+      positionTweenDelta >= tileReadyDelta + 2 && afterSwap.tileGrid.length === 64,
+    audiovisualFeedback: afterSwap.playCommands > beforeSwap.playCommands && particleReadyDelta > 0,
+    boundedAfterGameplay:
+      afterSwap.liveHandles === beforeSwap.liveHandles && afterSwap.callbacks === 12 &&
+      afterSwap.pending === 0 && afterSwap.jobs === 0,
+    firstFullTeardown: teardownClean(firstTeardown),
+    restartRecreatesOriginalShape:
+      secondRun.board.pass === true && secondRun.settled.tileGrid.length === 64 &&
+      secondRun.settled.playersConstructed === 12 && secondRun.settled.callbacks === 12,
+    repeatedFullTeardown: teardownClean(secondTeardown),
+  };
+
+  const boundaryErrors = [];
+  if (secondTeardown.afterAudio.callbackErrors !== 0) boundaryErrors.push("callbackErrors > 0");
+  if (secondTeardown.afterAudio.failure !== null) boundaryErrors.push(`failure: ${secondTeardown.afterAudio.failure}`);
+
+  const staleRejected =
+    (firstTeardown.sceneTreeStaleProbe === 1 ? 1 : 0) +
+    (secondTeardown.sceneTreeStaleProbe === 1 ? 1 : 0);
+
+  return {
+    protocolVersion: firstRun.settled.protocol,
+    startup: {
+      loaded: firstRun.board.pass === true,
+      outcome: firstRun.board.pass === true ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: afterSwap.liveHandles,
+      liveAfterTeardown: secondTeardown.afterAudio.liveHandles,
+      staleRejected,
+    },
+    crossings: {
+      packedSceneInstantiations: afterSwap.packedSceneInstantiations,
+      addChildCommands: afterSwap.addChildCommands,
+      positionTweenTargets: afterSwap.positionTweenTargets,
+      audioPlayCommands: afterSwap.playCommands,
+    },
+    callbacks: {
+      settledDuringGameplay: afterSwap.callbacks,
+      afterTeardown: secondTeardown.afterAudio.callbacks,
+    },
+    connections: {
+      signalCallbacksSettled: afterSwap.callbacks,
+      afterTeardown: secondTeardown.afterAudio.callbacks,
+    },
+    scheduler: {
+      pendingCoroutines: secondTeardown.afterAudio.pending,
+      registeredJobs: secondTeardown.afterAudio.jobs,
+    },
+    teardown: {
+      outcome: teardownClean(firstTeardown) && teardownClean(secondTeardown) ? "clean" : "incomplete",
+      ownerRegistriesToBaseline:
+        secondTeardown.afterAudio.liveHandles === 0 &&
+        secondTeardown.afterAudio.callbacks === 0 &&
+        secondTeardown.afterAudio.pending === 0 &&
+        secondTeardown.afterAudio.jobs === 0,
+    },
+    boundaryErrors,
+  };
+}

--- a/scripts/web/drivers/envelope.mjs
+++ b/scripts/web/drivers/envelope.mjs
@@ -1,0 +1,84 @@
+// envelope.mjs -- shared helpers for the Web export-smoke browser drivers.
+//
+// collectPayload() reports served-file sizes (drivers run in Node, so they can
+// read the export dir directly). buildEnvelope() maps a demo module's result
+// into the versioned v1 result envelope that result_schema.py validates.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA_VERSION = 1;
+
+export function collectPayload(exportDir, url, sourceChecksum) {
+  const files = [];
+  let totalBytes = 0;
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        const bytes = fs.statSync(full).size;
+        files.push({ name: path.relative(exportDir, full), bytes });
+        totalBytes += bytes;
+      }
+    }
+  };
+  walk(exportDir);
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return { url, files, totalBytes, sourceTreeChecksum: sourceChecksum };
+}
+
+// demoResult contract (produced by each demo module):
+//   protocolVersion : number
+//   startup         : { loaded, outcome, durationMs }
+//   checks          : { [name]: boolean }   (every gameplay/teardown assertion)
+//   handles         : { liveAfterGameplay, liveAfterTeardown, staleRejected }
+//   crossings       : { [name]: number }    (non-empty)
+//   callbacks       : { [name]: number }
+//   connections     : { [name]: number }
+//   scheduler       : { [name]: number }
+//   teardown        : { outcome, ownerRegistriesToBaseline }
+//   boundaryErrors  : string[]               (bridge/telemetry-reported faults)
+export function buildEnvelope({
+  demo,
+  browser,
+  payload,
+  durationMs,
+  consoleEvents,
+  demoResult,
+}) {
+  const checks = demoResult.checks;
+  const checkNames = Object.keys(checks);
+  const passed = checkNames.filter((name) => checks[name] === true).length;
+  const total = checkNames.length;
+  const failed = total - passed;
+
+  const consoleErrors = consoleEvents.map((event) => `${event.type}: ${event.text}`);
+  const boundaryErrors = [...(demoResult.boundaryErrors ?? [])];
+
+  const loaded = demoResult.startup.loaded === true;
+  const pass = failed === 0 && loaded && boundaryErrors.length === 0 && consoleErrors.length === 0;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    demo,
+    protocolVersion: demoResult.protocolVersion,
+    pass,
+    durationMs,
+    artifact: payload,
+    browser,
+    startup: demoResult.startup,
+    assertions: {
+      summary: { total, passed, failed, skipped: 0 },
+      checks,
+    },
+    crossings: demoResult.crossings,
+    handles: demoResult.handles,
+    callbacks: demoResult.callbacks,
+    connections: demoResult.connections,
+    scheduler: demoResult.scheduler,
+    console: { errors: consoleErrors, boundaryErrors },
+    teardown: demoResult.teardown,
+  };
+}

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -1,0 +1,229 @@
+// firefox_bidi.mjs -- Firefox production Web export-smoke driver (Task 57f).
+//
+// Self-launches headless Firefox with WebDriver BiDi, drives the demo over BiDi,
+// and emits the versioned v1 result envelope. Firefox is an explicit LOCAL
+// release gate (Chrome is the CI gate).
+//
+// BiDi serializes return values, so evaluate() deserializes them back into plain
+// JS -- keeping the shared demo modules (which expect plain objects) unchanged.
+//
+// Args match the other drivers: --url --result --demo --timeout --source-checksum
+// --export-dir [--browser-binary].
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runMatch3 } from "./demos/match3.mjs";
+import { runBunnymark } from "./demos/bunnymark.mjs";
+import { buildEnvelope, collectPayload } from "./envelope.mjs";
+
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark };
+const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    if (!argv[i].startsWith("--")) throw new Error(`unexpected argument: ${argv[i]}`);
+    args[argv[i].slice(2)] = argv[i + 1];
+  }
+  for (const req of ["url", "result", "demo", "timeout", "source-checksum", "export-dir"]) {
+    if (!args[req]) throw new Error(`firefox_bidi: missing --${req}`);
+  }
+  return args;
+}
+
+// Reconstruct plain JS from a BiDi RemoteValue (with a generous object depth).
+function deserialize(node) {
+  if (node == null || typeof node !== "object") return node;
+  switch (node.type) {
+    case "undefined":
+      return undefined;
+    case "null":
+      return null;
+    case "string":
+    case "boolean":
+      return node.value;
+    case "number":
+      return typeof node.value === "string" ? Number(node.value) : node.value;
+    case "bigint":
+      return Number(node.value);
+    case "array":
+    case "set":
+      return (node.value ?? []).map(deserialize);
+    case "object":
+    case "map":
+      return Object.fromEntries(
+        (node.value ?? []).map(([key, value]) => [
+          typeof key === "string" ? key : deserialize(key),
+          deserialize(value),
+        ]),
+      );
+    default:
+      return node.value;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const timeoutMs = Number(args.timeout) * 1000;
+  const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+
+  const runDemo = DEMOS[args.demo];
+  if (!runDemo) throw new Error(`firefox_bidi: unknown demo '${args.demo}'`);
+
+  const firefoxBinary = args["browser-binary"] ?? DEFAULT_FIREFOX;
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "kanama-firefox-"));
+  // Headless Firefox needs software WebGL for Godot's Compatibility renderer.
+  fs.writeFileSync(
+    path.join(profileDir, "user.js"),
+    [
+      'user_pref("remote.active-protocols", 2);',
+      'user_pref("webgl.force-enabled", true);',
+      'user_pref("webgl.disabled", false);',
+      'user_pref("gfx.webrender.software", true);',
+      'user_pref("dom.webgl.software.render", true);',
+    ].join("\n"),
+  );
+
+  const port = 9300 + Math.floor(Math.random() * 500);
+  const firefox = spawn(
+    firefoxBinary,
+    ["--headless", "--no-remote", `--profile`, profileDir, `--remote-debugging-port=${port}`, "about:blank"],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  let socket = null;
+  const cleanup = () => {
+    try {
+      socket?.close();
+    } catch {
+      // ignore
+    }
+    if (!firefox.killed) firefox.kill("SIGKILL");
+    try {
+      fs.rmSync(profileDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  };
+  process.on("exit", cleanup);
+
+  try {
+    // Poll-connect to the BiDi session endpoint until Firefox is listening.
+    const endpoint = `ws://127.0.0.1:${port}/session`;
+    while (Date.now() < deadline) {
+      try {
+        const candidate = new WebSocket(endpoint);
+        await new Promise((resolve, reject) => {
+          candidate.addEventListener("open", resolve, { once: true });
+          candidate.addEventListener("error", reject, { once: true });
+        });
+        socket = candidate;
+        break;
+      } catch {
+        if (firefox.exitCode !== null) throw new Error(`Firefox exited early (${firefox.exitCode})`);
+        await delay(250);
+      }
+    }
+    if (!socket) throw new Error("Firefox BiDi endpoint never became reachable");
+
+    let nextId = 1;
+    const pending = new Map();
+    const logEntries = [];
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (message.id != null) {
+        const waiter = pending.get(message.id);
+        if (waiter) {
+          pending.delete(message.id);
+          if (message.type === "error") waiter.reject(new Error(`${message.error}: ${message.message}`));
+          else waiter.resolve(message.result);
+        }
+        return;
+      }
+      if (message.method === "log.entryAdded") logEntries.push(message.params);
+    });
+    const command = (method, params = {}) => {
+      const id = nextId++;
+      socket.send(JSON.stringify({ id, method, params }));
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+    };
+
+    await command("session.new", { capabilities: { alwaysMatch: { acceptInsecureCerts: true } } });
+    await command("session.subscribe", { events: ["log.entryAdded"] });
+    const tree = await command("browsingContext.getTree", { maxDepth: 1 });
+    const context = tree.contexts[0]?.context;
+    if (!context) throw new Error("Firefox exposed no browsing context");
+
+    const evaluate = async (expression) => {
+      const result = await command("script.evaluate", {
+        expression,
+        target: { context },
+        awaitPromise: true,
+        resultOwnership: "none",
+        serializationOptions: { maxObjectDepth: 99, maxDomDepth: 0 },
+        userActivation: true,
+      });
+      if (result.type === "exception") {
+        throw new Error(result.exceptionDetails?.text ?? `evaluate failed: ${expression.slice(0, 80)}`);
+      }
+      return deserialize(result.result);
+    };
+    const navigate = (url) => command("browsingContext.navigate", { context, url, wait: "complete" });
+    const pointer = (press, release) =>
+      command("input.performActions", {
+        context,
+        actions: [
+          {
+            type: "pointer",
+            id: "mouse",
+            parameters: { pointerType: "mouse" },
+            actions: [
+              { type: "pointerMove", x: Math.round(press.x), y: Math.round(press.y), origin: "viewport" },
+              { type: "pointerDown", button: 0 },
+              { type: "pause", duration: 100 },
+              { type: "pointerMove", x: Math.round(release.x), y: Math.round(release.y), origin: "viewport", duration: 50 },
+              { type: "pause", duration: 25 },
+              { type: "pointerUp", button: 0 },
+            ],
+          },
+        ],
+      });
+
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
+
+    const browserVersion = await evaluate("navigator.userAgent");
+    const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);
+    const consoleEvents = logEntries
+      .filter((entry) => entry.level === "error")
+      .map((entry) => ({ type: "console.error", text: entry.text ?? "error" }));
+
+    const envelope = buildEnvelope({
+      demo: args.demo,
+      browser: { engine: "firefox", name: "Firefox", version: String(browserVersion) },
+      payload,
+      durationMs: Date.now() - startedAt,
+      consoleEvents,
+      demoResult,
+    });
+
+    fs.writeFileSync(args.result, `${JSON.stringify(envelope, null, 2)}\n`);
+    try {
+      await command("session.end");
+    } catch {
+      // ignore
+    }
+    cleanup();
+    process.exit(envelope.pass ? 0 : 1);
+  } catch (error) {
+    cleanup();
+    process.stderr.write(`firefox_bidi: ${error.stack ?? error}\n`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -94,6 +94,15 @@ async function main() {
       // Viewport-origin coordinates are CSS client pixels (W3C), which the demo
       // already produces. Safari requires the trailing DELETE /actions release
       // to actually finalize and dispatch the pointer sequence.
+      // Discrete waypoints (not one interpolated move) so Godot reliably tracks
+      // the pointer to the release position before the button release -- Main.input
+      // reads getLocalMousePosition() at mouse-up, and a single move can race.
+      const px = Math.round(press.x);
+      const py = Math.round(press.y);
+      const rx = Math.round(release.x);
+      const ry = Math.round(release.y);
+      const mx = Math.round((px + rx) / 2);
+      const my = Math.round((py + ry) / 2);
       await wd("POST", `/session/${sessionId}/actions`, {
         actions: [
           {
@@ -101,11 +110,13 @@ async function main() {
             id: "mouse",
             parameters: { pointerType: "mouse" },
             actions: [
-              { type: "pointerMove", duration: 0, x: Math.round(press.x), y: Math.round(press.y), origin: "viewport" },
+              { type: "pointerMove", duration: 0, x: px, y: py, origin: "viewport" },
               { type: "pointerDown", button: 0 },
-              { type: "pause", duration: 100 },
-              { type: "pointerMove", duration: 100, x: Math.round(release.x), y: Math.round(release.y), origin: "viewport" },
-              { type: "pause", duration: 25 },
+              { type: "pause", duration: 120 },
+              { type: "pointerMove", duration: 80, x: mx, y: my, origin: "viewport" },
+              { type: "pause", duration: 40 },
+              { type: "pointerMove", duration: 80, x: rx, y: ry, origin: "viewport" },
+              { type: "pause", duration: 200 },
               { type: "pointerUp", button: 0 },
             ],
           },

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -1,0 +1,154 @@
+// safari_webdriver.mjs -- Safari production Web export-smoke driver (Task 57f).
+//
+// Drives Safari over classic W3C WebDriver via `safaridriver`. Safari is an
+// explicit LOCAL release gate (Chrome is the CI gate). It requires a one-time
+// `safaridriver --enable` and "Allow Remote Automation" in Safari's Develop menu.
+//
+// SafariDriver exposes no browser-log endpoint, so console errors cannot be
+// collected here; the gate instead asserts bridge callback/telemetry via the
+// demo module's boundaryErrors plus every gameplay and teardown invariant.
+//
+// Args match the other drivers: --url --result --demo --timeout --source-checksum
+// --export-dir [--browser-binary(unused)].
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+import { runMatch3 } from "./demos/match3.mjs";
+import { runBunnymark } from "./demos/bunnymark.mjs";
+import { buildEnvelope, collectPayload } from "./envelope.mjs";
+
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark };
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    if (!argv[i].startsWith("--")) throw new Error(`unexpected argument: ${argv[i]}`);
+    args[argv[i].slice(2)] = argv[i + 1];
+  }
+  for (const req of ["url", "result", "demo", "timeout", "source-checksum", "export-dir"]) {
+    if (!args[req]) throw new Error(`safari_webdriver: missing --${req}`);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const deadline = Date.now() + Number(args.timeout) * 1000;
+  const startedAt = Date.now();
+
+  const runDemo = DEMOS[args.demo];
+  if (!runDemo) throw new Error(`safari_webdriver: unknown demo '${args.demo}'`);
+
+  const port = 9500 + Math.floor(Math.random() * 400);
+  const driver = spawn("safaridriver", ["-p", String(port)], { stdio: ["ignore", "pipe", "pipe"] });
+  const base = `http://127.0.0.1:${port}`;
+  let sessionId = null;
+
+  const cleanup = () => {
+    if (!driver.killed) driver.kill("SIGKILL");
+  };
+  process.on("exit", cleanup);
+
+  const wd = async (method, endpoint, body) => {
+    const response = await fetch(`${base}${endpoint}`, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const json = await response.json();
+    if (!response.ok || json.value?.error) {
+      throw new Error(`WebDriver ${method} ${endpoint} failed: ${JSON.stringify(json.value ?? json)}`);
+    }
+    return json.value;
+  };
+
+  try {
+    // Wait for the safaridriver HTTP server, then open a session.
+    while (Date.now() < deadline) {
+      try {
+        const value = await wd("POST", "/session", {
+          capabilities: { alwaysMatch: { browserName: "safari" } },
+        });
+        sessionId = value.sessionId;
+        break;
+      } catch (error) {
+        if (driver.exitCode !== null) throw new Error(`safaridriver exited (${driver.exitCode})`);
+        await delay(300);
+      }
+    }
+    if (!sessionId) throw new Error("Safari session could not be created (is Remote Automation enabled?)");
+
+    await wd("POST", `/session/${sessionId}/window/rect`, { x: 0, y: 0, width: 1280, height: 900 });
+
+    // W3C execute/sync returns a JSON-cloned value. eval(arguments[0]) evaluates
+    // the demo's expression (or "stmt; value") uniformly and returns its value.
+    const evaluate = async (expression) =>
+      (await wd("POST", `/session/${sessionId}/execute/sync`, {
+        script: "return eval(arguments[0]);",
+        args: [expression],
+      }));
+    const navigate = (url) => wd("POST", `/session/${sessionId}/url`, { url });
+    const pointer = async (press, release) => {
+      // Viewport-origin coordinates are CSS client pixels (W3C), which the demo
+      // already produces. Safari requires the trailing DELETE /actions release
+      // to actually finalize and dispatch the pointer sequence.
+      await wd("POST", `/session/${sessionId}/actions`, {
+        actions: [
+          {
+            type: "pointer",
+            id: "mouse",
+            parameters: { pointerType: "mouse" },
+            actions: [
+              { type: "pointerMove", duration: 0, x: Math.round(press.x), y: Math.round(press.y), origin: "viewport" },
+              { type: "pointerDown", button: 0 },
+              { type: "pause", duration: 100 },
+              { type: "pointerMove", duration: 100, x: Math.round(release.x), y: Math.round(release.y), origin: "viewport" },
+              { type: "pause", duration: 25 },
+              { type: "pointerUp", button: 0 },
+            ],
+          },
+        ],
+      });
+      await wd("DELETE", `/session/${sessionId}/actions`);
+    };
+
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
+
+    const browserVersion = await evaluate("navigator.userAgent");
+    const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);
+
+    // No SafariDriver console endpoint: rely on the demo's bridge telemetry.
+    const envelope = buildEnvelope({
+      demo: args.demo,
+      browser: { engine: "safari", name: "Safari", version: String(browserVersion) },
+      payload,
+      durationMs: Date.now() - startedAt,
+      consoleEvents: [],
+      demoResult,
+    });
+
+    fs.writeFileSync(args.result, `${JSON.stringify(envelope, null, 2)}\n`);
+    try {
+      await wd("DELETE", `/session/${sessionId}`);
+    } catch {
+      // ignore
+    }
+    cleanup();
+    process.exit(envelope.pass ? 0 : 1);
+  } catch (error) {
+    if (sessionId) {
+      try {
+        await wd("DELETE", `/session/${sessionId}`);
+      } catch {
+        // ignore
+      }
+    }
+    cleanup();
+    process.stderr.write(`safari_webdriver: ${error.stack ?? error}\n`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/scripts/web/result_schema.py
+++ b/scripts/web/result_schema.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Versioned Web export-smoke result envelope and its fail-loud validator.
+
+Task 57f formalizes the ad-hoc Task-57 per-browser result JSON into a single
+machine-readable envelope shared by the Chrome, Firefox, and Safari drivers.
+Every driver writes this envelope; ``scripts/web_export_smoke.sh`` validates it
+before a browser may be declared green.
+
+The validator is deliberately strict: a missing required field or a skipped
+assertion is a harness failure, not a warning. A run is never green from page
+load alone -- ``startup.loaded`` is necessary but never sufficient.
+
+Usage:
+    python3 result_schema.py <result.json>          # validate, exit non-zero on failure
+    python3 result_schema.py --print-version        # emit the current schema version
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from numbers import Real
+from typing import Any, Callable
+
+# Bump when the envelope shape changes in a way drivers must follow.
+SCHEMA_VERSION = 1
+
+# Browser engines that may report a result. Each is validated identically; the
+# smoke shell decides which are CI gates (Chrome) vs local release gates.
+KNOWN_ENGINES = ("chrome", "firefox", "safari")
+
+
+class SchemaError(Exception):
+    """Raised when a result envelope violates the schema."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SchemaError(message)
+
+
+def _get(mapping: Any, key: str, path: str) -> Any:
+    _require(isinstance(mapping, dict), f"{path} must be an object")
+    _require(key in mapping, f"{path}.{key} is required")
+    value = mapping[key]
+    _require(value is not None, f"{path}.{key} must not be null (skipped fields fail the harness)")
+    return value
+
+
+def _check_type(value: Any, kind: type | tuple[type, ...], path: str) -> Any:
+    # bool is a subclass of int; guard against it leaking into numeric fields.
+    if kind in (int, Real) and isinstance(value, bool):
+        raise SchemaError(f"{path} must be numeric, not a boolean")
+    _require(isinstance(value, kind), f"{path} has the wrong type")
+    return value
+
+
+def _non_negative(value: Any, path: str) -> Real:
+    _check_type(value, Real, path)
+    _require(value >= 0, f"{path} must be non-negative")
+    return value
+
+
+def _validate_artifact(artifact: Any) -> None:
+    path = "artifact"
+    _check_type(_get(artifact, "url", path), str, f"{path}.url")
+    files = _get(artifact, "files", path)
+    _check_type(files, list, f"{path}.files")
+    _require(len(files) > 0, f"{path}.files must list at least one served payload file")
+    for index, entry in enumerate(files):
+        entry_path = f"{path}.files[{index}]"
+        _check_type(_get(entry, "name", entry_path), str, f"{entry_path}.name")
+        _non_negative(_get(entry, "bytes", entry_path), f"{entry_path}.bytes")
+    _non_negative(_get(artifact, "totalBytes", path), f"{path}.totalBytes")
+    # Source-tree immutability evidence: a checksum the shell can compare
+    # against the pre-run source tree to prove the export did not mutate it.
+    _check_type(_get(artifact, "sourceTreeChecksum", path), str, f"{path}.sourceTreeChecksum")
+
+
+def _validate_browser(browser: Any) -> None:
+    path = "browser"
+    engine = _get(browser, "engine", path)
+    _require(
+        engine in KNOWN_ENGINES,
+        f"{path}.engine must be one of {KNOWN_ENGINES}, got {engine!r}",
+    )
+    _check_type(_get(browser, "name", path), str, f"{path}.name")
+    _check_type(_get(browser, "version", path), str, f"{path}.version")
+
+
+def _validate_startup(startup: Any) -> None:
+    path = "startup"
+    _check_type(_get(startup, "loaded", path), bool, f"{path}.loaded")
+    _check_type(_get(startup, "outcome", path), str, f"{path}.outcome")
+    _non_negative(_get(startup, "durationMs", path), f"{path}.durationMs")
+
+
+def _validate_assertions(assertions: Any) -> None:
+    path = "assertions"
+    summary = _get(assertions, "summary", path)
+    total = _non_negative(_get(summary, "total", f"{path}.summary"), f"{path}.summary.total")
+    passed = _non_negative(_get(summary, "passed", f"{path}.summary"), f"{path}.summary.passed")
+    failed = _non_negative(_get(summary, "failed", f"{path}.summary"), f"{path}.summary.failed")
+    skipped = _non_negative(_get(summary, "skipped", f"{path}.summary"), f"{path}.summary.skipped")
+    _require(total > 0, f"{path}.summary.total must be > 0 (a page-load-only run is never green)")
+    _require(skipped == 0, f"{path}.summary.skipped must be 0; skipped assertions fail the harness")
+    _require(
+        passed + failed == total,
+        f"{path}.summary passed+failed ({passed}+{failed}) must equal total ({total})",
+    )
+    checks = _get(assertions, "checks", path)
+    _check_type(checks, dict, f"{path}.checks")
+    _require(len(checks) > 0, f"{path}.checks must be non-empty")
+    observed_passed = 0
+    for name, value in checks.items():
+        _require(
+            isinstance(value, bool),
+            f"{path}.checks.{name} must be a boolean (a skipped/incomplete check fails the harness)",
+        )
+        observed_passed += 1 if value else 0
+    _require(
+        observed_passed == passed and len(checks) == total,
+        f"{path}.checks must be consistent with the summary "
+        f"(checks={len(checks)}/passed={observed_passed} vs total={total}/passed={passed})",
+    )
+
+
+def _validate_handles(handles: Any) -> None:
+    path = "handles"
+    _non_negative(_get(handles, "liveAfterGameplay", path), f"{path}.liveAfterGameplay")
+    # Teardown must return the handle registry to baseline.
+    live_after_teardown = _non_negative(
+        _get(handles, "liveAfterTeardown", path), f"{path}.liveAfterTeardown"
+    )
+    _require(
+        live_after_teardown == 0,
+        f"{path}.liveAfterTeardown must be 0 after full teardown, got {live_after_teardown}",
+    )
+    # Stale-handle rejection is a required, exercised invariant.
+    _non_negative(_get(handles, "staleRejected", path), f"{path}.staleRejected")
+
+
+def _validate_counter_group(mapping: Any, path: str, keys: tuple[str, ...]) -> None:
+    for key in keys:
+        _non_negative(_get(mapping, key, path), f"{path}.{key}")
+
+
+def _validate_console(console: Any) -> None:
+    path = "console"
+    errors = _get(console, "errors", path)
+    _check_type(errors, list, f"{path}.errors")
+    boundary = _get(console, "boundaryErrors", path)
+    _check_type(boundary, list, f"{path}.boundaryErrors")
+
+
+def _validate_teardown(teardown: Any) -> None:
+    path = "teardown"
+    _check_type(_get(teardown, "outcome", path), str, f"{path}.outcome")
+    _check_type(
+        _get(teardown, "ownerRegistriesToBaseline", path),
+        bool,
+        f"{path}.ownerRegistriesToBaseline",
+    )
+
+
+_TOP_LEVEL: tuple[tuple[str, Callable[[Any], None]], ...] = (
+    ("artifact", _validate_artifact),
+    ("browser", _validate_browser),
+    ("startup", _validate_startup),
+    ("assertions", _validate_assertions),
+    ("handles", _validate_handles),
+    ("console", _validate_console),
+    ("teardown", _validate_teardown),
+)
+
+
+def validate(envelope: Any) -> None:
+    """Validate a parsed result envelope, raising SchemaError on the first fault."""
+    _require(isinstance(envelope, dict), "result envelope must be a JSON object")
+
+    version = _get(envelope, "schemaVersion", "envelope")
+    _check_type(version, int, "schemaVersion")
+    _require(
+        version == SCHEMA_VERSION,
+        f"schemaVersion must be {SCHEMA_VERSION}, got {version}",
+    )
+
+    demo = _get(envelope, "demo", "envelope")
+    _check_type(demo, str, "demo")
+    _require(demo != "", "demo must be non-empty")
+
+    protocol = _get(envelope, "protocolVersion", "envelope")
+    _check_type(protocol, int, "protocolVersion")
+    _require(protocol > 0, "protocolVersion must be positive")
+
+    _non_negative(_get(envelope, "durationMs", "envelope"), "durationMs")
+
+    for key, validator in _TOP_LEVEL:
+        validator(_get(envelope, key, "envelope"))
+
+    # Crossing counters and the lifecycle registries (callbacks, connections,
+    # scheduler) are required groups; each driver reports the counters relevant
+    # to its demo, but the group itself must be present and numeric.
+    _validate_counter_group(_get(envelope, "crossings", "envelope"), "crossings", ())
+    crossings = envelope["crossings"]
+    _require(isinstance(crossings, dict) and len(crossings) > 0, "crossings must be a non-empty object")
+    for name, value in crossings.items():
+        _non_negative(value, f"crossings.{name}")
+
+    for group in ("callbacks", "connections", "scheduler"):
+        mapping = _get(envelope, group, "envelope")
+        _check_type(mapping, dict, group)
+        for name, value in mapping.items():
+            _non_negative(value, f"{group}.{name}")
+
+    # An overall pass mirror must agree with the assertion summary.
+    overall = _get(envelope, "pass", "envelope")
+    _check_type(overall, bool, "pass")
+    summary = envelope["assertions"]["summary"]
+    expected_pass = summary["failed"] == 0 and envelope["startup"]["loaded"] is True
+    _require(
+        overall == expected_pass,
+        f"pass ({overall}) must reflect startup.loaded and zero failed assertions ({expected_pass})",
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate a Web export-smoke result envelope.")
+    parser.add_argument("result", nargs="?", help="path to the result JSON envelope")
+    parser.add_argument(
+        "--print-version",
+        action="store_true",
+        help="print the current schema version and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.print_version:
+        print(SCHEMA_VERSION)
+        return 0
+
+    if not args.result:
+        parser.error("a result JSON path is required unless --print-version is given")
+
+    try:
+        with open(args.result, encoding="utf-8") as handle:
+            envelope = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"web_export_smoke: could not read result {args.result}: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        validate(envelope)
+    except SchemaError as error:
+        print(f"web_export_smoke: result schema violation in {args.result}: {error}", file=sys.stderr)
+        return 1
+
+    print(f"web_export_smoke: result {args.result} satisfies schema v{SCHEMA_VERSION}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web/scaffold_selftest.sh
+++ b/scripts/web/scaffold_selftest.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# scaffold_selftest.sh -- exercises web_export_smoke.sh against a static fake
+# fixture (Task 57f1 scaffold validation). It proves the shell's mechanics only:
+# argument parsing, ephemeral port + process cleanup, timeout and error capture,
+# result-schema validation, source-tree immutability, and the pass gate. It does
+# NOT claim Bunnymark or Match3 pass -- those need real browsers (Task 57f
+# Phase 3).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE="$ROOT_DIR/scripts/web_export_smoke.sh"
+FIXTURE="$ROOT_DIR/scripts/fixtures/web-fake-export"
+FAKE_DRIVER="$FIXTURE/fake_driver.py"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/kanama-web-scaffold.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+PASSES=0
+FAILURES=0
+
+note() { echo "  $*"; }
+ok() { PASSES=$((PASSES + 1)); echo "PASS: $1"; }
+bad() { FAILURES=$((FAILURES + 1)); echo "FAIL: $1" >&2; }
+
+# Run one scenario: fresh fixture copy, run the shell with a fake-driver mode,
+# assert the exit code, then assert no owned process leaked.
+run_case() {
+  local name="$1" expected_status="$2" mode="$3"; shift 3
+  local case_dir="$WORK/$name"
+  local export_dir="$case_dir/export"
+  local result="$case_dir/result.json"
+  mkdir -p "$export_dir"
+  cp -R "$FIXTURE/index.html" "$FIXTURE/kanama-web-fake.js" "$export_dir/"
+
+  local driver_cmd="python3 $FAKE_DRIVER --mode $mode"
+  if [[ "$mode" == "mutate" ]]; then
+    driver_cmd="$driver_cmd --mutate-path $export_dir/index.html"
+  fi
+
+  local status=0
+  "$SMOKE" \
+    --export-dir "$export_dir" \
+    --demo "fake" \
+    --result "$result" \
+    --timeout 2 \
+    --log-dir "$case_dir/logs" \
+    --driver-cmd "$driver_cmd" \
+    >"$case_dir/stdout.log" 2>"$case_dir/stderr.log" || status=$?
+
+  if [[ "$status" -eq "$expected_status" ]]; then
+    ok "$name (exit $status)"
+  else
+    bad "$name expected exit $expected_status, got $status"
+    note "stderr: $(tail -n3 "$case_dir/stderr.log" 2>/dev/null || true)"
+  fi
+
+  # No owned process may survive: neither the static server for this export nor
+  # the fake driver for this result.
+  if pgrep -f "serve_export.py $export_dir" >/dev/null 2>&1; then
+    bad "$name leaked a static server process"
+  fi
+  if pgrep -f "fake_driver.py.*$result" >/dev/null 2>&1; then
+    bad "$name leaked a driver process"
+  fi
+
+  # On failure the shell must preserve logs and the result path must be reported.
+  if [[ "$expected_status" -ne 0 ]]; then
+    if [[ ! -f "$case_dir/logs/result.driver.log" ]]; then
+      bad "$name did not preserve the driver log on failure"
+    fi
+  fi
+}
+
+echo "== scaffold self-test: web_export_smoke.sh =="
+
+run_case success           0 success
+run_case failed-assertion  1 fail
+run_case malformed-result  1 malformed
+run_case schema-violation  1 schema-violation
+run_case wrong-checksum    1 wrong-checksum
+run_case driver-crash      1 crash
+run_case driver-timeout    1 timeout
+run_case tree-mutation     1 mutate
+
+# Success case must yield a schema-valid result on disk.
+if [[ -f "$WORK/success/result.json" ]] \
+   && python3 "$ROOT_DIR/scripts/web/result_schema.py" "$WORK/success/result.json" >/dev/null; then
+  ok "success result validates against the schema"
+else
+  bad "success result missing or invalid"
+fi
+
+# Argument validation: missing --export-dir must be a usage error (exit 2).
+usage_status=0
+"$SMOKE" --demo fake --result "$WORK/x.json" --driver-cmd "python3 $FAKE_DRIVER --mode success" \
+  >/dev/null 2>&1 || usage_status=$?
+if [[ "$usage_status" -eq 2 ]]; then
+  ok "missing --export-dir is a usage error (exit 2)"
+else
+  bad "missing --export-dir expected exit 2, got $usage_status"
+fi
+
+echo "== scaffold self-test: $PASSES passed, $FAILURES failed =="
+[[ "$FAILURES" -eq 0 ]]

--- a/scripts/web/serve_export.py
+++ b/scripts/web/serve_export.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Serve an already-built Web export over an ephemeral localhost HTTP port.
+
+The Web export-smoke shell owns this server's lifecycle. It binds 127.0.0.1 on
+an OS-chosen port (port 0), prints the resolved port as ``PORT=<n>`` on stdout so
+the caller can construct the artifact URL without racing on a fixed port, then
+serves the export directory read-only until it is terminated.
+
+The server never mutates the served tree. COOP/COEP headers are intentionally
+NOT sent: the preview backend is the single-thread Compatibility renderer, which
+does not require cross-origin isolation.
+
+Usage:
+    python3 serve_export.py <export-dir>
+"""
+
+from __future__ import annotations
+
+import http.server
+import socket
+import sys
+from functools import partial
+
+
+class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler with the correct Wasm MIME type and quiet logs."""
+
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+        ".js": "text/javascript",
+        ".mjs": "text/javascript",
+    }
+
+    def log_message(self, *args: object) -> None:  # noqa: D401 - silence per-request noise
+        # The shell captures failures via the driver/result; per-request access
+        # logging would only add noise to the preserved diagnostics.
+        return
+
+    def end_headers(self) -> None:
+        # No-store keeps re-runs from serving a stale export out of a browser
+        # cache; cache-busting query strings are a belt-and-braces second layer.
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: serve_export.py <export-dir>", file=sys.stderr)
+        return 2
+
+    export_dir = argv[0]
+    handler = partial(_QuietHandler, directory=export_dir)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+    # Announce the resolved port on a single line the shell greps for, then flush
+    # so the caller never blocks waiting on a buffered pipe.
+    print(f"PORT={port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# web_export_smoke.sh -- production Web export smoke harness (Task 57f).
+#
+# Serves an ALREADY-BUILT Web export over an ephemeral localhost port, runs a
+# per-browser driver that plays and tears down the demo, validates the driver's
+# machine-readable result against the versioned schema, and proves the served
+# tree was not mutated. It never builds the export (that is `exportWeb`), never
+# downloads a browser, and never declares a browser green from page load alone.
+#
+# The shell owns the HTTP server and the driver process group; the driver owns
+# its browser. On timeout or failure the shell kills only the processes it
+# started and preserves logs and the result for diagnosis.
+#
+# Usage:
+#   scripts/web_export_smoke.sh \
+#       --engine <chrome|firefox|safari> \
+#       --export-dir <dir> \
+#       --demo <bunnymark|match3> \
+#       --result <result.json> \
+#       [--browser-binary <path>] \
+#       [--timeout <seconds>] \
+#       [--log-dir <dir>] \
+#       [--driver-cmd "<command>"]   # override driver (scaffold self-test/advanced)
+#
+# Chrome is the intended CI gate; Firefox and Safari are explicit local release
+# gates.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT_DIR/scripts/web"
+
+ENGINE=""
+EXPORT_DIR=""
+DEMO=""
+RESULT=""
+BROWSER_BINARY=""
+TIMEOUT=300
+LOG_DIR=""
+DRIVER_CMD=""
+
+die() {
+  echo "web_export_smoke: $*" >&2
+  exit 2
+}
+
+usage() {
+  sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --engine) ENGINE="${2:?}"; shift 2 ;;
+    --export-dir) EXPORT_DIR="${2:?}"; shift 2 ;;
+    --demo) DEMO="${2:?}"; shift 2 ;;
+    --result) RESULT="${2:?}"; shift 2 ;;
+    --browser-binary) BROWSER_BINARY="${2:?}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?}"; shift 2 ;;
+    --log-dir) LOG_DIR="${2:?}"; shift 2 ;;
+    --driver-cmd) DRIVER_CMD="${2:?}"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$EXPORT_DIR" ]] || die "--export-dir is required"
+[[ -n "$DEMO" ]] || die "--demo is required"
+[[ -n "$RESULT" ]] || die "--result is required"
+[[ -d "$EXPORT_DIR" ]] || die "export dir not found: $EXPORT_DIR"
+[[ -f "$EXPORT_DIR/index.html" ]] || die "export dir has no index.html: $EXPORT_DIR"
+[[ "$TIMEOUT" =~ ^[0-9]+$ ]] || die "--timeout must be an integer number of seconds"
+
+# Resolve absolute paths so nothing depends on the caller's working directory.
+EXPORT_DIR="$(cd "$EXPORT_DIR" && pwd)"
+mkdir -p "$(dirname "$RESULT")"
+RESULT="$(cd "$(dirname "$RESULT")" && pwd)/$(basename "$RESULT")"
+
+if [[ -z "$LOG_DIR" ]]; then
+  LOG_DIR="$(dirname "$RESULT")"
+fi
+mkdir -p "$LOG_DIR"
+LOG_DIR="$(cd "$LOG_DIR" && pwd)"
+DRIVER_LOG="$LOG_DIR/$(basename "$RESULT" .json).driver.log"
+SERVER_LOG="$LOG_DIR/$(basename "$RESULT" .json).server.log"
+
+# Determine the driver command. Either an explicit override or the built-in
+# per-engine driver. Real engines require --engine; the override path is for the
+# scaffold self-test's fake fixture and does not require a known engine.
+if [[ -z "$DRIVER_CMD" ]]; then
+  [[ -n "$ENGINE" ]] || die "--engine is required unless --driver-cmd is given"
+  driver_file=""
+  case "$ENGINE" in
+    chrome) driver_file="$WEB_DIR/drivers/chrome_cdp.mjs" ;;
+    firefox) driver_file="$WEB_DIR/drivers/firefox_bidi.mjs" ;;
+    safari) driver_file="$WEB_DIR/drivers/safari_webdriver.mjs" ;;
+    *) die "unknown --engine: $ENGINE (expected chrome|firefox|safari)" ;;
+  esac
+  [[ -f "$driver_file" ]] || die "driver not yet formalized: $driver_file (Task 57f Phase 3)"
+  DRIVER_CMD="node $driver_file"
+fi
+
+# --- source-tree immutability: checksum the served tree before the run. -------
+tree_checksum() {
+  # Deterministic checksum over sorted (relative-path, sha256) pairs. Portable
+  # across macOS (shasum) and Linux CI (sha256sum) via python3.
+  python3 - "$1" <<'PY'
+import hashlib, os, sys
+root = sys.argv[1]
+digest = hashlib.sha256()
+for dirpath, dirnames, filenames in os.walk(root):
+    dirnames.sort()
+    for name in sorted(filenames):
+        path = os.path.join(dirpath, name)
+        rel = os.path.relpath(path, root)
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+print(digest.hexdigest())
+PY
+}
+
+CHECKSUM_BEFORE="$(tree_checksum "$EXPORT_DIR")"
+
+# --- process bookkeeping: kill only what we start. ----------------------------
+SERVER_PID=""
+DRIVER_PID=""
+FAILED=0
+
+cleanup() {
+  local status=$?
+  # Terminate the driver's whole process group (it owns the browser it spawned).
+  if [[ -n "$DRIVER_PID" ]] && kill -0 "$DRIVER_PID" 2>/dev/null; then
+    kill -TERM -- "-$DRIVER_PID" 2>/dev/null || kill -TERM "$DRIVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      kill -0 "$DRIVER_PID" 2>/dev/null || break
+      sleep 0.2
+    done
+    kill -KILL -- "-$DRIVER_PID" 2>/dev/null || kill -KILL "$DRIVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ "$FAILED" -ne 0 || "$status" -ne 0 ]]; then
+    echo "web_export_smoke: FAILED -- logs preserved:" >&2
+    echo "  driver log: $DRIVER_LOG" >&2
+    echo "  server log: $SERVER_LOG" >&2
+    [[ -f "$RESULT" ]] && echo "  result:     $RESULT (may be partial)" >&2
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "web_export_smoke: $*" >&2
+  FAILED=1
+  exit 1
+}
+
+# --- serve the export on an ephemeral port. -----------------------------------
+: >"$SERVER_LOG"
+python3 "$WEB_DIR/serve_export.py" "$EXPORT_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+PORT=""
+for _ in $(seq 1 100); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    fail "static server exited before announcing a port (see $SERVER_LOG)"
+  fi
+  PORT="$(sed -n 's/^PORT=//p' "$SERVER_LOG" | head -n1)"
+  [[ -n "$PORT" ]] && break
+  sleep 0.1
+done
+[[ -n "$PORT" ]] || fail "static server did not announce a port within 10s"
+URL="http://127.0.0.1:$PORT/"
+echo "web_export_smoke: serving $EXPORT_DIR at $URL (server pid $SERVER_PID)"
+
+# --- run the driver under a finite timeout, in its own process group. ---------
+: >"$DRIVER_LOG"
+rm -f "$RESULT"
+
+# The driver receives everything explicitly: no workstation-absolute assumptions.
+# `setsid` puts it in its own process group so a timeout kill reaps the browser.
+run_driver() {
+  exec setsid bash -c '
+    exec "$@"
+  ' _ $DRIVER_CMD \
+    --url "$URL" \
+    --result "$RESULT" \
+    --demo "$DEMO" \
+    --timeout "$TIMEOUT" \
+    --source-checksum "$CHECKSUM_BEFORE" \
+    ${BROWSER_BINARY:+--browser-binary "$BROWSER_BINARY"}
+}
+
+# Fallback when setsid is unavailable (macOS lacks it by default): run directly.
+if ! command -v setsid >/dev/null 2>&1; then
+  run_driver() {
+    # shellcheck disable=SC2086
+    exec $DRIVER_CMD \
+      --url "$URL" \
+      --result "$RESULT" \
+      --demo "$DEMO" \
+      --timeout "$TIMEOUT" \
+      --source-checksum "$CHECKSUM_BEFORE" \
+      ${BROWSER_BINARY:+--browser-binary "$BROWSER_BINARY"}
+  }
+fi
+
+( run_driver ) >"$DRIVER_LOG" 2>&1 &
+DRIVER_PID=$!
+
+# Enforce the finite timeout without a foreground `sleep` builtin dependency.
+DEADLINE=$(( $(date +%s) + TIMEOUT + 15 ))  # driver has its own timeout; +15s grace
+DRIVER_STATUS=""
+while :; do
+  if ! kill -0 "$DRIVER_PID" 2>/dev/null; then
+    wait "$DRIVER_PID"; DRIVER_STATUS=$?
+    break
+  fi
+  if [[ "$(date +%s)" -ge "$DEADLINE" ]]; then
+    echo "web_export_smoke: driver exceeded ${TIMEOUT}s (+grace); terminating" >&2
+    kill -TERM -- "-$DRIVER_PID" 2>/dev/null || kill -TERM "$DRIVER_PID" 2>/dev/null || true
+    sleep 1
+    kill -KILL -- "-$DRIVER_PID" 2>/dev/null || kill -KILL "$DRIVER_PID" 2>/dev/null || true
+    DRIVER_PID=""
+    fail "driver timed out after ${TIMEOUT}s (see $DRIVER_LOG)"
+  fi
+  sleep 0.5
+done
+DRIVER_PID=""
+
+if [[ "$DRIVER_STATUS" -ne 0 ]]; then
+  fail "driver exited with status $DRIVER_STATUS (see $DRIVER_LOG)"
+fi
+
+# --- validate the result envelope against the versioned schema. ---------------
+[[ -f "$RESULT" ]] || fail "driver produced no result at $RESULT"
+if ! python3 "$WEB_DIR/result_schema.py" "$RESULT"; then
+  fail "result schema validation failed for $RESULT"
+fi
+
+# --- prove the served tree was not mutated by serving/driving. ----------------
+CHECKSUM_AFTER="$(tree_checksum "$EXPORT_DIR")"
+if [[ "$CHECKSUM_BEFORE" != "$CHECKSUM_AFTER" ]]; then
+  fail "served export tree was mutated during the run (checksum drift)"
+fi
+
+# The driver must have echoed the pre-run checksum into the envelope, tying its
+# own evidence to the tree the shell actually served.
+ENVELOPE_CHECKSUM="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["artifact"]["sourceTreeChecksum"])' "$RESULT")"
+if [[ "$ENVELOPE_CHECKSUM" != "$CHECKSUM_BEFORE" ]]; then
+  fail "result envelope checksum does not match the served tree"
+fi
+
+# --- overall pass gate. -------------------------------------------------------
+OVERALL_PASS="$(python3 -c 'import json,sys; print("1" if json.load(open(sys.argv[1]))["pass"] else "0")' "$RESULT")"
+if [[ "$OVERALL_PASS" != "1" ]]; then
+  fail "driver reported pass=false (see $RESULT)"
+fi
+
+echo "web_export_smoke: PASS -- $DEMO on ${ENGINE:-custom} ($RESULT)"

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -194,6 +194,7 @@ run_driver() {
     --demo "$DEMO" \
     --timeout "$TIMEOUT" \
     --source-checksum "$CHECKSUM_BEFORE" \
+    --export-dir "$EXPORT_DIR" \
     ${BROWSER_BINARY:+--browser-binary "$BROWSER_BINARY"}
 }
 
@@ -207,6 +208,7 @@ if ! command -v setsid >/dev/null 2>&1; then
       --demo "$DEMO" \
       --timeout "$TIMEOUT" \
       --source-checksum "$CHECKSUM_BEFORE" \
+      --export-dir "$EXPORT_DIR" \
       ${BROWSER_BINARY:+--browser-binary "$BROWSER_BINARY"}
   }
 fi

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.security.MessageDigest
 
 plugins {
@@ -760,5 +761,279 @@ tasks.register<Exec>("exportWebMatch3") {
         check(exportDir.resolve("kanama-web-spike.js").isFile) {
             "Kotlin/Wasm loader was not installed into the Match3 export"
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 57f -- stable, user-facing Web entry points.
+//
+// `buildWebScripts` publishes the generated GDScript proxy bundle (proxies +
+// manifest + protocol) alongside the Kotlin/Wasm runtime a project attaches.
+// `exportWeb` turns a validated demo into a self-contained, cache-busted,
+// HTTP-servable directory with a release payload report. Both reuse the same
+// generated resources and staging machinery as the per-demo tasks above, so
+// their protocol version and proxy shapes cannot drift from one another.
+// ---------------------------------------------------------------------------
+
+val webScriptsBundle = layout.buildDirectory.dir("web-scripts")
+val webExportRoot = layout.buildDirectory.dir("web-export")
+val webDemo = providers.gradleProperty("kanamaWebDemo").orElse("match3")
+
+// The single renderer/thread contract for the Kotlin/Wasm preview backend.
+val webRendererName = "gl_compatibility"
+val webThreadsSupported = false
+
+fun readProtocolVersion(): Int {
+    val protocolFile =
+        webProxyResources.get().file("KanamaWebProtocol.generated.json").asFile
+    check(protocolFile.isFile) { "Missing generated Web protocol descriptor: $protocolFile" }
+    val match = Regex("\"protocolVersion\"\\s*:\\s*(\\d+)").find(protocolFile.readText())
+    return match?.groupValues?.get(1)?.toInt()
+        ?: error("Could not read protocolVersion from $protocolFile")
+}
+
+tasks.register("buildWebScripts") {
+    group = "kanama-web"
+    description =
+        "Generates the Web GDScript proxies + protocol and collects the Kotlin/Wasm runtime bundle."
+    dependsOn("kspKotlinWasmJs", "wasmJsBrowserDistribution")
+    inputs.dir(webProxyResources)
+    inputs.dir(webDistribution)
+    inputs.dir(webSpikeAssets)
+    outputs.dir(webScriptsBundle)
+
+    doLast {
+        val bundle = webScriptsBundle.get().asFile
+        delete(bundle)
+        bundle.mkdirs()
+
+        // Generated GDScript proxies, manifest, and protocol descriptor.
+        val generatedDir = bundle.resolve("generated")
+        copy {
+            from(webProxyResources)
+            into(generatedDir)
+        }
+
+        // Kotlin/Wasm runtime: the webpack loader + its content-hashed wasm,
+        // plus the versioned JS bridge and HTML shell the project attaches.
+        val runtimeDir = bundle.resolve("runtime")
+        copy {
+            from(webDistribution) {
+                include("*.js", "*.wasm")
+            }
+            into(runtimeDir)
+        }
+        copy {
+            from(webSpikeAssets)
+            into(runtimeDir)
+        }
+
+        // No source maps ship by default (webpack sourceMaps=false); fail loud
+        // if that policy ever regresses into the published bundle.
+        val leakedSourceMaps =
+            fileTree(bundle) { include("**/*.map") }.files.map { it.name }
+        check(leakedSourceMaps.isEmpty()) {
+            "Web script bundle must not ship source maps: $leakedSourceMaps"
+        }
+
+        val protocolVersion = readProtocolVersion()
+        val report = bundle.resolve("build-web-scripts.report.json")
+        val runtimeFiles =
+            runtimeDir.walkTopDown().filter { it.isFile }.sortedBy { it.name }.toList()
+        val proxyFiles =
+            generatedDir.walkTopDown().filter { it.isFile }.sortedBy { it.name }.toList()
+        report.writeText(
+            buildString {
+                append("{\n")
+                append("  \"protocolVersion\": $protocolVersion,\n")
+                append("  \"renderer\": \"$webRendererName\",\n")
+                append("  \"threadsSupported\": $webThreadsSupported,\n")
+                append("  \"sourceMaps\": false,\n")
+                append("  \"proxies\": [")
+                append(proxyFiles.joinToString(", ") { "\"${it.name}\"" })
+                append("],\n")
+                append("  \"runtime\": [")
+                append(runtimeFiles.joinToString(", ") { "\"${it.name}\"" })
+                append("]\n")
+                append("}\n")
+            }
+        )
+        logger.lifecycle(
+            "[kanama:web] buildWebScripts published protocol $protocolVersion to $bundle"
+        )
+    }
+}
+
+fun stageTaskFor(demo: String): String =
+    when (demo) {
+        "match3" -> "stageWebMatch3Project"
+        "bunnymark" -> "stageWebBunnymarkProject"
+        else -> error("Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark)")
+    }
+
+fun stagingDirFor(demo: String): File =
+    when (demo) {
+        "match3" -> webMatch3Staging.get().asFile
+        "bunnymark" -> webBunnymarkStaging.get().asFile
+        else -> error("Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark)")
+    }
+
+tasks.register<Exec>("exportWeb") {
+    group = "kanama-web"
+    description =
+        "Exports a validated demo (-PkanamaWebDemo=match3|bunnymark) to a self-contained, " +
+            "cache-busted, HTTP-servable directory with a release payload report."
+    dependsOn("buildWebScripts", "wasmJsBrowserDistribution")
+    dependsOn(webDemo.map(::stageTaskFor))
+    inputs.property("kanamaWebDemo", webDemo)
+    inputs.dir(webDistribution)
+    inputs.dir(webSpikeAssets)
+    outputs.dir(webExportRoot)
+
+    doFirst {
+        val demo = webDemo.get()
+        val godotExecutable =
+            providers.gradleProperty("kanamaGodotExecutable").orNull
+                ?: error("Pass -PkanamaGodotExecutable=/absolute/path/to/godot")
+        val webTemplateRelease =
+            providers.gradleProperty("kanamaWebTemplateRelease").orNull
+                ?: error("Pass -PkanamaWebTemplateRelease=/absolute/path/to/web_nothreads_release.zip")
+        val webTemplateFile = file(webTemplateRelease)
+        check(webTemplateFile.isFile) { "Godot Web release template not found: $webTemplateFile" }
+
+        val stagingDir = stagingDirFor(demo)
+        val stagedPreset = stagingDir.resolve("export_presets.cfg")
+        check(stagedPreset.isFile) { "Staged project has no export_presets.cfg: $stagedPreset" }
+        stagedPreset.writeText(
+            stagedPreset
+                .readText()
+                .replace(
+                    "custom_template/release=\"\"",
+                    "custom_template/release=\"${webTemplateFile.absolutePath}\"",
+                )
+        )
+
+        val exportDir = webExportRoot.get().dir(demo).asFile
+        delete(exportDir)
+        exportDir.mkdirs()
+        commandLine(
+            godotExecutable,
+            "--headless",
+            "--path",
+            stagingDir.absolutePath,
+            "--export-release",
+            "Web",
+            exportDir.resolve("index.html").absolutePath,
+        )
+    }
+
+    doLast {
+        val demo = webDemo.get()
+        val exportDir = webExportRoot.get().dir(demo).asFile
+
+        // Install the Kotlin/Wasm runtime, versioned bridge into the export.
+        copy {
+            from(webDistribution) {
+                include("*.js", "*.wasm")
+            }
+            into(exportDir)
+        }
+        copy {
+            from(webSpikeAssets.file("kanama-web-bridge.js"))
+            into(exportDir)
+        }
+
+        val indexHtml = exportDir.resolve("index.html")
+        check(indexHtml.isFile) { "Godot Web export did not produce index.html for $demo" }
+        val spikeLoader = exportDir.resolve("kanama-web-spike.js")
+        val bridge = exportDir.resolve("kanama-web-bridge.js")
+        check(spikeLoader.isFile) { "Kotlin/Wasm loader missing from $demo export" }
+        check(bridge.isFile) { "Versioned JS bridge missing from $demo export" }
+
+        // Cache-busting: the Kotlin gameplay wasm is already content-hashed by
+        // webpack (its filename is its hash), and kanama-web-spike.js references
+        // it by that name. Only the two fixed-name entry scripts can go stale, so
+        // stamp them with a content-derived build id the browser treats as a new
+        // resource. This is safe: they are <script src> tags, not module imports.
+        val buildId =
+            MessageDigest.getInstance("SHA-256").let { digest ->
+                digest.update(spikeLoader.readBytes())
+                digest.update(bridge.readBytes())
+                digest.digest().joinToString("") { "%02x".format(it) }.substring(0, 16)
+            }
+        val originalIndex = indexHtml.readText()
+        check(originalIndex.contains("src=\"kanama-web-spike.js\"")) {
+            "Exported shell is missing the kanama-web-spike.js script tag"
+        }
+        check(originalIndex.contains("src=\"kanama-web-bridge.js\"")) {
+            "Exported shell is missing the kanama-web-bridge.js script tag"
+        }
+        indexHtml.writeText(
+            originalIndex
+                .replace(
+                    "src=\"kanama-web-spike.js\"",
+                    "src=\"kanama-web-spike.js?v=$buildId\"",
+                )
+                .replace(
+                    "src=\"kanama-web-bridge.js\"",
+                    "src=\"kanama-web-bridge.js?v=$buildId\"",
+                )
+        )
+
+        // Self-contained check: no workstation-absolute path may leak into the
+        // served HTML, and the payload must not reference the staging tree.
+        val servedIndex = indexHtml.readText()
+        val stagingPath = stagingDirFor(demo).absolutePath
+        check(!servedIndex.contains(stagingPath)) {
+            "Exported index.html leaks the staging path $stagingPath"
+        }
+        check(!servedIndex.contains(System.getProperty("user.home"))) {
+            "Exported index.html leaks a workstation-absolute path"
+        }
+
+        val wasmFiles = exportDir.listFiles { file -> file.extension == "wasm" }?.toList().orEmpty()
+        check(wasmFiles.isNotEmpty()) { "Web export has no wasm payload for $demo" }
+        check(fileTree(exportDir) { include("**/*.map") }.files.isEmpty()) {
+            "Web export must not ship source maps for $demo"
+        }
+
+        // Release payload report: every served file and its size, for budget
+        // tracking and the export-smoke harness to cross-check.
+        val protocolVersion = readProtocolVersion()
+        val servedFiles =
+            exportDir
+                .walkTopDown()
+                .filter { it.isFile }
+                .map { it.relativeTo(exportDir).invariantSeparatorsPath to it.length() }
+                .sortedBy { it.first }
+                .toList()
+        val totalBytes = servedFiles.sumOf { it.second }
+        val reportDir = exportDir.resolve("kanama-web")
+        reportDir.mkdirs()
+        val report = reportDir.resolve("export-report.json")
+        report.writeText(
+            buildString {
+                append("{\n")
+                append("  \"demo\": \"$demo\",\n")
+                append("  \"protocolVersion\": $protocolVersion,\n")
+                append("  \"buildId\": \"$buildId\",\n")
+                append("  \"renderer\": \"$webRendererName\",\n")
+                append("  \"threadsSupported\": $webThreadsSupported,\n")
+                append("  \"sourceMaps\": false,\n")
+                append("  \"totalBytes\": $totalBytes,\n")
+                append("  \"files\": [\n")
+                append(
+                    servedFiles.joinToString(",\n") { (path, size) ->
+                        "    {\"name\": \"$path\", \"bytes\": $size}"
+                    }
+                )
+                append("\n  ]\n")
+                append("}\n")
+            }
+        )
+        logger.lifecycle(
+            "[kanama:web] exportWeb produced $demo export ($totalBytes bytes, protocol " +
+                "$protocolVersion, buildId $buildId) at $exportDir"
+        )
     }
 }

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -9,8 +9,27 @@ plugins {
 
 val webScriptSourceRoot =
     layout.projectDirectory.dir("src/commonMain/kotlin/net/multigesture/kanama/web")
-val extraWebScriptSourceRoot =
+
+// The Web gameplay script root. An explicit -PkanamaWebExtraScriptSourceDir wins;
+// otherwise it is derived from the selected demo's checkout as <projectDir>/web,
+// where the committed web/kotlin-src/*.kt live. This keeps exportWeb free of any
+// second workstation path -- pointing at the demo checkout is enough.
+val extraWebScriptSourceRoot: File? =
     providers.gradleProperty("kanamaWebExtraScriptSourceDir").orNull?.let(rootProject::file)
+        ?: run {
+            val demo = providers.gradleProperty("kanamaWebDemo").orElse("match3").get()
+            val projectDirProperty =
+                when (demo) {
+                    "match3" -> "kanamaWebMatch3ProjectDir"
+                    "bunnymark" -> "kanamaWebBunnymarkProjectDir"
+                    else -> null
+                }
+            projectDirProperty
+                ?.let { providers.gradleProperty(it).orNull }
+                ?.let(rootProject::file)
+                ?.resolve("web")
+                ?.takeIf { it.resolve("kotlin-src").isDirectory }
+        }
 
 kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)


### PR DESCRIPTION
Promotes the Web backend from **In development** to **Experimental (Kotlin/Wasm preview)** on Godot 4.7 stable, with a reproducible export workflow and a versioned export-smoke harness.

## What's included
- **`buildWebScripts` / `exportWeb`** Gradle entry points: disposable staging → Godot export → Wasm install → content-hash cache-busting → self-contained HTTP-servable directory + release payload report (no source maps).
- **Reproducible from a clean checkout** — auto-derives the Web script root from `<demo>/web/kotlin-src` (no second workstation path).
- **Versioned export-smoke harness** (`scripts/web_export_smoke.sh`): serves a built export on an ephemeral port, drives a full play + teardown sequence in a real browser, validates a v1 result envelope, and proves source-tree immutability. Never green from page load alone.
- **Per-browser drivers** behind a shared `evaluate/navigate/pointer` transport: Chrome (CDP, CI gate), Firefox (BiDi), Safari (WebDriver).
- **`docs/exporting/web.md`** export guide + mkdocs nav; `local_ci.sh` web gates (`--skip-web`: driver syntax, scaffold self-test, Kotlin/Wasm compile + fail-loud coverage gate).
- **Experimental wording flip** across README, docs/index, version-support, web-internals, exporting/web.md, and CHANGELOG.

## Evidence
Both demos (Starter-Kit-Match3, Bunnymark) pass the automated production export smoke in **Chrome** (CI) and **Firefox**. In **Safari**, Bunnymark passes automatically and Match3 is verified running by hand (the SafariDriver drag can't synthesize the swipe reliably — a harness limitation, not a runtime defect; documented).

## Not in scope / still true
Not a Supported target: single-thread Compatibility renderer only, source-checkout export (no packaged addon), two-demo corpus. Depends on the companion `kanama-demos` branch adding `web/kotlin-src` for the two demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)