### PR TITLE
Task 60d: wire the platformer demo into the Web CI smoke harness

### DIFF
--- a/scripts/fixtures/web-fake-export/fake_driver.py
+++ b/scripts/fixtures/web-fake-export/fake_driver.py
@@ -57,7 +57,7 @@ def _envelope(demo: str, checksum: str, *, passing: bool) -> dict:
         "callbacks": {"pending": 0},
         "connections": {"open": 0},
         "scheduler": {"pendingCoroutines": 0},
-        "console": {"errors": [], "boundaryErrors": []},
+        "console": {"errors": [], "warnings": [], "boundaryErrors": []},
         "teardown": {"outcome": "clean", "ownerRegistriesToBaseline": True},
     }
 

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -26,9 +26,10 @@ import { runMatch3 } from "./demos/match3.mjs";
 import { runBunnymark } from "./demos/bunnymark.mjs";
 import { runDodge } from "./demos/dodge.mjs";
 import { runWeb3d } from "./demos/web3d.mjs";
+import { runPlatformer } from "./demos/platformer.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -1,0 +1,199 @@
+// demos/platformer.mjs -- Starter-Kit-3D-Platformer play + teardown assertions.
+//
+// The platformer is self-driven for smoke purposes: without any synthesized input the
+// CharacterBody3D player still runs gravity + move_and_slide every physics tick, coins
+// spin, clouds bob, and the View camera follows -- so _physics_process and _process both
+// advance with their command mutations applied. This driver OBSERVES that both frame
+// pumps run (physics AND process), that commands flow, then triggers
+// SmokeQuit.smoke_teardown and polls the live-handle count to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[platformer ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        mainHandle: bridge.platformerMainHandle,
+        smokeQuitHandle: bridge.platformerSmokeQuitHandle,
+        readyCount: bridge.readyCount,
+        mainReady: classCount(".Main"),
+        playerReady: classCount(".Player"),
+        hudReady: classCount(".Hud"),
+        coinReady: classCount(".Coin"),
+        processCalls: bridge.processCalls,
+        physicsCalls: bridge.physicsProcessCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.processCalls = Math.max(peak.processCalls, snap.processCalls);
+      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(`process=${snap.processCalls} physics=${snap.physicsCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} crossings=${snap.crossings} errs=${snap.callbackErrors}`);
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runPlatformer({ url, evaluate, navigate, deadline }) {
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?platformer=${Date.now()}`);
+
+  const readyDeadline = Math.min(deadline, Date.now() + 45_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "platformer" &&
+      snap.protocol > 0 &&
+      snap.mainReady >= 1 &&
+      snap.playerReady >= 1 &&
+      snap.hudReady >= 1 &&
+      snap.coinReady >= 1 &&
+      snap.mainHandle > 0 &&
+      snap.smokeQuitHandle > 0
+    ) {
+      ready = snap;
+      break;
+    }
+    await delay(100);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm 3D platformer did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`ready: readyCount=${ready.readyCount} mainHandle=${ready.mainHandle} protocol=${ready.protocol}`);
+
+  // Observe the game running idle: the player's _physics_process (gravity +
+  // move_and_slide) advances physicsCalls and its velocity/position mutations advance
+  // appliedCommands; coins/clouds/view advance processCalls.
+  const seed = {
+    processCalls: ready.processCalls,
+    physicsCalls: ready.physicsCalls,
+    appliedCommands: ready.appliedCommands,
+    maxLiveHandles: ready.maxLiveHandles,
+    crossings: ready.crossings,
+    callbackErrors: 0,
+  };
+  const gameplay = await observe(
+    evaluate,
+    seed,
+    8_000,
+    deadline,
+    (snap) =>
+      snap.physicsCalls >= ready.physicsCalls + 30 &&
+      snap.processCalls >= ready.processCalls + 30 &&
+      snap.appliedCommands >= ready.appliedCommands + 30,
+  );
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? ready;
+  trace(`gameplay: process=${peak.processCalls} physics=${peak.physicsCalls} applied=${peak.appliedCommands} live=${atPeak.liveHandles}`);
+
+  // Full teardown: SmokeQuit.smoke_teardown (its only @RegisterFunction, method#1) frees
+  // the scene root; every node exits the tree and releases its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.platformerSmokeQuitHandle, 1); true",
+  );
+  const teardown = await observe(evaluate, peak, 8_000, deadline, (snap) => snap.liveHandles === 0);
+  const settled = teardown.last ?? atPeak;
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} pending=${settled.pending} jobs=${settled.jobs} errs=${settled.callbackErrors}`);
+
+  const protocolVersion = ready.protocol;
+  const checks = {
+    modePlatformer: ready.mode === "platformer",
+    protocol8: protocolVersion === 8,
+    sceneScriptsReady:
+      ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
+    // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and
+    // _process (coins/clouds/camera) each advanced many frames.
+    physicsFramesAdvanced: peak.physicsCalls >= ready.physicsCalls + 30,
+    processFramesAdvanced: peak.processCalls >= ready.processCalls + 30,
+    gameplayCommandsApplied: peak.appliedCommands >= ready.appliedCommands + 30,
+    // move_and_slide/is_on_floor are immediate kotlin->godot crossings every physics tick.
+    crossingsAdvanced: peak.crossings > ready.crossings,
+    fullTeardownToZero: settled.liveHandles === 0,
+    noCallbackFaults: peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready.mode === "platformer",
+      outcome: ready.mode === "platformer" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      processCalls: peak.processCalls,
+      physicsProcessCalls: peak.physicsCalls,
+      appliedCommands: peak.appliedCommands,
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+    },
+    boundaryErrors,
+  };
+}

