### PR TITLE
Task 60d: the Starter-Kit-3D-Platformer is playable on the Web backend

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -61,6 +61,8 @@ enum class GodotCallShape {
   LONG_DOUBLE_ARG,
   NOARGS_RET_STRING_SINGLETON,
   STRINGNAME_ARG_SINGLETON,
+  STRINGNAME_DOUBLE_ARG,
+  STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON,
 }
 
 @InternalKanamaBackendApi
@@ -434,6 +436,26 @@ interface GodotBackendSpi {
     callSite: GodotCallSite,
     value: String,
   ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  fun invokeStringNameDoubleArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+    doubleValue: Double,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Singleton two-StringName → Double query (no receiver): e.g. Input.get_axis. */
+  fun invokeStringNameStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    first: String,
+    second: String,
+  ): Double {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -989,6 +1011,40 @@ object GodotBackendCalls {
     requireShape(descriptor, GodotCallShape.STRINGNAME_ARG_SINGLETON)
     val selected = requireBackend()
     selected.invokeStringNameArgSingleton(descriptor, resolve(selected, descriptor), value)
+  }
+
+  fun invokeStringNameDoubleArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: String,
+    doubleValue: Double,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_DOUBLE_ARG)
+    require(doubleValue.isFinite())
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeStringNameDoubleArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+      doubleValue,
+    )
+  }
+
+  fun invokeStringNameStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    first: String,
+    second: String,
+  ): Double {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON)
+    val selected = requireBackend()
+    return selected.invokeStringNameStringNameRetDoubleSingleton(
+      descriptor,
+      resolve(selected, descriptor),
+      first,
+      second,
+    )
   }
 
   private fun resolve(selected: GodotBackendSpi, descriptor: GodotCallDescriptor): GodotCallSite {

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -1125,4 +1125,26 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.SNAPSHOT_READ,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val ANIMATIONPLAYER_PLAY =
+    GodotCallDescriptor(
+      opcode = 103,
+      className = "AnimationPlayer",
+      methodName = "play",
+      hash = 3118260607L,
+      shape = GodotCallShape.STRINGNAME_DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_GET_AXIS =
+    GodotCallDescriptor(
+      opcode = 104,
+      className = "Input",
+      methodName = "get_axis",
+      hash = 1958752504L,
+      shape = GodotCallShape.STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -1147,4 +1147,15 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val OBJECT_CALL =
+    GodotCallDescriptor(
+      opcode = 105,
+      className = "Object",
+      methodName = "call",
+      hash = 3400424181L,
+      shape = GodotCallShape.STRINGNAME_STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -233,6 +233,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendObjectPropertySetter()
     appendObjectArrayPropertySetter()
     appendLongMethodDispatcher()
+    appendLongVoidMethodDispatcher()
     appendVector2iMethodDispatcher()
     appendObjectMethodDispatcher()
     appendObjectObjectLongMethodDispatcher()
@@ -456,6 +457,33 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
     appendLine("      else -> unknown(\"script\", scriptId)")
     appendLine("    }")
+    appendLine()
+  }
+
+  private fun StringBuilder.appendLongVoidMethodDispatcher() {
+    appendLine(
+      "  fun callLongVoid(scriptId: Int, methodId: Int, script: KanamaWebScript, value: Long) {"
+    )
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (methodId) {")
+      input.model.methods.forEachIndexed { methodIndex, method ->
+        if (
+          method.returnType == null &&
+            method.args.size == 1 &&
+            method.args.single().type == TypeMapping.INT
+        ) {
+          appendLine(
+            "        ${methodIndex + 1} -> (script as ${input.model.simpleName}).${method.kotlinName}(value)"
+          )
+        }
+      }
+      appendLine("        else -> unknown(\"method\", methodId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine("  }")
     appendLine()
   }
 
@@ -1254,6 +1282,16 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 105 and target_object != null:")
+    appendLine(
+      "\t\t\tvar call_method := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\t\t\tvar call_arg := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 12)))"
+    )
+    appendLine("\t\t\ttarget_object.call(StringName(call_method), call_arg)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
     appendLine("\t\telif opcode == 103 and target_object is AnimationPlayer:")
     appendLine("\t\t\tvar anim_id := bytes.decode_s32(offset + 8)")
     appendLine("\t\t\tvar anim_name := String(_kanama_bridge.resolveCommandStringName(anim_id))")
@@ -1644,19 +1682,34 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         }
         method.returnType == null &&
           method.args.size == 1 &&
+          method.args.single().type == TypeMapping.INT -> {
+          val arg = method.args.single()
+          appendLine("\t_kanama_bridge.callLongVoid(_kanama_handle, ${index + 1}, ${arg.name})")
+        }
+        method.returnType == null &&
+          method.args.size == 1 &&
           method.args.single().type == TypeMapping.OBJECT &&
           method.args.single().objectWrapperFqName != null -> {
           // Registered function taking a single Godot object (e.g. a body_entered signal
-          // handler): register the node under a transient handle so the Kotlin side can
-          // reconstruct its wrapper, invoke, then release it.
+          // handler). A Kanama-scripted node is passed as its SCRIPT handle (mirrors node
+          // lookup) so the Kotlin side can resolve kotlinScriptInstance on it; anything else
+          // rides a transient handle registered for the call, then released.
           val arg = method.args.single()
+          appendLine("\tvar script_arg_handle := 0")
+          appendLine("\tif ${arg.name}.has_method(\"_kanama_ensure_created\"):")
+          appendLine("\t\tscript_arg_handle = int(${arg.name}.call(\"_kanama_ensure_created\"))")
+          appendLine("\tif script_arg_handle != 0:")
           appendLine(
-            "\tvar arg_handle := int(_kanama_bridge.allocateTransientObjectHandle(_kanama_handle))"
+            "\t\t_kanama_bridge.callObject(_kanama_handle, ${index + 1}, script_arg_handle)"
           )
-          appendLine("\t_kanama_object_handles[arg_handle] = ${arg.name}")
-          appendLine("\t_kanama_bridge.callObject(_kanama_handle, ${index + 1}, arg_handle)")
-          appendLine("\t_kanama_object_handles.erase(arg_handle)")
-          appendLine("\t_kanama_bridge.releaseTransientObjectHandle(arg_handle)")
+          appendLine("\telse:")
+          appendLine(
+            "\t\tvar arg_handle := int(_kanama_bridge.allocateTransientObjectHandle(_kanama_handle))"
+          )
+          appendLine("\t\t_kanama_object_handles[arg_handle] = ${arg.name}")
+          appendLine("\t\t_kanama_bridge.callObject(_kanama_handle, ${index + 1}, arg_handle)")
+          appendLine("\t\t_kanama_object_handles.erase(arg_handle)")
+          appendLine("\t\t_kanama_bridge.releaseTransientObjectHandle(arg_handle)")
         }
         method.returnType == null &&
           method.args.size == 3 &&

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -873,6 +873,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine()
       appendLine("func _physics_process(delta: float) -> void:")
       appendLine("\tif _kanama_handle != 0:")
+      if (model.attachTo == "CharacterBody3D") {
+        // Post-slide velocity refresh: the script reads self.velocity each tick, and after
+        // move_and_slide the engine's velocity differs from the last written value.
+        appendLine("\t\tvar body: CharacterBody3D = self")
+        appendLine(
+          "\t\t_kanama_bridge.refreshVelocitySnapshot(_kanama_handle, body.velocity.x, body.velocity.y, body.velocity.z)"
+        )
+      }
       appendLine("\t\t_kanama_bridge.physicsFrame(_kanama_handle, delta)")
     }
     if (model.virtuals.any { it.virtualName == "_input" }) {
@@ -1246,6 +1254,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 103 and target_object is AnimationPlayer:")
+    appendLine("\t\t\tvar anim_id := bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tvar anim_name := String(_kanama_bridge.resolveCommandStringName(anim_id))")
+    appendLine(
+      "\t\t\t(target_object as AnimationPlayer).play(StringName(anim_name), bytes.decode_double(offset + 12))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
     appendLine("\t\telse:")
     appendLine(
       "\t\t\tpush_error(\"Invalid Kanama Web command opcode/object: %d/%d\" % [opcode, object_handle])"
@@ -1334,6 +1350,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine(
       "\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, node_2d.position.x, node_2d.position.y, node_2d.scale.x, node_2d.scale.y, node_2d.modulate.r, node_2d.modulate.g, node_2d.modulate.b, node_2d.modulate.a, node_2d.rotation)"
     )
+    appendLine("\tif value is Node3D:")
+    appendLine("\t\tvar node_3d := value as Node3D")
+    appendLine(
+      "\t\t_kanama_bridge.refreshNode3DSnapshot(result_handle, node_3d.position.x, node_3d.position.y, node_3d.position.z, node_3d.rotation.x, node_3d.rotation.y, node_3d.rotation.z, node_3d.scale.x, node_3d.scale.y, node_3d.scale.z)"
+    )
     appendLine("\t_kanama_bridge.recordImmediateObjectHandle(result_handle)")
     appendLine("\treturn result_handle")
     appendLine()
@@ -1357,6 +1378,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvar node_2d := value as Node2D")
     appendLine(
       "\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, node_2d.position.x, node_2d.position.y, node_2d.scale.x, node_2d.scale.y, node_2d.modulate.r, node_2d.modulate.g, node_2d.modulate.b, node_2d.modulate.a, node_2d.rotation)"
+    )
+    appendLine("\tif value is Node3D:")
+    appendLine("\t\tvar node_3d := value as Node3D")
+    appendLine(
+      "\t\t_kanama_bridge.refreshNode3DSnapshot(result_handle, node_3d.position.x, node_3d.position.y, node_3d.position.z, node_3d.rotation.x, node_3d.rotation.y, node_3d.rotation.z, node_3d.scale.x, node_3d.scale.y, node_3d.scale.z)"
     )
     appendLine("\t_kanama_bridge.recordImmediateObjectHandle(result_handle)")
     appendLine("\treturn result_handle")
@@ -1532,6 +1558,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int((value as Node).is_in_group(StringName(String(args[2]))))")
     appendLine("\t\telif opcode == 100 and value is SceneTree:")
     appendLine("\t\t\tresult = int((value as SceneTree).reload_current_scene())")
+    appendLine("\t\telif opcode == 104:")
+    appendLine("\t\t\tvar axis_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tresult = int(round(Input.get_axis(StringName(axis_parts[0]), StringName(axis_parts[1])) * 1000.0))"
+    )
     appendLine("\t\telif opcode == 83:")
     appendLine("\t\t\tresult = int(OS.has_feature(String(args[2])))")
     appendLine("\t\telif opcode == 86:")

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -144,6 +144,8 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     100: {},
     101: {"vec3_slot": _ROTATION_DEGREES3},
     102: {"vec3_slot": _ROTATION_DEGREES3},
+    103: {},
+    104: {},
 }
 
 
@@ -353,6 +355,28 @@ def body_NOARGS_RET_VECTOR3(calls):
         ")",
     ]
     return lines
+
+
+def body_STRINGNAME_DOUBLE_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_QUEUED})",
+        f"require({_opcode_guard(calls)})",
+        "require(doubleValue.isFinite())",
+        "commands.appendStringNameDoubleMutation("
+        "descriptor.opcode, receiver.webId(), value, doubleValue)",
+    ]
+
+
+def body_STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Two action names are packed into one query string (unit separator) and the axis is",
+        "// returned scaled by 1000 through the shared object-query transport.",
+        'return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), '
+        'first + "\\u001f" + second) / 1000.0',
+    ]
 
 
 def body_STRINGNAME_ARG_SINGLETON(calls):
