### PR TITLE
chore: pre-push ktfmt hook to catch unformatted Kotlin before CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Kanama pre-push hook — reject pushes containing unformatted Kotlin, the same check
+# CI's local-ci gate runs (scripts/local_ci.sh -> ktfmtCheck). Catches it in ~seconds
+# locally instead of burning a CI round-trip.
+#
+# Install once per clone:  scripts/install-git-hooks.sh
+set -euo pipefail
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+echo "[pre-push] ktfmtCheck (matches CI)…"
+if ! "$ROOT_DIR/gradlew" -q -p "$ROOT_DIR" ktfmtCheck; then
+  echo "" >&2
+  echo "[pre-push] BLOCKED: Kotlin is not ktfmt-formatted." >&2
+  echo "  Fix all modules at once with:  ./gradlew ktfmtFormat" >&2
+  echo "  then re-commit and push again. (Bypass in emergencies: git push --no-verify)" >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,18 @@ your changes before pushing:
 ```
 
 `local_ci.sh` runs `ktfmtCheck` as a gate stage, so an unformatted change fails
-CI. Two things are deliberately **not** formatted:
+CI. To catch that locally in seconds instead of a CI round-trip, install the
+pre-push hook once per clone:
+
+```sh
+scripts/install-git-hooks.sh   # points core.hooksPath at .githooks
+```
+
+The `.githooks/pre-push` hook runs `ktfmtCheck` before every push and refuses
+unformatted Kotlin (it never rewrites files; run `./gradlew ktfmtFormat` yourself,
+or `git push --no-verify` to bypass in an emergency).
+
+Two things are deliberately **not** formatted:
 
 - Generated Godot API wrappers under `**/net/multigesture/kanama/api/**` — they
   are byte-compared against `scripts/generate_api_wrapper.py` by the drift gate,

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# One-time setup: point this clone's git hooks at the version-controlled .githooks dir.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+git -C "$ROOT_DIR" config core.hooksPath .githooks
+echo "Installed: core.hooksPath -> .githooks"
+echo "  pre-push now runs ./gradlew ktfmtCheck (blocks unformatted Kotlin, the CI gate)."


### PR DESCRIPTION
Follow-up to #96 (unformatted Kotlin only local-ci's ktfmtCheck caught, costing a round-trip). Adds a version-controlled pre-push hook running the same `./gradlew ktfmtCheck` locally: `.githooks/pre-push` (refuses unformatted Kotlin, never rewrites; `./gradlew ktfmtFormat` to fix, `git push --no-verify` to bypass), `scripts/install-git-hooks.sh` (sets core.hooksPath), and a CONTRIBUTING.md note. Dogfooded on this branch's own push. Opt-in per clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)