--- a/scripts/web/drivers/envelope.mjs
+++ b/scripts/web/drivers/envelope.mjs
@@ -54,7 +54,21 @@ export function buildEnvelope({
   const total = checkNames.length;
   const failed = total - passed;
 
-  const consoleErrors = consoleEvents.map((event) => `${event.type}: ${event.text}`);
+  // Godot's web shell routes engine stderr to console.error, so engine WARNINGs the
+  // engine itself recovered from (e.g. per-GPU texture-format fallbacks) arrive as
+  // console errors. Those must not make the gate GPU/driver-dependent: record them as
+  // warnings, fail only on everything else. Each WARNING is followed by an "at:" source
+  // line, classified with the warning it belongs to.
+  const consoleErrors = [];
+  const consoleWarnings = [];
+  let lastWasWarning = false;
+  for (const event of consoleEvents) {
+    const isWarning =
+      event.type === "console.error" &&
+      (event.text.startsWith("WARNING:") || (lastWasWarning && /^\s*at: /.test(event.text)));
+    (isWarning ? consoleWarnings : consoleErrors).push(`${event.type}: ${event.text}`);
+    lastWasWarning = isWarning;
+  }
   const boundaryErrors = [...(demoResult.boundaryErrors ?? [])];
 
   const loaded = demoResult.startup.loaded === true;
@@ -78,7 +92,7 @@ export function buildEnvelope({
     callbacks: demoResult.callbacks,
     connections: demoResult.connections,
     scheduler: demoResult.scheduler,
-    console: { errors: consoleErrors, boundaryErrors },
+    console: { errors: consoleErrors, warnings: consoleWarnings, boundaryErrors },
     teardown: demoResult.teardown,
   };
 }

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -19,9 +19,10 @@ import { runMatch3 } from "./demos/match3.mjs";
 import { runBunnymark } from "./demos/bunnymark.mjs";
 import { runDodge } from "./demos/dodge.mjs";
 import { runWeb3d } from "./demos/web3d.mjs";
+import { runPlatformer } from "./demos/platformer.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -18,9 +18,10 @@ import { runMatch3 } from "./demos/match3.mjs";
 import { runBunnymark } from "./demos/bunnymark.mjs";
 import { runDodge } from "./demos/dodge.mjs";
 import { runWeb3d } from "./demos/web3d.mjs";
+import { runPlatformer } from "./demos/platformer.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web/result_schema.py
+++ b/scripts/web/result_schema.py
@@ -150,6 +150,8 @@ def _validate_console(console: Any) -> None:
     path = "console"
     errors = _get(console, "errors", path)
     _check_type(errors, list, f"{path}.errors")
+    warnings = _get(console, "warnings", path)
+    _check_type(warnings, list, f"{path}.warnings")
     boundary = _get(console, "boundaryErrors", path)
     _check_type(boundary, list, f"{path}.boundaryErrors")
 

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1159,6 +1159,37 @@ tasks.register("stageWebPlatformerProject") {
                 }
             }
 
+        // The demo targets Forward+ (with a mobile gl_compatibility override); the Web
+        // template only runs the Compatibility renderer, so pin it explicitly and turn off
+        // screen-space AA -- Compatibility rejects it with a console error on every run,
+        // which would trip the smoke's zero-console-errors gate (match3 precedent above).
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val forwardFeature = "config/features=PackedStringArray(\"4.7\", \"Forward Plus\")"
+        val mobileRenderer = "renderer/rendering_method.mobile=\"gl_compatibility\""
+        val screenSpaceAa = "anti_aliasing/quality/screen_space_aa=1"
+        check(stagedProjectText.contains(forwardFeature)) {
+            "platformer renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(mobileRenderer)) {
+            "platformer mobile renderer setting changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(screenSpaceAa)) {
+            "platformer screen-space AA setting changed; update the Web staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    forwardFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    mobileRenderer,
+                    "renderer/rendering_method=\"gl_compatibility\"\n$mobileRenderer",
+                )
+                .replace(screenSpaceAa, "anti_aliasing/quality/screen_space_aa=0")
+        )
+
         val shell = stagingDir.resolve("kanama-web/shell.html")
         val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
         shell.writeText(


### PR DESCRIPTION
First 60d exit-gate slice: the Starter-Kit-3D-Platformer joins the in-browser CI smoke list.

## What

- **`scripts/web/drivers/demos/platformer.mjs`** — new smoke driver, registered in the chrome/firefox/safari engine drivers. The platformer is self-driven for smoke purposes: with no synthesized input the CharacterBody3D player still runs gravity + `move_and_slide` every physics tick, coins spin, clouds bob, and the camera follows. The driver asserts both frame pumps advance (`physicsFramesAdvanced`, `processFramesAdvanced` — first smoke to assert `_physics_process` explicitly), command flow, crossings, then triggers `SmokeQuit.smoke_teardown` and polls live handles to zero.
- **`stageWebPlatformerProject`** — pins the staged (disposable) project to `gl_compatibility` and zeroes `screen_space_aa`, mirroring the match3 staging transform. The demo targets Forward+; the Web template only runs Compatibility, which rejects screen-space AA with a console error on every run — that noise would permanently trip the smoke's zero-console-errors gate.
- **envelope/schema** — Godot's web shell routes engine stderr to `console.error`, so recovered engine WARNINGs (e.g. Firefox's `BPTC_RGBA not supported by hardware, converting to RGBA8` texture fallback) arrived as gate-failing console errors, making the gate GPU/driver-dependent. `WARNING:`-prefixed lines (plus their `at:` source line) are now recorded under `console.warnings` and do not fail the run; anything else still does. Schema validates the new list.

## Verification

| Gate | Result |
|---|---|
| platformer Chrome | wrapper-PASS, 9/9 checks, liveAfterTeardown=0 |
| platformer Firefox | wrapper-PASS, 9/9 (BPTC fallback recorded as warning) |
| platformer Safari | wrapper-PASS, 9/9 |
| web3d / dodge / match3 Chrome regression | wrapper-PASS (7/7, 10/10, 11/11) |
| scaffold selftest | 10/10 |

Physics telemetry from the Chrome run: 120 `_physics_process` calls vs 96 `_process` calls over the observation window, 396 applied commands, 234 kotlin→godot crossings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)