@@ -873,6 +897,11 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
     ),
     "NOARGS_RET_STRING_SINGLETON": ([], "String"),
     "STRINGNAME_ARG_SINGLETON": (["value: String"], ""),
+    "STRINGNAME_DOUBLE_ARG": (
+        ["receiver: GodotHandle", "value: String", "doubleValue: Double"],
+        "",
+    ),
+    "STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON": (["first: String", "second: String"], "Double"),
     "NOARGS_RET_RECT2": (["receiver: GodotHandle"], "GodotRect2"),
     "NOARGS_VOID": (["receiver: GodotHandle"], ""),
     "TEXTURE2D_VECTOR2_COLOR_ARGS": (
@@ -1060,6 +1089,8 @@ EMIT_ORDER = [
     "LONG_DOUBLE_ARG",
     "NOARGS_RET_STRING_SINGLETON",
     "STRINGNAME_ARG_SINGLETON",
+    "STRINGNAME_DOUBLE_ARG",
+    "STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON",
 ]
 
 

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -146,6 +146,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     102: {"vec3_slot": _ROTATION_DEGREES3},
     103: {},
     104: {},
+    105: {},
 }
 
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -1593,6 +1593,26 @@
       "returnOwnership": "BORROWED",
       "semantics": "Read a -1..1 input axis (negative/positive actions) via the active script proxy singleton (character/camera movement).",
       "introducedBy": "60d-input"
