### PR TITLE
Release 0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ release shape.
 
 ## Current Baseline
 
-- Kanama release line: `0.3.0` (tagged 2026-07-16; a pre-1.0 preview baseline).
+- Kanama release line: `0.4.0` (tagged 2026-07-24; a pre-1.0 preview baseline).
 - Godot baseline: Godot `4.7 stable` (re-pin only on stable releases; bumps
   follow `docs/contributing/godot-upgrade.md`).
 - Desktop runtime/build JDK: JDK `25+`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable user-facing changes will be recorded here.
 This project uses a Keep a Changelog-style format and follows semantic
 versioning once public releases begin.
 
-## Unreleased
+## 0.4.0 - 2026-07-24
 
 ### Added
 
@@ -90,16 +90,10 @@ versioning once public releases begin.
 - Migrated off deprecated 4.7 GDExtension functions and converged the JVM and iOS
   backends on the same entry points: `classdb_construct_object3` (was
   `construct_object2` on desktop/Android) and `get_godot_version2` (was
-  `get_godot_version`). A resource from an `X.create()` factory (e.g.
-  `PackedScene.create()`) holds only Godot's construction placeholder reference;
-  `save` decodes its `Ref<Resource>` argument into a transient reference and
-  releases it on return, which dropped that placeholder to zero and freed the
-  object while the Kotlin wrapper still pointed at it — the `.tscn` was written
-  correctly, then the process segfaulted. `save` now holds a protective
-  reference across the call and keeps it only if the resource still has another
-  holder, so the wrapper stays valid (and, for a just-created resource, becomes
-  owned — `close()` frees it). Resources already owned or held by the scene tree
-  are unaffected. Desktop, Android, and iOS.
+  `get_godot_version`). This is what makes a freshly created resource owned at
+  construction (see the `X.create()` fix above), which is why the earlier
+  issue-#81 `ResourceSaver.save` protective-reference guard could be removed —
+  `save` needs no special-casing now.
 - A throwing `@ScriptProperty` accessor no longer aborts the process. Generated
   property get/set dispatch ran inside an FFM upcall stub with no exception guard
   (unlike method calls), so any `Throwable` escaping a user getter/setter unwound

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img alt="JDK 25+" src="https://img.shields.io/badge/JDK-25%2B-f89820.svg">
   <img alt="Android: supported" src="https://img.shields.io/badge/Android-supported-3ddc84.svg">
   <img alt="iOS: supported" src="https://img.shields.io/badge/iOS-supported-000000.svg">
-  <img alt="Status: 0.3.0 preview" src="https://img.shields.io/badge/status-0.3.0_preview-478cbf.svg">
+  <img alt="Status: 0.4.0 preview" src="https://img.shields.io/badge/status-0.4.0_preview-478cbf.svg">
 </p>
 
 Kanama lets Kotlin scripts attach to Godot nodes through a GDExtension runtime.
@@ -26,14 +26,14 @@ the JVM ecosystem.
 
 ## Related Projects
 
-Kanama is a preview-stage (`0.3.0`) project using a Panama/FFM-based GDExtension
+Kanama is a preview-stage (`0.4.0`) project using a Panama/FFM-based GDExtension
 architecture. If you want a more established Kotlin integration for Godot today, also
 evaluate [Godot Kotlin/JVM](https://godot-kotl.in/en/stable/). It is a
 separate project with a different runtime and export model.
 
 ## Status
 
-Kanama is desktop-first. The `0.3.0` preview baseline is
+Kanama is desktop-first. The `0.4.0` preview baseline is
 Godot 4.7 stable. macOS arm64, Windows x86_64, and Linux x86_64/arm64 are
 **supported** on 4.7 stable. Use the
 [Godot 4.7 stable archive](https://godotengine.org/download/archive/4.7-stable/)
@@ -42,7 +42,7 @@ release kits and store add-ons are package artifacts that can be built from
 source today and are the intended release path; exported-game packaging remains
 a separate release-readiness track.
 
-Android is **Supported** on 4.7 stable for the v0.3.0 line: the workflow builds a
+Android is **Supported** on 4.7 stable for the v0.4.0 line: the workflow builds a
 Godot Android plugin AAR and uses
 [PanamaPort](https://github.com/vova7878/PanamaPort) for the Android FFM layer.
 Device-validated across four models (Pixel 7 / Moto g 5G 2023 / Galaxy S10+ /
@@ -72,7 +72,7 @@ source-checkout export (no packaged addon), and a two-demo corpus. See the
 [Web Internals](docs/contributing/web-internals.md) for the architecture.
 
 See [Version Support](docs/reference/version-support.md) for the current test matrix and
-the `0.3.0` public preview criteria.
+the `0.4.0` public preview criteria.
 
 ## Highlights
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 group = "net.multigesture.kanama"
 
-version = "0.3.0"
+version = "0.4.0"
 
 val packageMavenRepositoryDir = layout.buildDirectory.dir("package/maven")
 val panamaPortCoreDependency =

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -1,6 +1,6 @@
 # Version Support
 
-Kanama `0.3.0` is the current public release (a pre-1.0 preview baseline). This
+Kanama `0.4.0` is the current public release (a pre-1.0 preview baseline). This
 page records the platforms and engine versions validated for it.
 
 ## Current Support Claims
@@ -44,7 +44,7 @@ TPS, package, and native-artifact gates against Godot 4.7 stable (x86_64 on
 
 ## Kanama Version
 
-The current Gradle artifact version is `0.3.0`.
+The current Gradle artifact version is `0.4.0`.
 
 Release version changes should be paired with matching Gradle coordinates, docs
 snippets, demo project versions, badges, changelog headings, and a passing

--- a/project-scripts/build.gradle.kts
+++ b/project-scripts/build.gradle.kts
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.gradle.KspAATask
 import java.security.MessageDigest
 
 group = "net.multigesture.kanama"
-version = "0.3.0"
+version = "0.4.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Cut **0.4.0** (minor — the accumulated work since 0.3.0 includes a source-breaking change + a new feature, so not a patch).

## Contents (from the CHANGELOG Unreleased → 0.4.0)
- **Added:** Web backend → Experimental (Kotlin/Wasm preview); `newScriptInstance<T>()`.
- **Changed:** source-breaking non-null `meta:"required"` object params; `Resource` extends `RefCounted`; self-announcing `local_ci` failures.
- **Fixed:** #91 (`create()`'d resource freed by `close()` after hand-off) via `construct_object3` — subsumes #81; deprecated 4.7 GDExtension APIs migrated (`construct_object3`, `get_godot_version2`); `@ScriptProperty` accessor containment; `Node.setOwner(null)`; more.

## Release-prep in this PR
- `build.gradle.kts` version 0.3.0 → 0.4.0; CHANGELOG retitled (+ reconciled the stale #81 save-guard prose); README, `version-support.md`, AGENTS release line, `project-scripts` bumped.

## Pre-release gates
`mkdocs --strict` ✓ · `packageDistributions` ✓ (v0.4.0 kits) · `package_install_smoke` ✓ · `fresh_clone_smoke` (re-running after demos PRs #8/#9 landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)