### PR TITLE
Emit indexed properties reached through an inherited accessor

### DIFF
--- a/docs/contributing/api-coverage.md
+++ b/docs/contributing/api-coverage.md
@@ -11,11 +11,11 @@ Generated drafts are emitted to `build/wrapper-generator/drafts` during local ru
 | Metric | Count | Coverage |
 | --- | ---: | --- |
 | API classes | 1036 |  |
-| Classes with generated output | 844 | `██████████░░` 81.5% |
+| Classes with generated output | 845 | `██████████░░` 81.6% |
 | Classes with complete method generation | 761 | `█████████░░░` 73.5% |
 | Methods generated | 15332/16822 (91.1%) | `███████████░` 91.1% |
 | Methods skipped | 1490 |  |
-| Properties generated | 4072/4162 (97.8%) | `████████████` 97.8% |
+| Properties generated | 4090/4162 (98.3%) | `████████████` 98.3% |
 | Signals generated | 503/503 (100.0%) | `████████████` 100.0% |
 
 **Reading the numbers above:** "Methods generated" counts against *all* methods in `extension_api.json`, including the 1437 engine virtuals — which are deliberately not emitted as callable wrappers (a script overrides them via `@OverrideVirtual`) — and the documented by-design skips (root-`Object` policy methods, `RefCounted` lifetime, the Dictionary passthrough revert). Callable-method coverage is the **Promoted Source Summary** below; a sub-100% figure here is not unfinished work.

--- a/docs/contributing/wrapper-generator-report.md
+++ b/docs/contributing/wrapper-generator-report.md
@@ -15,11 +15,11 @@ Generated drafts are not automatically promoted. A class only becomes public sou
 | Metric | Count |
 | --- | ---: |
 | API classes | 1036 |
-| Classes with generated output | 844 |
+| Classes with generated output | 845 |
 | Classes with complete method generation | 761 |
 | Methods generated | 15332/16822 (91.1%) |
 | Methods skipped | 1490 |
