### PR TITLE
Generate indexed properties generically + property-coverage gate

### DIFF
--- a/docs/contributing/wrapper-generator-report.md
+++ b/docs/contributing/wrapper-generator-report.md
@@ -19,7 +19,7 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | Classes with complete method generation | 761 |
 | Methods generated | 15332/16822 (91.1%) |
 | Methods skipped | 1490 |
-| Properties generated | 3657/4162 (87.9%) |
+| Properties generated | 4072/4162 (97.8%) |
 | Signals generated | 503/503 (100.0%) |
 
 ## Skip Categories
@@ -60,19 +60,19 @@ These classes have every method covered by the conservative generator. Promotion
 | Environment | 188/188 | 93/93 | 0/0 |
 | PhysicsServer3D | 175/175 | 0/0 | 0/0 |
 | NavigationServer3D | 154/154 | 0/0 | 3/3 |
-| BaseMaterial3D | 154/154 | 74/131 | 0/0 |
+| BaseMaterial3D | 154/154 | 131/131 | 0/0 |
 | RichTextLabel | 138/138 | 30/30 | 4/4 |
 | NavigationServer2D | 137/137 | 0/0 | 3/3 |
 | RenderingDevice | 135/135 | 0/0 | 0/0 |
-| Viewport | 130/130 | 46/50 | 2/2 |
+| Viewport | 130/130 | 50/50 | 2/2 |
 | TreeItem | 125/125 | 4/4 | 0/0 |
 | PhysicsServer2D | 119/119 | 0/0 | 0/0 |
-| ParticleProcessMaterial | 116/116 | 53/124 | 1/1 |
+| ParticleProcessMaterial | 116/116 | 124/124 | 1/1 |
 | FontFile | 106/106 | 17/22 | 0/0 |
 | PopupMenu | 102/102 | 14/14 | 4/4 |
 | LineEdit | 97/97 | 36/36 | 4/4 |
 | TileSet | 90/90 | 5/5 | 0/0 |
-| CPUParticles3D | 90/90 | 39/77 | 1/1 |
+| CPUParticles3D | 90/90 | 77/77 | 1/1 |
 | NavigationAgent3D | 86/86 | 33/33 | 6/6 |
 | ItemList | 85/85 | 18/18 | 5/5 |
 | Animation | 85/85 | 4/4 | 0/0 |
@@ -80,7 +80,7 @@ These classes have every method covered by the conservative generator. Promotion
 | OS | 83/83 | 3/3 | 0/0 |
 | NavigationAgent2D | 80/80 | 30/30 | 6/6 |
 | Input | 77/77 | 5/5 | 1/1 |
-| CPUParticles2D | 77/77 | 33/69 | 1/1 |
+| CPUParticles2D | 77/77 | 69/69 | 1/1 |
 | Image | 76/76 | 0/1 | 0/0 |
 | AccessibilityServer | 75/75 | 0/0 | 0/0 |
 | Tree | 72/72 | 16/16 | 15/15 |
@@ -91,9 +91,9 @@ These classes have every method covered by the conservative generator. Promotion
 | NativeMenu | 69/69 | 0/0 | 0/0 |
 | FileAccess | 68/68 | 1/1 | 0/0 |
 | LookAtModifier3D | 63/63 | 30/30 | 0/0 |
-| GPUParticles3D | 63/63 | 28/32 | 1/1 |
+| GPUParticles3D | 63/63 | 32/32 | 1/1 |
 | TextParagraph | 62/62 | 13/13 | 0/0 |
-| Label3D | 61/61 | 29/33 | 0/0 |
+| Label3D | 61/61 | 33/33 | 0/0 |
 | TabBar | 60/60 | 14/14 | 8/8 |
 | NavigationMesh | 58/58 | 25/26 | 0/0 |
 | GPUParticles2D | 57/57 | 26/26 | 1/1 |
@@ -102,14 +102,14 @@ These classes have every method covered by the conservative generator. Promotion
 | GridMap | 56/56 | 13/13 | 2/2 |
 | TileData | 54/54 | 11/11 | 1/1 |
 | AnimationPlayer | 54/54 | 12/12 | 2/2 |
-| Camera2D | 52/52 | 20/28 | 0/0 |
+| Camera2D | 52/52 | 28/28 | 0/0 |
 | TabContainer | 51/51 | 12/12 | 7/7 |
 
 ## Near Ready Classes
 
 | Class | Methods | Properties | Signals | Skips |
 | --- | ---: | ---: | ---: | ---: |
-| Window | 133/134 (99.3%) | 28/41 | 16/16 | 1 |
+| Window | 133/134 (99.3%) | 41/41 | 16/16 | 1 |
 | CanvasItem | 93/94 (98.9%) | 16/16 | 4/4 | 1 |
 | RigidBody3D | 59/60 (98.3%) | 23/23 | 5/5 | 1 |
 | RigidBody2D | 58/59 (98.3%) | 23/23 | 5/5 | 1 |
@@ -125,7 +125,7 @@ These classes have every method covered by the conservative generator. Promotion
 | EditorProperty | 35/37 (94.6%) | 12/12 | 13/13 | 2 |
 | AStarGrid2D | 33/35 (94.3%) | 9/9 | 0/0 | 2 |
 | CompositorEffect | 14/15 (93.3%) | 7/7 | 0/0 | 1 |
-| Control | 181/195 (92.8%) | 49/63 | 10/10 | 14 |
+| Control | 181/195 (92.8%) | 61/63 | 10/10 | 14 |
 | PrimitiveMesh | 12/13 (92.3%) | 5/5 | 0/0 | 1 |
 | VisualInstance3D | 12/13 (92.3%) | 3/3 | 0/0 | 1 |
 | BaseButton | 23/25 (92.0%) | 10/10 | 4/4 | 2 |
@@ -152,18 +152,18 @@ These classes have every method covered by the conservative generator. Promotion
 | TextEdit | 249/255 | 47/47 | 7/7 | 6 |
 | TextServer | 244/244 | 0/0 | 0/0 | 0 |
 | Environment | 188/188 | 93/93 | 0/0 | 0 |
-| Control | 181/195 | 49/63 | 10/10 | 14 |
+| Control | 181/195 | 61/63 | 10/10 | 14 |
 | PhysicsServer3D | 175/175 | 0/0 | 0/0 | 0 |
-| BaseMaterial3D | 154/154 | 74/131 | 0/0 | 0 |
+| BaseMaterial3D | 154/154 | 131/131 | 0/0 | 0 |
 | NavigationServer3D | 154/154 | 0/0 | 3/3 | 0 |
 | RichTextLabel | 138/138 | 30/30 | 4/4 | 0 |
 | NavigationServer2D | 137/137 | 0/0 | 3/3 | 0 |
 | RenderingDevice | 135/135 | 0/0 | 0/0 | 0 |
-| Window | 133/134 | 28/41 | 16/16 | 1 |
-| Viewport | 130/130 | 46/50 | 2/2 | 0 |
+| Window | 133/134 | 41/41 | 16/16 | 1 |
+| Viewport | 130/130 | 50/50 | 2/2 | 0 |
 | TreeItem | 125/125 | 4/4 | 0/0 | 0 |
 | Node | 121/133 | 14/14 | 11/11 | 12 |
 | PhysicsServer2D | 119/119 | 0/0 | 0/0 | 0 |