+    },
+    {
+      "opcode": 105,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "call",
+      "hash": 3400424181,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "isVararg": true,
+      "typedVarargTail": [
+        "String"
+      ],
+      "semantics": "Queue a dynamic one-String-argument method call (the platformer's native GDScript Audio autoload play(path)); the Variant return is discarded.",
+      "introducedBy": "60d-audio"
     }
   ],
   "compositions": [

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -1557,6 +1557,42 @@
       "returnOwnership": "BORROWED",
       "semantics": "Read Node3D rotation_degrees from the Web snapshot (camera view).",
       "introducedBy": "60d-platformer"
+    },
+    {
+      "opcode": 103,
+      "scope": "class",
+      "className": "AnimationPlayer",
+      "methodName": "play",
+      "hash": 3118260607,
+      "arguments": [
+        "StringName",
+        "float",
+        "float",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Play a named animation with a custom blend (custom_speed/from_end baked to Godot defaults in the proxy).",
+      "introducedBy": "60d-animation"
+    },
+    {
+      "opcode": 104,
+      "scope": "class",
+      "className": "Input",
+      "methodName": "get_axis",
+      "hash": 1958752504,
+      "arguments": [
+        "StringName",
+        "StringName"
+      ],
+      "returnType": "float",
+      "shape": "STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read a -1..1 input axis (negative/positive actions) via the active script proxy singleton (character/camera movement).",
+      "introducedBy": "60d-input"
     }
   ],
   "compositions": [

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1137,10 +1137,22 @@ tasks.register("stageWebPlatformerProject") {
             .files
             .forEach { stagedFile ->
                 val original = stagedFile.readText()
-                val rewritten =
+                var rewritten =
                     mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
                         text.replace(sourcePath, proxyPath)
                     }
+                // Godot resolves Script ext_resources by UID before path; a rewritten reference
+                // whose original .gd (and its UID) still exists in the staged tree would silently
+                // load the ORIGINAL script instead of the generated proxy. Strip the UID from
+                // rewritten references so the text path wins.
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
                 if (rewritten != original) stagedFile.writeText(rewritten)
                 check(!rewritten.contains("res://kotlin-src/")) {
                     "Unmapped Kotlin attachment remains in staged file: $stagedFile"
@@ -1399,6 +1411,10 @@ tasks.register<Exec>("exportWeb") {
     inputs.property("kanamaWebDemo", webDemo)
     inputs.dir(webDistribution)
     inputs.dir(webSpikeAssets)
+    // The staged project is what Godot actually exports; without it as an input a
+    // proxy/staging-only change (e.g. a regenerated GDScript applier) leaves exportWeb UP-TO-DATE
+    // and ships a stale export.
+    inputs.dir(webDemo.map(::stagingDirFor))
     outputs.dir(webExportRoot)
 
     doFirst {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebDodgeApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebDodgeApi.kt
@@ -73,10 +73,7 @@ class CollisionShape2D(godotObject: GodotHandle) : Node2D(godotObject) {
   fun setDisabled(disabled: Boolean) {
     CollisionShape2DBackendContractProbe(backendHandle).setDisabled(disabled)
   }
-
-  fun setDeferred(property: String, value: Boolean) {
-    CollisionShape2DBackendContractProbe(backendHandle).setDeferredBool(property, value)
-  }
+  // set_deferred rides the inherited Node.setDeferred (same Object.set_deferred opcode).
 }
 
 class Timer(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -3,6 +3,8 @@
 package net.multigesture.kanama.api
 
 import net.multigesture.kanama.backend.GDBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors
 import net.multigesture.kanama.backend.ClassDBBackendContractProbe
 import net.multigesture.kanama.backend.CanvasItemInputBackendContractProbe
 import net.multigesture.kanama.backend.CanvasItemBackendContractProbe
@@ -50,6 +52,10 @@ open class GodotObject internal constructor(internal val backendHandle: BackendG
     }
     if (args.size == 1 && args[0] is Int) {
       Node2DBackendContractProbe(backendHandle).emitSignal(signal, args[0] as Int)
+      return
+    }
+    if (args.size == 1 && args[0] is Long) {
+      Node2DBackendContractProbe(backendHandle).emitSignal(signal, (args[0] as Long).toInt())
       return
     }
     if (args.size == 1 && args[0] is Vector2i) {
@@ -107,6 +113,33 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
     }
 
   fun createTween(): Tween? = NodeBackendContractProbe(backendHandle).createTween()?.let(::Tween)
+
+  fun isInGroup(group: String): Boolean =
+    GodotBackendCalls.invokeStringNameRetBool(
+      InitialGodotCallDescriptors.NODE_IS_IN_GROUP,
+      backendHandle,
+      group,
+    )
+
+  /** Dynamic one-String-argument method call (e.g. a native GDScript autoload's play(path)). */
+  fun call(method: String, argument: String) {
+    GodotBackendCalls.invokeStringNameStringNameArg(
+      InitialGodotCallDescriptors.OBJECT_CALL,
+      backendHandle,
+      method,
+      argument,
+    )
+  }
+
+  /** Object.set_deferred with a Boolean value (physics-safe property writes). */
+  fun setDeferred(property: String, value: Boolean) {
+    GodotBackendCalls.invokeStringNameBoolArg(
+      InitialGodotCallDescriptors.OBJECT_SET_DEFERRED,
+      backendHandle,
+      property,
+      value,
+    )
+  }
 }
 
 open class CanvasItem internal constructor(backendHandle: BackendGodotHandle) : Node(backendHandle) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.suspendCancellableCoroutine
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.AudioStreamPlayerBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors
 import net.multigesture.kanama.backend.InputActionBackendContractProbe
 import net.multigesture.kanama.backend.InputBackendContractProbe
 import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
@@ -218,6 +220,14 @@ class AudioStreamPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHa
     AudioStreamPlayerBackendContractProbe(backendHandle).setPitchScale(value)
   }
 
+  fun setStreamPaused(paused: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER_SET_STREAM_PAUSED,
+      backendHandle,
+      paused,
+    )
+  }
+
   fun play(fromPosition: Double = 0.0) {
     AudioStreamPlayerBackendContractProbe(backendHandle).play(fromPosition)
   }
@@ -354,6 +364,13 @@ object Input {
   fun actionRelease(action: String) {
     InputActionBackendContractProbe.actionRelease(action)
   }
+
+  fun getAxis(negativeAction: String, positiveAction: String): Double =
+    GodotBackendCalls.invokeStringNameStringNameRetDoubleSingleton(
+      InitialGodotCallDescriptors.INPUT_GET_AXIS,
+      negativeAction,
+      positiveAction,
+    )
 }
 
 class SceneTree internal constructor(backendHandle: BackendGodotHandle) : GodotObject(backendHandle) {
@@ -363,6 +380,13 @@ class SceneTree internal constructor(backendHandle: BackendGodotHandle) : GodotO
 
   fun callGroup(group: String, method: String) {
     SceneTreeBackendContractProbe(backendHandle).callGroup(group, method)
+  }
+
+  fun reloadCurrentScene() {
+    GodotBackendCalls.invokeNoArgsRetLong(
+      InitialGodotCallDescriptors.SCENETREE_RELOAD_CURRENT_SCENE,
+      backendHandle,
+    )
   }
 
   /** Instance form of [Companion.delaySeconds] for `getTree().delaySeconds(...)` call sites. */

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -97,6 +97,16 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
   fun setSpeedScale(scale: Double) {
     GodotBackendCalls.invokeDoubleArg(D.ANIMATIONPLAYER_SET_SPEED_SCALE, backendHandle, scale)
   }
+
+  /** Play a named animation (custom_speed/from_end baked to Godot defaults in the proxy). */
+  fun play(animation: String, customBlend: Double = -1.0) {
+    GodotBackendCalls.invokeStringNameDoubleArg(
+      D.ANIMATIONPLAYER_PLAY,
+      backendHandle,
+      animation,
+      customBlend,
+    )
+  }
 }
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -282,6 +282,15 @@ fun kanamaWebCallInt(objectId: Int, methodId: Int, value: Int): Int {
 }
 
 @JsExport
+fun kanamaWebCallLongVoid(objectId: Int, methodId: Int, value: Int): Int {
+  return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
+    KanamaWebProjectRegistry.callLongVoid(record.scriptId, methodId, record.script, value.toLong())
+    commands.flush()
+    1
+  }
+}
+
+@JsExport
 fun kanamaWebCallNoArgs(objectId: Int, methodId: Int): Int {
   return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
     KanamaWebProjectRegistry.callNoArgs(record.scriptId, methodId, record.script)

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -471,6 +471,12 @@ fun kanamaWebLoadRenderingMethodSnapshot(objectId: Int, value: String): Int {
 }
 
 @JsExport
+fun kanamaWebLoadVelocitySnapshot(objectId: Int, x: Double, y: Double, z: Double): Int {
+  loadWebVelocitySnapshot(objectId, x, y, z)
+  return 1
+}
+
+@JsExport
 fun kanamaWebLoadAnimationNames(objectId: Int, joined: String): Int {
   loadWebAnimationNames(objectId, joined)
   return 1

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -299,6 +299,20 @@ internal fun loadWebNode3DSnapshot(
   rotation3Snapshots[objectId] =
     GodotVector3(rotationX.toFloat(), rotationY.toFloat(), rotationZ.toFloat())
   scale3Snapshots[objectId] = GodotVector3(scaleX.toFloat(), scaleY.toFloat(), scaleZ.toFloat())
+  // rotation_degrees is by definition rotation in degrees; derive it from the same refresh so
+  // reads work before any write (the camera rig reads it at ready).
+  val toDegrees = 180.0 / kotlin.math.PI
+  rotationDegrees3Snapshots[objectId] =
+    GodotVector3(
+      (rotationX * toDegrees).toFloat(),
+      (rotationY * toDegrees).toFloat(),
+      (rotationZ * toDegrees).toFloat(),
+    )
+}
+
+/** CharacterBody3D velocity refresh: the proxy pushes the post-slide velocity each physics tick. */
+internal fun loadWebVelocitySnapshot(objectId: Int, x: Double, y: Double, z: Double) {
+  velocity3Snapshots[objectId] = GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
 }
 
 internal fun loadWebViewportRectSnapshot(

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
@@ -50,6 +50,16 @@ internal class WebCommandBuffer(capacity: Int) {
     words[offset + 4] = z.toBits()
   }
 
+  fun appendStringNameDoubleMutation(opcode: Int, objectHandle: Int, name: String, value: Double) {
+    val bits = value.toBits()
+    val offset = reserve(WORDS_STRINGNAME_DOUBLE)
+    words[offset] = opcode
+    words[offset + 1] = objectHandle
+    words[offset + 2] = internWebCommandStringName(name)
+    words[offset + 3] = bits.toInt()
+    words[offset + 4] = (bits ushr 32).toInt()
+  }
+
   fun appendLongDoubleMutation(
     opcode: Int,
     objectHandle: Int,
@@ -212,6 +222,7 @@ internal class WebCommandBuffer(capacity: Int) {
     const val WORDS_OBJECT_BOOL_LONG_ARGS = 5
     const val WORDS_VECTOR3 = 5
     const val WORDS_LONG_DOUBLE = 5
+    const val WORDS_STRINGNAME_DOUBLE = 5
     const val WORDS_COLOR = 6
     const val WORDS_DRAW_TEXTURE = 9
     const val MAX_WORDS_PER_COMMAND = WORDS_DRAW_TEXTURE

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -385,7 +385,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode == 68)
+    require(descriptor.opcode in setOf(68, 105))
     commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
   }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -792,6 +792,39 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
   }
 
+  override fun invokeStringNameDoubleArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+    doubleValue: Double,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 103)
+    require(doubleValue.isFinite())
+    commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
+  }
+
+  override fun invokeStringNameStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    first: String,
+    second: String,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 104)
+    commands.flush()
+    // Two action names are packed into one query string (unit separator) and the axis is
+    // returned scaled by 1000 through the shared object-query transport.
+    return immediateWebObjectQuery(
+      descriptor.opcode,
+      requireActiveWebScriptHandle(),
+      first + "\u001f" + second,
+    ) / 1000.0
+  }
+
   private fun requireOpcode(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {
     require(callSite.backendToken() == descriptor.opcode.toLong()) {
       "Web Godot call-site opcode does not match ${descriptor.className}.${descriptor.methodName}"

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -63,7 +63,8 @@
       opcode === 78 ||
       opcode === 84 ||
       opcode === 88 ||
-      opcode === 101
+      opcode === 101 ||
+      opcode === 103
     ) return 5;
     if (opcode === 32) return 6;
     if (opcode === 6) return 9;
@@ -889,6 +890,9 @@
     },
     refreshRenderingMethodSnapshot(handle, method) {
       return this.api.kanamaWebLoadRenderingMethodSnapshot(handle, String(method));
+    },
+    refreshVelocitySnapshot(handle, x, y, z) {
+      return this.api.kanamaWebLoadVelocitySnapshot(handle, x, y, z);
     },
     refreshViewportRectSnapshot(handle, x, y, width, height) {
       return this.api.kanamaWebLoadViewportRectSnapshot(handle, x, y, width, height);

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -54,6 +54,7 @@
       opcode === 96 ||
       opcode === 97 ||
       opcode === 99 ||
+      opcode === 105 ||
       opcode === 1000
     ) return 4;
     if (
@@ -556,6 +557,15 @@
         "registered_function",
         `method#${methodId}`,
         () => this.api.kanamaWebCallInt(handle, methodId, value),
+        0,
+      );
+    },
+    callLongVoid(handle, methodId, value) {
+      return this.invoke(
+        handle,
+        "registered_function",
+        `method#${methodId}`,
+        () => this.api.kanamaWebCallLongVoid(handle, methodId, value),
         0,
       );
     },