-| Properties generated | 4072/4162 (97.8%) |
+| Properties generated | 4090/4162 (98.3%) |
 | Signals generated | 503/503 (100.0%) |
 
 ## Skip Categories

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/AreaLight3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/AreaLight3D.kt
@@ -10,6 +10,18 @@ import net.multigesture.kanama.types.Vector2
  * Generated from Godot docs: AreaLight3D
  */
 class AreaLight3D(handle: MemorySegment) : Light3D(handle) {
+    var areaRange: Double
+        @JvmName("areaRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setAreaRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var areaAttenuation: Double
+        @JvmName("areaAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setAreaAttenuationProperty")
+        set(value) = setParam(6L, value)
+
     var areaNormalizeEnergy: Boolean
         @JvmName("areaNormalizeEnergyProperty")
         get() = isAreaNormalizingEnergy()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/DirectionalLight3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/DirectionalLight3D.kt
@@ -15,11 +15,47 @@ class DirectionalLight3D(handle: MemorySegment) : Light3D(handle) {
         @JvmName("setDirectionalShadowModeProperty")
         set(value) = setShadowMode(value)
 
+    var directionalShadowSplit1: Double
+        @JvmName("directionalShadowSplit1Property")
+        get() = getParam(10L)
+        @JvmName("setDirectionalShadowSplit1Property")
+        set(value) = setParam(10L, value)
+
+    var directionalShadowSplit2: Double
+        @JvmName("directionalShadowSplit2Property")
+        get() = getParam(11L)
+        @JvmName("setDirectionalShadowSplit2Property")
+        set(value) = setParam(11L, value)
+
+    var directionalShadowSplit3: Double
+        @JvmName("directionalShadowSplit3Property")
+        get() = getParam(12L)
+        @JvmName("setDirectionalShadowSplit3Property")
+        set(value) = setParam(12L, value)
+
     var directionalShadowBlendSplits: Boolean
         @JvmName("directionalShadowBlendSplitsProperty")
         get() = isBlendSplitsEnabled()
         @JvmName("setDirectionalShadowBlendSplitsProperty")
         set(value) = setBlendSplits(value)
+
+    var directionalShadowFadeStart: Double
+        @JvmName("directionalShadowFadeStartProperty")
+        get() = getParam(13L)
+        @JvmName("setDirectionalShadowFadeStartProperty")
+        set(value) = setParam(13L, value)
+
+    var directionalShadowMaxDistance: Double
+        @JvmName("directionalShadowMaxDistanceProperty")
+        get() = getParam(9L)
+        @JvmName("setDirectionalShadowMaxDistanceProperty")
+        set(value) = setParam(9L, value)
+
+    var directionalShadowPancakeSize: Double
+        @JvmName("directionalShadowPancakeSizeProperty")
+        get() = getParam(16L)
+        @JvmName("setDirectionalShadowPancakeSizeProperty")
+        set(value) = setParam(16L, value)
 
     var skyMode: Long
         @JvmName("skyModeProperty")

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FontVariation.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FontVariation.kt
@@ -35,6 +35,30 @@ class FontVariation(handle: MemorySegment) : Font(handle) {
         @JvmName("setVariationTransformProperty")
         set(value) = setVariationTransform(value)
 
+    var spacingGlyph: Int
+        @JvmName("spacingGlyphProperty")
+        get() = getSpacing(0L)
+        @JvmName("setSpacingGlyphProperty")
+        set(value) = setSpacing(0L, value)
+
+    var spacingSpace: Int
+        @JvmName("spacingSpaceProperty")
+        get() = getSpacing(1L)
+        @JvmName("setSpacingSpaceProperty")
+        set(value) = setSpacing(1L, value)
+
+    var spacingTop: Int
+        @JvmName("spacingTopProperty")
+        get() = getSpacing(2L)
+        @JvmName("setSpacingTopProperty")
+        set(value) = setSpacing(2L, value)
+
+    var spacingBottom: Int
+        @JvmName("spacingBottomProperty")
+        get() = getSpacing(3L)
+        @JvmName("setSpacingBottomProperty")
+        set(value) = setSpacing(3L, value)
+
     var baselineOffset: Double
         @JvmName("baselineOffsetProperty")
         get() = getBaselineOffset()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/OmniLight3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/OmniLight3D.kt
@@ -9,6 +9,18 @@ import net.multigesture.kanama.binding.runtime.*
  * Generated from Godot docs: OmniLight3D
  */
 class OmniLight3D(handle: MemorySegment) : Light3D(handle) {
+    var omniRange: Double
+        @JvmName("omniRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setOmniRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var omniAttenuation: Double
+        @JvmName("omniAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setOmniAttenuationProperty")
+        set(value) = setParam(6L, value)
+
     var omniShadowMode: Long
         @JvmName("omniShadowModeProperty")
         get() = getShadowMode()

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/SpotLight3D.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/SpotLight3D.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 import net.multigesture.kanama.binding.runtime.*
 
@@ -8,6 +9,30 @@ import net.multigesture.kanama.binding.runtime.*
  * Generated from Godot docs: SpotLight3D
  */
 class SpotLight3D(handle: MemorySegment) : Light3D(handle) {
+    var spotRange: Double
+        @JvmName("spotRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setSpotRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var spotAttenuation: Double
+        @JvmName("spotAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setSpotAttenuationProperty")
+        set(value) = setParam(6L, value)
+
+    var spotAngle: Double
+        @JvmName("spotAngleProperty")
+        get() = getParam(7L)
+        @JvmName("setSpotAngleProperty")
+        set(value) = setParam(7L, value)
+
+    var spotAngleAttenuation: Double
+        @JvmName("spotAngleAttenuationProperty")
+        get() = getParam(8L)
+        @JvmName("setSpotAngleAttenuationProperty")
+        set(value) = setParam(8L, value)
+
     // No conservative instance methods emitted yet.
 
     companion object {

--- a/scripts/check_property_coverage.py
+++ b/scripts/check_property_coverage.py
@@ -7,9 +7,9 @@ does not is either:
 
   * backed by a private `_get_*` engine internal (no public bound accessor — genuinely
     unwrappable, allowed by rule), or
-  * a documented generator limitation in KNOWN_UNWRAPPABLE_PROPERTIES below (mostly indexed
-    properties whose accessor is *inherited*, e.g. SpotLight3D.spot_range via Light3D.get_param,
-    and redeclared-getter cases), or
+  * a documented generator limitation in KNOWN_UNWRAPPABLE_PROPERTIES below (non-indexed
+    properties whose getter lives on a parent while the setter is local, e.g. CurveTexture.width,
+    and `..._count` / vertex-array accessors the generator does not model), or
   * a NEW silent drop — which fails this gate.
 
 This is the durable guard that turned the `albedo_texture` regression (indexed properties were
@@ -35,15 +35,15 @@ from check_wrapper_generator import API_DIR, DESKTOP_HANDSHAPED
 ROOT = Path(__file__).resolve().parents[1]
 
 # (class, raw_property_name) pairs on generated classes whose property the generator cannot yet
-# express. Overwhelmingly indexed properties reached through an *inherited* accessor (get_param on
-# the Light3D subclasses) or a getter that lives on a parent while the setter is local
-# (CurveTexture.width). Keep sorted; see module docstring for how to retire an entry.
+# express. Mostly a getter inherited from a parent paired with a local setter, or no bound getter
+# at all (CurveTexture.width -> Texture2D.get_width), plus `..._count` and vertex/index array
+# accessors the generator does not model. Indexed properties reached through an inherited accessor
+# (the Light3D get_param subclasses) are now emitted, so they are no longer listed here.
+# Keep sorted; see module docstring for how to retire an entry.
 KNOWN_UNWRAPPABLE_PROPERTIES: frozenset[tuple[str, str]] = frozenset(
     {
         ("AimModifier3D", "setting_count"),
         ("AnimationNodeTransition", "input_count"),
-        ("AreaLight3D", "area_attenuation"),
-        ("AreaLight3D", "area_range"),
         ("ArrayOccluder3D", "indices"),
         ("ArrayOccluder3D", "vertices"),
         ("ConvertTransformModifier3D", "setting_count"),
@@ -51,12 +51,6 @@ KNOWN_UNWRAPPABLE_PROPERTIES: frozenset[tuple[str, str]] = frozenset(
         ("CurveTexture", "width"),
         ("CurveXYZTexture", "width"),
         ("DirectionalLight2D", "height"),
-        ("DirectionalLight3D", "directional_shadow_fade_start"),
-        ("DirectionalLight3D", "directional_shadow_max_distance"),
-        ("DirectionalLight3D", "directional_shadow_pancake_size"),
-        ("DirectionalLight3D", "directional_shadow_split_1"),
-        ("DirectionalLight3D", "directional_shadow_split_2"),
-        ("DirectionalLight3D", "directional_shadow_split_3"),
         ("ExternalTexture", "size"),
         ("FontFile", "font_name"),
         ("FontFile", "font_stretch"),
@@ -64,10 +58,6 @@ KNOWN_UNWRAPPABLE_PROPERTIES: frozenset[tuple[str, str]] = frozenset(
         ("FontFile", "font_weight"),
         ("FontFile", "style_name"),
         ("FontVariation", "opentype_features"),
-        ("FontVariation", "spacing_bottom"),
-        ("FontVariation", "spacing_glyph"),
-        ("FontVariation", "spacing_space"),
-        ("FontVariation", "spacing_top"),
         ("GradientTexture1D", "width"),
         ("GradientTexture2D", "height"),
         ("GradientTexture2D", "width"),
@@ -82,17 +72,11 @@ KNOWN_UNWRAPPABLE_PROPERTIES: frozenset[tuple[str, str]] = frozenset(
         ("NoiseTexture3D", "depth"),
         ("NoiseTexture3D", "height"),
         ("NoiseTexture3D", "width"),
-        ("OmniLight3D", "omni_attenuation"),
-        ("OmniLight3D", "omni_range"),
         ("PlaceholderMesh", "aabb"),
         ("PlaceholderTexture2D", "size"),
         ("PlaceholderTextureLayered", "layers"),
         ("PointLight2D", "height"),
         ("SplineIK3D", "setting_count"),
-        ("SpotLight3D", "spot_angle"),
-        ("SpotLight3D", "spot_angle_attenuation"),
-        ("SpotLight3D", "spot_attenuation"),
-        ("SpotLight3D", "spot_range"),
         ("SystemFont", "font_stretch"),
         ("SystemFont", "font_weight"),
         ("TwoBoneIK3D", "setting_count"),

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -2044,6 +2044,35 @@ def first_method(cls: ApiClass, name: str) -> ApiMethod | None:
     return methods[0] if methods else None
 
 
+def resolve_inherited_accessor(
+    cls: ApiClass,
+    name: str,
+    object_types: set[str],
+    wrapper_classes: set[str],
+    api_classes: dict[str, ApiClass],
+    api_dir: Path,
+) -> tuple[ApiClass, ApiMethod] | None:
+    """Find an indexed property's accessor on the nearest ancestor that both declares and emits it.
+
+    Godot redeclares indexed accessors on subclasses (SpotLight3D.spot_range -> Light3D.get_param).
+    The method lives on the ancestor, so a plain `getParam(idx)` call on the subclass resolves through
+    Kotlin inheritance. Returns the ancestor and its method only when the ancestor is a wrapper class
+    that actually emits the accessor (unsupported_reason clears it) — otherwise the inherited call
+    would not exist.
+    """
+    cursor = api_classes.get(cls.inherits) if cls.inherits else None
+    while cursor is not None:
+        method = first_method(cursor, name)
+        if method is not None:
+            if cursor.name not in wrapper_classes:
+                return None
+            if unsupported_reason(cursor.name, method, object_types, wrapper_classes, api_classes, api_dir) is not None:
+                return None
+            return cursor, method
+        cursor = api_classes.get(cursor.inherits) if cursor.inherits else None
+    return None
+
+
 def property_setter_type(
     class_name: str,
     setter_method: ApiMethod,
@@ -2091,10 +2120,7 @@ def render_property(
     setter = str(prop.get("setter") or "")
     if setter and setter not in emitted_methods and setter.startswith("_") and setter[1:] in emitted_methods:
         setter = setter[1:]
-    if not getter or getter not in emitted_methods:
-        return None
-    getter_method = first_method(cls, getter)
-    if getter_method is None:
+    if not getter:
         return None
     # Indexed properties (Godot idiom: albedo_texture -> get_texture(param)/set_texture(param, tex),
     # light_energy -> get_param/set_param, ...) carry an "index" bound as the accessor's first
@@ -2103,6 +2129,20 @@ def render_property(
     # Without an index a getter that takes arguments is not a property accessor we can express.
     prop_index = prop.get("index")
     has_index = isinstance(prop_index, int)
+
+    # Resolve the getter to (owner_class_name, method): a class-local emitted method, or — for an
+    # indexed property whose accessor is inherited (SpotLight3D.spot_range -> Light3D.get_param) —
+    # the nearest ancestor that emits it. `method_function_name(owner, ...)` yields the same call
+    # (getParam) that Kotlin inheritance resolves on the subclass.
+    getter_owner = cls.name
+    getter_method = first_method(cls, getter) if getter in emitted_methods else None
+    if getter_method is None and has_index:
+        inherited = resolve_inherited_accessor(cls, getter, object_types, wrapper_classes, api_classes, api_dir)
+        if inherited is not None:
+            owner_cls, getter_method = inherited
+            getter_owner = owner_cls.name
+    if getter_method is None:
+        return None
     if has_index:
         if len(getter_method.argument_types) != 1:
             return None
@@ -2128,7 +2168,7 @@ def render_property(
     # take no index.
     if has_index:
         index_kotlin = kotlin_parameter_type(
-            cls.name,
+            getter_owner,
             getter,
             getter_method.argument_names[0],
             getter_method.argument_metas[0],
@@ -2141,27 +2181,30 @@ def render_property(
     else:
         index_arg = ""
     value_slot = 1 if has_index else 0
-    getter_call = f"{method_function_name(cls.name, getter)}({index_arg})"
+    getter_call = f"{method_function_name(getter_owner, getter)}({index_arg})"
 
-    if setter and setter in emitted_methods:
-        setter_method = first_method(cls, setter)
+    # Resolve the setter the same way (local, or inherited for an indexed property).
+    setter_owner = cls.name
+    setter_method = first_method(cls, setter) if (setter and setter in emitted_methods) else None
+    if setter_method is None and setter and has_index:
+        inherited = resolve_inherited_accessor(cls, setter, object_types, wrapper_classes, api_classes, api_dir)
+        if inherited is not None:
+            owner_cls, setter_method = inherited
+            setter_owner = owner_cls.name
+    if setter_method is not None:
         # property_setter_type gates validity: it needs an argument at `value_slot` (so an indexed
         # setter must carry index+value), a void return, and defaults on every argument past the
         # value — which allows plain setters with trailing defaulted args (set_position(pos,
         # keep_offsets = false)) to stay writable.
-        setter_type = (
-            property_setter_type(
-                cls.name, setter_method, object_types, wrapper_classes, api_classes, value_slot
-            )
-            if setter_method is not None
-            else None
+        setter_type = property_setter_type(
+            setter_owner, setter_method, object_types, wrapper_classes, api_classes, value_slot
         )
         if setter_type != property_type:
-            setter = ""
+            setter_method = None
 
-    if setter and setter in emitted_methods:
+    if setter_method is not None:
         setter_args = f"{index_arg}, value" if has_index else "value"
-        setter_call = f"{method_function_name(cls.name, setter)}({setter_args})"
+        setter_call = f"{method_function_name(setter_owner, setter)}({setter_args})"
         return "\n".join(
             [
                 f"    var {property_name}: {property_type}",

--- a/src/main/kotlin/net/multigesture/kanama/api/AreaLight3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/AreaLight3D.kt
@@ -11,6 +11,18 @@ import net.multigesture.kanama.types.Vector2
  * Generated from Godot docs: AreaLight3D
  */
 class AreaLight3D(handle: MemorySegment) : Light3D(handle) {
+    var areaRange: Double
+        @JvmName("areaRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setAreaRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var areaAttenuation: Double
+        @JvmName("areaAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setAreaAttenuationProperty")
+        set(value) = setParam(6L, value)
+
     var areaNormalizeEnergy: Boolean
         @JvmName("areaNormalizeEnergyProperty")
         get() = isAreaNormalizingEnergy()

--- a/src/main/kotlin/net/multigesture/kanama/api/DirectionalLight3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/DirectionalLight3D.kt
@@ -16,11 +16,47 @@ class DirectionalLight3D(handle: MemorySegment) : Light3D(handle) {
         @JvmName("setDirectionalShadowModeProperty")
         set(value) = setShadowMode(value)
 
+    var directionalShadowSplit1: Double
+        @JvmName("directionalShadowSplit1Property")
+        get() = getParam(10L)
+        @JvmName("setDirectionalShadowSplit1Property")
+        set(value) = setParam(10L, value)
+
+    var directionalShadowSplit2: Double
+        @JvmName("directionalShadowSplit2Property")
+        get() = getParam(11L)
+        @JvmName("setDirectionalShadowSplit2Property")
+        set(value) = setParam(11L, value)
+
+    var directionalShadowSplit3: Double
+        @JvmName("directionalShadowSplit3Property")
+        get() = getParam(12L)
+        @JvmName("setDirectionalShadowSplit3Property")
+        set(value) = setParam(12L, value)
+
     var directionalShadowBlendSplits: Boolean
         @JvmName("directionalShadowBlendSplitsProperty")
         get() = isBlendSplitsEnabled()
         @JvmName("setDirectionalShadowBlendSplitsProperty")
         set(value) = setBlendSplits(value)
+
+    var directionalShadowFadeStart: Double
+        @JvmName("directionalShadowFadeStartProperty")
+        get() = getParam(13L)
+        @JvmName("setDirectionalShadowFadeStartProperty")
+        set(value) = setParam(13L, value)
+
+    var directionalShadowMaxDistance: Double
+        @JvmName("directionalShadowMaxDistanceProperty")
+        get() = getParam(9L)
+        @JvmName("setDirectionalShadowMaxDistanceProperty")
+        set(value) = setParam(9L, value)
+
+    var directionalShadowPancakeSize: Double
+        @JvmName("directionalShadowPancakeSizeProperty")
+        get() = getParam(16L)
+        @JvmName("setDirectionalShadowPancakeSizeProperty")
+        set(value) = setParam(16L, value)
 
     var skyMode: Long
         @JvmName("skyModeProperty")

--- a/src/main/kotlin/net/multigesture/kanama/api/FontVariation.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/FontVariation.kt
@@ -42,6 +42,30 @@ class FontVariation(handle: MemorySegment) : Font(handle) {
         @JvmName("setVariationTransformProperty")
         set(value) = setVariationTransform(value)
 
+    var spacingGlyph: Int
+        @JvmName("spacingGlyphProperty")
+        get() = getSpacing(0L)
+        @JvmName("setSpacingGlyphProperty")
+        set(value) = setSpacing(0L, value)
+
+    var spacingSpace: Int
+        @JvmName("spacingSpaceProperty")
+        get() = getSpacing(1L)
+        @JvmName("setSpacingSpaceProperty")
+        set(value) = setSpacing(1L, value)
+
+    var spacingTop: Int
+        @JvmName("spacingTopProperty")
+        get() = getSpacing(2L)
+        @JvmName("setSpacingTopProperty")
+        set(value) = setSpacing(2L, value)
+
+    var spacingBottom: Int
+        @JvmName("spacingBottomProperty")
+        get() = getSpacing(3L)
+        @JvmName("setSpacingBottomProperty")
+        set(value) = setSpacing(3L, value)
+
     var baselineOffset: Double
         @JvmName("baselineOffsetProperty")
         get() = getBaselineOffset()

--- a/src/main/kotlin/net/multigesture/kanama/api/OmniLight3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/OmniLight3D.kt
@@ -10,6 +10,18 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
  * Generated from Godot docs: OmniLight3D
  */
 class OmniLight3D(handle: MemorySegment) : Light3D(handle) {
+    var omniRange: Double
+        @JvmName("omniRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setOmniRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var omniAttenuation: Double
+        @JvmName("omniAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setOmniAttenuationProperty")
+        set(value) = setParam(6L, value)
+
     var omniShadowMode: Long
         @JvmName("omniShadowModeProperty")
         get() = getShadowMode()

--- a/src/main/kotlin/net/multigesture/kanama/api/SpotLight3D.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/SpotLight3D.kt
@@ -1,6 +1,7 @@
 package net.multigesture.kanama.api
 
 import java.lang.foreign.MemorySegment
+import kotlin.jvm.JvmName
 import net.multigesture.kanama.binding.runtime.ObjectCalls
 
 /**
@@ -9,6 +10,30 @@ import net.multigesture.kanama.binding.runtime.ObjectCalls
  * Generated from Godot docs: SpotLight3D
  */
 class SpotLight3D(handle: MemorySegment) : Light3D(handle) {
+    var spotRange: Double
+        @JvmName("spotRangeProperty")
+        get() = getParam(4L)
+        @JvmName("setSpotRangeProperty")
+        set(value) = setParam(4L, value)
+
+    var spotAttenuation: Double
+        @JvmName("spotAttenuationProperty")
+        get() = getParam(6L)
+        @JvmName("setSpotAttenuationProperty")
+        set(value) = setParam(6L, value)
+
+    var spotAngle: Double
+        @JvmName("spotAngleProperty")
+        get() = getParam(7L)
+        @JvmName("setSpotAngleProperty")
+        set(value) = setParam(7L, value)
+
+    var spotAngleAttenuation: Double
+        @JvmName("spotAngleAttenuationProperty")
+        get() = getParam(8L)
+        @JvmName("setSpotAngleAttenuationProperty")
+        set(value) = setParam(8L, value)
+
     // No conservative instance methods emitted yet.
 
     companion object {


### PR DESCRIPTION
Stacked on #88.

## What

Indexed properties whose accessor is redeclared on a subclass but *implemented on a parent* were still dropped — the generator only looked for the getter/setter on the class itself. This recovers:

- `SpotLight3D.spot_range` / `spot_attenuation` / `spot_angle` / `spot_angle_attenuation`
- `OmniLight3D.omni_range` / `omni_attenuation`
- `AreaLight3D.area_range` / `area_attenuation`
- `DirectionalLight3D.directional_shadow_*` (6)
- `FontVariation.spacing_*` (4)

…18 properties in total, all via inherited `get_param`/`set_param`/`get_spacing`.

## How

`render_property` now resolves an indexed property's getter and setter from the nearest ancestor that declares **and emits** them (`resolve_inherited_accessor`). The emitted call — `getParam(4L)` / `setParam(4L, value)` — resolves on the subclass through Kotlin inheritance, so no per-class method binds are added. Non-indexed and class-local properties produce identical output (unchanged).

Re-adopted 5 desktop + 5 iOS wrappers and removed the 18 now-covered entries from `KNOWN_UNWRAPPABLE_PROPERTIES` (57 → 39). The coverage gate flagged those entries as stale first — demonstrating its self-cleaning teeth.

## Validation
- ✅ JVM compile; wrapper drift gate; `sync_kdoc --check`; full Python audit suite; property-coverage gate; generator-report doc regenerated
- ⏳ iOS Xcode / native bootstrap: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)