### PR TITLE
Decide, document, and test the Web RefCounted ownership model (Task 60a)

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -138,6 +138,50 @@ tables are owned per script/owner and released at owner, direct, and full
 teardown. The validated runs return every owned registry to baseline after both
 gameplay and full scene teardown; stale handle use after teardown fails.
 
+### RefCounted resource ownership (create/close on the handle bridge)
+
+The user-facing contract is the **same** as the pointer backends —
+[*close what you create*](../game-dev/properties-resources.md): a factory
+(`X.create()`) or a temporary load hands back an owning handle, you hand the value
+to the engine, then release your handle with `use { }`/`close()`; the engine keeps
+its own reference so the object lives on. The **implementation is different**, and
+that difference is the answer 60a owed for this backend (issue #91 was an
+FFI-backend bug and its fix does not apply here):
+
+- **Pointer backends** (desktop/Android/iOS) construct via
+  `classdb_construct_object3` (an already-owning object) and `close()` `ptrcall`s
+  `RefCounted.unreference()` to drop the caller's reference.
+- **Web holds no pointers and makes no `ptrcall`.** The real Godot object lives
+  engine-side and **GDScript refcounts it**; the bridge only carries an opaque
+  handle ID interned in the owning script's object table. So the Web model is
+  **"drop the handle = release the reference"**: `close()` (e.g.
+  `Texture2D.close()` → `releaseWebResource`) emits a release-handle bridge command
+  that runs the generated GDScript `_kanama_resource_release`, which *erases the
+  handle from that script's `_kanama_object_handles`* — dropping GDScript's
+  reference. If nothing else holds the object, its engine-side refcount reaches
+  zero and Godot frees it; if the caller already handed it to a node/resource, the
+  engine's own reference keeps it alive.
+
+**There is no `init_ref` claim to get wrong** (the #91 root cause) because the
+bridge never constructs the native object itself — it asks GDScript to, and
+GDScript's return value is already a live, refcounted reference. **The
+created-then-handed-off-then-closed case survives** for the same reason it must on
+the pointer backends: the handoff (e.g. `AudioStreamPlayer.setStream`) is applied
+**before** the temporary handle is released, so the engine takes its reference
+first. `AudioStreamPlayer.setStreamFromPath` is the canonical example —
+`load → setStream(player) → finally { releaseWebResource(temp) }` — and it is
+covered by an explicit **bridge-level ownership assertion** in the Match3 export
+smoke (`scripts/web/drivers/demos/match3.mjs`): the stream resources are loaded
+and handed off with zero failures, they play (survived their temp release), and
+every resource handle returns to baseline at teardown (no leak).
+
+Practical consequence for generated wrappers: a Web `X.create()` proxy returns an
+**owning** handle and `close()` is a real "release this reference" command — the
+bridge does **not** silently GC handles behind your back, so *the same
+`use { }`/`close()` discipline the docs teach applies on Web*, and forgetting it
+leaks the same way (until the owning script tears down and its whole object table
+is released).
+
 ## Validation Fixtures
 
 The current fixtures are per-browser driver scripts plus machine-readable JSON

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -280,6 +280,13 @@ you never close leaks its reference — and Godot prints `Leaked instance: <Clas
 at exit in editor/debug runs, which is your signal that a `use { }`/`close()` is
 missing.
 
+The **Web (Kotlin/Wasm)** backend reaches Godot over a JavaScript *handle bridge*
+rather than an FFI pointer boundary, but the rule is identical: `close()`/`use { }`
+emits a release-handle command that drops the engine-side reference, and the bridge
+does not GC handles for you either — so the same code, unchanged, is correct on
+Web. Only the mechanism differs; see
+[Web internals → RefCounted resource ownership](../contributing/web-internals.md).
+
 For more detail, see [Calling Godot APIs](godot-api.md#resource-ownership).
 
 ## Resource Slots

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -47,6 +47,8 @@ async function snapshot(evaluate) {
       positionTweenTargets: bridge.match3PositionTweenTargets,
       playCommands: bridge.match3AudioPlayCommands,
       playersConstructed: bridge.match3AudioPlayersConstructed,
+      audioResourceLoads: bridge.match3AudioResourceLoads,
+      audioResourceLoadFailures: bridge.match3AudioResourceLoadFailures,
       sceneTreeHandles: [...bridge.sceneTreeHandlesByOwner.entries()],
       sceneTreeHandlesCreated: bridge.match3SceneTreeHandlesCreated,
       sceneTreeHandleReuses: bridge.match3SceneTreeHandleReuses,
@@ -237,6 +239,16 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
       packedDelta === tileReadyDelta + particleReadyDelta && addDelta === packedDelta &&
       positionTweenDelta >= tileReadyDelta + 2 && afterSwap.tileGrid.length === 64,
     audiovisualFeedback: afterSwap.playCommands > beforeSwap.playCommands && particleReadyDelta > 0,
+    // Bridge-level RefCounted ownership (Task 60a): Match3 audio loads a stream via
+    // ResourceLoader (setStreamFromPath), hands it to a player, then releases the temp
+    // wrapper. Ownership holds iff every load-and-handoff succeeded (the handed-off
+    // resource survived its temp release), the streams actually played, and no resource
+    // handle leaked at teardown.
+    resourceOwnershipHandoffSurvives:
+      afterSwap.audioResourceLoads > 0 &&
+      afterSwap.audioResourceLoadFailures === 0 &&
+      afterSwap.playCommands > beforeSwap.playCommands &&
+      secondTeardown.afterAudio.liveHandles === 0,
     boundedAfterGameplay:
       afterSwap.liveHandles === beforeSwap.liveHandles && afterSwap.callbacks === 12 &&
       afterSwap.pending === 0 && afterSwap.jobs === 0,


### PR DESCRIPTION
Closes the 60a required-work bullet + exit-gate checkbox: the Web bridge's RefCounted `create()`/`close()` ownership model is now **decided, documented, and covered by a bridge-level test**.

## Why it wasn't covered by the #91 fix
Issue #91 was an FFI-backend bug — desktop/Android's `classdb_construct_object2` returned an *unclaimed placeholder* needing a manual `init_ref` claim — and the 0.4.0 fix (migrate to `construct_object3`, matching iOS) is pure native-pointer machinery. **The Web bridge holds opaque handle IDs and makes no `ptrcall`**, so none of that applies; the real object lives engine-side and GDScript refcounts it. 60a owed a Web-specific answer.

## Decision
**Web is "drop the handle = release the reference."** `close()` (e.g. `Texture2D.close()` → `releaseWebResource`) emits a release-handle command that runs the generated GDScript `_kanama_resource_release`, erasing the handle from the owning script's object table so GDScript drops its reference. A created-then-handed-off resource **survives** because the handoff (e.g. `AudioStreamPlayer.setStream`) is applied *before* the temp is released, so the engine takes its reference first. There is **no `init_ref` to get wrong**. The user-facing "close what you create" contract is unchanged — only the mechanism differs.

## Changes
- `docs/contributing/web-internals.md` — new **RefCounted resource ownership** section.
- `docs/game-dev/properties-resources.md` — note that the same `use{}`/`close()` discipline holds on Web via handle release (not `unreference()`).
- `scripts/web/drivers/demos/match3.mjs` — explicit **`resourceOwnershipHandoffSurvives`** assertion: audio streams load + hand off with zero failures, play (survived their temp release), and every resource handle returns to baseline at teardown.

## Verification
`mkdocs --strict`, `node --check`, and a real **Match3 Chrome export smoke**: `resourceOwnershipHandoffSurvives=true`, **11/11 assertions**, schema v1, protocol 6.

Self-contained (docs + one driver assertion) off 0.4.0 main; independent of the in-flight 60b work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)