### PR DESCRIPTION
Follow-up to #98: the real platformer is now **fully playable at full gameplay fidelity** in Chrome — verified by driving real key events in headless Chrome: full sessions with all 32 scripts ready, 1100+ physics ticks, **0 callback errors, 0 console errors**.

## Playable core (commit 1)
WASD camera-relative movement (`Input.get_axis`), single/double jump, walk/idle/jump animations (`AnimationPlayer.play`, new `STRINGNAME_DOUBLE_ARG` + two-StringName→Double singleton shapes, opcodes 103–104), footstep pause/pitch, facing lerp, squash-stretch, camera follow/rotation/zoom, fall-respawn scene reload.

**Real bugs the play run surfaced + fixed:** Godot resolving rewritten Script ext_resources by their *original UID* (silently loading native `main.gd` — staging now strips UIDs); `exportWeb` shipping stale exports (staged project now a declared input); three missing-snapshot classes (`rotation_degrees` derived from the Node3D refresh, post-slide `velocity` refreshed per physics tick, unscripted looked-up Node3D transforms seeded at lookup/instantiate); benchmark scalar opcode 100 → 1000.

## Full gameplay fidelity (commit 2)
- **One-shot audio**: `Object.call` with a one-String vararg tail (opcode 105) — jump/land/coin/break sounds fire through the native GDScript Audio autoload. `Node.call`/`setDeferred`/`isInGroup` wrappers.
- **Coin scoring**: object-arg registered-fn dispatch passes Kanama-scripted nodes as their **script handle**, so `Coin` resolves `kotlinScriptInstance<Player>()` → `collectCoin()` → `coin_collected` signal (generated `PlayerSignals`, `emitSignal(Long)`) → HUD label via a new void-one-Int `callLongVoid` dispatch.
- **Brick break**: programmatic `GodotSignal.connect` on BottomDetector, group gate, sound + particles + hide + collision-off + deferred monitoring-off + one-second coroutine free.

No deferred gameplay remains in the Web ports.

## Verified
Drift gates PASS; processor + common-api tests pass; regression smokes **web3d 7/7**, **dodge 10/10**, **match3 11/11** all PASS at the new dispatch/bridge.

Companion kanama-demos commits: full-fidelity `Player/View/Coin/Brick` Web ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)