-| ParticleProcessMaterial | 116/116 | 53/124 | 1/1 | 0 |
+| ParticleProcessMaterial | 116/116 | 124/124 | 1/1 | 0 |
 | CodeEdit | 114/117 | 22/22 | 5/5 | 3 |
 | FontFile | 106/106 | 17/22 | 0/0 | 0 |

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/AudioStreamPlaylist.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/AudioStreamPlaylist.kt
@@ -33,6 +33,390 @@ class AudioStreamPlaylist(handle: MemorySegment) : AudioStream(handle) {
         @JvmName("setStreamCountProperty")
         set(value) = setStreamCount(value)
 
+    var stream0: AudioStream?
+        @JvmName("stream0Property")
+        get() = getListStream(0)
+        @JvmName("setStream0Property")
+        set(value) = setListStream(0, value)
+
+    var stream1: AudioStream?
+        @JvmName("stream1Property")
+        get() = getListStream(1)
+        @JvmName("setStream1Property")
+        set(value) = setListStream(1, value)
+
+    var stream2: AudioStream?
+        @JvmName("stream2Property")
+        get() = getListStream(2)
+        @JvmName("setStream2Property")
+        set(value) = setListStream(2, value)
+
+    var stream3: AudioStream?
+        @JvmName("stream3Property")
+        get() = getListStream(3)
+        @JvmName("setStream3Property")
+        set(value) = setListStream(3, value)
+
+    var stream4: AudioStream?
+        @JvmName("stream4Property")
+        get() = getListStream(4)
+        @JvmName("setStream4Property")
+        set(value) = setListStream(4, value)
+
+    var stream5: AudioStream?
+        @JvmName("stream5Property")
+        get() = getListStream(5)
+        @JvmName("setStream5Property")
+        set(value) = setListStream(5, value)
+
+    var stream6: AudioStream?
+        @JvmName("stream6Property")
+        get() = getListStream(6)
+        @JvmName("setStream6Property")
+        set(value) = setListStream(6, value)
+
+    var stream7: AudioStream?
+        @JvmName("stream7Property")
+        get() = getListStream(7)
+        @JvmName("setStream7Property")
+        set(value) = setListStream(7, value)
+
+    var stream8: AudioStream?
+        @JvmName("stream8Property")
+        get() = getListStream(8)
+        @JvmName("setStream8Property")
+        set(value) = setListStream(8, value)
+
+    var stream9: AudioStream?
+        @JvmName("stream9Property")
+        get() = getListStream(9)
+        @JvmName("setStream9Property")
+        set(value) = setListStream(9, value)
+
+    var stream10: AudioStream?
+        @JvmName("stream10Property")
+        get() = getListStream(10)
+        @JvmName("setStream10Property")
+        set(value) = setListStream(10, value)
+
+    var stream11: AudioStream?
+        @JvmName("stream11Property")
+        get() = getListStream(11)
+        @JvmName("setStream11Property")
+        set(value) = setListStream(11, value)
+
+    var stream12: AudioStream?
+        @JvmName("stream12Property")
+        get() = getListStream(12)
+        @JvmName("setStream12Property")
+        set(value) = setListStream(12, value)
+
+    var stream13: AudioStream?
+        @JvmName("stream13Property")
+        get() = getListStream(13)
+        @JvmName("setStream13Property")
+        set(value) = setListStream(13, value)
+
+    var stream14: AudioStream?
+        @JvmName("stream14Property")
+        get() = getListStream(14)
+        @JvmName("setStream14Property")
+        set(value) = setListStream(14, value)
+
+    var stream15: AudioStream?
+        @JvmName("stream15Property")
+        get() = getListStream(15)
+        @JvmName("setStream15Property")
+        set(value) = setListStream(15, value)
+
+    var stream16: AudioStream?
+        @JvmName("stream16Property")
+        get() = getListStream(16)
+        @JvmName("setStream16Property")
+        set(value) = setListStream(16, value)
+
+    var stream17: AudioStream?
+        @JvmName("stream17Property")
+        get() = getListStream(17)
+        @JvmName("setStream17Property")
+        set(value) = setListStream(17, value)
+
+    var stream18: AudioStream?
+        @JvmName("stream18Property")
+        get() = getListStream(18)
+        @JvmName("setStream18Property")
+        set(value) = setListStream(18, value)
+
+    var stream19: AudioStream?
+        @JvmName("stream19Property")
+        get() = getListStream(19)
+        @JvmName("setStream19Property")
+        set(value) = setListStream(19, value)
+
+    var stream20: AudioStream?
+        @JvmName("stream20Property")
+        get() = getListStream(20)
+        @JvmName("setStream20Property")
+        set(value) = setListStream(20, value)
+
+    var stream21: AudioStream?
+        @JvmName("stream21Property")
+        get() = getListStream(21)
+        @JvmName("setStream21Property")
+        set(value) = setListStream(21, value)
+
+    var stream22: AudioStream?
+        @JvmName("stream22Property")
+        get() = getListStream(22)
+        @JvmName("setStream22Property")
+        set(value) = setListStream(22, value)
+
+    var stream23: AudioStream?
+        @JvmName("stream23Property")
+        get() = getListStream(23)
+        @JvmName("setStream23Property")
+        set(value) = setListStream(23, value)
+
+    var stream24: AudioStream?
+        @JvmName("stream24Property")
+        get() = getListStream(24)
+        @JvmName("setStream24Property")
+        set(value) = setListStream(24, value)
+
+    var stream25: AudioStream?
+        @JvmName("stream25Property")
+        get() = getListStream(25)
+        @JvmName("setStream25Property")
+        set(value) = setListStream(25, value)
+
+    var stream26: AudioStream?
+        @JvmName("stream26Property")
+        get() = getListStream(26)
+        @JvmName("setStream26Property")
+        set(value) = setListStream(26, value)
+
+    var stream27: AudioStream?
+        @JvmName("stream27Property")
+        get() = getListStream(27)
+        @JvmName("setStream27Property")
+        set(value) = setListStream(27, value)
+
+    var stream28: AudioStream?
+        @JvmName("stream28Property")
+        get() = getListStream(28)
+        @JvmName("setStream28Property")
+        set(value) = setListStream(28, value)
+
+    var stream29: AudioStream?
+        @JvmName("stream29Property")
+        get() = getListStream(29)
+        @JvmName("setStream29Property")
+        set(value) = setListStream(29, value)
+
+    var stream30: AudioStream?
+        @JvmName("stream30Property")
+        get() = getListStream(30)
+        @JvmName("setStream30Property")
+        set(value) = setListStream(30, value)
+
+    var stream31: AudioStream?
+        @JvmName("stream31Property")
+        get() = getListStream(31)
+        @JvmName("setStream31Property")
+        set(value) = setListStream(31, value)
+
+    var stream32: AudioStream?
+        @JvmName("stream32Property")
+        get() = getListStream(32)
+        @JvmName("setStream32Property")
+        set(value) = setListStream(32, value)
+
+    var stream33: AudioStream?
+        @JvmName("stream33Property")
+        get() = getListStream(33)
+        @JvmName("setStream33Property")
+        set(value) = setListStream(33, value)
+
+    var stream34: AudioStream?
+        @JvmName("stream34Property")
+        get() = getListStream(34)
+        @JvmName("setStream34Property")
+        set(value) = setListStream(34, value)
+
+    var stream35: AudioStream?
+        @JvmName("stream35Property")
+        get() = getListStream(35)
+        @JvmName("setStream35Property")
+        set(value) = setListStream(35, value)
+
+    var stream36: AudioStream?
+        @JvmName("stream36Property")
+        get() = getListStream(36)
+        @JvmName("setStream36Property")
+        set(value) = setListStream(36, value)
+
+    var stream37: AudioStream?
+        @JvmName("stream37Property")
+        get() = getListStream(37)
+        @JvmName("setStream37Property")
+        set(value) = setListStream(37, value)
+
+    var stream38: AudioStream?
+        @JvmName("stream38Property")
+        get() = getListStream(38)
+        @JvmName("setStream38Property")
+        set(value) = setListStream(38, value)
+
+    var stream39: AudioStream?
+        @JvmName("stream39Property")
+        get() = getListStream(39)
+        @JvmName("setStream39Property")
+        set(value) = setListStream(39, value)
+
+    var stream40: AudioStream?
+        @JvmName("stream40Property")
+        get() = getListStream(40)
+        @JvmName("setStream40Property")
+        set(value) = setListStream(40, value)
+
+    var stream41: AudioStream?
+        @JvmName("stream41Property")
+        get() = getListStream(41)
+        @JvmName("setStream41Property")
+        set(value) = setListStream(41, value)
+
+    var stream42: AudioStream?
+        @JvmName("stream42Property")
+        get() = getListStream(42)
+        @JvmName("setStream42Property")
+        set(value) = setListStream(42, value)
+
+    var stream43: AudioStream?
+        @JvmName("stream43Property")
+        get() = getListStream(43)
+        @JvmName("setStream43Property")
+        set(value) = setListStream(43, value)
+
+    var stream44: AudioStream?
+        @JvmName("stream44Property")
+        get() = getListStream(44)
+        @JvmName("setStream44Property")
+        set(value) = setListStream(44, value)
+
+    var stream45: AudioStream?
+        @JvmName("stream45Property")
+        get() = getListStream(45)
+        @JvmName("setStream45Property")
+        set(value) = setListStream(45, value)
+
+    var stream46: AudioStream?
+        @JvmName("stream46Property")
+        get() = getListStream(46)
+        @JvmName("setStream46Property")
+        set(value) = setListStream(46, value)
+
+    var stream47: AudioStream?
+        @JvmName("stream47Property")
+        get() = getListStream(47)
+        @JvmName("setStream47Property")
+        set(value) = setListStream(47, value)
+
+    var stream48: AudioStream?
+        @JvmName("stream48Property")
+        get() = getListStream(48)
+        @JvmName("setStream48Property")
+        set(value) = setListStream(48, value)
+
+    var stream49: AudioStream?
+        @JvmName("stream49Property")
+        get() = getListStream(49)
+        @JvmName("setStream49Property")
+        set(value) = setListStream(49, value)
+
+    var stream50: AudioStream?
+        @JvmName("stream50Property")
+        get() = getListStream(50)
+        @JvmName("setStream50Property")
+        set(value) = setListStream(50, value)
+
+    var stream51: AudioStream?
+        @JvmName("stream51Property")
+        get() = getListStream(51)
+        @JvmName("setStream51Property")
+        set(value) = setListStream(51, value)
+
+    var stream52: AudioStream?
+        @JvmName("stream52Property")
+        get() = getListStream(52)
+        @JvmName("setStream52Property")
+        set(value) = setListStream(52, value)
+
+    var stream53: AudioStream?
+        @JvmName("stream53Property")
+        get() = getListStream(53)
+        @JvmName("setStream53Property")
+        set(value) = setListStream(53, value)
+
+    var stream54: AudioStream?
+        @JvmName("stream54Property")
+        get() = getListStream(54)
+        @JvmName("setStream54Property")
+        set(value) = setListStream(54, value)
+
+    var stream55: AudioStream?
+        @JvmName("stream55Property")
+        get() = getListStream(55)
+        @JvmName("setStream55Property")
+        set(value) = setListStream(55, value)
+
+    var stream56: AudioStream?
+        @JvmName("stream56Property")
+        get() = getListStream(56)
+        @JvmName("setStream56Property")
+        set(value) = setListStream(56, value)
+
+    var stream57: AudioStream?
+        @JvmName("stream57Property")
+        get() = getListStream(57)
+        @JvmName("setStream57Property")
+        set(value) = setListStream(57, value)
+
+    var stream58: AudioStream?
+        @JvmName("stream58Property")
+        get() = getListStream(58)
+        @JvmName("setStream58Property")
+        set(value) = setListStream(58, value)
+
+    var stream59: AudioStream?
+        @JvmName("stream59Property")
+        get() = getListStream(59)
+        @JvmName("setStream59Property")
+        set(value) = setListStream(59, value)
+
+    var stream60: AudioStream?
+        @JvmName("stream60Property")
+        get() = getListStream(60)
+        @JvmName("setStream60Property")
+        set(value) = setListStream(60, value)
+
+    var stream61: AudioStream?
+        @JvmName("stream61Property")
+        get() = getListStream(61)
+        @JvmName("setStream61Property")
+        set(value) = setListStream(61, value)
+
+    var stream62: AudioStream?
+        @JvmName("stream62Property")
+        get() = getListStream(62)
+        @JvmName("setStream62Property")
+        set(value) = setListStream(62, value)
+
+    var stream63: AudioStream?
+        @JvmName("stream63Property")
+        get() = getListStream(63)
+        @JvmName("setStream63Property")
+        set(value) = setListStream(63, value)
+
     fun setStreamCount(streamCount: Int) {
         ObjectCalls.ptrcallWithIntArg(setStreamCountBind, handle, streamCount)
     }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/BaseMaterial3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/BaseMaterial3D.kt
@@ -59,6 +59,12 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setDepthDrawModeProperty")
         set(value) = setDepthDrawMode(value)
 
+    var noDepthTest: Boolean
+        @JvmName("noDepthTestProperty")
+        get() = getFlag(0L)
+        @JvmName("setNoDepthTestProperty")
+        set(value) = setFlag(0L, value)
+
     var depthTest: Long
         @JvmName("depthTestProperty")
         get() = getDepthTest()
@@ -83,11 +89,65 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setSpecularModeProperty")
         set(value) = setSpecularMode(value)
 
+    var disableAmbientLight: Boolean
+        @JvmName("disableAmbientLightProperty")
+        get() = getFlag(14L)
+        @JvmName("setDisableAmbientLightProperty")
+        set(value) = setFlag(14L, value)
+
+    var disableFog: Boolean
+        @JvmName("disableFogProperty")
+        get() = getFlag(21L)
+        @JvmName("setDisableFogProperty")
+        set(value) = setFlag(21L, value)
+
+    var disableSpecularOcclusion: Boolean
+        @JvmName("disableSpecularOcclusionProperty")
+        get() = getFlag(22L)
+        @JvmName("setDisableSpecularOcclusionProperty")
+        set(value) = setFlag(22L, value)
+
+    var vertexColorUseAsAlbedo: Boolean
+        @JvmName("vertexColorUseAsAlbedoProperty")
+        get() = getFlag(1L)
+        @JvmName("setVertexColorUseAsAlbedoProperty")
+        set(value) = setFlag(1L, value)
+
+    var vertexColorIsSrgb: Boolean
+        @JvmName("vertexColorIsSrgbProperty")
+        get() = getFlag(2L)
+        @JvmName("setVertexColorIsSrgbProperty")
+        set(value) = setFlag(2L, value)
+
     var albedoColor: Color
         @JvmName("albedoColorProperty")
         get() = getAlbedo()
         @JvmName("setAlbedoColorProperty")
         set(value) = setAlbedo(value)
+
+    var albedoTexture: Texture2D?
+        @JvmName("albedoTextureProperty")
+        get() = getTexture(0L)
+        @JvmName("setAlbedoTextureProperty")
+        set(value) = setTexture(0L, value)
+
+    var albedoTextureForceSrgb: Boolean
+        @JvmName("albedoTextureForceSrgbProperty")
+        get() = getFlag(12L)
+        @JvmName("setAlbedoTextureForceSrgbProperty")
+        set(value) = setFlag(12L, value)
+
+    var albedoTextureMsdf: Boolean
+        @JvmName("albedoTextureMsdfProperty")
+        get() = getFlag(20L)
+        @JvmName("setAlbedoTextureMsdfProperty")
+        set(value) = setFlag(20L, value)
+
+    var ormTexture: Texture2D?
+        @JvmName("ormTextureProperty")
+        get() = getTexture(17L)
+        @JvmName("setOrmTextureProperty")
+        set(value) = setTexture(17L, value)
 
     var metallic: Double
         @JvmName("metallicProperty")
@@ -101,6 +161,12 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setMetallicSpecularProperty")
         set(value) = setSpecular(value)
 
+    var metallicTexture: Texture2D?
+        @JvmName("metallicTextureProperty")
+        get() = getTexture(1L)
+        @JvmName("setMetallicTextureProperty")
+        set(value) = setTexture(1L, value)
+
     var metallicTextureChannel: Long
         @JvmName("metallicTextureChannelProperty")
         get() = getMetallicTextureChannel()
@@ -113,11 +179,23 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setRoughnessProperty")
         set(value) = setRoughness(value)
 
+    var roughnessTexture: Texture2D?
+        @JvmName("roughnessTextureProperty")
+        get() = getTexture(2L)
+        @JvmName("setRoughnessTextureProperty")
+        set(value) = setTexture(2L, value)
+
     var roughnessTextureChannel: Long
         @JvmName("roughnessTextureChannelProperty")
         get() = getRoughnessTextureChannel()
         @JvmName("setRoughnessTextureChannelProperty")
         set(value) = setRoughnessTextureChannel(value)
+
+    var emissionEnabled: Boolean
+        @JvmName("emissionEnabledProperty")
+        get() = getFeature(0L)
+        @JvmName("setEmissionEnabledProperty")
+        set(value) = setFeature(0L, value)
 
     var emission: Color
         @JvmName("emissionProperty")
@@ -143,11 +221,53 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setEmissionOperatorProperty")
         set(value) = setEmissionOperator(value)
 
+    var emissionOnUv2: Boolean
+        @JvmName("emissionOnUv2Property")
+        get() = getFlag(11L)
+        @JvmName("setEmissionOnUv2Property")
+        set(value) = setFlag(11L, value)
+
+    var emissionTexture: Texture2D?
+        @JvmName("emissionTextureProperty")
+        get() = getTexture(3L)
+        @JvmName("setEmissionTextureProperty")
+        set(value) = setTexture(3L, value)
+
+    var normalEnabled: Boolean
+        @JvmName("normalEnabledProperty")
+        get() = getFeature(1L)
+        @JvmName("setNormalEnabledProperty")
+        set(value) = setFeature(1L, value)
+
     var normalScale: Double
         @JvmName("normalScaleProperty")
         get() = getNormalScale()
         @JvmName("setNormalScaleProperty")
         set(value) = setNormalScale(value)
+
+    var normalTexture: Texture2D?
+        @JvmName("normalTextureProperty")
+        get() = getTexture(4L)
+        @JvmName("setNormalTextureProperty")
+        set(value) = setTexture(4L, value)
+
+    var bentNormalEnabled: Boolean
+        @JvmName("bentNormalEnabledProperty")
+        get() = getFeature(12L)
+        @JvmName("setBentNormalEnabledProperty")
+        set(value) = setFeature(12L, value)
+
+    var bentNormalTexture: Texture2D?
+        @JvmName("bentNormalTextureProperty")
+        get() = getTexture(18L)
+        @JvmName("setBentNormalTextureProperty")
+        set(value) = setTexture(18L, value)
+
+    var rimEnabled: Boolean
+        @JvmName("rimEnabledProperty")
+        get() = getFeature(2L)
+        @JvmName("setRimEnabledProperty")
+        set(value) = setFeature(2L, value)
 
     var rim: Double
         @JvmName("rimProperty")
@@ -161,6 +281,18 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setRimTintProperty")
         set(value) = setRimTint(value)
 
+    var rimTexture: Texture2D?
+        @JvmName("rimTextureProperty")
+        get() = getTexture(5L)
+        @JvmName("setRimTextureProperty")
+        set(value) = setTexture(5L, value)
+
+    var clearcoatEnabled: Boolean
+        @JvmName("clearcoatEnabledProperty")
+        get() = getFeature(3L)
+        @JvmName("setClearcoatEnabledProperty")
+        set(value) = setFeature(3L, value)
+
     var clearcoat: Double
         @JvmName("clearcoatProperty")
         get() = getClearcoat()
@@ -173,11 +305,35 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setClearcoatRoughnessProperty")
         set(value) = setClearcoatRoughness(value)
 
+    var clearcoatTexture: Texture2D?
+        @JvmName("clearcoatTextureProperty")
+        get() = getTexture(6L)
+        @JvmName("setClearcoatTextureProperty")
+        set(value) = setTexture(6L, value)
+
+    var anisotropyEnabled: Boolean
+        @JvmName("anisotropyEnabledProperty")
+        get() = getFeature(4L)
+        @JvmName("setAnisotropyEnabledProperty")
+        set(value) = setFeature(4L, value)
+
     var anisotropy: Double
         @JvmName("anisotropyProperty")
         get() = getAnisotropy()
         @JvmName("setAnisotropyProperty")
         set(value) = setAnisotropy(value)
+
+    var anisotropyFlowmap: Texture2D?
+        @JvmName("anisotropyFlowmapProperty")
+        get() = getTexture(7L)
+        @JvmName("setAnisotropyFlowmapProperty")
+        set(value) = setTexture(7L, value)
+
+    var aoEnabled: Boolean
+        @JvmName("aoEnabledProperty")
+        get() = getFeature(5L)
+        @JvmName("setAoEnabledProperty")
+        set(value) = setFeature(5L, value)
 
     var aoLightAffect: Double
         @JvmName("aoLightAffectProperty")
@@ -185,11 +341,29 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setAoLightAffectProperty")
         set(value) = setAoLightAffect(value)
 
+    var aoTexture: Texture2D?
+        @JvmName("aoTextureProperty")
+        get() = getTexture(8L)
+        @JvmName("setAoTextureProperty")
+        set(value) = setTexture(8L, value)
+
+    var aoOnUv2: Boolean
+        @JvmName("aoOnUv2Property")
+        get() = getFlag(10L)
+        @JvmName("setAoOnUv2Property")
+        set(value) = setFlag(10L, value)
+
     var aoTextureChannel: Long
         @JvmName("aoTextureChannelProperty")
         get() = getAoTextureChannel()
         @JvmName("setAoTextureChannelProperty")
         set(value) = setAoTextureChannel(value)
+
+    var heightmapEnabled: Boolean
+        @JvmName("heightmapEnabledProperty")
+        get() = getFeature(6L)
+        @JvmName("setHeightmapEnabledProperty")
+        set(value) = setFeature(6L, value)
 
     var heightmapScale: Double
         @JvmName("heightmapScaleProperty")
@@ -227,17 +401,59 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setHeightmapFlipBinormalProperty")
         set(value) = setHeightmapDeepParallaxFlipBinormal(value)
 
+    var heightmapTexture: Texture2D?
+        @JvmName("heightmapTextureProperty")
+        get() = getTexture(9L)
+        @JvmName("setHeightmapTextureProperty")
+        set(value) = setTexture(9L, value)
+
+    var heightmapFlipTexture: Boolean
+        @JvmName("heightmapFlipTextureProperty")
+        get() = getFlag(17L)
+        @JvmName("setHeightmapFlipTextureProperty")
+        set(value) = setFlag(17L, value)
+
+    var subsurfScatterEnabled: Boolean
+        @JvmName("subsurfScatterEnabledProperty")
+        get() = getFeature(7L)
+        @JvmName("setSubsurfScatterEnabledProperty")
+        set(value) = setFeature(7L, value)
+
     var subsurfScatterStrength: Double
         @JvmName("subsurfScatterStrengthProperty")
         get() = getSubsurfaceScatteringStrength()
         @JvmName("setSubsurfScatterStrengthProperty")
         set(value) = setSubsurfaceScatteringStrength(value)
 
+    var subsurfScatterSkinMode: Boolean
+        @JvmName("subsurfScatterSkinModeProperty")
+        get() = getFlag(18L)
+        @JvmName("setSubsurfScatterSkinModeProperty")
+        set(value) = setFlag(18L, value)
+
+    var subsurfScatterTexture: Texture2D?
+        @JvmName("subsurfScatterTextureProperty")
+        get() = getTexture(10L)
+        @JvmName("setSubsurfScatterTextureProperty")
+        set(value) = setTexture(10L, value)
+
+    var subsurfScatterTransmittanceEnabled: Boolean
+        @JvmName("subsurfScatterTransmittanceEnabledProperty")
+        get() = getFeature(8L)
+        @JvmName("setSubsurfScatterTransmittanceEnabledProperty")
+        set(value) = setFeature(8L, value)
+
     var subsurfScatterTransmittanceColor: Color
         @JvmName("subsurfScatterTransmittanceColorProperty")
         get() = getTransmittanceColor()
         @JvmName("setSubsurfScatterTransmittanceColorProperty")
         set(value) = setTransmittanceColor(value)
+
+    var subsurfScatterTransmittanceTexture: Texture2D?
+        @JvmName("subsurfScatterTransmittanceTextureProperty")
+        get() = getTexture(11L)
+        @JvmName("setSubsurfScatterTransmittanceTextureProperty")
+        set(value) = setTexture(11L, value)
 
     var subsurfScatterTransmittanceDepth: Double
         @JvmName("subsurfScatterTransmittanceDepthProperty")
@@ -251,11 +467,29 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setSubsurfScatterTransmittanceBoostProperty")
         set(value) = setTransmittanceBoost(value)
 
+    var backlightEnabled: Boolean
+        @JvmName("backlightEnabledProperty")
+        get() = getFeature(9L)
+        @JvmName("setBacklightEnabledProperty")
+        set(value) = setFeature(9L, value)
+
     var backlight: Color
         @JvmName("backlightProperty")
         get() = getBacklight()
         @JvmName("setBacklightProperty")
         set(value) = setBacklight(value)
+
+    var backlightTexture: Texture2D?
+        @JvmName("backlightTextureProperty")
+        get() = getTexture(12L)
+        @JvmName("setBacklightTextureProperty")
+        set(value) = setTexture(12L, value)
+
+    var refractionEnabled: Boolean
+        @JvmName("refractionEnabledProperty")
+        get() = getFeature(10L)
+        @JvmName("setRefractionEnabledProperty")
+        set(value) = setFeature(10L, value)
 
     var refractionScale: Double
         @JvmName("refractionScaleProperty")
@@ -263,11 +497,29 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setRefractionScaleProperty")
         set(value) = setRefraction(value)
 
+    var refractionTexture: Texture2D?
+        @JvmName("refractionTextureProperty")
+        get() = getTexture(13L)
+        @JvmName("setRefractionTextureProperty")
+        set(value) = setTexture(13L, value)
+
     var refractionTextureChannel: Long
         @JvmName("refractionTextureChannelProperty")
         get() = getRefractionTextureChannel()
         @JvmName("setRefractionTextureChannelProperty")
         set(value) = setRefractionTextureChannel(value)
+
+    var detailEnabled: Boolean
+        @JvmName("detailEnabledProperty")
+        get() = getFeature(11L)
+        @JvmName("setDetailEnabledProperty")
+        set(value) = setFeature(11L, value)
+
+    var detailMask: Texture2D?
+        @JvmName("detailMaskProperty")
+        get() = getTexture(14L)
+        @JvmName("setDetailMaskProperty")
+        set(value) = setTexture(14L, value)
 
     var detailBlendMode: Long
         @JvmName("detailBlendModeProperty")
@@ -281,6 +533,18 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setDetailUvLayerProperty")
         set(value) = setDetailUv(value)
 
+    var detailAlbedo: Texture2D?
+        @JvmName("detailAlbedoProperty")
+        get() = getTexture(15L)
+        @JvmName("setDetailAlbedoProperty")
+        set(value) = setTexture(15L, value)
+
+    var detailNormal: Texture2D?
+        @JvmName("detailNormalProperty")
+        get() = getTexture(16L)
+        @JvmName("setDetailNormalProperty")
+        set(value) = setTexture(16L, value)
+
     var uv1Scale: Vector3
         @JvmName("uv1ScaleProperty")
         get() = getUv1Scale()
@@ -293,11 +557,23 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setUv1OffsetProperty")
         set(value) = setUv1Offset(value)
 
+    var uv1Triplanar: Boolean
+        @JvmName("uv1TriplanarProperty")
+        get() = getFlag(6L)
+        @JvmName("setUv1TriplanarProperty")
+        set(value) = setFlag(6L, value)
+
     var uv1TriplanarSharpness: Double
         @JvmName("uv1TriplanarSharpnessProperty")
         get() = getUv1TriplanarBlendSharpness()
         @JvmName("setUv1TriplanarSharpnessProperty")
         set(value) = setUv1TriplanarBlendSharpness(value)
+
+    var uv1WorldTriplanar: Boolean
+        @JvmName("uv1WorldTriplanarProperty")
+        get() = getFlag(8L)
+        @JvmName("setUv1WorldTriplanarProperty")
+        set(value) = setFlag(8L, value)
 
     var uv2Scale: Vector3
         @JvmName("uv2ScaleProperty")
@@ -311,11 +587,23 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setUv2OffsetProperty")
         set(value) = setUv2Offset(value)
 
+    var uv2Triplanar: Boolean
+        @JvmName("uv2TriplanarProperty")
+        get() = getFlag(7L)
+        @JvmName("setUv2TriplanarProperty")
+        set(value) = setFlag(7L, value)
+
     var uv2TriplanarSharpness: Double
         @JvmName("uv2TriplanarSharpnessProperty")
         get() = getUv2TriplanarBlendSharpness()
         @JvmName("setUv2TriplanarSharpnessProperty")
         set(value) = setUv2TriplanarBlendSharpness(value)
+
+    var uv2WorldTriplanar: Boolean
+        @JvmName("uv2WorldTriplanarProperty")
+        get() = getFlag(9L)
+        @JvmName("setUv2WorldTriplanarProperty")
+        set(value) = setFlag(9L, value)
 
     var textureFilter: Long
         @JvmName("textureFilterProperty")
@@ -323,11 +611,35 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setTextureFilterProperty")
         set(value) = setTextureFilter(value)
 
+    var textureRepeat: Boolean
+        @JvmName("textureRepeatProperty")
+        get() = getFlag(16L)
+        @JvmName("setTextureRepeatProperty")
+        set(value) = setFlag(16L, value)
+
+    var disableReceiveShadows: Boolean
+        @JvmName("disableReceiveShadowsProperty")
+        get() = getFlag(13L)
+        @JvmName("setDisableReceiveShadowsProperty")
+        set(value) = setFlag(13L, value)
+
+    var shadowToOpacity: Boolean
+        @JvmName("shadowToOpacityProperty")
+        get() = getFlag(15L)
+        @JvmName("setShadowToOpacityProperty")
+        set(value) = setFlag(15L, value)
+
     var billboardMode: Long
         @JvmName("billboardModeProperty")
         get() = getBillboardMode()
         @JvmName("setBillboardModeProperty")
         set(value) = setBillboardMode(value)
+
+    var billboardKeepScale: Boolean
+        @JvmName("billboardKeepScaleProperty")
+        get() = getFlag(5L)
+        @JvmName("setBillboardKeepScaleProperty")
+        set(value) = setFlag(5L, value)
 
     var particlesAnimHFrames: Int
         @JvmName("particlesAnimHFramesProperty")
@@ -359,17 +671,47 @@ open class BaseMaterial3D(handle: MemorySegment) : Material(handle) {
         @JvmName("setGrowAmountProperty")
         set(value) = setGrow(value)
 
+    var fixedSize: Boolean
+        @JvmName("fixedSizeProperty")
+        get() = getFlag(4L)
+        @JvmName("setFixedSizeProperty")
+        set(value) = setFlag(4L, value)
+
+    var usePointSize: Boolean
+        @JvmName("usePointSizeProperty")
+        get() = getFlag(3L)
+        @JvmName("setUsePointSizeProperty")
+        set(value) = setFlag(3L, value)
+
     var pointSize: Double
         @JvmName("pointSizeProperty")
         get() = getPointSize()
         @JvmName("setPointSizeProperty")
         set(value) = setPointSize(value)
 
+    var useParticleTrails: Boolean
+        @JvmName("useParticleTrailsProperty")
+        get() = getFlag(19L)
+        @JvmName("setUseParticleTrailsProperty")
+        set(value) = setFlag(19L, value)
+
+    var useZClipScale: Boolean
+        @JvmName("useZClipScaleProperty")
+        get() = getFlag(23L)
+        @JvmName("setUseZClipScaleProperty")
+        set(value) = setFlag(23L, value)
+
     var zClipScale: Double
         @JvmName("zClipScaleProperty")
         get() = getZClipScale()
         @JvmName("setZClipScaleProperty")
         set(value) = setZClipScale(value)
+
+    var useFovOverride: Boolean
+        @JvmName("useFovOverrideProperty")
+        get() = getFlag(24L)
+        @JvmName("setUseFovOverrideProperty")
+        set(value) = setFlag(24L, value)
 
     var fovOverride: Double
         @JvmName("fovOverrideProperty")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CPUParticles2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CPUParticles2D.kt
@@ -149,6 +149,12 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         @JvmName("setEmissionRingRadiusProperty")
         set(value) = setEmissionRingRadius(value)
 
+    var particleFlagAlignY: Boolean
+        @JvmName("particleFlagAlignYProperty")
+        get() = getParticleFlag(0L)
+        @JvmName("setParticleFlagAlignYProperty")
+        set(value) = setParticleFlag(0L, value)
+
     var direction: Vector2
         @JvmName("directionProperty")
         get() = getDirection()
@@ -166,6 +172,162 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         get() = getGravity()
         @JvmName("setGravityProperty")
         set(value) = setGravity(value)
+
+    var initialVelocityMin: Double
+        @JvmName("initialVelocityMinProperty")
+        get() = getParamMin(0L)
+        @JvmName("setInitialVelocityMinProperty")
+        set(value) = setParamMin(0L, value)
+
+    var initialVelocityMax: Double
+        @JvmName("initialVelocityMaxProperty")
+        get() = getParamMax(0L)
+        @JvmName("setInitialVelocityMaxProperty")
+        set(value) = setParamMax(0L, value)
+
+    var angularVelocityMin: Double
+        @JvmName("angularVelocityMinProperty")
+        get() = getParamMin(1L)
+        @JvmName("setAngularVelocityMinProperty")
+        set(value) = setParamMin(1L, value)
+
+    var angularVelocityMax: Double
+        @JvmName("angularVelocityMaxProperty")
+        get() = getParamMax(1L)
+        @JvmName("setAngularVelocityMaxProperty")
+        set(value) = setParamMax(1L, value)
+
+    var angularVelocityCurve: Curve?
+        @JvmName("angularVelocityCurveProperty")
+        get() = getParamCurve(1L)
+        @JvmName("setAngularVelocityCurveProperty")
+        set(value) = setParamCurve(1L, value)
+
+    var orbitVelocityMin: Double
+        @JvmName("orbitVelocityMinProperty")
+        get() = getParamMin(2L)
+        @JvmName("setOrbitVelocityMinProperty")
+        set(value) = setParamMin(2L, value)
+
+    var orbitVelocityMax: Double
+        @JvmName("orbitVelocityMaxProperty")
+        get() = getParamMax(2L)
+        @JvmName("setOrbitVelocityMaxProperty")
+        set(value) = setParamMax(2L, value)
+
+    var orbitVelocityCurve: Curve?
+        @JvmName("orbitVelocityCurveProperty")
+        get() = getParamCurve(2L)
+        @JvmName("setOrbitVelocityCurveProperty")
+        set(value) = setParamCurve(2L, value)
+
+    var linearAccelMin: Double
+        @JvmName("linearAccelMinProperty")
+        get() = getParamMin(3L)
+        @JvmName("setLinearAccelMinProperty")
+        set(value) = setParamMin(3L, value)
+
+    var linearAccelMax: Double
+        @JvmName("linearAccelMaxProperty")
+        get() = getParamMax(3L)
+        @JvmName("setLinearAccelMaxProperty")
+        set(value) = setParamMax(3L, value)
+
+    var linearAccelCurve: Curve?
+        @JvmName("linearAccelCurveProperty")
+        get() = getParamCurve(3L)
+        @JvmName("setLinearAccelCurveProperty")
+        set(value) = setParamCurve(3L, value)
+
+    var radialAccelMin: Double
+        @JvmName("radialAccelMinProperty")
+        get() = getParamMin(4L)
+        @JvmName("setRadialAccelMinProperty")
+        set(value) = setParamMin(4L, value)
+
+    var radialAccelMax: Double
+        @JvmName("radialAccelMaxProperty")
+        get() = getParamMax(4L)
+        @JvmName("setRadialAccelMaxProperty")
+        set(value) = setParamMax(4L, value)
+
+    var radialAccelCurve: Curve?
+        @JvmName("radialAccelCurveProperty")
+        get() = getParamCurve(4L)
+        @JvmName("setRadialAccelCurveProperty")
+        set(value) = setParamCurve(4L, value)
+
+    var tangentialAccelMin: Double
+        @JvmName("tangentialAccelMinProperty")
+        get() = getParamMin(5L)
+        @JvmName("setTangentialAccelMinProperty")
+        set(value) = setParamMin(5L, value)
+
+    var tangentialAccelMax: Double
+        @JvmName("tangentialAccelMaxProperty")
+        get() = getParamMax(5L)
+        @JvmName("setTangentialAccelMaxProperty")
+        set(value) = setParamMax(5L, value)
+
+    var tangentialAccelCurve: Curve?
+        @JvmName("tangentialAccelCurveProperty")
+        get() = getParamCurve(5L)
+        @JvmName("setTangentialAccelCurveProperty")
+        set(value) = setParamCurve(5L, value)
+
+    var dampingMin: Double
+        @JvmName("dampingMinProperty")
+        get() = getParamMin(6L)
+        @JvmName("setDampingMinProperty")
+        set(value) = setParamMin(6L, value)
+
+    var dampingMax: Double
+        @JvmName("dampingMaxProperty")
+        get() = getParamMax(6L)
+        @JvmName("setDampingMaxProperty")
+        set(value) = setParamMax(6L, value)
+
+    var dampingCurve: Curve?
+        @JvmName("dampingCurveProperty")
+        get() = getParamCurve(6L)
+        @JvmName("setDampingCurveProperty")
+        set(value) = setParamCurve(6L, value)
+
+    var angleMin: Double
+        @JvmName("angleMinProperty")
+        get() = getParamMin(7L)
+        @JvmName("setAngleMinProperty")
+        set(value) = setParamMin(7L, value)
+
+    var angleMax: Double
+        @JvmName("angleMaxProperty")
+        get() = getParamMax(7L)
+        @JvmName("setAngleMaxProperty")
+        set(value) = setParamMax(7L, value)
+
+    var angleCurve: Curve?
+        @JvmName("angleCurveProperty")
+        get() = getParamCurve(7L)
+        @JvmName("setAngleCurveProperty")
+        set(value) = setParamCurve(7L, value)
+
+    var scaleAmountMin: Double
+        @JvmName("scaleAmountMinProperty")
+        get() = getParamMin(8L)
+        @JvmName("setScaleAmountMinProperty")
+        set(value) = setParamMin(8L, value)
+
+    var scaleAmountMax: Double
+        @JvmName("scaleAmountMaxProperty")
+        get() = getParamMax(8L)
+        @JvmName("setScaleAmountMaxProperty")
+        set(value) = setParamMax(8L, value)
+
+    var scaleAmountCurve: Curve?
+        @JvmName("scaleAmountCurveProperty")
+        get() = getParamCurve(8L)
+        @JvmName("setScaleAmountCurveProperty")
+        set(value) = setParamCurve(8L, value)
 
     var splitScale: Boolean
         @JvmName("splitScaleProperty")
@@ -202,6 +364,60 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         get() = getColorInitialRamp()
         @JvmName("setColorInitialRampProperty")
         set(value) = setColorInitialRamp(value)
+
+    var hueVariationMin: Double
+        @JvmName("hueVariationMinProperty")
+        get() = getParamMin(9L)
+        @JvmName("setHueVariationMinProperty")
+        set(value) = setParamMin(9L, value)
+
+    var hueVariationMax: Double
+        @JvmName("hueVariationMaxProperty")
+        get() = getParamMax(9L)
+        @JvmName("setHueVariationMaxProperty")
+        set(value) = setParamMax(9L, value)
+
+    var hueVariationCurve: Curve?
+        @JvmName("hueVariationCurveProperty")
+        get() = getParamCurve(9L)
+        @JvmName("setHueVariationCurveProperty")
+        set(value) = setParamCurve(9L, value)
+
+    var animSpeedMin: Double
+        @JvmName("animSpeedMinProperty")
+        get() = getParamMin(10L)
+        @JvmName("setAnimSpeedMinProperty")
+        set(value) = setParamMin(10L, value)
+
+    var animSpeedMax: Double
+        @JvmName("animSpeedMaxProperty")
+        get() = getParamMax(10L)
+        @JvmName("setAnimSpeedMaxProperty")
+        set(value) = setParamMax(10L, value)
+
+    var animSpeedCurve: Curve?
+        @JvmName("animSpeedCurveProperty")
+        get() = getParamCurve(10L)
+        @JvmName("setAnimSpeedCurveProperty")
+        set(value) = setParamCurve(10L, value)
+
+    var animOffsetMin: Double
+        @JvmName("animOffsetMinProperty")
+        get() = getParamMin(11L)
+        @JvmName("setAnimOffsetMinProperty")
+        set(value) = setParamMin(11L, value)
+
+    var animOffsetMax: Double
+        @JvmName("animOffsetMaxProperty")
+        get() = getParamMax(11L)
+        @JvmName("setAnimOffsetMaxProperty")
+        set(value) = setParamMax(11L, value)
+
+    var animOffsetCurve: Curve?
+        @JvmName("animOffsetCurveProperty")
+        get() = getParamCurve(11L)
+        @JvmName("setAnimOffsetCurveProperty")
+        set(value) = setParamCurve(11L, value)
 
     fun setEmitting(emitting: Boolean) {
         ObjectCalls.ptrcallWithBoolArg(setEmittingBind, handle, emitting)

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CPUParticles3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/CPUParticles3D.kt
@@ -166,6 +166,24 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setEmissionRingConeAngleProperty")
         set(value) = setEmissionRingConeAngle(value)
 
+    var particleFlagAlignY: Boolean
+        @JvmName("particleFlagAlignYProperty")
+        get() = getParticleFlag(0L)
+        @JvmName("setParticleFlagAlignYProperty")
+        set(value) = setParticleFlag(0L, value)
+
+    var particleFlagRotateY: Boolean
+        @JvmName("particleFlagRotateYProperty")
+        get() = getParticleFlag(1L)
+        @JvmName("setParticleFlagRotateYProperty")
+        set(value) = setParticleFlag(1L, value)
+
+    var particleFlagDisableZ: Boolean
+        @JvmName("particleFlagDisableZProperty")
+        get() = getParticleFlag(2L)
+        @JvmName("setParticleFlagDisableZProperty")
+        set(value) = setParticleFlag(2L, value)
+
     var direction: Vector3
         @JvmName("directionProperty")
         get() = getDirection()
@@ -189,6 +207,162 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         get() = getGravity()
         @JvmName("setGravityProperty")
         set(value) = setGravity(value)
+
+    var initialVelocityMin: Double
+        @JvmName("initialVelocityMinProperty")
+        get() = getParamMin(0L)
+        @JvmName("setInitialVelocityMinProperty")
+        set(value) = setParamMin(0L, value)
+
+    var initialVelocityMax: Double
+        @JvmName("initialVelocityMaxProperty")
+        get() = getParamMax(0L)
+        @JvmName("setInitialVelocityMaxProperty")
+        set(value) = setParamMax(0L, value)
+
+    var angularVelocityMin: Double
+        @JvmName("angularVelocityMinProperty")
+        get() = getParamMin(1L)
+        @JvmName("setAngularVelocityMinProperty")
+        set(value) = setParamMin(1L, value)
+
+    var angularVelocityMax: Double
+        @JvmName("angularVelocityMaxProperty")
+        get() = getParamMax(1L)
+        @JvmName("setAngularVelocityMaxProperty")
+        set(value) = setParamMax(1L, value)
+
+    var angularVelocityCurve: Curve?
+        @JvmName("angularVelocityCurveProperty")
+        get() = getParamCurve(1L)
+        @JvmName("setAngularVelocityCurveProperty")
+        set(value) = setParamCurve(1L, value)
+
+    var orbitVelocityMin: Double
+        @JvmName("orbitVelocityMinProperty")
+        get() = getParamMin(2L)
+        @JvmName("setOrbitVelocityMinProperty")
+        set(value) = setParamMin(2L, value)
+
+    var orbitVelocityMax: Double
+        @JvmName("orbitVelocityMaxProperty")
+        get() = getParamMax(2L)
+        @JvmName("setOrbitVelocityMaxProperty")
+        set(value) = setParamMax(2L, value)
+
+    var orbitVelocityCurve: Curve?
+        @JvmName("orbitVelocityCurveProperty")
+        get() = getParamCurve(2L)
+        @JvmName("setOrbitVelocityCurveProperty")
+        set(value) = setParamCurve(2L, value)
+
+    var linearAccelMin: Double
+        @JvmName("linearAccelMinProperty")
+        get() = getParamMin(3L)
+        @JvmName("setLinearAccelMinProperty")
+        set(value) = setParamMin(3L, value)
+
+    var linearAccelMax: Double
+        @JvmName("linearAccelMaxProperty")
+        get() = getParamMax(3L)
+        @JvmName("setLinearAccelMaxProperty")
+        set(value) = setParamMax(3L, value)
+
+    var linearAccelCurve: Curve?
+        @JvmName("linearAccelCurveProperty")
+        get() = getParamCurve(3L)
+        @JvmName("setLinearAccelCurveProperty")
+        set(value) = setParamCurve(3L, value)
+
+    var radialAccelMin: Double
+        @JvmName("radialAccelMinProperty")
+        get() = getParamMin(4L)
+        @JvmName("setRadialAccelMinProperty")
+        set(value) = setParamMin(4L, value)
+
+    var radialAccelMax: Double
+        @JvmName("radialAccelMaxProperty")
+        get() = getParamMax(4L)
+        @JvmName("setRadialAccelMaxProperty")
+        set(value) = setParamMax(4L, value)
+
+    var radialAccelCurve: Curve?
+        @JvmName("radialAccelCurveProperty")
+        get() = getParamCurve(4L)
+        @JvmName("setRadialAccelCurveProperty")
+        set(value) = setParamCurve(4L, value)
+
+    var tangentialAccelMin: Double
+        @JvmName("tangentialAccelMinProperty")
+        get() = getParamMin(5L)
+        @JvmName("setTangentialAccelMinProperty")
+        set(value) = setParamMin(5L, value)
+
+    var tangentialAccelMax: Double
+        @JvmName("tangentialAccelMaxProperty")
+        get() = getParamMax(5L)
+        @JvmName("setTangentialAccelMaxProperty")
+        set(value) = setParamMax(5L, value)
+
+    var tangentialAccelCurve: Curve?
+        @JvmName("tangentialAccelCurveProperty")
+        get() = getParamCurve(5L)
+        @JvmName("setTangentialAccelCurveProperty")
+        set(value) = setParamCurve(5L, value)
+
+    var dampingMin: Double
+        @JvmName("dampingMinProperty")
+        get() = getParamMin(6L)
+        @JvmName("setDampingMinProperty")
+        set(value) = setParamMin(6L, value)
+
+    var dampingMax: Double
+        @JvmName("dampingMaxProperty")
+        get() = getParamMax(6L)
+        @JvmName("setDampingMaxProperty")
+        set(value) = setParamMax(6L, value)
+
+    var dampingCurve: Curve?
+        @JvmName("dampingCurveProperty")
+        get() = getParamCurve(6L)
+        @JvmName("setDampingCurveProperty")
+        set(value) = setParamCurve(6L, value)
+
+    var angleMin: Double
+        @JvmName("angleMinProperty")
+        get() = getParamMin(7L)
+        @JvmName("setAngleMinProperty")
+        set(value) = setParamMin(7L, value)
+
+    var angleMax: Double
+        @JvmName("angleMaxProperty")
+        get() = getParamMax(7L)
+        @JvmName("setAngleMaxProperty")
+        set(value) = setParamMax(7L, value)
+
+    var angleCurve: Curve?
+        @JvmName("angleCurveProperty")
+        get() = getParamCurve(7L)
+        @JvmName("setAngleCurveProperty")
+        set(value) = setParamCurve(7L, value)
+
+    var scaleAmountMin: Double
+        @JvmName("scaleAmountMinProperty")
+        get() = getParamMin(8L)
+        @JvmName("setScaleAmountMinProperty")
+        set(value) = setParamMin(8L, value)
+
+    var scaleAmountMax: Double
+        @JvmName("scaleAmountMaxProperty")
+        get() = getParamMax(8L)
+        @JvmName("setScaleAmountMaxProperty")
+        set(value) = setParamMax(8L, value)
+
+    var scaleAmountCurve: Curve?
+        @JvmName("scaleAmountCurveProperty")
+        get() = getParamCurve(8L)
+        @JvmName("setScaleAmountCurveProperty")
+        set(value) = setParamCurve(8L, value)
 
     var splitScale: Boolean
         @JvmName("splitScaleProperty")
@@ -231,6 +405,60 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         get() = getColorInitialRamp()
         @JvmName("setColorInitialRampProperty")
         set(value) = setColorInitialRamp(value)
+
+    var hueVariationMin: Double
+        @JvmName("hueVariationMinProperty")
+        get() = getParamMin(9L)
+        @JvmName("setHueVariationMinProperty")
+        set(value) = setParamMin(9L, value)
+
+    var hueVariationMax: Double
+        @JvmName("hueVariationMaxProperty")
+        get() = getParamMax(9L)
+        @JvmName("setHueVariationMaxProperty")
+        set(value) = setParamMax(9L, value)
+
+    var hueVariationCurve: Curve?
+        @JvmName("hueVariationCurveProperty")
+        get() = getParamCurve(9L)
+        @JvmName("setHueVariationCurveProperty")
+        set(value) = setParamCurve(9L, value)
+
+    var animSpeedMin: Double
+        @JvmName("animSpeedMinProperty")
+        get() = getParamMin(10L)
+        @JvmName("setAnimSpeedMinProperty")
+        set(value) = setParamMin(10L, value)
+
+    var animSpeedMax: Double
+        @JvmName("animSpeedMaxProperty")
+        get() = getParamMax(10L)
+        @JvmName("setAnimSpeedMaxProperty")
+        set(value) = setParamMax(10L, value)
+
+    var animSpeedCurve: Curve?
+        @JvmName("animSpeedCurveProperty")
+        get() = getParamCurve(10L)
+        @JvmName("setAnimSpeedCurveProperty")
+        set(value) = setParamCurve(10L, value)
+
+    var animOffsetMin: Double
+        @JvmName("animOffsetMinProperty")
+        get() = getParamMin(11L)
+        @JvmName("setAnimOffsetMinProperty")
+        set(value) = setParamMin(11L, value)
+
+    var animOffsetMax: Double
+        @JvmName("animOffsetMaxProperty")
+        get() = getParamMax(11L)
+        @JvmName("setAnimOffsetMaxProperty")
+        set(value) = setParamMax(11L, value)
+
+    var animOffsetCurve: Curve?
+        @JvmName("animOffsetCurveProperty")
+        get() = getParamCurve(11L)
+        @JvmName("setAnimOffsetCurveProperty")
+        set(value) = setParamCurve(11L, value)
 
     fun setEmitting(emitting: Boolean) {
         ObjectCalls.ptrcallWithBoolArg(setEmittingBind, handle, emitting)

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Camera2D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Camera2D.kt
@@ -56,6 +56,30 @@ class Camera2D(handle: MemorySegment) : Node2D(handle) {
         @JvmName("setLimitEnabledProperty")
         set(value) = setLimitEnabled(value)
 
+    var limitLeft: Int
+        @JvmName("limitLeftProperty")
+        get() = getLimit(0L)
+        @JvmName("setLimitLeftProperty")
+        set(value) = setLimit(0L, value)
+
+    var limitTop: Int
+        @JvmName("limitTopProperty")
+        get() = getLimit(1L)
+        @JvmName("setLimitTopProperty")
+        set(value) = setLimit(1L, value)
+
+    var limitRight: Int
+        @JvmName("limitRightProperty")
+        get() = getLimit(2L)
+        @JvmName("setLimitRightProperty")
+        set(value) = setLimit(2L, value)
+
+    var limitBottom: Int
+        @JvmName("limitBottomProperty")
+        get() = getLimit(3L)
+        @JvmName("setLimitBottomProperty")
+        set(value) = setLimit(3L, value)
+
     var limitSmoothed: Boolean
         @JvmName("limitSmoothedProperty")
         get() = isLimitSmoothingEnabled()
@@ -109,6 +133,30 @@ class Camera2D(handle: MemorySegment) : Node2D(handle) {
         get() = getDragVerticalOffset()
         @JvmName("setDragVerticalOffsetProperty")
         set(value) = setDragVerticalOffset(value)
+
+    var dragLeftMargin: Double
+        @JvmName("dragLeftMarginProperty")
+        get() = getDragMargin(0L)
+        @JvmName("setDragLeftMarginProperty")
+        set(value) = setDragMargin(0L, value)
+
+    var dragTopMargin: Double
+        @JvmName("dragTopMarginProperty")
+        get() = getDragMargin(1L)
+        @JvmName("setDragTopMarginProperty")
+        set(value) = setDragMargin(1L, value)
+
+    var dragRightMargin: Double
+        @JvmName("dragRightMarginProperty")
+        get() = getDragMargin(2L)
+        @JvmName("setDragRightMarginProperty")
+        set(value) = setDragMargin(2L, value)
+
+    var dragBottomMargin: Double
+        @JvmName("dragBottomMarginProperty")
+        get() = getDragMargin(3L)
+        @JvmName("setDragBottomMarginProperty")
+        set(value) = setDragMargin(3L, value)
 
     var editorDrawScreen: Boolean
         @JvmName("editorDrawScreenProperty")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ConeTwistJoint3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/ConeTwistJoint3D.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.binding.runtime.*
 
@@ -8,6 +9,36 @@ import net.multigesture.kanama.binding.runtime.*
  * Generated from Godot docs: ConeTwistJoint3D
  */
 class ConeTwistJoint3D(handle: MemorySegment) : Joint3D(handle) {
+    var swingSpan: Double
+        @JvmName("swingSpanProperty")
+        get() = getParam(0L)
+        @JvmName("setSwingSpanProperty")
+        set(value) = setParam(0L, value)
+
+    var twistSpan: Double
+        @JvmName("twistSpanProperty")
+        get() = getParam(1L)
+        @JvmName("setTwistSpanProperty")
+        set(value) = setParam(1L, value)
+
+    var bias: Double
+        @JvmName("biasProperty")
+        get() = getParam(2L)
+        @JvmName("setBiasProperty")
+        set(value) = setParam(2L, value)
+
+    var softness: Double
+        @JvmName("softnessProperty")
+        get() = getParam(3L)
+        @JvmName("setSoftnessProperty")
+        set(value) = setParam(3L, value)
+
+    var relaxation: Double
+        @JvmName("relaxationProperty")
+        get() = getParam(4L)
+        @JvmName("setRelaxationProperty")
+        set(value) = setParam(4L, value)
+
     fun setParam(param: Long, value: Double) {
         ObjectCalls.ptrcallWithLongAndDoubleArg(setParamBind, handle, param, value)
     }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Control.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Control.kt
@@ -37,6 +37,54 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
         @JvmName("setClipContentsProperty")
         set(value) = setClipContents(value)
 
+    var anchorLeft: Double
+        @JvmName("anchorLeftProperty")
+        get() = getAnchor(0L)
+        @JvmName("setAnchorLeftProperty")
+        set(value) = setAnchor(0L, value)
+
+    var anchorTop: Double
+        @JvmName("anchorTopProperty")
+        get() = getAnchor(1L)
+        @JvmName("setAnchorTopProperty")
+        set(value) = setAnchor(1L, value)
+
+    var anchorRight: Double
+        @JvmName("anchorRightProperty")
+        get() = getAnchor(2L)
+        @JvmName("setAnchorRightProperty")
+        set(value) = setAnchor(2L, value)
+
+    var anchorBottom: Double
+        @JvmName("anchorBottomProperty")
+        get() = getAnchor(3L)
+        @JvmName("setAnchorBottomProperty")
+        set(value) = setAnchor(3L, value)
+
+    var offsetLeft: Double
+        @JvmName("offsetLeftProperty")
+        get() = getOffset(0L)
+        @JvmName("setOffsetLeftProperty")
+        set(value) = setOffset(0L, value)
+
+    var offsetTop: Double
+        @JvmName("offsetTopProperty")
+        get() = getOffset(1L)
+        @JvmName("setOffsetTopProperty")
+        set(value) = setOffset(1L, value)
+
+    var offsetRight: Double
+        @JvmName("offsetRightProperty")
+        get() = getOffset(2L)
+        @JvmName("setOffsetRightProperty")
+        set(value) = setOffset(2L, value)
+
+    var offsetBottom: Double
+        @JvmName("offsetBottomProperty")
+        get() = getOffset(3L)
+        @JvmName("setOffsetBottomProperty")
+        set(value) = setOffset(3L, value)
+
     var growHorizontal: Long
         @JvmName("growHorizontalProperty")
         get() = getHGrowDirection()
@@ -198,6 +246,30 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
         get() = getTooltipAutoTranslateMode()
         @JvmName("setTooltipAutoTranslateModeProperty")
         set(value) = setTooltipAutoTranslateMode(value)
+
+    var focusNeighborLeft: NodePath
+        @JvmName("focusNeighborLeftProperty")
+        get() = getFocusNeighbor(0L)
+        @JvmName("setFocusNeighborLeftProperty")
+        set(value) = setFocusNeighbor(0L, value)
+
+    var focusNeighborTop: NodePath
+        @JvmName("focusNeighborTopProperty")
+        get() = getFocusNeighbor(1L)
+        @JvmName("setFocusNeighborTopProperty")
+        set(value) = setFocusNeighbor(1L, value)
+
+    var focusNeighborRight: NodePath
+        @JvmName("focusNeighborRightProperty")
+        get() = getFocusNeighbor(2L)
+        @JvmName("setFocusNeighborRightProperty")
+        set(value) = setFocusNeighbor(2L, value)
+
+    var focusNeighborBottom: NodePath
+        @JvmName("focusNeighborBottomProperty")
+        get() = getFocusNeighbor(3L)
+        @JvmName("setFocusNeighborBottomProperty")
+        set(value) = setFocusNeighbor(3L, value)
 
     var focusNext: NodePath
         @JvmName("focusNextProperty")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Decal.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Decal.kt
@@ -17,6 +17,30 @@ class Decal(handle: MemorySegment) : VisualInstance3D(handle) {
         @JvmName("setSizeProperty")
         set(value) = setSize(value)
 
+    var textureAlbedo: Texture2D?
+        @JvmName("textureAlbedoProperty")
+        get() = getTexture(0L)
+        @JvmName("setTextureAlbedoProperty")
+        set(value) = setTexture(0L, value)
+
+    var textureNormal: Texture2D?
+        @JvmName("textureNormalProperty")
+        get() = getTexture(1L)
+        @JvmName("setTextureNormalProperty")
+        set(value) = setTexture(1L, value)
+
+    var textureOrm: Texture2D?
+        @JvmName("textureOrmProperty")
+        get() = getTexture(2L)
+        @JvmName("setTextureOrmProperty")
+        set(value) = setTexture(2L, value)
+
+    var textureEmission: Texture2D?
+        @JvmName("textureEmissionProperty")
+        get() = getTexture(3L)
+        @JvmName("setTextureEmissionProperty")
+        set(value) = setTexture(3L, value)
+
     var emissionEnergy: Double
         @JvmName("emissionEnergyProperty")
         get() = getEmissionEnergy()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FileDialog.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FileDialog.kt
@@ -67,6 +67,60 @@ open class FileDialog(handle: MemorySegment) : ConfirmationDialog(handle) {
         @JvmName("setOptionCountProperty")
         set(value) = setOptionCount(value)
 
+    var hiddenFilesToggleEnabled: Boolean
+        @JvmName("hiddenFilesToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(0L)
+        @JvmName("setHiddenFilesToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(0L, value)
+
+    var fileFilterToggleEnabled: Boolean
+        @JvmName("fileFilterToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(2L)
+        @JvmName("setFileFilterToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(2L, value)
+
+    var fileSortOptionsEnabled: Boolean
+        @JvmName("fileSortOptionsEnabledProperty")
+        get() = isCustomizationFlagEnabled(3L)
+        @JvmName("setFileSortOptionsEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(3L, value)
+
+    var folderCreationEnabled: Boolean
+        @JvmName("folderCreationEnabledProperty")
+        get() = isCustomizationFlagEnabled(1L)
+        @JvmName("setFolderCreationEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(1L, value)
+
+    var favoritesEnabled: Boolean
+        @JvmName("favoritesEnabledProperty")
+        get() = isCustomizationFlagEnabled(4L)
+        @JvmName("setFavoritesEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(4L, value)
+
+    var recentListEnabled: Boolean
+        @JvmName("recentListEnabledProperty")
+        get() = isCustomizationFlagEnabled(5L)
+        @JvmName("setRecentListEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(5L, value)
+
+    var layoutToggleEnabled: Boolean
+        @JvmName("layoutToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(6L)
+        @JvmName("setLayoutToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(6L, value)
+
+    var overwriteWarningEnabled: Boolean
+        @JvmName("overwriteWarningEnabledProperty")
+        get() = isCustomizationFlagEnabled(7L)
+        @JvmName("setOverwriteWarningEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(7L, value)
+
+    var deletingEnabled: Boolean
+        @JvmName("deletingEnabledProperty")
+        get() = isCustomizationFlagEnabled(8L)
+        @JvmName("setDeletingEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(8L, value)
+
     var currentDir: String
         @JvmName("currentDirProperty")
         get() = getCurrentDir()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/GPUParticles3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/GPUParticles3D.kt
@@ -176,6 +176,30 @@ class GPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setDrawPassesProperty")
         set(value) = setDrawPasses(value)
 
+    var drawPass1: Mesh?
+        @JvmName("drawPass1Property")
+        get() = getDrawPassMesh(0)
+        @JvmName("setDrawPass1Property")
+        set(value) = setDrawPassMesh(0, value)
+
+    var drawPass2: Mesh?
+        @JvmName("drawPass2Property")
+        get() = getDrawPassMesh(1)
+        @JvmName("setDrawPass2Property")
+        set(value) = setDrawPassMesh(1, value)
+
+    var drawPass3: Mesh?
+        @JvmName("drawPass3Property")
+        get() = getDrawPassMesh(2)
+        @JvmName("setDrawPass3Property")
+        set(value) = setDrawPassMesh(2, value)
+
+    var drawPass4: Mesh?
+        @JvmName("drawPass4Property")
+        get() = getDrawPassMesh(3)
+        @JvmName("setDrawPass4Property")
+        set(value) = setDrawPassMesh(3, value)
+
     var drawSkin: Skin?
         @JvmName("drawSkinProperty")
         get() = getSkin()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Label3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Label3D.kt
@@ -29,6 +29,30 @@ class Label3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setBillboardProperty")
         set(value) = setBillboardMode(value)
 
+    var shaded: Boolean
+        @JvmName("shadedProperty")
+        get() = getDrawFlag(0L)
+        @JvmName("setShadedProperty")
+        set(value) = setDrawFlag(0L, value)
+
+    var doubleSided: Boolean
+        @JvmName("doubleSidedProperty")
+        get() = getDrawFlag(1L)
+        @JvmName("setDoubleSidedProperty")
+        set(value) = setDrawFlag(1L, value)
+
+    var noDepthTest: Boolean
+        @JvmName("noDepthTestProperty")
+        get() = getDrawFlag(2L)
+        @JvmName("setNoDepthTestProperty")
+        set(value) = setDrawFlag(2L, value)
+
+    var fixedSize: Boolean
+        @JvmName("fixedSizeProperty")
+        get() = getDrawFlag(3L)
+        @JvmName("setFixedSizeProperty")
+        set(value) = setDrawFlag(3L, value)
+
     var alphaCut: Long
         @JvmName("alphaCutProperty")
         get() = getAlphaCutMode()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Light3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Light3D.kt
@@ -10,6 +10,18 @@ import net.multigesture.kanama.types.Color
  * Generated from Godot docs: Light3D
  */
 open class Light3D(handle: MemorySegment) : VisualInstance3D(handle) {
+    var lightIntensityLumens: Double
+        @JvmName("lightIntensityLumensProperty")
+        get() = getParam(20L)
+        @JvmName("setLightIntensityLumensProperty")
+        set(value) = setParam(20L, value)
+
+    var lightIntensityLux: Double
+        @JvmName("lightIntensityLuxProperty")
+        get() = getParam(20L)
+        @JvmName("setLightIntensityLuxProperty")
+        set(value) = setParam(20L, value)
+
     var lightTemperature: Double
         @JvmName("lightTemperatureProperty")
         get() = getTemperature()
@@ -22,17 +34,53 @@ open class Light3D(handle: MemorySegment) : VisualInstance3D(handle) {
         @JvmName("setLightColorProperty")
         set(value) = setColor(value)
 
+    var lightEnergy: Double
+        @JvmName("lightEnergyProperty")
+        get() = getParam(0L)
+        @JvmName("setLightEnergyProperty")
+        set(value) = setParam(0L, value)
+
+    var lightIndirectEnergy: Double
+        @JvmName("lightIndirectEnergyProperty")
+        get() = getParam(1L)
+        @JvmName("setLightIndirectEnergyProperty")
+        set(value) = setParam(1L, value)
+
+    var lightVolumetricFogEnergy: Double
+        @JvmName("lightVolumetricFogEnergyProperty")
+        get() = getParam(2L)
+        @JvmName("setLightVolumetricFogEnergyProperty")
+        set(value) = setParam(2L, value)
+
     var lightProjector: Texture2D?
         @JvmName("lightProjectorProperty")
         get() = getProjector()
         @JvmName("setLightProjectorProperty")
         set(value) = setProjector(value)
 
+    var lightSize: Double
+        @JvmName("lightSizeProperty")
+        get() = getParam(5L)
+        @JvmName("setLightSizeProperty")
+        set(value) = setParam(5L, value)
+
+    var lightAngularDistance: Double
+        @JvmName("lightAngularDistanceProperty")
+        get() = getParam(5L)
+        @JvmName("setLightAngularDistanceProperty")
+        set(value) = setParam(5L, value)
+
     var lightNegative: Boolean
         @JvmName("lightNegativeProperty")
         get() = isNegative()
         @JvmName("setLightNegativeProperty")
         set(value) = setNegative(value)
+
+    var lightSpecular: Double
+        @JvmName("lightSpecularProperty")
+        get() = getParam(3L)
+        @JvmName("setLightSpecularProperty")
+        set(value) = setParam(3L, value)
 
     var lightBakeMode: Long
         @JvmName("lightBakeModeProperty")
@@ -52,11 +100,41 @@ open class Light3D(handle: MemorySegment) : VisualInstance3D(handle) {
         @JvmName("setShadowEnabledProperty")
         set(value) = setShadow(value)
 
+    var shadowBias: Double
+        @JvmName("shadowBiasProperty")
+        get() = getParam(15L)
+        @JvmName("setShadowBiasProperty")
+        set(value) = setParam(15L, value)
+
+    var shadowNormalBias: Double
+        @JvmName("shadowNormalBiasProperty")
+        get() = getParam(14L)
+        @JvmName("setShadowNormalBiasProperty")
+        set(value) = setParam(14L, value)
+
     var shadowReverseCullFace: Boolean
         @JvmName("shadowReverseCullFaceProperty")
         get() = getShadowReverseCullFace()
         @JvmName("setShadowReverseCullFaceProperty")
         set(value) = setShadowReverseCullFace(value)
+
+    var shadowTransmittanceBias: Double
+        @JvmName("shadowTransmittanceBiasProperty")
+        get() = getParam(19L)
+        @JvmName("setShadowTransmittanceBiasProperty")
+        set(value) = setParam(19L, value)
+
+    var shadowOpacity: Double
+        @JvmName("shadowOpacityProperty")
+        get() = getParam(17L)
+        @JvmName("setShadowOpacityProperty")
+        set(value) = setParam(17L, value)
+
+    var shadowBlur: Double
+        @JvmName("shadowBlurProperty")
+        get() = getParam(18L)
+        @JvmName("setShadowBlurProperty")
+        set(value) = setParam(18L, value)
 
     var shadowCasterMask: Long
         @JvmName("shadowCasterMaskProperty")
@@ -217,15 +295,6 @@ open class Light3D(handle: MemorySegment) : VisualInstance3D(handle) {
     fun getCorrelatedColor(): Color {
         return ObjectCalls.ptrcallNoArgsRetColor(getCorrelatedColorBind, handle)
     }
-
-    // ── Kanama iOS sugar (generator custom-section, not from Godot docs) ───────
-    // lightEnergy is an indexed (get_param/set_param) property; the property renderer
-    // skips indexed getters, so expose it explicitly to match the Android/desktop API.
-    var lightEnergy: Double
-        @JvmName("lightEnergyProperty")
-        get() = getParam(PARAM_ENERGY)
-        @JvmName("setLightEnergyProperty")
-        set(value) = setParam(PARAM_ENERGY, value)
 
     companion object {
         const val PARAM_ENERGY: Long = 0L

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/NinePatchRect.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/NinePatchRect.kt
@@ -28,6 +28,30 @@ class NinePatchRect(handle: MemorySegment) : Control(handle) {
         @JvmName("setRegionRectProperty")
         set(value) = setRegionRect(value)
 
+    var patchMarginLeft: Int
+        @JvmName("patchMarginLeftProperty")
+        get() = getPatchMargin(0L)
+        @JvmName("setPatchMarginLeftProperty")
+        set(value) = setPatchMargin(0L, value)
+
+    var patchMarginTop: Int
+        @JvmName("patchMarginTopProperty")
+        get() = getPatchMargin(1L)
+        @JvmName("setPatchMarginTopProperty")
+        set(value) = setPatchMargin(1L, value)
+
+    var patchMarginRight: Int
+        @JvmName("patchMarginRightProperty")
+        get() = getPatchMargin(2L)
+        @JvmName("setPatchMarginRightProperty")
+        set(value) = setPatchMargin(2L, value)
+
+    var patchMarginBottom: Int
+        @JvmName("patchMarginBottomProperty")
+        get() = getPatchMargin(3L)
+        @JvmName("setPatchMarginBottomProperty")
+        set(value) = setPatchMargin(3L, value)
+
     var axisStretchHorizontal: Long
         @JvmName("axisStretchHorizontalProperty")
         get() = getHAxisStretchMode()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsBody3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/PhysicsBody3D.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.binding.runtime.*
 import net.multigesture.kanama.types.Transform3D
@@ -10,6 +11,42 @@ import net.multigesture.kanama.types.Vector3
  * Generated from Godot docs: PhysicsBody3D
  */
 open class PhysicsBody3D(handle: MemorySegment) : CollisionObject3D(handle) {
+    var axisLockLinearX: Boolean
+        @JvmName("axisLockLinearXProperty")
+        get() = getAxisLock(1L)
+        @JvmName("setAxisLockLinearXProperty")
+        set(value) = setAxisLock(1L, value)
+
+    var axisLockLinearY: Boolean
+        @JvmName("axisLockLinearYProperty")
+        get() = getAxisLock(2L)
+        @JvmName("setAxisLockLinearYProperty")
+        set(value) = setAxisLock(2L, value)
+
+    var axisLockLinearZ: Boolean
+        @JvmName("axisLockLinearZProperty")
+        get() = getAxisLock(4L)
+        @JvmName("setAxisLockLinearZProperty")
+        set(value) = setAxisLock(4L, value)
+
+    var axisLockAngularX: Boolean
+        @JvmName("axisLockAngularXProperty")
+        get() = getAxisLock(8L)
+        @JvmName("setAxisLockAngularXProperty")
+        set(value) = setAxisLock(8L, value)
+
+    var axisLockAngularY: Boolean
+        @JvmName("axisLockAngularYProperty")
+        get() = getAxisLock(16L)
+        @JvmName("setAxisLockAngularYProperty")
+        set(value) = setAxisLock(16L, value)
+
+    var axisLockAngularZ: Boolean
+        @JvmName("axisLockAngularZProperty")
+        get() = getAxisLock(32L)
+        @JvmName("setAxisLockAngularZProperty")
+        set(value) = setAxisLock(32L, value)
+
     fun moveAndCollide(motion: Vector3, testOnly: Boolean = false, safeMargin: Double = 0.001, recoveryAsCollision: Boolean = false, maxCollisions: Int = 1): KinematicCollision3D? {
         return KinematicCollision3D.wrap(ObjectCalls.ptrcallWithVector3BoolFloatBoolIntArgsRetObject(moveAndCollideBind, handle, motion, testOnly, safeMargin, recoveryAsCollision, maxCollisions))
     }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/SpriteBase3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/SpriteBase3D.kt
@@ -60,6 +60,36 @@ open class SpriteBase3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setBillboardProperty")
         set(value) = setBillboardMode(value)
 
+    var transparent: Boolean
+        @JvmName("transparentProperty")
+        get() = getDrawFlag(0L)
+        @JvmName("setTransparentProperty")
+        set(value) = setDrawFlag(0L, value)
+
+    var shaded: Boolean
+        @JvmName("shadedProperty")
+        get() = getDrawFlag(1L)
+        @JvmName("setShadedProperty")
+        set(value) = setDrawFlag(1L, value)
+
+    var doubleSided: Boolean
+        @JvmName("doubleSidedProperty")
+        get() = getDrawFlag(2L)
+        @JvmName("setDoubleSidedProperty")
+        set(value) = setDrawFlag(2L, value)
+
+    var noDepthTest: Boolean
+        @JvmName("noDepthTestProperty")
+        get() = getDrawFlag(3L)
+        @JvmName("setNoDepthTestProperty")
+        set(value) = setDrawFlag(3L, value)
+
+    var fixedSize: Boolean
+        @JvmName("fixedSizeProperty")
+        get() = getDrawFlag(4L)
+        @JvmName("setFixedSizeProperty")
+        set(value) = setDrawFlag(4L, value)
+
     var alphaCut: Long
         @JvmName("alphaCutProperty")
         get() = getAlphaCutMode()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBox.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBox.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.binding.runtime.*
 import net.multigesture.kanama.types.RID
@@ -11,6 +12,30 @@ import net.multigesture.kanama.types.Vector2
  * Generated from Godot docs: StyleBox
  */
 open class StyleBox(handle: MemorySegment) : Resource(handle) {
+    var contentMarginLeft: Double
+        @JvmName("contentMarginLeftProperty")
+        get() = getContentMargin(0L)
+        @JvmName("setContentMarginLeftProperty")
+        set(value) = setContentMargin(0L, value)
+
+    var contentMarginTop: Double
+        @JvmName("contentMarginTopProperty")
+        get() = getContentMargin(1L)
+        @JvmName("setContentMarginTopProperty")
+        set(value) = setContentMargin(1L, value)
+
+    var contentMarginRight: Double
+        @JvmName("contentMarginRightProperty")
+        get() = getContentMargin(2L)
+        @JvmName("setContentMarginRightProperty")
+        set(value) = setContentMargin(2L, value)
+
+    var contentMarginBottom: Double
+        @JvmName("contentMarginBottomProperty")
+        get() = getContentMargin(3L)
+        @JvmName("setContentMarginBottomProperty")
+        set(value) = setContentMargin(3L, value)
+
     fun getMinimumSize(): Vector2 {
         return ObjectCalls.ptrcallNoArgsRetVector2(getMinimumSizeBind, handle)
     }

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBoxFlat.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBoxFlat.kt
@@ -29,6 +29,30 @@ class StyleBoxFlat(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setSkewProperty")
         set(value) = setSkew(value)
 
+    var borderWidthLeft: Int
+        @JvmName("borderWidthLeftProperty")
+        get() = getBorderWidth(0L)
+        @JvmName("setBorderWidthLeftProperty")
+        set(value) = setBorderWidth(0L, value)
+
+    var borderWidthTop: Int
+        @JvmName("borderWidthTopProperty")
+        get() = getBorderWidth(1L)
+        @JvmName("setBorderWidthTopProperty")
+        set(value) = setBorderWidth(1L, value)
+
+    var borderWidthRight: Int
+        @JvmName("borderWidthRightProperty")
+        get() = getBorderWidth(2L)
+        @JvmName("setBorderWidthRightProperty")
+        set(value) = setBorderWidth(2L, value)
+
+    var borderWidthBottom: Int
+        @JvmName("borderWidthBottomProperty")
+        get() = getBorderWidth(3L)
+        @JvmName("setBorderWidthBottomProperty")
+        set(value) = setBorderWidth(3L, value)
+
     var borderColor: Color
         @JvmName("borderColorProperty")
         get() = getBorderColor()
@@ -41,11 +65,59 @@ class StyleBoxFlat(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setBorderBlendProperty")
         set(value) = setBorderBlend(value)
 
+    var cornerRadiusTopLeft: Int
+        @JvmName("cornerRadiusTopLeftProperty")
+        get() = getCornerRadius(0L)
+        @JvmName("setCornerRadiusTopLeftProperty")
+        set(value) = setCornerRadius(0L, value)
+
+    var cornerRadiusTopRight: Int
+        @JvmName("cornerRadiusTopRightProperty")
+        get() = getCornerRadius(1L)
+        @JvmName("setCornerRadiusTopRightProperty")
+        set(value) = setCornerRadius(1L, value)
+
+    var cornerRadiusBottomRight: Int
+        @JvmName("cornerRadiusBottomRightProperty")
+        get() = getCornerRadius(2L)
+        @JvmName("setCornerRadiusBottomRightProperty")
+        set(value) = setCornerRadius(2L, value)
+
+    var cornerRadiusBottomLeft: Int
+        @JvmName("cornerRadiusBottomLeftProperty")
+        get() = getCornerRadius(3L)
+        @JvmName("setCornerRadiusBottomLeftProperty")
+        set(value) = setCornerRadius(3L, value)
+
     var cornerDetail: Int
         @JvmName("cornerDetailProperty")
         get() = getCornerDetail()
         @JvmName("setCornerDetailProperty")
         set(value) = setCornerDetail(value)
+
+    var expandMarginLeft: Double
+        @JvmName("expandMarginLeftProperty")
+        get() = getExpandMargin(0L)
+        @JvmName("setExpandMarginLeftProperty")
+        set(value) = setExpandMargin(0L, value)
+
+    var expandMarginTop: Double
+        @JvmName("expandMarginTopProperty")
+        get() = getExpandMargin(1L)
+        @JvmName("setExpandMarginTopProperty")
+        set(value) = setExpandMargin(1L, value)
+
+    var expandMarginRight: Double
+        @JvmName("expandMarginRightProperty")
+        get() = getExpandMargin(2L)
+        @JvmName("setExpandMarginRightProperty")
+        set(value) = setExpandMargin(2L, value)
+
+    var expandMarginBottom: Double
+        @JvmName("expandMarginBottomProperty")
+        get() = getExpandMargin(3L)
+        @JvmName("setExpandMarginBottomProperty")
+        set(value) = setExpandMargin(3L, value)
 
     var shadowColor: Color
         @JvmName("shadowColorProperty")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBoxTexture.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/StyleBoxTexture.kt
@@ -17,6 +17,54 @@ class StyleBoxTexture(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setTextureProperty")
         set(value) = setTexture(value)
 
+    var textureMarginLeft: Double
+        @JvmName("textureMarginLeftProperty")
+        get() = getTextureMargin(0L)
+        @JvmName("setTextureMarginLeftProperty")
+        set(value) = setTextureMargin(0L, value)
+
+    var textureMarginTop: Double
+        @JvmName("textureMarginTopProperty")
+        get() = getTextureMargin(1L)
+        @JvmName("setTextureMarginTopProperty")
+        set(value) = setTextureMargin(1L, value)
+
+    var textureMarginRight: Double
+        @JvmName("textureMarginRightProperty")
+        get() = getTextureMargin(2L)
+        @JvmName("setTextureMarginRightProperty")
+        set(value) = setTextureMargin(2L, value)
+
+    var textureMarginBottom: Double
+        @JvmName("textureMarginBottomProperty")
+        get() = getTextureMargin(3L)
+        @JvmName("setTextureMarginBottomProperty")
+        set(value) = setTextureMargin(3L, value)
+
+    var expandMarginLeft: Double
+        @JvmName("expandMarginLeftProperty")
+        get() = getExpandMargin(0L)
+        @JvmName("setExpandMarginLeftProperty")
+        set(value) = setExpandMargin(0L, value)
+
+    var expandMarginTop: Double
+        @JvmName("expandMarginTopProperty")
+        get() = getExpandMargin(1L)
+        @JvmName("setExpandMarginTopProperty")
+        set(value) = setExpandMargin(1L, value)
+
+    var expandMarginRight: Double
+        @JvmName("expandMarginRightProperty")
+        get() = getExpandMargin(2L)
+        @JvmName("setExpandMarginRightProperty")
+        set(value) = setExpandMargin(2L, value)
+
+    var expandMarginBottom: Double
+        @JvmName("expandMarginBottomProperty")
+        get() = getExpandMargin(3L)
+        @JvmName("setExpandMarginBottomProperty")
+        set(value) = setExpandMargin(3L, value)
+
     var axisStretchHorizontal: Long
         @JvmName("axisStretchHorizontalProperty")
         get() = getHAxisStretchMode()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/TextureProgressBar.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/TextureProgressBar.kt
@@ -41,6 +41,30 @@ class TextureProgressBar(handle: MemorySegment) : Range(handle) {
         @JvmName("setNinePatchStretchProperty")
         set(value) = setNinePatchStretch(value)
 
+    var stretchMarginLeft: Int
+        @JvmName("stretchMarginLeftProperty")
+        get() = getStretchMargin(0L)
+        @JvmName("setStretchMarginLeftProperty")
+        set(value) = setStretchMargin(0L, value)
+
+    var stretchMarginTop: Int
+        @JvmName("stretchMarginTopProperty")
+        get() = getStretchMargin(1L)
+        @JvmName("setStretchMarginTopProperty")
+        set(value) = setStretchMargin(1L, value)
+
+    var stretchMarginRight: Int
+        @JvmName("stretchMarginRightProperty")
+        get() = getStretchMargin(2L)
+        @JvmName("setStretchMarginRightProperty")
+        set(value) = setStretchMargin(2L, value)
+
+    var stretchMarginBottom: Int
+        @JvmName("stretchMarginBottomProperty")
+        get() = getStretchMargin(3L)
+        @JvmName("setStretchMarginBottomProperty")
+        set(value) = setStretchMargin(3L, value)
+
     var textureUnder: Texture2D?
         @JvmName("textureUnderProperty")
         get() = getUnderTexture()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Viewport.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Viewport.kt
@@ -259,6 +259,30 @@ open class Viewport(handle: MemorySegment) : Node(handle) {
         @JvmName("setPositionalShadowAtlas16BitsProperty")
         set(value) = setPositionalShadowAtlas16Bits(value)
 
+    var positionalShadowAtlasQuad0: Long
+        @JvmName("positionalShadowAtlasQuad0Property")
+        get() = getPositionalShadowAtlasQuadrantSubdiv(0)
+        @JvmName("setPositionalShadowAtlasQuad0Property")
+        set(value) = setPositionalShadowAtlasQuadrantSubdiv(0, value)
+
+    var positionalShadowAtlasQuad1: Long
+        @JvmName("positionalShadowAtlasQuad1Property")
+        get() = getPositionalShadowAtlasQuadrantSubdiv(1)
+        @JvmName("setPositionalShadowAtlasQuad1Property")
+        set(value) = setPositionalShadowAtlasQuadrantSubdiv(1, value)
+
+    var positionalShadowAtlasQuad2: Long
+        @JvmName("positionalShadowAtlasQuad2Property")
+        get() = getPositionalShadowAtlasQuadrantSubdiv(2)
+        @JvmName("setPositionalShadowAtlasQuad2Property")
+        set(value) = setPositionalShadowAtlasQuadrantSubdiv(2, value)
+
+    var positionalShadowAtlasQuad3: Long
+        @JvmName("positionalShadowAtlasQuad3Property")
+        get() = getPositionalShadowAtlasQuadrantSubdiv(3)
+        @JvmName("setPositionalShadowAtlasQuad3Property")
+        set(value) = setPositionalShadowAtlasQuadrantSubdiv(3, value)
+
     var canvasTransform: Transform2D
         @JvmName("canvasTransformProperty")
         get() = getCanvasTransform()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Window.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/Window.kt
@@ -87,6 +87,84 @@ open class Window(handle: MemorySegment) : Viewport(handle) {
         @JvmName("setExclusiveProperty")
         set(value) = setExclusive(value)
 
+    var unresizable: Boolean
+        @JvmName("unresizableProperty")
+        get() = getFlag(0L)
+        @JvmName("setUnresizableProperty")
+        set(value) = setFlag(0L, value)
+
+    var borderless: Boolean
+        @JvmName("borderlessProperty")
+        get() = getFlag(1L)
+        @JvmName("setBorderlessProperty")
+        set(value) = setFlag(1L, value)
+
+    var alwaysOnTop: Boolean
+        @JvmName("alwaysOnTopProperty")
+        get() = getFlag(2L)
+        @JvmName("setAlwaysOnTopProperty")
+        set(value) = setFlag(2L, value)
+
+    var transparent: Boolean
+        @JvmName("transparentProperty")
+        get() = getFlag(3L)
+        @JvmName("setTransparentProperty")
+        set(value) = setFlag(3L, value)
+
+    var unfocusable: Boolean
+        @JvmName("unfocusableProperty")
+        get() = getFlag(4L)
+        @JvmName("setUnfocusableProperty")
+        set(value) = setFlag(4L, value)
+
+    var popupWindow: Boolean
+        @JvmName("popupWindowProperty")
+        get() = getFlag(5L)
+        @JvmName("setPopupWindowProperty")
+        set(value) = setFlag(5L, value)
+
+    var extendToTitle: Boolean
+        @JvmName("extendToTitleProperty")
+        get() = getFlag(6L)
+        @JvmName("setExtendToTitleProperty")
+        set(value) = setFlag(6L, value)
+
+    var mousePassthrough: Boolean
+        @JvmName("mousePassthroughProperty")
+        get() = getFlag(7L)
+        @JvmName("setMousePassthroughProperty")
+        set(value) = setFlag(7L, value)
+
+    var sharpCorners: Boolean
+        @JvmName("sharpCornersProperty")
+        get() = getFlag(8L)
+        @JvmName("setSharpCornersProperty")
+        set(value) = setFlag(8L, value)
+
+    var excludeFromCapture: Boolean
+        @JvmName("excludeFromCaptureProperty")
+        get() = getFlag(9L)
+        @JvmName("setExcludeFromCaptureProperty")
+        set(value) = setFlag(9L, value)
+
+    var popupWmHint: Boolean
+        @JvmName("popupWmHintProperty")
+        get() = getFlag(10L)
+        @JvmName("setPopupWmHintProperty")
+        set(value) = setFlag(10L, value)
+
+    var minimizeDisabled: Boolean
+        @JvmName("minimizeDisabledProperty")
+        get() = getFlag(11L)
+        @JvmName("setMinimizeDisabledProperty")
+        set(value) = setFlag(11L, value)
+
+    var maximizeDisabled: Boolean
+        @JvmName("maximizeDisabledProperty")
+        get() = getFlag(12L)
+        @JvmName("setMaximizeDisabledProperty")
+        set(value) = setFlag(12L, value)
+
     var forceNative: Boolean
         @JvmName("forceNativeProperty")
         get() = getForceNative()

--- a/scripts/check_property_coverage.py
+++ b/scripts/check_property_coverage.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Property-coverage gate: fail on any *silently dropped* generated wrapper property.
+
+Every property in extension_api.json that lives on a generated wrapper class must resolve
+to a Kotlin `var`/`val` member — on the class itself or an ancestor wrapper. A property that
+does not is either:
+
+  * backed by a private `_get_*` engine internal (no public bound accessor — genuinely
+    unwrappable, allowed by rule), or
+  * a documented generator limitation in KNOWN_UNWRAPPABLE_PROPERTIES below (mostly indexed
+    properties whose accessor is *inherited*, e.g. SpotLight3D.spot_range via Light3D.get_param,
+    and redeclared-getter cases), or
+  * a NEW silent drop — which fails this gate.
+
+This is the durable guard that turned the `albedo_texture` regression (indexed properties were
+skipped with no signal) into a build failure. Hand-shaped classes (DESKTOP_HANDSHAPED) are
+exempt, exactly as in the wrapper drift gate — their surface is curated by hand.
+
+Retiring an entry: teach the generator to emit the property (e.g. resolve inherited accessors),
+re-adopt, and delete the line here — a now-covered allow-list entry also fails the gate, so the
+list cannot rot.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from generate_api_wrapper import PROPERTY_NAME_OVERRIDES, camel_name
+
+from check_wrapper_generator import API_DIR, DESKTOP_HANDSHAPED
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# (class, raw_property_name) pairs on generated classes whose property the generator cannot yet
+# express. Overwhelmingly indexed properties reached through an *inherited* accessor (get_param on
+# the Light3D subclasses) or a getter that lives on a parent while the setter is local
+# (CurveTexture.width). Keep sorted; see module docstring for how to retire an entry.
+KNOWN_UNWRAPPABLE_PROPERTIES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("AimModifier3D", "setting_count"),
+        ("AnimationNodeTransition", "input_count"),
+        ("AreaLight3D", "area_attenuation"),
+        ("AreaLight3D", "area_range"),
+        ("ArrayOccluder3D", "indices"),
+        ("ArrayOccluder3D", "vertices"),
+        ("ConvertTransformModifier3D", "setting_count"),
+        ("CopyTransformModifier3D", "setting_count"),
+        ("CurveTexture", "width"),
+        ("CurveXYZTexture", "width"),
+        ("DirectionalLight2D", "height"),
+        ("DirectionalLight3D", "directional_shadow_fade_start"),
+        ("DirectionalLight3D", "directional_shadow_max_distance"),
+        ("DirectionalLight3D", "directional_shadow_pancake_size"),
+        ("DirectionalLight3D", "directional_shadow_split_1"),
+        ("DirectionalLight3D", "directional_shadow_split_2"),
+        ("DirectionalLight3D", "directional_shadow_split_3"),
+        ("ExternalTexture", "size"),
+        ("FontFile", "font_name"),
+        ("FontFile", "font_stretch"),
+        ("FontFile", "font_style"),
+        ("FontFile", "font_weight"),
+        ("FontFile", "style_name"),
+        ("FontVariation", "opentype_features"),
+        ("FontVariation", "spacing_bottom"),
+        ("FontVariation", "spacing_glyph"),
+        ("FontVariation", "spacing_space"),
+        ("FontVariation", "spacing_top"),
+        ("GradientTexture1D", "width"),
+        ("GradientTexture2D", "height"),
+        ("GradientTexture2D", "width"),
+        ("ImageTexture", "image"),
+        ("InputEventAction", "pressed"),
+        ("InputEventJoypadButton", "pressed"),
+        ("InputEventScreenTouch", "canceled"),
+        ("InputEventScreenTouch", "pressed"),
+        ("IterateIK3D", "setting_count"),
+        ("Node2D", "global_transform"),
+        ("Node2D", "transform"),
+        ("NoiseTexture3D", "depth"),
+        ("NoiseTexture3D", "height"),
+        ("NoiseTexture3D", "width"),
+        ("OmniLight3D", "omni_attenuation"),
+        ("OmniLight3D", "omni_range"),
+        ("PlaceholderMesh", "aabb"),
+        ("PlaceholderTexture2D", "size"),
+        ("PlaceholderTextureLayered", "layers"),
+        ("PointLight2D", "height"),
+        ("SplineIK3D", "setting_count"),
+        ("SpotLight3D", "spot_angle"),
+        ("SpotLight3D", "spot_angle_attenuation"),
+        ("SpotLight3D", "spot_attenuation"),
+        ("SpotLight3D", "spot_range"),
+        ("SystemFont", "font_stretch"),
+        ("SystemFont", "font_weight"),
+        ("TwoBoneIK3D", "setting_count"),
+        ("VisibleOnScreenNotifier3D", "aabb"),
+    }
+)
+
+_MEMBER_RE = re.compile(r"^    (?:open |override |final |lateinit )*(?:var|val) (\w+)\s*:", re.MULTILINE)
+
+
+def _wrapped_members() -> dict[str, set[str]]:
+    return {f.stem: set(_MEMBER_RE.findall(f.read_text(encoding="utf-8"))) for f in Path(API_DIR).glob("*.kt")}
+
+
+def main() -> int:
+    api = json.loads((ROOT / "extension_api.json").read_text(encoding="utf-8"))
+    by_name = {c["name"]: c for c in api["classes"]}
+    wrapped = _wrapped_members()
+
+    def covered(class_name: str, member: str) -> bool:
+        cursor: str | None = class_name
+        while cursor:
+            if member in wrapped.get(cursor, set()):
+                return True
+            cursor = by_name.get(cursor, {}).get("inherits")
+        return False
+
+    new_drops: list[tuple[str, str, str]] = []
+    allowed_hits: set[tuple[str, str]] = set()
+    private_getter = 0
+
+    for cls in api["classes"]:
+        name = cls["name"]
+        if name not in wrapped or name in DESKTOP_HANDSHAPED:
+            continue
+        for prop in cls.get("properties", ()):
+            raw = str(prop.get("name") or "")
+            member = PROPERTY_NAME_OVERRIDES.get((name, raw), camel_name(raw))
+            if not member or covered(name, member):
+                continue
+            getter = str(prop.get("getter") or "")
+            if getter.startswith("_"):
+                private_getter += 1  # private engine internal — no public accessor to bind
+            elif (name, raw) in KNOWN_UNWRAPPABLE_PROPERTIES:
+                allowed_hits.add((name, raw))
+            else:
+                new_drops.append((name, raw, getter))
+
+    stale = sorted(KNOWN_UNWRAPPABLE_PROPERTIES - allowed_hits)
+
+    rc = 0
+    if new_drops:
+        rc = 1
+        print(
+            f"[property_coverage] FAIL {len(new_drops)} generated property(ies) are silently dropped "
+            "(no wrapper member, not private, not allow-listed):",
+            file=sys.stderr,
+        )
+        for name, raw, getter in sorted(new_drops):
+            print(f"    {name}.{raw} (getter={getter or '<none>'})", file=sys.stderr)
+        print(
+            "    Fix the generator to emit them, or add to KNOWN_UNWRAPPABLE_PROPERTIES with a reason.",
+            file=sys.stderr,
+        )
+    if stale:
+        rc = 1
+        print(
+            f"[property_coverage] FAIL {len(stale)} KNOWN_UNWRAPPABLE_PROPERTIES entries are now covered "
+            "(remove them):",
+            file=sys.stderr,
+        )
+        for name, raw in stale:
+            print(f"    {name}.{raw}", file=sys.stderr)
+
+    if rc == 0:
+        print(
+            f"[property_coverage] PASS wrapped-class properties covered "
+            f"(exempt: {private_getter} private-getter, {len(allowed_hits)} known-unwrappable, "
+            f"hand-shaped classes skipped)"
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -696,16 +696,6 @@ IOS_CUSTOM_MEMBER_SECTIONS = {
     // ArrayMesh; this overload matches the desktop/Android commit() default-arg call.
     fun commit(): ArrayMesh? = commit(null)
 """.strip("\n"),
-    "Light3D": """
-    // ── Kanama iOS sugar (generator custom-section, not from Godot docs) ───────
-    // lightEnergy is an indexed (get_param/set_param) property; the property renderer
-    // skips indexed getters, so expose it explicitly to match the Android/desktop API.
-    var lightEnergy: Double
-        @JvmName("lightEnergyProperty")
-        get() = getParam(PARAM_ENERGY)
-        @JvmName("setLightEnergyProperty")
-        set(value) = setParam(PARAM_ENERGY, value)
-""".strip("\n"),
     "Viewport": """
     // getCamera3D/getCamera2D camelCase aliases (the generator emits getCamera3d/getCamera2d);
     // match the Android aliases so shared demo code resolves on both backends.
@@ -2060,14 +2050,18 @@ def property_setter_type(
     object_types: set[str],
     wrapper_classes: set[str],
     api_classes: dict[str, ApiClass],
+    value_slot: int = 0,
 ) -> str | None:
-    if not setter_method.argument_types:
+    # `value_slot` is the argument index that carries the property's value. It is 0 for plain
+    # setters and 1 for indexed setters (set_texture(param, texture)), where slot 0 is the bound
+    # index. Arguments past the value slot must all default (nothing extra to pass).
+    if len(setter_method.argument_types) <= value_slot:
         return None
-    if any(default is None for default in setter_method.argument_defaults[1:]):
+    if any(default is None for default in setter_method.argument_defaults[value_slot + 1 :]):
         return None
     if setter_method.logical_return_kind(object_types) != "void":
         return None
-    setter_kind = setter_method.logical_arg_kinds(object_types)[0]
+    setter_kind = setter_method.logical_arg_kinds(object_types)[value_slot]
     # Route through the same contextual policy the method renderer uses, so a nullable Object setter
     # (e.g. Node.set_owner(owner: Node?)) yields a nullable property type — otherwise render_property
     # sees a Node? getter and a Node setter, the types mismatch, and it suppresses the setter (the
@@ -2075,10 +2069,10 @@ def property_setter_type(
     return kotlin_parameter_type(
         class_name,
         setter_method.name,
-        setter_method.argument_names[0],
-        setter_method.argument_metas[0],
+        setter_method.argument_names[value_slot],
+        setter_method.argument_metas[value_slot],
         setter_kind,
-        setter_method.argument_types[0],
+        setter_method.argument_types[value_slot],
         wrapper_classes,
         api_classes,
     )
@@ -2102,7 +2096,17 @@ def render_property(
     getter_method = first_method(cls, getter)
     if getter_method is None:
         return None
-    if getter_method.argument_types:
+    # Indexed properties (Godot idiom: albedo_texture -> get_texture(param)/set_texture(param, tex),
+    # light_energy -> get_param/set_param, ...) carry an "index" bound as the accessor's first
+    # argument. The getter then takes exactly the index (1 arg) and the setter takes index + value
+    # (2 args); we pre-bind the index literal and treat the trailing slot as the property value.
+    # Without an index a getter that takes arguments is not a property accessor we can express.
+    prop_index = prop.get("index")
+    has_index = isinstance(prop_index, int)
+    if has_index:
+        if len(getter_method.argument_types) != 1:
+            return None
+    elif getter_method.argument_types:
         return None
     raw_property_name = str(prop.get("name") or "")
     if IOS_AUDIT_ONLY and (cls.name, raw_property_name) in IOS_PROPERTY_SUPPRESS:
@@ -2119,12 +2123,36 @@ def render_property(
         api_classes,
         api_dir,
     )
-    getter_call = f"{method_function_name(cls.name, getter)}()"
+    # The bound index literal must match the accessor's first-arg Kotlin type: enum/int64 indices
+    # are `Long` (getTexture(0L)), plain int32 indices are `Int` (getStream(0)). Plain accessors
+    # take no index.
+    if has_index:
+        index_kotlin = kotlin_parameter_type(
+            cls.name,
+            getter,
+            getter_method.argument_names[0],
+            getter_method.argument_metas[0],
+            getter_method.logical_arg_kinds(object_types)[0],
+            getter_method.argument_types[0],
+            wrapper_classes,
+            api_classes,
+        )
+        index_arg = f"{prop_index}" if index_kotlin == "Int" else f"{prop_index}L"
+    else:
+        index_arg = ""
+    value_slot = 1 if has_index else 0
+    getter_call = f"{method_function_name(cls.name, getter)}({index_arg})"
 
     if setter and setter in emitted_methods:
         setter_method = first_method(cls, setter)
+        # property_setter_type gates validity: it needs an argument at `value_slot` (so an indexed
+        # setter must carry index+value), a void return, and defaults on every argument past the
+        # value — which allows plain setters with trailing defaulted args (set_position(pos,
+        # keep_offsets = false)) to stay writable.
         setter_type = (
-            property_setter_type(cls.name, setter_method, object_types, wrapper_classes, api_classes)
+            property_setter_type(
+                cls.name, setter_method, object_types, wrapper_classes, api_classes, value_slot
+            )
             if setter_method is not None
             else None
         )
@@ -2132,7 +2160,8 @@ def render_property(
             setter = ""
 
     if setter and setter in emitted_methods:
-        setter_call = f"{method_function_name(cls.name, setter)}(value)"
+        setter_args = f"{index_arg}, value" if has_index else "value"
+        setter_call = f"{method_function_name(cls.name, setter)}({setter_args})"
         return "\n".join(
             [
                 f"    var {property_name}: {property_type}",

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -212,6 +212,9 @@ python3 "$ROOT_DIR/scripts/audit_singleton_refcounted_policy.py"
 stage "conservative wrapper generator fixture"
 python3 "$ROOT_DIR/scripts/check_wrapper_generator.py"
 
+stage "generated property coverage gate"
+python3 "$ROOT_DIR/scripts/check_property_coverage.py"
+
 stage "iOS no-silent-stubs check"
 python3 "$ROOT_DIR/scripts/check_ios_no_silent_stubs.py"
 

--- a/src/main/kotlin/net/multigesture/kanama/api/AudioStreamPlaylist.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/AudioStreamPlaylist.kt
@@ -32,6 +32,390 @@ class AudioStreamPlaylist(handle: MemorySegment) : AudioStream(handle) {
         @JvmName("setStreamCountProperty")
         set(value) = setStreamCount(value)
 
+    var stream0: AudioStream?
+        @JvmName("stream0Property")
+        get() = getListStream(0)
+        @JvmName("setStream0Property")
+        set(value) = setListStream(0, value)
+
+    var stream1: AudioStream?
+        @JvmName("stream1Property")
+        get() = getListStream(1)
+        @JvmName("setStream1Property")
+        set(value) = setListStream(1, value)
+
+    var stream2: AudioStream?
+        @JvmName("stream2Property")
+        get() = getListStream(2)
+        @JvmName("setStream2Property")
+        set(value) = setListStream(2, value)
+
+    var stream3: AudioStream?
+        @JvmName("stream3Property")
+        get() = getListStream(3)
+        @JvmName("setStream3Property")
+        set(value) = setListStream(3, value)
+
+    var stream4: AudioStream?
+        @JvmName("stream4Property")
+        get() = getListStream(4)
+        @JvmName("setStream4Property")
+        set(value) = setListStream(4, value)
+
+    var stream5: AudioStream?
+        @JvmName("stream5Property")
+        get() = getListStream(5)
+        @JvmName("setStream5Property")
+        set(value) = setListStream(5, value)
+
+    var stream6: AudioStream?
+        @JvmName("stream6Property")
+        get() = getListStream(6)
+        @JvmName("setStream6Property")
+        set(value) = setListStream(6, value)
+
+    var stream7: AudioStream?
+        @JvmName("stream7Property")
+        get() = getListStream(7)
+        @JvmName("setStream7Property")
+        set(value) = setListStream(7, value)
+
+    var stream8: AudioStream?
+        @JvmName("stream8Property")
+        get() = getListStream(8)
+        @JvmName("setStream8Property")
+        set(value) = setListStream(8, value)
+
+    var stream9: AudioStream?
+        @JvmName("stream9Property")
+        get() = getListStream(9)
+        @JvmName("setStream9Property")
+        set(value) = setListStream(9, value)
+
+    var stream10: AudioStream?
+        @JvmName("stream10Property")
+        get() = getListStream(10)
+        @JvmName("setStream10Property")
+        set(value) = setListStream(10, value)
+
+    var stream11: AudioStream?
+        @JvmName("stream11Property")
+        get() = getListStream(11)
+        @JvmName("setStream11Property")
+        set(value) = setListStream(11, value)
+
+    var stream12: AudioStream?
+        @JvmName("stream12Property")
+        get() = getListStream(12)
+        @JvmName("setStream12Property")
+        set(value) = setListStream(12, value)
+
+    var stream13: AudioStream?
+        @JvmName("stream13Property")
+        get() = getListStream(13)
+        @JvmName("setStream13Property")
+        set(value) = setListStream(13, value)
+
+    var stream14: AudioStream?
+        @JvmName("stream14Property")
+        get() = getListStream(14)
+        @JvmName("setStream14Property")
+        set(value) = setListStream(14, value)
+
+    var stream15: AudioStream?
+        @JvmName("stream15Property")
+        get() = getListStream(15)
+        @JvmName("setStream15Property")
+        set(value) = setListStream(15, value)
+
+    var stream16: AudioStream?
+        @JvmName("stream16Property")
+        get() = getListStream(16)
+        @JvmName("setStream16Property")
+        set(value) = setListStream(16, value)
+
+    var stream17: AudioStream?
+        @JvmName("stream17Property")
+        get() = getListStream(17)
+        @JvmName("setStream17Property")
+        set(value) = setListStream(17, value)
+
+    var stream18: AudioStream?
+        @JvmName("stream18Property")
+        get() = getListStream(18)
+        @JvmName("setStream18Property")
+        set(value) = setListStream(18, value)
+
+    var stream19: AudioStream?
+        @JvmName("stream19Property")
+        get() = getListStream(19)
+        @JvmName("setStream19Property")
+        set(value) = setListStream(19, value)
+
+    var stream20: AudioStream?
+        @JvmName("stream20Property")
+        get() = getListStream(20)
+        @JvmName("setStream20Property")
+        set(value) = setListStream(20, value)
+
+    var stream21: AudioStream?
+        @JvmName("stream21Property")
+        get() = getListStream(21)
+        @JvmName("setStream21Property")
+        set(value) = setListStream(21, value)
+
+    var stream22: AudioStream?
+        @JvmName("stream22Property")
+        get() = getListStream(22)
+        @JvmName("setStream22Property")
+        set(value) = setListStream(22, value)
+
+    var stream23: AudioStream?
+        @JvmName("stream23Property")
+        get() = getListStream(23)
+        @JvmName("setStream23Property")
+        set(value) = setListStream(23, value)
+
+    var stream24: AudioStream?
+        @JvmName("stream24Property")
+        get() = getListStream(24)
+        @JvmName("setStream24Property")
+        set(value) = setListStream(24, value)
+
+    var stream25: AudioStream?
+        @JvmName("stream25Property")
+        get() = getListStream(25)
+        @JvmName("setStream25Property")
+        set(value) = setListStream(25, value)
+
+    var stream26: AudioStream?
+        @JvmName("stream26Property")
+        get() = getListStream(26)
+        @JvmName("setStream26Property")
+        set(value) = setListStream(26, value)
+
+    var stream27: AudioStream?
+        @JvmName("stream27Property")
+        get() = getListStream(27)
+        @JvmName("setStream27Property")
+        set(value) = setListStream(27, value)
+
+    var stream28: AudioStream?
+        @JvmName("stream28Property")
+        get() = getListStream(28)
+        @JvmName("setStream28Property")
+        set(value) = setListStream(28, value)
+
+    var stream29: AudioStream?
+        @JvmName("stream29Property")
+        get() = getListStream(29)
+        @JvmName("setStream29Property")
+        set(value) = setListStream(29, value)
+
+    var stream30: AudioStream?
+        @JvmName("stream30Property")
+        get() = getListStream(30)
+        @JvmName("setStream30Property")
+        set(value) = setListStream(30, value)
+
+    var stream31: AudioStream?
+        @JvmName("stream31Property")
+        get() = getListStream(31)
+        @JvmName("setStream31Property")
+        set(value) = setListStream(31, value)
+
+    var stream32: AudioStream?
+        @JvmName("stream32Property")
+        get() = getListStream(32)
+        @JvmName("setStream32Property")
+        set(value) = setListStream(32, value)
+
+    var stream33: AudioStream?
+        @JvmName("stream33Property")
+        get() = getListStream(33)
+        @JvmName("setStream33Property")
+        set(value) = setListStream(33, value)
+
+    var stream34: AudioStream?
+        @JvmName("stream34Property")
+        get() = getListStream(34)
+        @JvmName("setStream34Property")
+        set(value) = setListStream(34, value)
+
+    var stream35: AudioStream?
+        @JvmName("stream35Property")
+        get() = getListStream(35)
+        @JvmName("setStream35Property")
+        set(value) = setListStream(35, value)
+
+    var stream36: AudioStream?
+        @JvmName("stream36Property")
+        get() = getListStream(36)
+        @JvmName("setStream36Property")
+        set(value) = setListStream(36, value)
+
+    var stream37: AudioStream?
+        @JvmName("stream37Property")
+        get() = getListStream(37)
+        @JvmName("setStream37Property")
+        set(value) = setListStream(37, value)
+
+    var stream38: AudioStream?
+        @JvmName("stream38Property")
+        get() = getListStream(38)
+        @JvmName("setStream38Property")
+        set(value) = setListStream(38, value)
+
+    var stream39: AudioStream?
+        @JvmName("stream39Property")
+        get() = getListStream(39)
+        @JvmName("setStream39Property")
+        set(value) = setListStream(39, value)
+
+    var stream40: AudioStream?
+        @JvmName("stream40Property")
+        get() = getListStream(40)
+        @JvmName("setStream40Property")
+        set(value) = setListStream(40, value)
+
+    var stream41: AudioStream?
+        @JvmName("stream41Property")
+        get() = getListStream(41)
+        @JvmName("setStream41Property")
+        set(value) = setListStream(41, value)
+
+    var stream42: AudioStream?
+        @JvmName("stream42Property")
+        get() = getListStream(42)
+        @JvmName("setStream42Property")
+        set(value) = setListStream(42, value)
+
+    var stream43: AudioStream?
+        @JvmName("stream43Property")
+        get() = getListStream(43)
+        @JvmName("setStream43Property")
+        set(value) = setListStream(43, value)
+
+    var stream44: AudioStream?
+        @JvmName("stream44Property")
+        get() = getListStream(44)
+        @JvmName("setStream44Property")
+        set(value) = setListStream(44, value)
+
+    var stream45: AudioStream?
+        @JvmName("stream45Property")
+        get() = getListStream(45)
+        @JvmName("setStream45Property")
+        set(value) = setListStream(45, value)
+
+    var stream46: AudioStream?
+        @JvmName("stream46Property")
+        get() = getListStream(46)
+        @JvmName("setStream46Property")
+        set(value) = setListStream(46, value)
+
+    var stream47: AudioStream?
+        @JvmName("stream47Property")
+        get() = getListStream(47)
+        @JvmName("setStream47Property")
+        set(value) = setListStream(47, value)
+
+    var stream48: AudioStream?
+        @JvmName("stream48Property")
+        get() = getListStream(48)
+        @JvmName("setStream48Property")
+        set(value) = setListStream(48, value)
+
+    var stream49: AudioStream?
+        @JvmName("stream49Property")
+        get() = getListStream(49)
+        @JvmName("setStream49Property")
+        set(value) = setListStream(49, value)
+
+    var stream50: AudioStream?
+        @JvmName("stream50Property")
+        get() = getListStream(50)
+        @JvmName("setStream50Property")
+        set(value) = setListStream(50, value)
+
+    var stream51: AudioStream?
+        @JvmName("stream51Property")
+        get() = getListStream(51)
+        @JvmName("setStream51Property")
+        set(value) = setListStream(51, value)
+
+    var stream52: AudioStream?
+        @JvmName("stream52Property")
+        get() = getListStream(52)
+        @JvmName("setStream52Property")
+        set(value) = setListStream(52, value)
+
+    var stream53: AudioStream?
+        @JvmName("stream53Property")
+        get() = getListStream(53)
+        @JvmName("setStream53Property")
+        set(value) = setListStream(53, value)
+
+    var stream54: AudioStream?
+        @JvmName("stream54Property")
+        get() = getListStream(54)
+        @JvmName("setStream54Property")
+        set(value) = setListStream(54, value)
+
+    var stream55: AudioStream?
+        @JvmName("stream55Property")
+        get() = getListStream(55)
+        @JvmName("setStream55Property")
+        set(value) = setListStream(55, value)
+
+    var stream56: AudioStream?
+        @JvmName("stream56Property")
+        get() = getListStream(56)
+        @JvmName("setStream56Property")
+        set(value) = setListStream(56, value)
+
+    var stream57: AudioStream?
+        @JvmName("stream57Property")
+        get() = getListStream(57)
+        @JvmName("setStream57Property")
+        set(value) = setListStream(57, value)
+
+    var stream58: AudioStream?
+        @JvmName("stream58Property")
+        get() = getListStream(58)
+        @JvmName("setStream58Property")
+        set(value) = setListStream(58, value)
+
+    var stream59: AudioStream?
+        @JvmName("stream59Property")
+        get() = getListStream(59)
+        @JvmName("setStream59Property")
+        set(value) = setListStream(59, value)
+
+    var stream60: AudioStream?
+        @JvmName("stream60Property")
+        get() = getListStream(60)
+        @JvmName("setStream60Property")
+        set(value) = setListStream(60, value)
+
+    var stream61: AudioStream?
+        @JvmName("stream61Property")
+        get() = getListStream(61)
+        @JvmName("setStream61Property")
+        set(value) = setListStream(61, value)
+
+    var stream62: AudioStream?
+        @JvmName("stream62Property")
+        get() = getListStream(62)
+        @JvmName("setStream62Property")
+        set(value) = setListStream(62, value)
+
+    var stream63: AudioStream?
+        @JvmName("stream63Property")
+        get() = getListStream(63)
+        @JvmName("setStream63Property")
+        set(value) = setListStream(63, value)
+
     fun setStreamCount(streamCount: Int) {
         ObjectCalls.ptrcallWithIntArg(setStreamCountBind, handle, streamCount)
     }

--- a/src/main/kotlin/net/multigesture/kanama/api/CPUParticles2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/CPUParticles2D.kt
@@ -156,6 +156,12 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         @JvmName("setEmissionRingRadiusProperty")
         set(value) = setEmissionRingRadius(value)
 
+    var particleFlagAlignY: Boolean
+        @JvmName("particleFlagAlignYProperty")
+        get() = getParticleFlag(0L)
+        @JvmName("setParticleFlagAlignYProperty")
+        set(value) = setParticleFlag(0L, value)
+
     var direction: Vector2
         @JvmName("directionProperty")
         get() = getDirection()
@@ -173,6 +179,162 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         get() = getGravity()
         @JvmName("setGravityProperty")
         set(value) = setGravity(value)
+
+    var initialVelocityMin: Double
+        @JvmName("initialVelocityMinProperty")
+        get() = getParamMin(0L)
+        @JvmName("setInitialVelocityMinProperty")
+        set(value) = setParamMin(0L, value)
+
+    var initialVelocityMax: Double
+        @JvmName("initialVelocityMaxProperty")
+        get() = getParamMax(0L)
+        @JvmName("setInitialVelocityMaxProperty")
+        set(value) = setParamMax(0L, value)
+
+    var angularVelocityMin: Double
+        @JvmName("angularVelocityMinProperty")
+        get() = getParamMin(1L)
+        @JvmName("setAngularVelocityMinProperty")
+        set(value) = setParamMin(1L, value)
+
+    var angularVelocityMax: Double
+        @JvmName("angularVelocityMaxProperty")
+        get() = getParamMax(1L)
+        @JvmName("setAngularVelocityMaxProperty")
+        set(value) = setParamMax(1L, value)
+
+    var angularVelocityCurve: Curve?
+        @JvmName("angularVelocityCurveProperty")
+        get() = getParamCurve(1L)
+        @JvmName("setAngularVelocityCurveProperty")
+        set(value) = setParamCurve(1L, value)
+
+    var orbitVelocityMin: Double
+        @JvmName("orbitVelocityMinProperty")
+        get() = getParamMin(2L)
+        @JvmName("setOrbitVelocityMinProperty")
+        set(value) = setParamMin(2L, value)
+
+    var orbitVelocityMax: Double
+        @JvmName("orbitVelocityMaxProperty")
+        get() = getParamMax(2L)
+        @JvmName("setOrbitVelocityMaxProperty")
+        set(value) = setParamMax(2L, value)
+
+    var orbitVelocityCurve: Curve?
+        @JvmName("orbitVelocityCurveProperty")
+        get() = getParamCurve(2L)
+        @JvmName("setOrbitVelocityCurveProperty")
+        set(value) = setParamCurve(2L, value)
+
+    var linearAccelMin: Double
+        @JvmName("linearAccelMinProperty")
+        get() = getParamMin(3L)
+        @JvmName("setLinearAccelMinProperty")
+        set(value) = setParamMin(3L, value)
+
+    var linearAccelMax: Double
+        @JvmName("linearAccelMaxProperty")
+        get() = getParamMax(3L)
+        @JvmName("setLinearAccelMaxProperty")
+        set(value) = setParamMax(3L, value)
+
+    var linearAccelCurve: Curve?
+        @JvmName("linearAccelCurveProperty")
+        get() = getParamCurve(3L)
+        @JvmName("setLinearAccelCurveProperty")
+        set(value) = setParamCurve(3L, value)
+
+    var radialAccelMin: Double
+        @JvmName("radialAccelMinProperty")
+        get() = getParamMin(4L)
+        @JvmName("setRadialAccelMinProperty")
+        set(value) = setParamMin(4L, value)
+
+    var radialAccelMax: Double
+        @JvmName("radialAccelMaxProperty")
+        get() = getParamMax(4L)
+        @JvmName("setRadialAccelMaxProperty")
+        set(value) = setParamMax(4L, value)
+
+    var radialAccelCurve: Curve?
+        @JvmName("radialAccelCurveProperty")
+        get() = getParamCurve(4L)
+        @JvmName("setRadialAccelCurveProperty")
+        set(value) = setParamCurve(4L, value)
+
+    var tangentialAccelMin: Double
+        @JvmName("tangentialAccelMinProperty")
+        get() = getParamMin(5L)
+        @JvmName("setTangentialAccelMinProperty")
+        set(value) = setParamMin(5L, value)
+
+    var tangentialAccelMax: Double
+        @JvmName("tangentialAccelMaxProperty")
+        get() = getParamMax(5L)
+        @JvmName("setTangentialAccelMaxProperty")
+        set(value) = setParamMax(5L, value)
+
+    var tangentialAccelCurve: Curve?
+        @JvmName("tangentialAccelCurveProperty")
+        get() = getParamCurve(5L)
+        @JvmName("setTangentialAccelCurveProperty")
+        set(value) = setParamCurve(5L, value)
+
+    var dampingMin: Double
+        @JvmName("dampingMinProperty")
+        get() = getParamMin(6L)
+        @JvmName("setDampingMinProperty")
+        set(value) = setParamMin(6L, value)
+
+    var dampingMax: Double
+        @JvmName("dampingMaxProperty")
+        get() = getParamMax(6L)
+        @JvmName("setDampingMaxProperty")
+        set(value) = setParamMax(6L, value)
+
+    var dampingCurve: Curve?
+        @JvmName("dampingCurveProperty")
+        get() = getParamCurve(6L)
+        @JvmName("setDampingCurveProperty")
+        set(value) = setParamCurve(6L, value)
+
+    var angleMin: Double
+        @JvmName("angleMinProperty")
+        get() = getParamMin(7L)
+        @JvmName("setAngleMinProperty")
+        set(value) = setParamMin(7L, value)
+
+    var angleMax: Double
+        @JvmName("angleMaxProperty")
+        get() = getParamMax(7L)
+        @JvmName("setAngleMaxProperty")
+        set(value) = setParamMax(7L, value)
+
+    var angleCurve: Curve?
+        @JvmName("angleCurveProperty")
+        get() = getParamCurve(7L)
+        @JvmName("setAngleCurveProperty")
+        set(value) = setParamCurve(7L, value)
+
+    var scaleAmountMin: Double
+        @JvmName("scaleAmountMinProperty")
+        get() = getParamMin(8L)
+        @JvmName("setScaleAmountMinProperty")
+        set(value) = setParamMin(8L, value)
+
+    var scaleAmountMax: Double
+        @JvmName("scaleAmountMaxProperty")
+        get() = getParamMax(8L)
+        @JvmName("setScaleAmountMaxProperty")
+        set(value) = setParamMax(8L, value)
+
+    var scaleAmountCurve: Curve?
+        @JvmName("scaleAmountCurveProperty")
+        get() = getParamCurve(8L)
+        @JvmName("setScaleAmountCurveProperty")
+        set(value) = setParamCurve(8L, value)
 
     var splitScale: Boolean
         @JvmName("splitScaleProperty")
@@ -209,6 +371,60 @@ class CPUParticles2D(handle: MemorySegment) : Node2D(handle) {
         get() = getColorInitialRamp()
         @JvmName("setColorInitialRampProperty")
         set(value) = setColorInitialRamp(value)
+
+    var hueVariationMin: Double
+        @JvmName("hueVariationMinProperty")
+        get() = getParamMin(9L)
+        @JvmName("setHueVariationMinProperty")
+        set(value) = setParamMin(9L, value)
+
+    var hueVariationMax: Double
+        @JvmName("hueVariationMaxProperty")
+        get() = getParamMax(9L)
+        @JvmName("setHueVariationMaxProperty")
+        set(value) = setParamMax(9L, value)
+
+    var hueVariationCurve: Curve?
+        @JvmName("hueVariationCurveProperty")
+        get() = getParamCurve(9L)
+        @JvmName("setHueVariationCurveProperty")
+        set(value) = setParamCurve(9L, value)
+
+    var animSpeedMin: Double
+        @JvmName("animSpeedMinProperty")
+        get() = getParamMin(10L)
+        @JvmName("setAnimSpeedMinProperty")
+        set(value) = setParamMin(10L, value)
+
+    var animSpeedMax: Double
+        @JvmName("animSpeedMaxProperty")
+        get() = getParamMax(10L)
+        @JvmName("setAnimSpeedMaxProperty")
+        set(value) = setParamMax(10L, value)
+
+    var animSpeedCurve: Curve?
+        @JvmName("animSpeedCurveProperty")
+        get() = getParamCurve(10L)
+        @JvmName("setAnimSpeedCurveProperty")
+        set(value) = setParamCurve(10L, value)
+
+    var animOffsetMin: Double
+        @JvmName("animOffsetMinProperty")
+        get() = getParamMin(11L)
+        @JvmName("setAnimOffsetMinProperty")
+        set(value) = setParamMin(11L, value)
+
+    var animOffsetMax: Double
+        @JvmName("animOffsetMaxProperty")
+        get() = getParamMax(11L)
+        @JvmName("setAnimOffsetMaxProperty")
+        set(value) = setParamMax(11L, value)
+
+    var animOffsetCurve: Curve?
+        @JvmName("animOffsetCurveProperty")
+        get() = getParamCurve(11L)
+        @JvmName("setAnimOffsetCurveProperty")
+        set(value) = setParamCurve(11L, value)
 
     /**
      * If `true`, particles are being emitted. `emitting` can be used to start and stop particles from

--- a/src/main/kotlin/net/multigesture/kanama/api/CPUParticles3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/CPUParticles3D.kt
@@ -181,6 +181,24 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setEmissionRingConeAngleProperty")
         set(value) = setEmissionRingConeAngle(value)
 
+    var particleFlagAlignY: Boolean
+        @JvmName("particleFlagAlignYProperty")
+        get() = getParticleFlag(0L)
+        @JvmName("setParticleFlagAlignYProperty")
+        set(value) = setParticleFlag(0L, value)
+
+    var particleFlagRotateY: Boolean
+        @JvmName("particleFlagRotateYProperty")
+        get() = getParticleFlag(1L)
+        @JvmName("setParticleFlagRotateYProperty")
+        set(value) = setParticleFlag(1L, value)
+
+    var particleFlagDisableZ: Boolean
+        @JvmName("particleFlagDisableZProperty")
+        get() = getParticleFlag(2L)
+        @JvmName("setParticleFlagDisableZProperty")
+        set(value) = setParticleFlag(2L, value)
+
     var direction: Vector3
         @JvmName("directionProperty")
         get() = getDirection()
@@ -204,6 +222,162 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         get() = getGravity()
         @JvmName("setGravityProperty")
         set(value) = setGravity(value)
+
+    var initialVelocityMin: Double
+        @JvmName("initialVelocityMinProperty")
+        get() = getParamMin(0L)
+        @JvmName("setInitialVelocityMinProperty")
+        set(value) = setParamMin(0L, value)
+
+    var initialVelocityMax: Double
+        @JvmName("initialVelocityMaxProperty")
+        get() = getParamMax(0L)
+        @JvmName("setInitialVelocityMaxProperty")
+        set(value) = setParamMax(0L, value)
+
+    var angularVelocityMin: Double
+        @JvmName("angularVelocityMinProperty")
+        get() = getParamMin(1L)
+        @JvmName("setAngularVelocityMinProperty")
+        set(value) = setParamMin(1L, value)
+
+    var angularVelocityMax: Double
+        @JvmName("angularVelocityMaxProperty")
+        get() = getParamMax(1L)
+        @JvmName("setAngularVelocityMaxProperty")
+        set(value) = setParamMax(1L, value)
+
+    var angularVelocityCurve: Curve?
+        @JvmName("angularVelocityCurveProperty")
+        get() = getParamCurve(1L)
+        @JvmName("setAngularVelocityCurveProperty")
+        set(value) = setParamCurve(1L, value)
+
+    var orbitVelocityMin: Double
+        @JvmName("orbitVelocityMinProperty")
+        get() = getParamMin(2L)
+        @JvmName("setOrbitVelocityMinProperty")
+        set(value) = setParamMin(2L, value)
+
+    var orbitVelocityMax: Double
+        @JvmName("orbitVelocityMaxProperty")
+        get() = getParamMax(2L)
+        @JvmName("setOrbitVelocityMaxProperty")
+        set(value) = setParamMax(2L, value)
+
+    var orbitVelocityCurve: Curve?
+        @JvmName("orbitVelocityCurveProperty")
+        get() = getParamCurve(2L)
+        @JvmName("setOrbitVelocityCurveProperty")
+        set(value) = setParamCurve(2L, value)
+
+    var linearAccelMin: Double
+        @JvmName("linearAccelMinProperty")
+        get() = getParamMin(3L)
+        @JvmName("setLinearAccelMinProperty")
+        set(value) = setParamMin(3L, value)
+
+    var linearAccelMax: Double
+        @JvmName("linearAccelMaxProperty")
+        get() = getParamMax(3L)
+        @JvmName("setLinearAccelMaxProperty")
+        set(value) = setParamMax(3L, value)
+
+    var linearAccelCurve: Curve?
+        @JvmName("linearAccelCurveProperty")
+        get() = getParamCurve(3L)
+        @JvmName("setLinearAccelCurveProperty")
+        set(value) = setParamCurve(3L, value)
+
+    var radialAccelMin: Double
+        @JvmName("radialAccelMinProperty")
+        get() = getParamMin(4L)
+        @JvmName("setRadialAccelMinProperty")
+        set(value) = setParamMin(4L, value)
+
+    var radialAccelMax: Double
+        @JvmName("radialAccelMaxProperty")
+        get() = getParamMax(4L)
+        @JvmName("setRadialAccelMaxProperty")
+        set(value) = setParamMax(4L, value)
+
+    var radialAccelCurve: Curve?
+        @JvmName("radialAccelCurveProperty")
+        get() = getParamCurve(4L)
+        @JvmName("setRadialAccelCurveProperty")
+        set(value) = setParamCurve(4L, value)
+
+    var tangentialAccelMin: Double
+        @JvmName("tangentialAccelMinProperty")
+        get() = getParamMin(5L)
+        @JvmName("setTangentialAccelMinProperty")
+        set(value) = setParamMin(5L, value)
+
+    var tangentialAccelMax: Double
+        @JvmName("tangentialAccelMaxProperty")
+        get() = getParamMax(5L)
+        @JvmName("setTangentialAccelMaxProperty")
+        set(value) = setParamMax(5L, value)
+
+    var tangentialAccelCurve: Curve?
+        @JvmName("tangentialAccelCurveProperty")
+        get() = getParamCurve(5L)
+        @JvmName("setTangentialAccelCurveProperty")
+        set(value) = setParamCurve(5L, value)
+
+    var dampingMin: Double
+        @JvmName("dampingMinProperty")
+        get() = getParamMin(6L)
+        @JvmName("setDampingMinProperty")
+        set(value) = setParamMin(6L, value)
+
+    var dampingMax: Double
+        @JvmName("dampingMaxProperty")
+        get() = getParamMax(6L)
+        @JvmName("setDampingMaxProperty")
+        set(value) = setParamMax(6L, value)
+
+    var dampingCurve: Curve?
+        @JvmName("dampingCurveProperty")
+        get() = getParamCurve(6L)
+        @JvmName("setDampingCurveProperty")
+        set(value) = setParamCurve(6L, value)
+
+    var angleMin: Double
+        @JvmName("angleMinProperty")
+        get() = getParamMin(7L)
+        @JvmName("setAngleMinProperty")
+        set(value) = setParamMin(7L, value)
+
+    var angleMax: Double
+        @JvmName("angleMaxProperty")
+        get() = getParamMax(7L)
+        @JvmName("setAngleMaxProperty")
+        set(value) = setParamMax(7L, value)
+
+    var angleCurve: Curve?
+        @JvmName("angleCurveProperty")
+        get() = getParamCurve(7L)
+        @JvmName("setAngleCurveProperty")
+        set(value) = setParamCurve(7L, value)
+
+    var scaleAmountMin: Double
+        @JvmName("scaleAmountMinProperty")
+        get() = getParamMin(8L)
+        @JvmName("setScaleAmountMinProperty")
+        set(value) = setParamMin(8L, value)
+
+    var scaleAmountMax: Double
+        @JvmName("scaleAmountMaxProperty")
+        get() = getParamMax(8L)
+        @JvmName("setScaleAmountMaxProperty")
+        set(value) = setParamMax(8L, value)
+
+    var scaleAmountCurve: Curve?
+        @JvmName("scaleAmountCurveProperty")
+        get() = getParamCurve(8L)
+        @JvmName("setScaleAmountCurveProperty")
+        set(value) = setParamCurve(8L, value)
 
     var splitScale: Boolean
         @JvmName("splitScaleProperty")
@@ -246,6 +420,60 @@ class CPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         get() = getColorInitialRamp()
         @JvmName("setColorInitialRampProperty")
         set(value) = setColorInitialRamp(value)
+
+    var hueVariationMin: Double
+        @JvmName("hueVariationMinProperty")
+        get() = getParamMin(9L)
+        @JvmName("setHueVariationMinProperty")
+        set(value) = setParamMin(9L, value)
+
+    var hueVariationMax: Double
+        @JvmName("hueVariationMaxProperty")
+        get() = getParamMax(9L)
+        @JvmName("setHueVariationMaxProperty")
+        set(value) = setParamMax(9L, value)
+
+    var hueVariationCurve: Curve?
+        @JvmName("hueVariationCurveProperty")
+        get() = getParamCurve(9L)
+        @JvmName("setHueVariationCurveProperty")
+        set(value) = setParamCurve(9L, value)
+
+    var animSpeedMin: Double
+        @JvmName("animSpeedMinProperty")
+        get() = getParamMin(10L)
+        @JvmName("setAnimSpeedMinProperty")
+        set(value) = setParamMin(10L, value)
+
+    var animSpeedMax: Double
+        @JvmName("animSpeedMaxProperty")
+        get() = getParamMax(10L)
+        @JvmName("setAnimSpeedMaxProperty")
+        set(value) = setParamMax(10L, value)
+
+    var animSpeedCurve: Curve?
+        @JvmName("animSpeedCurveProperty")
+        get() = getParamCurve(10L)
+        @JvmName("setAnimSpeedCurveProperty")
+        set(value) = setParamCurve(10L, value)
+
+    var animOffsetMin: Double
+        @JvmName("animOffsetMinProperty")
+        get() = getParamMin(11L)
+        @JvmName("setAnimOffsetMinProperty")
+        set(value) = setParamMin(11L, value)
+
+    var animOffsetMax: Double
+        @JvmName("animOffsetMaxProperty")
+        get() = getParamMax(11L)
+        @JvmName("setAnimOffsetMaxProperty")
+        set(value) = setParamMax(11L, value)
+
+    var animOffsetCurve: Curve?
+        @JvmName("animOffsetCurveProperty")
+        get() = getParamCurve(11L)
+        @JvmName("setAnimOffsetCurveProperty")
+        set(value) = setParamCurve(11L, value)
 
     /**
      * If `true`, particles are being emitted. `emitting` can be used to start and stop particles from

--- a/src/main/kotlin/net/multigesture/kanama/api/Camera2D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Camera2D.kt
@@ -57,6 +57,30 @@ class Camera2D(handle: MemorySegment) : Node2D(handle) {
         @JvmName("setLimitEnabledProperty")
         set(value) = setLimitEnabled(value)
 
+    var limitLeft: Int
+        @JvmName("limitLeftProperty")
+        get() = getLimit(0L)
+        @JvmName("setLimitLeftProperty")
+        set(value) = setLimit(0L, value)
+
+    var limitTop: Int
+        @JvmName("limitTopProperty")
+        get() = getLimit(1L)
+        @JvmName("setLimitTopProperty")
+        set(value) = setLimit(1L, value)
+
+    var limitRight: Int
+        @JvmName("limitRightProperty")
+        get() = getLimit(2L)
+        @JvmName("setLimitRightProperty")
+        set(value) = setLimit(2L, value)
+
+    var limitBottom: Int
+        @JvmName("limitBottomProperty")
+        get() = getLimit(3L)
+        @JvmName("setLimitBottomProperty")
+        set(value) = setLimit(3L, value)
+
     var limitSmoothed: Boolean
         @JvmName("limitSmoothedProperty")
         get() = isLimitSmoothingEnabled()
@@ -110,6 +134,30 @@ class Camera2D(handle: MemorySegment) : Node2D(handle) {
         get() = getDragVerticalOffset()
         @JvmName("setDragVerticalOffsetProperty")
         set(value) = setDragVerticalOffset(value)
+
+    var dragLeftMargin: Double
+        @JvmName("dragLeftMarginProperty")
+        get() = getDragMargin(0L)
+        @JvmName("setDragLeftMarginProperty")
+        set(value) = setDragMargin(0L, value)
+
+    var dragTopMargin: Double
+        @JvmName("dragTopMarginProperty")
+        get() = getDragMargin(1L)
+        @JvmName("setDragTopMarginProperty")
+        set(value) = setDragMargin(1L, value)
+
+    var dragRightMargin: Double
+        @JvmName("dragRightMarginProperty")
+        get() = getDragMargin(2L)
+        @JvmName("setDragRightMarginProperty")
+        set(value) = setDragMargin(2L, value)
+
+    var dragBottomMargin: Double
+        @JvmName("dragBottomMarginProperty")
+        get() = getDragMargin(3L)
+        @JvmName("setDragBottomMarginProperty")
+        set(value) = setDragMargin(3L, value)
 
     var editorDrawScreen: Boolean
         @JvmName("editorDrawScreenProperty")

--- a/src/main/kotlin/net/multigesture/kanama/api/ConeTwistJoint3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ConeTwistJoint3D.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 
 /**
@@ -10,6 +11,36 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
  * Generated from Godot docs: ConeTwistJoint3D
  */
 class ConeTwistJoint3D(handle: MemorySegment) : Joint3D(handle) {
+    var swingSpan: Double
+        @JvmName("swingSpanProperty")
+        get() = getParam(0L)
+        @JvmName("setSwingSpanProperty")
+        set(value) = setParam(0L, value)
+
+    var twistSpan: Double
+        @JvmName("twistSpanProperty")
+        get() = getParam(1L)
+        @JvmName("setTwistSpanProperty")
+        set(value) = setParam(1L, value)
+
+    var bias: Double
+        @JvmName("biasProperty")
+        get() = getParam(2L)
+        @JvmName("setBiasProperty")
+        set(value) = setParam(2L, value)
+
+    var softness: Double
+        @JvmName("softnessProperty")
+        get() = getParam(3L)
+        @JvmName("setSoftnessProperty")
+        set(value) = setParam(3L, value)
+
+    var relaxation: Double
+        @JvmName("relaxationProperty")
+        get() = getParam(4L)
+        @JvmName("setRelaxationProperty")
+        set(value) = setParam(4L, value)
+
     /**
      * Twist is the rotation around the twist axis, this value defined how far the joint can twist.
      * Twist is locked if below 0.05.

--- a/src/main/kotlin/net/multigesture/kanama/api/Control.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Control.kt
@@ -38,6 +38,54 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
         @JvmName("setClipContentsProperty")
         set(value) = setClipContents(value)
 
+    var anchorLeft: Double
+        @JvmName("anchorLeftProperty")
+        get() = getAnchor(0L)
+        @JvmName("setAnchorLeftProperty")
+        set(value) = setAnchor(0L, value)
+
+    var anchorTop: Double
+        @JvmName("anchorTopProperty")
+        get() = getAnchor(1L)
+        @JvmName("setAnchorTopProperty")
+        set(value) = setAnchor(1L, value)
+
+    var anchorRight: Double
+        @JvmName("anchorRightProperty")
+        get() = getAnchor(2L)
+        @JvmName("setAnchorRightProperty")
+        set(value) = setAnchor(2L, value)
+
+    var anchorBottom: Double
+        @JvmName("anchorBottomProperty")
+        get() = getAnchor(3L)
+        @JvmName("setAnchorBottomProperty")
+        set(value) = setAnchor(3L, value)
+
+    var offsetLeft: Double
+        @JvmName("offsetLeftProperty")
+        get() = getOffset(0L)
+        @JvmName("setOffsetLeftProperty")
+        set(value) = setOffset(0L, value)
+
+    var offsetTop: Double
+        @JvmName("offsetTopProperty")
+        get() = getOffset(1L)
+        @JvmName("setOffsetTopProperty")
+        set(value) = setOffset(1L, value)
+
+    var offsetRight: Double
+        @JvmName("offsetRightProperty")
+        get() = getOffset(2L)
+        @JvmName("setOffsetRightProperty")
+        set(value) = setOffset(2L, value)
+
+    var offsetBottom: Double
+        @JvmName("offsetBottomProperty")
+        get() = getOffset(3L)
+        @JvmName("setOffsetBottomProperty")
+        set(value) = setOffset(3L, value)
+
     var growHorizontal: Long
         @JvmName("growHorizontalProperty")
         get() = getHGrowDirection()
@@ -199,6 +247,30 @@ open class Control(handle: MemorySegment) : CanvasItem(handle) {
         get() = getTooltipAutoTranslateMode()
         @JvmName("setTooltipAutoTranslateModeProperty")
         set(value) = setTooltipAutoTranslateMode(value)
+
+    var focusNeighborLeft: NodePath
+        @JvmName("focusNeighborLeftProperty")
+        get() = getFocusNeighbor(0L)
+        @JvmName("setFocusNeighborLeftProperty")
+        set(value) = setFocusNeighbor(0L, value)
+
+    var focusNeighborTop: NodePath
+        @JvmName("focusNeighborTopProperty")
+        get() = getFocusNeighbor(1L)
+        @JvmName("setFocusNeighborTopProperty")
+        set(value) = setFocusNeighbor(1L, value)
+
+    var focusNeighborRight: NodePath
+        @JvmName("focusNeighborRightProperty")
+        get() = getFocusNeighbor(2L)
+        @JvmName("setFocusNeighborRightProperty")
+        set(value) = setFocusNeighbor(2L, value)
+
+    var focusNeighborBottom: NodePath
+        @JvmName("focusNeighborBottomProperty")
+        get() = getFocusNeighbor(3L)
+        @JvmName("setFocusNeighborBottomProperty")
+        set(value) = setFocusNeighbor(3L, value)
 
     var focusNext: NodePath
         @JvmName("focusNextProperty")

--- a/src/main/kotlin/net/multigesture/kanama/api/Decal.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Decal.kt
@@ -18,6 +18,30 @@ class Decal(handle: MemorySegment) : VisualInstance3D(handle) {
         @JvmName("setSizeProperty")
         set(value) = setSize(value)
 
+    var textureAlbedo: Texture2D?
+        @JvmName("textureAlbedoProperty")
+        get() = getTexture(0L)
+        @JvmName("setTextureAlbedoProperty")
+        set(value) = setTexture(0L, value)
+
+    var textureNormal: Texture2D?
+        @JvmName("textureNormalProperty")
+        get() = getTexture(1L)
+        @JvmName("setTextureNormalProperty")
+        set(value) = setTexture(1L, value)
+
+    var textureOrm: Texture2D?
+        @JvmName("textureOrmProperty")
+        get() = getTexture(2L)
+        @JvmName("setTextureOrmProperty")
+        set(value) = setTexture(2L, value)
+
+    var textureEmission: Texture2D?
+        @JvmName("textureEmissionProperty")
+        get() = getTexture(3L)
+        @JvmName("setTextureEmissionProperty")
+        set(value) = setTexture(3L, value)
+
     var emissionEnergy: Double
         @JvmName("emissionEnergyProperty")
         get() = getEmissionEnergy()

--- a/src/main/kotlin/net/multigesture/kanama/api/FileDialog.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/FileDialog.kt
@@ -70,6 +70,60 @@ open class FileDialog(handle: MemorySegment) : ConfirmationDialog(handle) {
         @JvmName("setOptionCountProperty")
         set(value) = setOptionCount(value)
 
+    var hiddenFilesToggleEnabled: Boolean
+        @JvmName("hiddenFilesToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(0L)
+        @JvmName("setHiddenFilesToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(0L, value)
+
+    var fileFilterToggleEnabled: Boolean
+        @JvmName("fileFilterToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(2L)
+        @JvmName("setFileFilterToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(2L, value)
+
+    var fileSortOptionsEnabled: Boolean
+        @JvmName("fileSortOptionsEnabledProperty")
+        get() = isCustomizationFlagEnabled(3L)
+        @JvmName("setFileSortOptionsEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(3L, value)
+
+    var folderCreationEnabled: Boolean
+        @JvmName("folderCreationEnabledProperty")
+        get() = isCustomizationFlagEnabled(1L)
+        @JvmName("setFolderCreationEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(1L, value)
+
+    var favoritesEnabled: Boolean
+        @JvmName("favoritesEnabledProperty")
+        get() = isCustomizationFlagEnabled(4L)
+        @JvmName("setFavoritesEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(4L, value)
+
+    var recentListEnabled: Boolean
+        @JvmName("recentListEnabledProperty")
+        get() = isCustomizationFlagEnabled(5L)
+        @JvmName("setRecentListEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(5L, value)
+
+    var layoutToggleEnabled: Boolean
+        @JvmName("layoutToggleEnabledProperty")
+        get() = isCustomizationFlagEnabled(6L)
+        @JvmName("setLayoutToggleEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(6L, value)
+
+    var overwriteWarningEnabled: Boolean
+        @JvmName("overwriteWarningEnabledProperty")
+        get() = isCustomizationFlagEnabled(7L)
+        @JvmName("setOverwriteWarningEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(7L, value)
+
+    var deletingEnabled: Boolean
+        @JvmName("deletingEnabledProperty")
+        get() = isCustomizationFlagEnabled(8L)
+        @JvmName("setDeletingEnabledProperty")
+        set(value) = setCustomizationFlagEnabled(8L, value)
+
     var currentDir: String
         @JvmName("currentDirProperty")
         get() = getCurrentDir()

--- a/src/main/kotlin/net/multigesture/kanama/api/GPUParticles3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GPUParticles3D.kt
@@ -177,6 +177,30 @@ class GPUParticles3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setDrawPassesProperty")
         set(value) = setDrawPasses(value)
 
+    var drawPass1: Mesh?
+        @JvmName("drawPass1Property")
+        get() = getDrawPassMesh(0)
+        @JvmName("setDrawPass1Property")
+        set(value) = setDrawPassMesh(0, value)
+
+    var drawPass2: Mesh?
+        @JvmName("drawPass2Property")
+        get() = getDrawPassMesh(1)
+        @JvmName("setDrawPass2Property")
+        set(value) = setDrawPassMesh(1, value)
+
+    var drawPass3: Mesh?
+        @JvmName("drawPass3Property")
+        get() = getDrawPassMesh(2)
+        @JvmName("setDrawPass3Property")
+        set(value) = setDrawPassMesh(2, value)
+
+    var drawPass4: Mesh?
+        @JvmName("drawPass4Property")
+        get() = getDrawPassMesh(3)
+        @JvmName("setDrawPass4Property")
+        set(value) = setDrawPassMesh(3, value)
+
     var drawSkin: Skin?
         @JvmName("drawSkinProperty")
         get() = getSkin()

--- a/src/main/kotlin/net/multigesture/kanama/api/Label3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Label3D.kt
@@ -30,6 +30,30 @@ class Label3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setBillboardProperty")
         set(value) = setBillboardMode(value)
 
+    var shaded: Boolean
+        @JvmName("shadedProperty")
+        get() = getDrawFlag(0L)
+        @JvmName("setShadedProperty")
+        set(value) = setDrawFlag(0L, value)
+
+    var doubleSided: Boolean
+        @JvmName("doubleSidedProperty")
+        get() = getDrawFlag(1L)
+        @JvmName("setDoubleSidedProperty")
+        set(value) = setDrawFlag(1L, value)
+
+    var noDepthTest: Boolean
+        @JvmName("noDepthTestProperty")
+        get() = getDrawFlag(2L)
+        @JvmName("setNoDepthTestProperty")
+        set(value) = setDrawFlag(2L, value)
+
+    var fixedSize: Boolean
+        @JvmName("fixedSizeProperty")
+        get() = getDrawFlag(3L)
+        @JvmName("setFixedSizeProperty")
+        set(value) = setDrawFlag(3L, value)
+
     var alphaCut: Long
         @JvmName("alphaCutProperty")
         get() = getAlphaCutMode()

--- a/src/main/kotlin/net/multigesture/kanama/api/NinePatchRect.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/NinePatchRect.kt
@@ -30,6 +30,30 @@ class NinePatchRect(handle: MemorySegment) : Control(handle) {
         @JvmName("setRegionRectProperty")
         set(value) = setRegionRect(value)
 
+    var patchMarginLeft: Int
+        @JvmName("patchMarginLeftProperty")
+        get() = getPatchMargin(0L)
+        @JvmName("setPatchMarginLeftProperty")
+        set(value) = setPatchMargin(0L, value)
+
+    var patchMarginTop: Int
+        @JvmName("patchMarginTopProperty")
+        get() = getPatchMargin(1L)
+        @JvmName("setPatchMarginTopProperty")
+        set(value) = setPatchMargin(1L, value)
+
+    var patchMarginRight: Int
+        @JvmName("patchMarginRightProperty")
+        get() = getPatchMargin(2L)
+        @JvmName("setPatchMarginRightProperty")
+        set(value) = setPatchMargin(2L, value)
+
+    var patchMarginBottom: Int
+        @JvmName("patchMarginBottomProperty")
+        get() = getPatchMargin(3L)
+        @JvmName("setPatchMarginBottomProperty")
+        set(value) = setPatchMargin(3L, value)
+
     var axisStretchHorizontal: Long
         @JvmName("axisStretchHorizontalProperty")
         get() = getHAxisStretchMode()

--- a/src/main/kotlin/net/multigesture/kanama/api/ParticleProcessMaterial.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ParticleProcessMaterial.kt
@@ -19,6 +19,36 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         @JvmName("setLifetimeRandomnessProperty")
         set(value) = setLifetimeRandomness(value)
 
+    var particleFlagAlignY: Boolean
+        @JvmName("particleFlagAlignYProperty")
+        get() = getParticleFlag(0L)
+        @JvmName("setParticleFlagAlignYProperty")
+        set(value) = setParticleFlag(0L, value)
+
+    var particleFlagRotateY: Boolean
+        @JvmName("particleFlagRotateYProperty")
+        get() = getParticleFlag(1L)
+        @JvmName("setParticleFlagRotateYProperty")
+        set(value) = setParticleFlag(1L, value)
+
+    var particleFlagDisableZ: Boolean
+        @JvmName("particleFlagDisableZProperty")
+        get() = getParticleFlag(2L)
+        @JvmName("setParticleFlagDisableZProperty")
+        set(value) = setParticleFlag(2L, value)
+
+    var particleFlagDampingAsFriction: Boolean
+        @JvmName("particleFlagDampingAsFrictionProperty")
+        get() = getParticleFlag(3L)
+        @JvmName("setParticleFlagDampingAsFrictionProperty")
+        set(value) = setParticleFlag(3L, value)
+
+    var particleFlagInheritEmitterScale: Boolean
+        @JvmName("particleFlagInheritEmitterScaleProperty")
+        get() = getParticleFlag(4L)
+        @JvmName("setParticleFlagInheritEmitterScaleProperty")
+        set(value) = setParticleFlag(4L, value)
+
     var emissionShapeOffset: Vector3
         @JvmName("emissionShapeOffsetProperty")
         get() = getEmissionShapeOffset()
@@ -103,6 +133,30 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         @JvmName("setEmissionRingConeAngleProperty")
         set(value) = setEmissionRingConeAngle(value)
 
+    var angle: Vector2
+        @JvmName("angleProperty")
+        get() = getParam(7L)
+        @JvmName("setAngleProperty")
+        set(value) = setParam(7L, value)
+
+    var angleMin: Double
+        @JvmName("angleMinProperty")
+        get() = getParamMin(7L)
+        @JvmName("setAngleMinProperty")
+        set(value) = setParamMin(7L, value)
+
+    var angleMax: Double
+        @JvmName("angleMaxProperty")
+        get() = getParamMax(7L)
+        @JvmName("setAngleMaxProperty")
+        set(value) = setParamMax(7L, value)
+
+    var angleCurve: Texture2D?
+        @JvmName("angleCurveProperty")
+        get() = getParamTexture(7L)
+        @JvmName("setAngleCurveProperty")
+        set(value) = setParamTexture(7L, value)
+
     var useRotation3d: Boolean
         @JvmName("useRotation3dProperty")
         get() = isUsingRotation3d()
@@ -151,6 +205,120 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         @JvmName("setFlatnessProperty")
         set(value) = setFlatness(value)
 
+    var initialVelocity: Vector2
+        @JvmName("initialVelocityProperty")
+        get() = getParam(0L)
+        @JvmName("setInitialVelocityProperty")
+        set(value) = setParam(0L, value)
+
+    var initialVelocityMin: Double
+        @JvmName("initialVelocityMinProperty")
+        get() = getParamMin(0L)
+        @JvmName("setInitialVelocityMinProperty")
+        set(value) = setParamMin(0L, value)
+
+    var initialVelocityMax: Double
+        @JvmName("initialVelocityMaxProperty")
+        get() = getParamMax(0L)
+        @JvmName("setInitialVelocityMaxProperty")
+        set(value) = setParamMax(0L, value)
+
+    var angularVelocity: Vector2
+        @JvmName("angularVelocityProperty")
+        get() = getParam(1L)
+        @JvmName("setAngularVelocityProperty")
+        set(value) = setParam(1L, value)
+
+    var angularVelocityMin: Double
+        @JvmName("angularVelocityMinProperty")
+        get() = getParamMin(1L)
+        @JvmName("setAngularVelocityMinProperty")
+        set(value) = setParamMin(1L, value)
+
+    var angularVelocityMax: Double
+        @JvmName("angularVelocityMaxProperty")
+        get() = getParamMax(1L)
+        @JvmName("setAngularVelocityMaxProperty")
+        set(value) = setParamMax(1L, value)
+
+    var angularVelocityCurve: Texture2D?
+        @JvmName("angularVelocityCurveProperty")
+        get() = getParamTexture(1L)
+        @JvmName("setAngularVelocityCurveProperty")
+        set(value) = setParamTexture(1L, value)
+
+    var directionalVelocity: Vector2
+        @JvmName("directionalVelocityProperty")
+        get() = getParam(16L)
+        @JvmName("setDirectionalVelocityProperty")
+        set(value) = setParam(16L, value)
+
+    var directionalVelocityMin: Double
+        @JvmName("directionalVelocityMinProperty")
+        get() = getParamMin(16L)
+        @JvmName("setDirectionalVelocityMinProperty")
+        set(value) = setParamMin(16L, value)
+
+    var directionalVelocityMax: Double
+        @JvmName("directionalVelocityMaxProperty")
+        get() = getParamMax(16L)
+        @JvmName("setDirectionalVelocityMaxProperty")
+        set(value) = setParamMax(16L, value)
+
+    var directionalVelocityCurve: Texture2D?
+        @JvmName("directionalVelocityCurveProperty")
+        get() = getParamTexture(16L)
+        @JvmName("setDirectionalVelocityCurveProperty")
+        set(value) = setParamTexture(16L, value)
+
+    var orbitVelocity: Vector2
+        @JvmName("orbitVelocityProperty")
+        get() = getParam(2L)
+        @JvmName("setOrbitVelocityProperty")
+        set(value) = setParam(2L, value)
+
+    var orbitVelocityMin: Double
+        @JvmName("orbitVelocityMinProperty")
+        get() = getParamMin(2L)
+        @JvmName("setOrbitVelocityMinProperty")
+        set(value) = setParamMin(2L, value)
+
+    var orbitVelocityMax: Double
+        @JvmName("orbitVelocityMaxProperty")
+        get() = getParamMax(2L)
+        @JvmName("setOrbitVelocityMaxProperty")
+        set(value) = setParamMax(2L, value)
+
+    var orbitVelocityCurve: Texture2D?
+        @JvmName("orbitVelocityCurveProperty")
+        get() = getParamTexture(2L)
+        @JvmName("setOrbitVelocityCurveProperty")
+        set(value) = setParamTexture(2L, value)
+
+    var radialVelocity: Vector2
+        @JvmName("radialVelocityProperty")
+        get() = getParam(15L)
+        @JvmName("setRadialVelocityProperty")
+        set(value) = setParam(15L, value)
+
+    var radialVelocityMin: Double
+        @JvmName("radialVelocityMinProperty")
+        get() = getParamMin(15L)
+        @JvmName("setRadialVelocityMinProperty")
+        set(value) = setParamMin(15L, value)
+
+    var radialVelocityMax: Double
+        @JvmName("radialVelocityMaxProperty")
+        get() = getParamMax(15L)
+        @JvmName("setRadialVelocityMaxProperty")
+        set(value) = setParamMax(15L, value)
+
+    var radialVelocityCurve: Texture2D?
+        @JvmName("radialVelocityCurveProperty")
+        get() = getParamTexture(15L)
+        @JvmName("setRadialVelocityCurveProperty")
+        set(value) = setParamTexture(15L, value)
+
     var velocityLimitCurve: Texture2D?
         @JvmName("velocityLimitCurveProperty")
         get() = getVelocityLimitCurve()
@@ -187,6 +355,102 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         @JvmName("setGravityProperty")
         set(value) = setGravity(value)
 
+    var linearAccel: Vector2
+        @JvmName("linearAccelProperty")
+        get() = getParam(3L)
+        @JvmName("setLinearAccelProperty")
+        set(value) = setParam(3L, value)
+
+    var linearAccelMin: Double
+        @JvmName("linearAccelMinProperty")
+        get() = getParamMin(3L)
+        @JvmName("setLinearAccelMinProperty")
+        set(value) = setParamMin(3L, value)
+
+    var linearAccelMax: Double
+        @JvmName("linearAccelMaxProperty")
+        get() = getParamMax(3L)
+        @JvmName("setLinearAccelMaxProperty")
+        set(value) = setParamMax(3L, value)
+
+    var linearAccelCurve: Texture2D?
+        @JvmName("linearAccelCurveProperty")
+        get() = getParamTexture(3L)
+        @JvmName("setLinearAccelCurveProperty")
+        set(value) = setParamTexture(3L, value)
+
+    var radialAccel: Vector2
+        @JvmName("radialAccelProperty")
+        get() = getParam(4L)
+        @JvmName("setRadialAccelProperty")
+        set(value) = setParam(4L, value)
+
+    var radialAccelMin: Double
+        @JvmName("radialAccelMinProperty")
+        get() = getParamMin(4L)
+        @JvmName("setRadialAccelMinProperty")
+        set(value) = setParamMin(4L, value)
+
+    var radialAccelMax: Double
+        @JvmName("radialAccelMaxProperty")
+        get() = getParamMax(4L)
+        @JvmName("setRadialAccelMaxProperty")
+        set(value) = setParamMax(4L, value)
+
+    var radialAccelCurve: Texture2D?
+        @JvmName("radialAccelCurveProperty")
+        get() = getParamTexture(4L)
+        @JvmName("setRadialAccelCurveProperty")
+        set(value) = setParamTexture(4L, value)
+
+    var tangentialAccel: Vector2
+        @JvmName("tangentialAccelProperty")
+        get() = getParam(5L)
+        @JvmName("setTangentialAccelProperty")
+        set(value) = setParam(5L, value)
+
+    var tangentialAccelMin: Double
+        @JvmName("tangentialAccelMinProperty")
+        get() = getParamMin(5L)
+        @JvmName("setTangentialAccelMinProperty")
+        set(value) = setParamMin(5L, value)
+
+    var tangentialAccelMax: Double
+        @JvmName("tangentialAccelMaxProperty")
+        get() = getParamMax(5L)
+        @JvmName("setTangentialAccelMaxProperty")
+        set(value) = setParamMax(5L, value)
+
+    var tangentialAccelCurve: Texture2D?
+        @JvmName("tangentialAccelCurveProperty")
+        get() = getParamTexture(5L)
+        @JvmName("setTangentialAccelCurveProperty")
+        set(value) = setParamTexture(5L, value)
+
+    var damping: Vector2
+        @JvmName("dampingProperty")
+        get() = getParam(6L)
+        @JvmName("setDampingProperty")
+        set(value) = setParam(6L, value)
+
+    var dampingMin: Double
+        @JvmName("dampingMinProperty")
+        get() = getParamMin(6L)
+        @JvmName("setDampingMinProperty")
+        set(value) = setParamMin(6L, value)
+
+    var dampingMax: Double
+        @JvmName("dampingMaxProperty")
+        get() = getParamMax(6L)
+        @JvmName("setDampingMaxProperty")
+        set(value) = setParamMax(6L, value)
+
+    var dampingCurve: Texture2D?
+        @JvmName("dampingCurveProperty")
+        get() = getParamTexture(6L)
+        @JvmName("setDampingCurveProperty")
+        set(value) = setParamTexture(6L, value)
+
     var attractorInteractionEnabled: Boolean
         @JvmName("attractorInteractionEnabledProperty")
         get() = isAttractorInteractionEnabled()
@@ -210,6 +474,54 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         get() = getScale3dMax()
         @JvmName("setScale3dMaxProperty")
         set(value) = setScale3dMax(value)
+
+    var scale: Vector2
+        @JvmName("scaleProperty")
+        get() = getParam(8L)
+        @JvmName("setScaleProperty")
+        set(value) = setParam(8L, value)
+
+    var scaleMin: Double
+        @JvmName("scaleMinProperty")
+        get() = getParamMin(8L)
+        @JvmName("setScaleMinProperty")
+        set(value) = setParamMin(8L, value)
+
+    var scaleMax: Double
+        @JvmName("scaleMaxProperty")
+        get() = getParamMax(8L)
+        @JvmName("setScaleMaxProperty")
+        set(value) = setParamMax(8L, value)
+
+    var scaleCurve: Texture2D?
+        @JvmName("scaleCurveProperty")
+        get() = getParamTexture(8L)
+        @JvmName("setScaleCurveProperty")
+        set(value) = setParamTexture(8L, value)
+
+    var scaleOverVelocity: Vector2
+        @JvmName("scaleOverVelocityProperty")
+        get() = getParam(17L)
+        @JvmName("setScaleOverVelocityProperty")
+        set(value) = setParam(17L, value)
+
+    var scaleOverVelocityMin: Double
+        @JvmName("scaleOverVelocityMinProperty")
+        get() = getParamMin(17L)
+        @JvmName("setScaleOverVelocityMinProperty")
+        set(value) = setParamMin(17L, value)
+
+    var scaleOverVelocityMax: Double
+        @JvmName("scaleOverVelocityMaxProperty")
+        get() = getParamMax(17L)
+        @JvmName("setScaleOverVelocityMaxProperty")
+        set(value) = setParamMax(17L, value)
+
+    var scaleOverVelocityCurve: Texture2D?
+        @JvmName("scaleOverVelocityCurveProperty")
+        get() = getParamTexture(17L)
+        @JvmName("setScaleOverVelocityCurveProperty")
+        set(value) = setParamTexture(17L, value)
 
     var color: Color
         @JvmName("colorProperty")
@@ -241,6 +553,78 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         @JvmName("setEmissionCurveProperty")
         set(value) = setEmissionCurve(value)
 
+    var hueVariation: Vector2
+        @JvmName("hueVariationProperty")
+        get() = getParam(9L)
+        @JvmName("setHueVariationProperty")
+        set(value) = setParam(9L, value)
+
+    var hueVariationMin: Double
+        @JvmName("hueVariationMinProperty")
+        get() = getParamMin(9L)
+        @JvmName("setHueVariationMinProperty")
+        set(value) = setParamMin(9L, value)
+
+    var hueVariationMax: Double
+        @JvmName("hueVariationMaxProperty")
+        get() = getParamMax(9L)
+        @JvmName("setHueVariationMaxProperty")
+        set(value) = setParamMax(9L, value)
+
+    var hueVariationCurve: Texture2D?
+        @JvmName("hueVariationCurveProperty")
+        get() = getParamTexture(9L)
+        @JvmName("setHueVariationCurveProperty")
+        set(value) = setParamTexture(9L, value)
+
+    var animSpeed: Vector2
+        @JvmName("animSpeedProperty")
+        get() = getParam(10L)
+        @JvmName("setAnimSpeedProperty")
+        set(value) = setParam(10L, value)
+
+    var animSpeedMin: Double
+        @JvmName("animSpeedMinProperty")
+        get() = getParamMin(10L)
+        @JvmName("setAnimSpeedMinProperty")
+        set(value) = setParamMin(10L, value)
+
+    var animSpeedMax: Double
+        @JvmName("animSpeedMaxProperty")
+        get() = getParamMax(10L)
+        @JvmName("setAnimSpeedMaxProperty")
+        set(value) = setParamMax(10L, value)
+
+    var animSpeedCurve: Texture2D?
+        @JvmName("animSpeedCurveProperty")
+        get() = getParamTexture(10L)
+        @JvmName("setAnimSpeedCurveProperty")
+        set(value) = setParamTexture(10L, value)
+
+    var animOffset: Vector2
+        @JvmName("animOffsetProperty")
+        get() = getParam(11L)
+        @JvmName("setAnimOffsetProperty")
+        set(value) = setParam(11L, value)
+
+    var animOffsetMin: Double
+        @JvmName("animOffsetMinProperty")
+        get() = getParamMin(11L)
+        @JvmName("setAnimOffsetMinProperty")
+        set(value) = setParamMin(11L, value)
+
+    var animOffsetMax: Double
+        @JvmName("animOffsetMaxProperty")
+        get() = getParamMax(11L)
+        @JvmName("setAnimOffsetMaxProperty")
+        set(value) = setParamMax(11L, value)
+
+    var animOffsetCurve: Texture2D?
+        @JvmName("animOffsetCurveProperty")
+        get() = getParamTexture(11L)
+        @JvmName("setAnimOffsetCurveProperty")
+        set(value) = setParamTexture(11L, value)
+
     var turbulenceEnabled: Boolean
         @JvmName("turbulenceEnabledProperty")
         get() = getTurbulenceEnabled()
@@ -270,6 +654,48 @@ class ParticleProcessMaterial(handle: MemorySegment) : Material(handle) {
         get() = getTurbulenceNoiseSpeedRandom()
         @JvmName("setTurbulenceNoiseSpeedRandomProperty")
         set(value) = setTurbulenceNoiseSpeedRandom(value)
+
+    var turbulenceInfluence: Vector2
+        @JvmName("turbulenceInfluenceProperty")
+        get() = getParam(13L)
+        @JvmName("setTurbulenceInfluenceProperty")
+        set(value) = setParam(13L, value)
+
+    var turbulenceInfluenceMin: Double
+        @JvmName("turbulenceInfluenceMinProperty")
+        get() = getParamMin(13L)
+        @JvmName("setTurbulenceInfluenceMinProperty")
+        set(value) = setParamMin(13L, value)
+
+    var turbulenceInfluenceMax: Double
+        @JvmName("turbulenceInfluenceMaxProperty")
+        get() = getParamMax(13L)
+        @JvmName("setTurbulenceInfluenceMaxProperty")
+        set(value) = setParamMax(13L, value)
+
+    var turbulenceInitialDisplacement: Vector2
+        @JvmName("turbulenceInitialDisplacementProperty")
+        get() = getParam(14L)
+        @JvmName("setTurbulenceInitialDisplacementProperty")
+        set(value) = setParam(14L, value)
+
+    var turbulenceInitialDisplacementMin: Double
+        @JvmName("turbulenceInitialDisplacementMinProperty")
+        get() = getParamMin(14L)
+        @JvmName("setTurbulenceInitialDisplacementMinProperty")
+        set(value) = setParamMin(14L, value)
+
+    var turbulenceInitialDisplacementMax: Double
+        @JvmName("turbulenceInitialDisplacementMaxProperty")
+        get() = getParamMax(14L)
+        @JvmName("setTurbulenceInitialDisplacementMaxProperty")
+        set(value) = setParamMax(14L, value)
+
+    var turbulenceInfluenceOverLife: Texture2D?
+        @JvmName("turbulenceInfluenceOverLifeProperty")
+        get() = getParamTexture(12L)
+        @JvmName("setTurbulenceInfluenceOverLifeProperty")
+        set(value) = setParamTexture(12L, value)
 
     var collisionMode: Long
         @JvmName("collisionModeProperty")

--- a/src/main/kotlin/net/multigesture/kanama/api/RDShaderSPIRV.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/RDShaderSPIRV.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 
 /**
@@ -9,6 +10,126 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
  * Generated from Godot docs: RDShaderSPIRV
  */
 class RDShaderSPIRV(handle: MemorySegment) : Resource(handle) {
+    var bytecodeVertex: ByteArray
+        @JvmName("bytecodeVertexProperty")
+        get() = getStageBytecode(0L)
+        @JvmName("setBytecodeVertexProperty")
+        set(value) = setStageBytecode(0L, value)
+
+    var bytecodeFragment: ByteArray
+        @JvmName("bytecodeFragmentProperty")
+        get() = getStageBytecode(1L)
+        @JvmName("setBytecodeFragmentProperty")
+        set(value) = setStageBytecode(1L, value)
+
+    var bytecodeTesselationControl: ByteArray
+        @JvmName("bytecodeTesselationControlProperty")
+        get() = getStageBytecode(2L)
+        @JvmName("setBytecodeTesselationControlProperty")
+        set(value) = setStageBytecode(2L, value)
+
+    var bytecodeTesselationEvaluation: ByteArray
+        @JvmName("bytecodeTesselationEvaluationProperty")
+        get() = getStageBytecode(3L)
+        @JvmName("setBytecodeTesselationEvaluationProperty")
+        set(value) = setStageBytecode(3L, value)
+
+    var bytecodeCompute: ByteArray
+        @JvmName("bytecodeComputeProperty")
+        get() = getStageBytecode(4L)
+        @JvmName("setBytecodeComputeProperty")
+        set(value) = setStageBytecode(4L, value)
+
+    var bytecodeRaygen: ByteArray
+        @JvmName("bytecodeRaygenProperty")
+        get() = getStageBytecode(5L)
+        @JvmName("setBytecodeRaygenProperty")
+        set(value) = setStageBytecode(5L, value)
+
+    var bytecodeAnyHit: ByteArray
+        @JvmName("bytecodeAnyHitProperty")
+        get() = getStageBytecode(6L)
+        @JvmName("setBytecodeAnyHitProperty")
+        set(value) = setStageBytecode(6L, value)
+
+    var bytecodeClosestHit: ByteArray
+        @JvmName("bytecodeClosestHitProperty")
+        get() = getStageBytecode(7L)
+        @JvmName("setBytecodeClosestHitProperty")
+        set(value) = setStageBytecode(7L, value)
+
+    var bytecodeMiss: ByteArray
+        @JvmName("bytecodeMissProperty")
+        get() = getStageBytecode(8L)
+        @JvmName("setBytecodeMissProperty")
+        set(value) = setStageBytecode(8L, value)
+
+    var bytecodeIntersection: ByteArray
+        @JvmName("bytecodeIntersectionProperty")
+        get() = getStageBytecode(9L)
+        @JvmName("setBytecodeIntersectionProperty")
+        set(value) = setStageBytecode(9L, value)
+
+    var compileErrorVertex: String
+        @JvmName("compileErrorVertexProperty")
+        get() = getStageCompileError(0L)
+        @JvmName("setCompileErrorVertexProperty")
+        set(value) = setStageCompileError(0L, value)
+
+    var compileErrorFragment: String
+        @JvmName("compileErrorFragmentProperty")
+        get() = getStageCompileError(1L)
+        @JvmName("setCompileErrorFragmentProperty")
+        set(value) = setStageCompileError(1L, value)
+
+    var compileErrorTesselationControl: String
+        @JvmName("compileErrorTesselationControlProperty")
+        get() = getStageCompileError(2L)
+        @JvmName("setCompileErrorTesselationControlProperty")
+        set(value) = setStageCompileError(2L, value)
+
+    var compileErrorTesselationEvaluation: String
+        @JvmName("compileErrorTesselationEvaluationProperty")
+        get() = getStageCompileError(3L)
+        @JvmName("setCompileErrorTesselationEvaluationProperty")
+        set(value) = setStageCompileError(3L, value)
+
+    var compileErrorCompute: String
+        @JvmName("compileErrorComputeProperty")
+        get() = getStageCompileError(4L)
+        @JvmName("setCompileErrorComputeProperty")
+        set(value) = setStageCompileError(4L, value)
+
+    var compileErrorRaygen: String
+        @JvmName("compileErrorRaygenProperty")
+        get() = getStageCompileError(5L)
+        @JvmName("setCompileErrorRaygenProperty")
+        set(value) = setStageCompileError(5L, value)
+
+    var compileErrorAnyHit: String
+        @JvmName("compileErrorAnyHitProperty")
+        get() = getStageCompileError(6L)
+        @JvmName("setCompileErrorAnyHitProperty")
+        set(value) = setStageCompileError(6L, value)
+
+    var compileErrorClosestHit: String
+        @JvmName("compileErrorClosestHitProperty")
+        get() = getStageCompileError(7L)
+        @JvmName("setCompileErrorClosestHitProperty")
+        set(value) = setStageCompileError(7L, value)
+
+    var compileErrorMiss: String
+        @JvmName("compileErrorMissProperty")
+        get() = getStageCompileError(8L)
+        @JvmName("setCompileErrorMissProperty")
+        set(value) = setStageCompileError(8L, value)
+
+    var compileErrorIntersection: String
+        @JvmName("compileErrorIntersectionProperty")
+        get() = getStageCompileError(9L)
+        @JvmName("setCompileErrorIntersectionProperty")
+        set(value) = setStageCompileError(9L, value)
+
     /**
      * The SPIR-V bytecode for the vertex shader stage.
      *

--- a/src/main/kotlin/net/multigesture/kanama/api/RDShaderSource.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/RDShaderSource.kt
@@ -10,6 +10,66 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
  * Generated from Godot docs: RDShaderSource
  */
 class RDShaderSource(handle: MemorySegment) : RefCounted(handle) {
+    var sourceVertex: String
+        @JvmName("sourceVertexProperty")
+        get() = getStageSource(0L)
+        @JvmName("setSourceVertexProperty")
+        set(value) = setStageSource(0L, value)
+
+    var sourceFragment: String
+        @JvmName("sourceFragmentProperty")
+        get() = getStageSource(1L)
+        @JvmName("setSourceFragmentProperty")
+        set(value) = setStageSource(1L, value)
+
+    var sourceTesselationControl: String
+        @JvmName("sourceTesselationControlProperty")
+        get() = getStageSource(2L)
+        @JvmName("setSourceTesselationControlProperty")
+        set(value) = setStageSource(2L, value)
+
+    var sourceTesselationEvaluation: String
+        @JvmName("sourceTesselationEvaluationProperty")
+        get() = getStageSource(3L)
+        @JvmName("setSourceTesselationEvaluationProperty")
+        set(value) = setStageSource(3L, value)
+
+    var sourceCompute: String
+        @JvmName("sourceComputeProperty")
+        get() = getStageSource(4L)
+        @JvmName("setSourceComputeProperty")
+        set(value) = setStageSource(4L, value)
+
+    var sourceRaygen: String
+        @JvmName("sourceRaygenProperty")
+        get() = getStageSource(5L)
+        @JvmName("setSourceRaygenProperty")
+        set(value) = setStageSource(5L, value)
+
+    var sourceAnyHit: String
+        @JvmName("sourceAnyHitProperty")
+        get() = getStageSource(6L)
+        @JvmName("setSourceAnyHitProperty")
+        set(value) = setStageSource(6L, value)
+
+    var sourceClosestHit: String
+        @JvmName("sourceClosestHitProperty")
+        get() = getStageSource(7L)
+        @JvmName("setSourceClosestHitProperty")
+        set(value) = setStageSource(7L, value)
+
+    var sourceMiss: String
+        @JvmName("sourceMissProperty")
+        get() = getStageSource(8L)
+        @JvmName("setSourceMissProperty")
+        set(value) = setStageSource(8L, value)
+
+    var sourceIntersection: String
+        @JvmName("sourceIntersectionProperty")
+        get() = getStageSource(9L)
+        @JvmName("setSourceIntersectionProperty")
+        set(value) = setStageSource(9L, value)
+
     var language: Long
         @JvmName("languageProperty")
         get() = getLanguage()

--- a/src/main/kotlin/net/multigesture/kanama/api/SpriteBase3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/SpriteBase3D.kt
@@ -61,6 +61,36 @@ open class SpriteBase3D(handle: MemorySegment) : GeometryInstance3D(handle) {
         @JvmName("setBillboardProperty")
         set(value) = setBillboardMode(value)
 
+    var transparent: Boolean
+        @JvmName("transparentProperty")
+        get() = getDrawFlag(0L)
+        @JvmName("setTransparentProperty")
+        set(value) = setDrawFlag(0L, value)
+
+    var shaded: Boolean
+        @JvmName("shadedProperty")
+        get() = getDrawFlag(1L)
+        @JvmName("setShadedProperty")
+        set(value) = setDrawFlag(1L, value)
+
+    var doubleSided: Boolean
+        @JvmName("doubleSidedProperty")
+        get() = getDrawFlag(2L)
+        @JvmName("setDoubleSidedProperty")
+        set(value) = setDrawFlag(2L, value)
+
+    var noDepthTest: Boolean
+        @JvmName("noDepthTestProperty")
+        get() = getDrawFlag(3L)
+        @JvmName("setNoDepthTestProperty")
+        set(value) = setDrawFlag(3L, value)
+
+    var fixedSize: Boolean
+        @JvmName("fixedSizeProperty")
+        get() = getDrawFlag(4L)
+        @JvmName("setFixedSizeProperty")
+        set(value) = setDrawFlag(4L, value)
+
     var alphaCut: Long
         @JvmName("alphaCutProperty")
         get() = getAlphaCutMode()

--- a/src/main/kotlin/net/multigesture/kanama/api/StyleBox.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/StyleBox.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.types.RID
 import net.multigesture.kanama.types.Rect2
@@ -12,6 +13,30 @@ import net.multigesture.kanama.types.Vector2
  * Generated from Godot docs: StyleBox
  */
 open class StyleBox(handle: MemorySegment) : Resource(handle) {
+    var contentMarginLeft: Double
+        @JvmName("contentMarginLeftProperty")
+        get() = getContentMargin(0L)
+        @JvmName("setContentMarginLeftProperty")
+        set(value) = setContentMargin(0L, value)
+
+    var contentMarginTop: Double
+        @JvmName("contentMarginTopProperty")
+        get() = getContentMargin(1L)
+        @JvmName("setContentMarginTopProperty")
+        set(value) = setContentMargin(1L, value)
+
+    var contentMarginRight: Double
+        @JvmName("contentMarginRightProperty")
+        get() = getContentMargin(2L)
+        @JvmName("setContentMarginRightProperty")
+        set(value) = setContentMargin(2L, value)
+
+    var contentMarginBottom: Double
+        @JvmName("contentMarginBottomProperty")
+        get() = getContentMargin(3L)
+        @JvmName("setContentMarginBottomProperty")
+        set(value) = setContentMargin(3L, value)
+
     /**
      * Returns the minimum size that this stylebox can be shrunk to.
      *

--- a/src/main/kotlin/net/multigesture/kanama/api/StyleBoxFlat.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/StyleBoxFlat.kt
@@ -30,6 +30,30 @@ class StyleBoxFlat(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setSkewProperty")
         set(value) = setSkew(value)
 
+    var borderWidthLeft: Int
+        @JvmName("borderWidthLeftProperty")
+        get() = getBorderWidth(0L)
+        @JvmName("setBorderWidthLeftProperty")
+        set(value) = setBorderWidth(0L, value)
+
+    var borderWidthTop: Int
+        @JvmName("borderWidthTopProperty")
+        get() = getBorderWidth(1L)
+        @JvmName("setBorderWidthTopProperty")
+        set(value) = setBorderWidth(1L, value)
+
+    var borderWidthRight: Int
+        @JvmName("borderWidthRightProperty")
+        get() = getBorderWidth(2L)
+        @JvmName("setBorderWidthRightProperty")
+        set(value) = setBorderWidth(2L, value)
+
+    var borderWidthBottom: Int
+        @JvmName("borderWidthBottomProperty")
+        get() = getBorderWidth(3L)
+        @JvmName("setBorderWidthBottomProperty")
+        set(value) = setBorderWidth(3L, value)
+
     var borderColor: Color
         @JvmName("borderColorProperty")
         get() = getBorderColor()
@@ -42,11 +66,59 @@ class StyleBoxFlat(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setBorderBlendProperty")
         set(value) = setBorderBlend(value)
 
+    var cornerRadiusTopLeft: Int
+        @JvmName("cornerRadiusTopLeftProperty")
+        get() = getCornerRadius(0L)
+        @JvmName("setCornerRadiusTopLeftProperty")
+        set(value) = setCornerRadius(0L, value)
+
+    var cornerRadiusTopRight: Int
+        @JvmName("cornerRadiusTopRightProperty")
+        get() = getCornerRadius(1L)
+        @JvmName("setCornerRadiusTopRightProperty")
+        set(value) = setCornerRadius(1L, value)
+
+    var cornerRadiusBottomRight: Int
+        @JvmName("cornerRadiusBottomRightProperty")
+        get() = getCornerRadius(2L)
+        @JvmName("setCornerRadiusBottomRightProperty")
+        set(value) = setCornerRadius(2L, value)
+
+    var cornerRadiusBottomLeft: Int
+        @JvmName("cornerRadiusBottomLeftProperty")
+        get() = getCornerRadius(3L)
+        @JvmName("setCornerRadiusBottomLeftProperty")
+        set(value) = setCornerRadius(3L, value)
+
     var cornerDetail: Int
         @JvmName("cornerDetailProperty")
         get() = getCornerDetail()
         @JvmName("setCornerDetailProperty")
         set(value) = setCornerDetail(value)
+
+    var expandMarginLeft: Double
+        @JvmName("expandMarginLeftProperty")
+        get() = getExpandMargin(0L)
+        @JvmName("setExpandMarginLeftProperty")
+        set(value) = setExpandMargin(0L, value)
+
+    var expandMarginTop: Double
+        @JvmName("expandMarginTopProperty")
+        get() = getExpandMargin(1L)
+        @JvmName("setExpandMarginTopProperty")
+        set(value) = setExpandMargin(1L, value)
+
+    var expandMarginRight: Double
+        @JvmName("expandMarginRightProperty")
+        get() = getExpandMargin(2L)
+        @JvmName("setExpandMarginRightProperty")
+        set(value) = setExpandMargin(2L, value)
+
+    var expandMarginBottom: Double
+        @JvmName("expandMarginBottomProperty")
+        get() = getExpandMargin(3L)
+        @JvmName("setExpandMarginBottomProperty")
+        set(value) = setExpandMargin(3L, value)
 
     var shadowColor: Color
         @JvmName("shadowColorProperty")

--- a/src/main/kotlin/net/multigesture/kanama/api/StyleBoxTexture.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/StyleBoxTexture.kt
@@ -18,6 +18,54 @@ class StyleBoxTexture(handle: MemorySegment) : StyleBox(handle) {
         @JvmName("setTextureProperty")
         set(value) = setTexture(value)
 
+    var textureMarginLeft: Double
+        @JvmName("textureMarginLeftProperty")
+        get() = getTextureMargin(0L)
+        @JvmName("setTextureMarginLeftProperty")
+        set(value) = setTextureMargin(0L, value)
+
+    var textureMarginTop: Double
+        @JvmName("textureMarginTopProperty")
+        get() = getTextureMargin(1L)
+        @JvmName("setTextureMarginTopProperty")
+        set(value) = setTextureMargin(1L, value)
+
+    var textureMarginRight: Double
+        @JvmName("textureMarginRightProperty")
+        get() = getTextureMargin(2L)
+        @JvmName("setTextureMarginRightProperty")
+        set(value) = setTextureMargin(2L, value)
+
+    var textureMarginBottom: Double
+        @JvmName("textureMarginBottomProperty")
+        get() = getTextureMargin(3L)
+        @JvmName("setTextureMarginBottomProperty")
+        set(value) = setTextureMargin(3L, value)
+
+    var expandMarginLeft: Double
+        @JvmName("expandMarginLeftProperty")
+        get() = getExpandMargin(0L)
+        @JvmName("setExpandMarginLeftProperty")
+        set(value) = setExpandMargin(0L, value)
+
+    var expandMarginTop: Double
+        @JvmName("expandMarginTopProperty")
+        get() = getExpandMargin(1L)
+        @JvmName("setExpandMarginTopProperty")
+        set(value) = setExpandMargin(1L, value)
+
+    var expandMarginRight: Double
+        @JvmName("expandMarginRightProperty")
+        get() = getExpandMargin(2L)
+        @JvmName("setExpandMarginRightProperty")
+        set(value) = setExpandMargin(2L, value)
+
+    var expandMarginBottom: Double
+        @JvmName("expandMarginBottomProperty")
+        get() = getExpandMargin(3L)
+        @JvmName("setExpandMarginBottomProperty")
+        set(value) = setExpandMargin(3L, value)
+
     var axisStretchHorizontal: Long
         @JvmName("axisStretchHorizontalProperty")
         get() = getHAxisStretchMode()

--- a/src/main/kotlin/net/multigesture/kanama/api/TextureProgressBar.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/TextureProgressBar.kt
@@ -42,6 +42,30 @@ class TextureProgressBar(handle: MemorySegment) : Range(handle) {
         @JvmName("setNinePatchStretchProperty")
         set(value) = setNinePatchStretch(value)
 
+    var stretchMarginLeft: Int
+        @JvmName("stretchMarginLeftProperty")
+        get() = getStretchMargin(0L)
+        @JvmName("setStretchMarginLeftProperty")
+        set(value) = setStretchMargin(0L, value)
+
+    var stretchMarginTop: Int
+        @JvmName("stretchMarginTopProperty")
+        get() = getStretchMargin(1L)
+        @JvmName("setStretchMarginTopProperty")
+        set(value) = setStretchMargin(1L, value)
+
+    var stretchMarginRight: Int
+        @JvmName("stretchMarginRightProperty")
+        get() = getStretchMargin(2L)
+        @JvmName("setStretchMarginRightProperty")
+        set(value) = setStretchMargin(2L, value)
+
+    var stretchMarginBottom: Int
+        @JvmName("stretchMarginBottomProperty")
+        get() = getStretchMargin(3L)
+        @JvmName("setStretchMarginBottomProperty")
+        set(value) = setStretchMargin(3L, value)
+
     var textureUnder: Texture2D?
         @JvmName("textureUnderProperty")
         get() = getUnderTexture()

--- a/src/main/kotlin/net/multigesture/kanama/api/Window.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/Window.kt
@@ -92,6 +92,84 @@ open class Window(handle: MemorySegment) : Viewport(handle) {
         @JvmName("setExclusiveProperty")
         set(value) = setExclusive(value)
 
+    var unresizable: Boolean
+        @JvmName("unresizableProperty")
+        get() = getFlag(0L)
+        @JvmName("setUnresizableProperty")
+        set(value) = setFlag(0L, value)
+
+    var borderless: Boolean
+        @JvmName("borderlessProperty")
+        get() = getFlag(1L)
+        @JvmName("setBorderlessProperty")
+        set(value) = setFlag(1L, value)
+
+    var alwaysOnTop: Boolean
+        @JvmName("alwaysOnTopProperty")
+        get() = getFlag(2L)
+        @JvmName("setAlwaysOnTopProperty")
+        set(value) = setFlag(2L, value)
+
+    var transparent: Boolean
+        @JvmName("transparentProperty")
+        get() = getFlag(3L)
+        @JvmName("setTransparentProperty")
+        set(value) = setFlag(3L, value)
+
+    var unfocusable: Boolean
+        @JvmName("unfocusableProperty")
+        get() = getFlag(4L)
+        @JvmName("setUnfocusableProperty")
+        set(value) = setFlag(4L, value)
+
+    var popupWindow: Boolean
+        @JvmName("popupWindowProperty")
+        get() = getFlag(5L)
+        @JvmName("setPopupWindowProperty")
+        set(value) = setFlag(5L, value)
+
+    var extendToTitle: Boolean
+        @JvmName("extendToTitleProperty")
+        get() = getFlag(6L)
+        @JvmName("setExtendToTitleProperty")
+        set(value) = setFlag(6L, value)
+
+    var mousePassthrough: Boolean
+        @JvmName("mousePassthroughProperty")
+        get() = getFlag(7L)
+        @JvmName("setMousePassthroughProperty")
+        set(value) = setFlag(7L, value)
+
+    var sharpCorners: Boolean
+        @JvmName("sharpCornersProperty")
+        get() = getFlag(8L)
+        @JvmName("setSharpCornersProperty")
+        set(value) = setFlag(8L, value)
+
+    var excludeFromCapture: Boolean
+        @JvmName("excludeFromCaptureProperty")
+        get() = getFlag(9L)
+        @JvmName("setExcludeFromCaptureProperty")
+        set(value) = setFlag(9L, value)
+
+    var popupWmHint: Boolean
+        @JvmName("popupWmHintProperty")
+        get() = getFlag(10L)
+        @JvmName("setPopupWmHintProperty")
+        set(value) = setFlag(10L, value)
+
+    var minimizeDisabled: Boolean
+        @JvmName("minimizeDisabledProperty")
+        get() = getFlag(11L)
+        @JvmName("setMinimizeDisabledProperty")
+        set(value) = setFlag(11L, value)
+
+    var maximizeDisabled: Boolean
+        @JvmName("maximizeDisabledProperty")
+        get() = getFlag(12L)
+        @JvmName("setMaximizeDisabledProperty")
+        set(value) = setFlag(12L, value)
+
     var forceNative: Boolean
         @JvmName("forceNativeProperty")
         get() = getForceNative()


### PR DESCRIPTION
Stacked on #87.

## Root fix

The wrapper generator skipped every property whose getter takes arguments, silently dropping all ~415 of Godot's *indexed* properties (`albedo_texture` → `get_texture(param)`, light params via `get_param`, audio-stream slots, style-box margins, particle/decal textures, …). #87 hand-patched only BaseMaterial3D; this fixes the root cause generically.

### Generator (`scripts/generate_api_wrapper.py`)
- `render_property` binds a property's `"index"` as the accessor's first argument, emitting `getTexture(0L)`/`setTexture(0L, value)`. The literal matches the accessor's first-arg Kotlin type — `Long` for enum/int64 indices, `Int` for int32 (`getListStream(0)`).
- `property_setter_type` gained a `value_slot` so an indexed setter marshals the value into `arg[1]` and still allows trailing defaulted args (also keeps `set_position(pos, keep_offsets=false)` writable).
- Dropped the now-redundant hand-written `Light3D.lightEnergy` custom section — emitted generically (`getParam(0L)`), no duplicate.

### Re-adoption
20 desktop + 21 iOS wrappers that gained indexed properties (`Control`, `Camera2D`, `Decal`, `StyleBox*`, `CPUParticles*`, `Window`, iOS `BaseMaterial3D`/`Light3D`, …). `ObjectCallsGenerated` is unchanged — properties add no method binds. Hand-shaped classes stay exempt.

### Prevention (`scripts/check_property_coverage.py`, wired into `local_ci.sh`)
New gate fails the build on any generated-class property that resolves to no wrapper member and is neither a private `_get_*` engine internal nor a documented `KNOWN_UNWRAPPABLE_PROPERTIES` gap (57 inherited-accessor cases, e.g. `SpotLight3D.spot_range` via `Light3D.get_param`). A now-covered allow-list entry also fails, so the list can't rot.

## Validation
- ✅ JVM + example-scripts compile; wrapper drift gate (desktop 988 / iOS 1013); `sync_kdoc --check`; full Python audit suite; new coverage gate (teeth-tested); generator-report doc regenerated
- ⏳ iOS Xcode / native bootstrap: relying on CI (not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)