### PR TITLE
Task 60e: character-controller tutorial runs on Web (families 141-151, protocol 12, object-carrying signals)

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -68,6 +68,8 @@ enum class GodotCallShape {
   OBJECT_RET_HANDLE,
   OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE,
   CALLABLE_RET_HANDLE,
+  NOARGS_RET_LONG_SINGLETON,
+  STRINGNAME_OBJECT_RET_INT,
 }
 
 @InternalKanamaBackendApi
@@ -515,6 +517,22 @@ interface GodotBackendSpi {
     target: GodotHandle,
     method: String,
   ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Singleton no-args Long query (no receiver): e.g. Input.get_mouse_mode. */
+  fun invokeNoArgsRetLongSingleton(descriptor: GodotCallDescriptor, callSite: GodotCallSite): Long {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Signal emission carrying one Godot-object argument. */
+  fun invokeStringNameObjectRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ): Int {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -1130,6 +1148,30 @@ object GodotBackendCalls {
     selected.invokeLongArgSingleton(descriptor, resolve(selected, descriptor), value)
   }
 
+  fun invokeNoArgsRetLongSingleton(descriptor: GodotCallDescriptor): Long {
+    requireShape(descriptor, GodotCallShape.NOARGS_RET_LONG_SINGLETON)
+    val selected = requireBackend()
+    return selected.invokeNoArgsRetLongSingleton(descriptor, resolve(selected, descriptor))
+  }
+
+  fun invokeStringNameObjectRetInt(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ): Int {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_OBJECT_RET_INT)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeStringNameObjectRetInt(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      value,
+    )
+  }
+
   fun invokeObjectRetHandle(
     descriptor: GodotCallDescriptor,
     receiver: GodotHandle,
@@ -1367,6 +1409,14 @@ class NodeBackendContractProbe(private val handle: GodotHandle) {
       method,
     )
 
+  fun setPhysicsProcess(enabled: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.NODE_SET_PHYSICS_PROCESS,
+      handle,
+      enabled,
+    )
+  }
+
   /** Dynamic one-Float-argument method call (FPS damage(amount) on ray hits). */
   fun callDouble(method: String, value: Double) {
     GodotBackendCalls.invokeStringNameDoubleArg(
@@ -1526,6 +1576,22 @@ class GPUParticles2DBackendContractProbe(private val handle: GodotHandle) {
         InitialGodotCallDescriptors.GPUPARTICLES2D_GET_LIFETIME,
         handle,
       )
+}
+
+/** Positional 3D audio playback (character-controller footsteps/jump/land). */
+@InternalKanamaBackendApi
+class AudioStreamPlayer3DBackendContractProbe(private val handle: GodotHandle) {
+  fun play(fromPosition: Double = 0.0) {
+    GodotBackendCalls.invokeDoubleArg(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_PLAY,
+      handle,
+      fromPosition,
+    )
+  }
+
+  fun stop() {
+    GodotBackendCalls.invokeNoArgsVoid(InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_STOP, handle)
+  }
 }
 
 /** Typed AudioStreamPlayer configuration and playback slice used by Match3's Audio autoload. */
@@ -1850,6 +1916,14 @@ class SignalBackendContractProbe(private val handle: GodotHandle) {
       name,
     )
 
+  fun emitObject(name: String, value: GodotHandle): Int =
+    GodotBackendCalls.invokeStringNameObjectRetInt(
+      InitialGodotCallDescriptors.OBJECT_EMIT_SIGNAL_OBJECT,
+      handle,
+      name,
+      value,
+    )
+
   fun emitVector2i(name: String, value: GodotVector2i): Int =
     GodotBackendCalls.invokeStringNameVector2iRetInt(
       InitialGodotCallDescriptors.OBJECT_EMIT_SIGNAL_VECTOR2I,
@@ -1868,6 +1942,36 @@ class GodotObjectBackendContractProbe(private val handle: GodotHandle) {
       handle,
       className,
     )
+
+  /** Object.get restricted to object-valued properties; non-objects resolve to null. */
+  fun getObjectProperty(name: String): GodotHandle? =
+    GodotBackendCalls.invokeNodePathRetHandle(
+      InitialGodotCallDescriptors.OBJECT_GET_OBJECT_PROPERTY,
+      handle,
+      name,
+    )
+
+  /** Object.set_indexed restricted to double values (AnimationTree blend parameters). */
+  fun setIndexedDouble(path: String, value: Double) {
+    GodotBackendCalls.invokeStringNameDoubleArg(
+      InitialGodotCallDescriptors.OBJECT_SET_INDEXED_DOUBLE,
+      handle,
+      path,
+      value,
+    )
+  }
+}
+
+/** State-machine playback transitions driven through the AnimationTree parameter object. */
+@InternalKanamaBackendApi
+class AnimationStateMachinePlaybackBackendContractProbe(private val handle: GodotHandle) {
+  fun travel(state: String) {
+    GodotBackendCalls.invokeStringNameArg(
+      InitialGodotCallDescriptors.ANIMATIONNODESTATEMACHINEPLAYBACK_TRAVEL,
+      handle,
+      state,
+    )
+  }
 }
 
 /** Typed InputEvent state queries shared by the generated input handoff. */
@@ -1977,6 +2081,28 @@ class Node3DBackendContractProbe(val handle: GodotHandle) {
       InitialGodotCallDescriptors.NODE3D_GET_GLOBAL_POSITION,
       handle,
     )
+
+  fun getGlobalRotation(): GodotVector3 =
+    GodotBackendCalls.invokeNoArgsRetVector3(
+      InitialGodotCallDescriptors.NODE3D_GET_GLOBAL_ROTATION,
+      handle,
+    )
+
+  fun setGlobalPosition(value: GodotVector3) {
+    GodotBackendCalls.invokeVector3Arg(
+      InitialGodotCallDescriptors.NODE3D_SET_GLOBAL_POSITION,
+      handle,
+      value,
+    )
+  }
+
+  fun setGlobalRotation(value: GodotVector3) {
+    GodotBackendCalls.invokeVector3Arg(
+      InitialGodotCallDescriptors.NODE3D_SET_GLOBAL_ROTATION,
+      handle,
+      value,
+    )
+  }
 }
 
 /** Typed CanvasLayer visibility slice used by the 3D platformer's mobile-control overlay. */
@@ -2283,4 +2409,7 @@ object InputActionBackendContractProbe {
   fun setMouseMode(mode: Long) {
     GodotBackendCalls.invokeLongArgSingleton(InitialGodotCallDescriptors.INPUT_SET_MOUSE_MODE, mode)
   }
+
+  fun getMouseMode(): Long =
+    GodotBackendCalls.invokeNoArgsRetLongSingleton(InitialGodotCallDescriptors.INPUT_GET_MOUSE_MODE)
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -1543,4 +1543,125 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.QUEUED_MUTATION,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val NODE3D_GET_GLOBAL_ROTATION =
+    GodotCallDescriptor(
+      opcode = 141,
+      className = "Node3D",
+      methodName = "get_global_rotation",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE3D_SET_GLOBAL_POSITION =
+    GodotCallDescriptor(
+      opcode = 142,
+      className = "Node3D",
+      methodName = "set_global_position",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE3D_SET_GLOBAL_ROTATION =
+    GodotCallDescriptor(
+      opcode = 143,
+      className = "Node3D",
+      methodName = "set_global_rotation",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_SET_PHYSICS_PROCESS =
+    GodotCallDescriptor(
+      opcode = 144,
+      className = "Node",
+      methodName = "set_physics_process",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_GET_MOUSE_MODE =
+    GodotCallDescriptor(
+      opcode = 145,
+      className = "Input",
+      methodName = "get_mouse_mode",
+      hash = 965286182L,
+      shape = GodotCallShape.NOARGS_RET_LONG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_PLAY =
+    GodotCallDescriptor(
+      opcode = 146,
+      className = "AudioStreamPlayer3D",
+      methodName = "play",
+      hash = 1958160172L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_STOP =
+    GodotCallDescriptor(
+      opcode = 147,
+      className = "AudioStreamPlayer3D",
+      methodName = "stop",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_EMIT_SIGNAL_OBJECT =
+    GodotCallDescriptor(
+      opcode = 148,
+      className = "Object",
+      methodName = "emit_signal",
+      hash = 4047867050L,
+      shape = GodotCallShape.STRINGNAME_OBJECT_RET_INT,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_GET_OBJECT_PROPERTY =
+    GodotCallDescriptor(
+      opcode = 149,
+      className = "Object",
+      methodName = "get",
+      hash = 2760726917L,
+      shape = GodotCallShape.NODEPATH_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONNODESTATEMACHINEPLAYBACK_TRAVEL =
+    GodotCallDescriptor(
+      opcode = 150,
+      className = "AnimationNodeStateMachinePlayback",
+      methodName = "travel",
+      hash = 3823612587L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_SET_INDEXED_DOUBLE =
+    GodotCallDescriptor(
+      opcode = 151,
+      className = "Object",
+      methodName = "set_indexed",
+      hash = 3500910842L,
+      shape = GodotCallShape.STRINGNAME_DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -8,7 +8,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 11
+    const val PROTOCOL_VERSION = 12
     const val PROTOCOL_SCHEMA_VERSION = 1
   }
 
@@ -626,6 +626,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         if (property.type == TypeMapping.INT && property.isMutable) {
           appendLine(
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = value"
+          )
+        }
+        // The proxy pushes exported bools through the long channel (1/0).
+        if (property.type == TypeMapping.BOOL && property.isMutable) {
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = value != 0L"
           )
         }
       }
@@ -1294,6 +1300,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 144 and target_object is Node:")
+    appendLine(
+      "\t\t\t(target_object as Node).set_physics_process(bytes.decode_s32(offset + 8) != 0)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 146 and target_object is AudioStreamPlayer3D:")
+    appendLine("\t\t\t(target_object as AudioStreamPlayer3D).play(bytes.decode_double(offset + 8))")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 147 and target_object is AudioStreamPlayer3D:")
+    appendLine("\t\t\t(target_object as AudioStreamPlayer3D).stop()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
     appendLine("\t\telif opcode == 46 and target_object is AudioStreamPlayer:")
     appendLine("\t\t\tvar stream_handle := bytes.decode_s32(offset + 8)")
     appendLine(
@@ -1525,6 +1545,26 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tvar anim_name := String(_kanama_bridge.resolveCommandStringName(anim_id))")
     appendLine(
       "\t\t\t(target_object as AnimationPlayer).play(StringName(anim_name), bytes.decode_double(offset + 12))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 150 and target_object is AnimationNodeStateMachinePlayback:")
+    appendLine("\t\t\tvar travel_id := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar travel_state := String(_kanama_bridge.resolveCommandStringName(travel_id))"
+    )
+    appendLine(
+      "\t\t\t(target_object as AnimationNodeStateMachinePlayback).travel(StringName(travel_state))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 151 and target_object != null:")
+    appendLine("\t\t\tvar indexed_id := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar indexed_path := String(_kanama_bridge.resolveCommandStringName(indexed_id))"
+    )
+    appendLine(
+      "\t\t\ttarget_object.set_indexed(NodePath(indexed_path), bytes.decode_double(offset + 12))"
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 20")
@@ -1895,6 +1935,27 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("func _kanama_web_signal_dispatch0(callback_id: int) -> void:")
     appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
     appendLine()
+    appendLine("func _kanama_web_signal_dispatch1(_arg: Variant, callback_id: int) -> void:")
+    appendLine("\t# One emitted argument, dropped by the Kotlin callback: rides the zero-arg path.")
+    appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
+    appendLine()
+    appendLine("func _kanama_web_signal_dispatch_object(arg: Variant, callback_id: int) -> void:")
+    appendLine("\tvar script_arg_handle := 0")
+    appendLine("\tif arg != null and arg.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\tscript_arg_handle = int(arg.call(\"_kanama_ensure_created\"))")
+    appendLine("\tif script_arg_handle != 0:")
+    appendLine(
+      "\t\t_kanama_bridge.dispatchSignalObject(_kanama_handle, callback_id, script_arg_handle)"
+    )
+    appendLine("\telse:")
+    appendLine(
+      "\t\tvar arg_handle := int(_kanama_bridge.allocateTransientObjectHandle(_kanama_handle))"
+    )
+    appendLine("\t\t_kanama_object_handles[arg_handle] = arg")
+    appendLine("\t\t_kanama_bridge.dispatchSignalObject(_kanama_handle, callback_id, arg_handle)")
+    appendLine("\t\t_kanama_object_handles.erase(arg_handle)")
+    appendLine("\t\t_kanama_bridge.releaseTransientObjectHandle(arg_handle)")
+    appendLine()
     appendLine("func _kanama_object_query(args: Array) -> int:")
     appendLine("\tvar opcode := int(args[0])")
     appendLine("\tvar object_handle := int(args[1])")
@@ -1994,6 +2055,56 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int(value.has_method(StringName(String(args[2]))))")
     appendLine("\t\telif opcode == 139 and value is Timer:")
     appendLine("\t\t\tresult = int((value as Timer).is_stopped())")
+    appendLine("\t\telif opcode == 142 and value is Node3D:")
+    appendLine("\t\t\tvar global_pos_node := value as Node3D")
+    appendLine("\t\t\tvar global_pos_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\tglobal_pos_node.global_position = Vector3(global_pos_parts[0], global_pos_parts[1], global_pos_parts[2])"
+    )
+    appendLine(
+      "\t\t\t_kanama_bridge.refreshNode3DSnapshot(object_handle, global_pos_node.position.x, global_pos_node.position.y, global_pos_node.position.z, global_pos_node.rotation.x, global_pos_node.rotation.y, global_pos_node.rotation.z, global_pos_node.scale.x, global_pos_node.scale.y, global_pos_node.scale.z)"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 143 and value is Node3D:")
+    appendLine("\t\t\tvar global_rot_node := value as Node3D")
+    appendLine("\t\t\tvar global_rot_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\tglobal_rot_node.global_rotation = Vector3(global_rot_parts[0], global_rot_parts[1], global_rot_parts[2])"
+    )
+    appendLine(
+      "\t\t\t_kanama_bridge.refreshNode3DSnapshot(object_handle, global_rot_node.position.x, global_rot_node.position.y, global_rot_node.position.z, global_rot_node.rotation.x, global_rot_node.rotation.y, global_rot_node.rotation.z, global_rot_node.scale.x, global_rot_node.scale.y, global_rot_node.scale.z)"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 145:")
+    appendLine("\t\t\tresult = int(Input.mouse_mode)")
+    appendLine("\t\telif opcode == 148 and value != null:")
+    appendLine("\t\t\tvar emit_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar emit_arg_handle := int(emit_parts[1])")
+    appendLine(
+      "\t\t\tvar emit_arg: Object = self if emit_arg_handle == _kanama_handle else _kanama_object_handles.get(emit_arg_handle)"
+    )
+    appendLine("\t\t\tif emit_arg == null:")
+    appendLine(
+      "\t\t\t\tpush_error(\"Unknown Kanama Web signal argument handle: %d\" % emit_arg_handle)"
+    )
+    appendLine("\t\t\t\tresult = ERR_INVALID_PARAMETER")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\tresult = value.emit_signal(StringName(emit_parts[0]), emit_arg)")
+    appendLine("\t\telif opcode == 149 and value != null:")
+    appendLine("\t\t\tvar get_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar got_variant: Variant = value.get(get_parts[0])")
+    appendLine("\t\t\tvar got: Object = got_variant if got_variant is Object else null")
+    appendLine("\t\t\tif got == null:")
+    appendLine("\t\t\t\tresult = 0")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\tresult = 0")
+    appendLine("\t\t\t\tfor existing_handle in _kanama_object_handles:")
+    appendLine("\t\t\t\t\tif is_same(_kanama_object_handles[existing_handle], got):")
+    appendLine("\t\t\t\t\t\tresult = int(existing_handle)")
+    appendLine("\t\t\t\t\t\tbreak")
+    appendLine("\t\t\t\tif result == 0:")
+    appendLine("\t\t\t\t\tresult = int(get_parts[1])")
+    appendLine("\t\t\t\t\t_kanama_object_handles[result] = got")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2026,6 +2137,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as RayCast3D).get_collision_normal()")
     appendLine("\telif opcode == 138 and value is Node3D:")
     appendLine("\t\tresult = (value as Node3D).global_position")
+    appendLine("\telif opcode == 141 and value is Node3D:")
+    appendLine("\t\tresult = (value as Node3D).global_rotation")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -72,7 +72,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 11"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 12"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -410,7 +410,7 @@ class WebScriptCodeEmitterTest {
     )
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 11"))
+    assertTrue(protocol.contains("\"protocolVersion\": 12"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -421,7 +421,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=11\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=12\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -183,6 +183,17 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     138: {},
     139: {},
     140: {},
+    141: {},
+    142: {"immediate_vec3_query": True},
+    143: {"immediate_vec3_query": True},
+    144: {},
+    145: {},
+    146: {},
+    147: {},
+    148: {},
+    149: {},
+    150: {},
+    151: {},
 }
 
 
@@ -495,16 +506,39 @@ def body_LONG_DOUBLE_ARG(calls):
 
 
 def body_VECTOR3_ARG(calls):
+    queued = [c for c in calls if c.execution_mode.value == "QUEUED_MUTATION"]
+    immediate = [c for c in calls if c.execution_mode.value == "IMMEDIATE_RESULT"]
     lines = [
-        f"require(descriptor.executionMode == {_QUEUED})",
         "val objectId = receiver.webId()",
+        "when (descriptor.executionMode) {",
+        f"{_QUEUED} -> {{",
         "commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)",
         "when (descriptor.opcode) {",
     ]
-    for c in calls:
+    for c in queued:
         lines.append(f"{c.opcode} -> webWriteVector3Snapshot(objectId, {_slot3(c.opcode)}, value)")
     lines.append('else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")')
     lines.append("}")
+    lines.append("}")
+    if immediate:
+        lines += [
+            f"{_IMMEDIATE} -> {{",
+            f"require({_opcode_guard(immediate)})",
+            "commands.flush()",
+            "// Three Float32 components packed into one query string (unit separator); the",
+            "// applier writes the global transform and re-pushes the node's snapshot.",
+            "val packed =",
+            'listOf(value.x, value.y, value.z).joinToString("\u001f")',
+            "check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {",
+            '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
+            "}",
+            "}",
+        ]
+    lines += [
+        f"{_SNAPSHOT} ->",
+        'error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")',
+        "}",
+    ]
     return lines
 
 
@@ -680,7 +714,12 @@ def body_NODEPATH_RET_HANDLE(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
         "commands.flush()",
-        "return registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))",
+        "return when (descriptor.opcode) {",
+        "17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))",
+        "149 ->",
+        "registerReturnedBrowserObject(immediateWebPropertyObjectQuery(receiver.webId(), path))",
+        'else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")',
+        "}",
     ]
 
 
@@ -851,6 +890,31 @@ def body_CALLABLE_RET_HANDLE(calls):
         "commands.flush()",
         "return registerReturnedBrowserObject(",
         "immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)",
+        ")",
+    ]
+
+
+def body_NOARGS_RET_LONG_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        'return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")',
+        ".toLong()",
+    ]
+
+
+def body_STRINGNAME_OBJECT_RET_INT(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Signal name and object handle packed into one query string (unit separator);",
+        "// the applier resolves the object from the shared handle dictionary and emits.",
+        "return immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'name + "\u001f" + value.webId().toString(),',
         ")",
     ]
 
@@ -1073,6 +1137,11 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ["receiver: GodotHandle", "target: GodotHandle", "method: String"],
         "GodotHandle?",
     ),
+    "NOARGS_RET_LONG_SINGLETON": ([], "Long"),
+    "STRINGNAME_OBJECT_RET_INT": (
+        ["receiver: GodotHandle", "name: String", "value: GodotHandle"],
+        "Int",
+    ),
     "NOARGS_RET_RECT2": (["receiver: GodotHandle"], "GodotRect2"),
     "NOARGS_VOID": (["receiver: GodotHandle"], ""),
     "TEXTURE2D_VECTOR2_COLOR_ARGS": (
@@ -1267,6 +1336,8 @@ EMIT_ORDER = [
     "OBJECT_RET_HANDLE",
     "OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE",
     "CALLABLE_RET_HANDLE",
+    "NOARGS_RET_LONG_SINGLETON",
+    "STRINGNAME_OBJECT_RET_INT",
 ]
 
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -2166,6 +2166,185 @@
       "returnOwnership": "BORROWED",
       "semantics": "Queue a render-layer mask write (FPS weapon models render on the overlay camera's layer 2).",
       "introducedBy": "60e-fps"
+    },
+    {
+      "opcode": 141,
+      "scope": "class",
+      "className": "Node3D",
+      "methodName": "get_global_rotation",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the node's world-space Euler rotation synchronously (a nested camera's global basis derives from it).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 142,
+      "scope": "class",
+      "className": "Node3D",
+      "methodName": "set_global_position",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Write the node's world-space position synchronously and re-push its transform snapshot (character respawn).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 143,
+      "scope": "class",
+      "className": "Node3D",
+      "methodName": "set_global_rotation",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Write the node's world-space Euler rotation synchronously and re-push its transform snapshot (skin facing).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 144,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "set_physics_process",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue toggling a node's _physics_process (the character controller freezes on flag reach).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 145,
+      "scope": "class",
+      "className": "Input",
+      "methodName": "get_mouse_mode",
+      "hash": 965286182,
+      "arguments": [],
+      "returnType": "enum::Input.MouseMode",
+      "shape": "NOARGS_RET_LONG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the mouse capture mode through the active script's proxy singleton.",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 146,
+      "scope": "class",
+      "className": "AudioStreamPlayer3D",
+      "methodName": "play",
+      "hash": 1958160172,
+      "arguments": [
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue playing a positional 3D audio stream (from_position baked default).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 147,
+      "scope": "class",
+      "className": "AudioStreamPlayer3D",
+      "methodName": "stop",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue stopping a positional 3D audio stream.",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 148,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "emit_signal",
+      "hash": 4047867050,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "enum::Error",
+      "shape": "STRINGNAME_OBJECT_RET_INT",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "isVararg": true,
+      "typedVarargTail": [
+        "Object"
+      ],
+      "descriptorName": "OBJECT_EMIT_SIGNAL_OBJECT",
+      "semantics": "Emit a signal carrying one Godot-object argument (the tutorial's kill-plane event forwards the touching body).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 149,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "get",
+      "hash": 2760726917,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "NODEPATH_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read an object-valued property (the tutorial's AnimationTree state-machine playback); non-object values resolve to a null handle.",
+      "introducedBy": "60e-corpus",
+      "descriptorName": "OBJECT_GET_OBJECT_PROPERTY"
+    },
+    {
+      "opcode": 150,
+      "scope": "class",
+      "className": "AnimationNodeStateMachinePlayback",
+      "methodName": "travel",
+      "hash": 3823612587,
+      "arguments": [
+        "StringName",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a state-machine transition to a named state (reset_on_teleport baked to Godot's default true).",
+      "introducedBy": "60e-corpus"
+    },
+    {
+      "opcode": 151,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "set_indexed",
+      "hash": 3500910842,
+      "arguments": [
+        "NodePath",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a double-valued indexed property write (AnimationTree blend parameters like the run tilt).",
+      "introducedBy": "60e-corpus",
+      "descriptorName": "OBJECT_SET_INDEXED_DOUBLE"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -29,9 +29,10 @@ import { runWeb3d } from "./demos/web3d.mjs";
 import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
+import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
 
 function parseArgs(argv) {
   const args = {};
@@ -236,9 +237,24 @@ async function main() {
       await call("Input.dispatchMouseEvent", { type: "mouseReleased", x: release.x, y: release.y, button: "left", buttons: 0, clickCount: 1 });
     };
 
+    // Trusted keyboard input (CDP synthesis needs key: AND text: to reach Godot).
+    const keys = async (type, value) => {
+      const isSpace = value === " ";
+      const code = isSpace ? "Space" : `Key${value.toUpperCase()}`;
+      const vk = isSpace ? 32 : value.toUpperCase().charCodeAt(0);
+      await call("Input.dispatchKeyEvent", {
+        type: type === "down" ? "keyDown" : "keyUp",
+        key: value,
+        code,
+        windowsVirtualKeyCode: vk,
+        nativeVirtualKeyCode: vk,
+        ...(type === "down" ? { text: value } : {}),
+      });
+    };
+
     // Drive the demo. The demo module returns startup + assertion + lifecycle
     // facts; console/exception capture stays here where CDP delivers it.
-    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -1,0 +1,256 @@
+// demos/charactercontroller.mjs -- 3D character-controller tutorial play + teardown
+// assertions for the Web smoke.
+//
+// The tutorial is input-driven: this driver dispatches synthetic DOM keyboard events
+// (transport-agnostic -- Godot's Web input listens on the canvas, so the same evaluate
+// path works on Chrome and Firefox) to hold move_up, and PROVES movement by reading the
+// player's global position through the bridge's immediate Vector3 channel (opcode 138)
+// before and after the hold. Gameplay around it is self-evidencing: the AnimationTree
+// state machine travels Idle/Move each physics tick, the blink timers cycle, and
+// SmokeQuit.smoke_teardown frees the Events autoload + scene root, draining every live
+// handle to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[charactercontroller ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        playerHandle: bridge.charPlayerHandle,
+        smokeQuitHandle: bridge.charSmokeQuitHandle,
+        readyCount: bridge.readyCount,
+        playerReady: classCount(".Player3DTemplate"),
+        skinReady: classCount(".SophiaSkin"),
+        eventsReady: classCount(".Events"),
+        smokeQuitReady: classCount(".SmokeQuit"),
+        flagReady: classCount(".Flag3D"),
+        killPlaneReady: classCount(".KillPlane3D"),
+        physicsCalls: bridge.physicsProcessCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        physicsAfterProcess: bridge.physicsAfterProcessSameTick ?? 0,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+// The player's world position through the immediate no-args Vector3 channel
+// (opcode 138 = Node3D.get_global_position on the player's script handle).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.charPlayerHandle;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+const keyExpression = (type, code, key, keyCode) => `(() => {
+  const canvas = document.querySelector("canvas");
+  canvas.focus();
+  canvas.dispatchEvent(new KeyboardEvent(${JSON.stringify(type)}, {
+    code: ${JSON.stringify(code)}, key: ${JSON.stringify(key)},
+    keyCode: ${keyCode}, which: ${keyCode}, bubbles: true, cancelable: true,
+  }));
+  return true;
+})()`;
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(`physics=${snap.physicsCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} errs=${snap.callbackErrors}`);
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runCharactercontroller({ url, evaluate, navigate, keys, deadline }) {
+  // Trusted per-engine key synthesis when the transport provides it; DOM-event
+  // fallback otherwise (works headless-Chrome, stalls headless-Firefox rAF).
+  const keyDown = keys ? () => keys("down", "w") : () => evaluate(keyExpression("keydown", "KeyW", "w", 87));
+  const keyUp = keys ? () => keys("up", "w") : () => evaluate(keyExpression("keyup", "KeyW", "w", 87));
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?charactercontroller=${Date.now()}`);
+
+  const readyDeadline = Math.min(deadline, Date.now() + 45_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "charactercontroller" &&
+      snap.protocol > 0 &&
+      snap.playerReady >= 1 &&
+      snap.skinReady >= 1 &&
+      snap.eventsReady >= 1 &&
+      snap.smokeQuitReady >= 1 &&
+      snap.flagReady >= 1 &&
+      snap.killPlaneReady >= 1 &&
+      snap.playerHandle > 0 &&
+      snap.smokeQuitHandle > 0
+    ) {
+      ready = snap;
+      break;
+    }
+    await delay(100);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm character-controller tutorial did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`ready: readyCount=${ready.readyCount} playerHandle=${ready.playerHandle} protocol=${ready.protocol}`);
+
+  // Let the scene settle (gravity snap to floor), then take the movement baseline.
+  // Counters restart from the post-settle snapshot: on fast-ticking engines the settle
+  // itself consumes physics frames and must not eat into the movement window.
+  await observe(evaluate, { ...seedFrom(ready), callbackErrors: 0 }, 2_000, deadline, null);
+  const baseline = (await snapshot(evaluate)) ?? ready;
+  const startPosition = await playerPosition(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  trace(`start position: ${JSON.stringify(startPosition)}`);
+
+  // Hold move_up (W) via synthetic DOM keys: the camera-relative controller
+  // accelerates, the skin travels to Move, dust particles emit.
+  await keyDown();
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    6_000,
+    deadline,
+    (snap, p) => p.physicsCalls >= baseline.physicsCalls + 150,
+  );
+  await keyUp();
+  const runPosition = await playerPosition(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? ready;
+  const displacement = runPosition
+    ? Math.hypot(runPosition.x - startPosition.x, runPosition.z - startPosition.z)
+    : 0;
+  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
+
+  // Full teardown: SmokeQuit.smoke_teardown (method#1) frees the Events autoload and
+  // the scene root; every node exits the tree and releases its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.charSmokeQuitHandle, 1); true",
+  );
+  const teardown = await observe(evaluate, peak, 8_000, deadline, (snap) => snap.liveHandles === 0);
+  const settled = teardown.last ?? atPeak;
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} errs=${settled.callbackErrors}`);
+
+  const protocolVersion = ready.protocol;
+  const checks = {
+    modeCharactercontroller: ready.mode === "charactercontroller",
+    protocol12: protocolVersion === 12,
+    sceneScriptsReady:
+      ready.playerReady >= 1 &&
+      ready.skinReady >= 1 &&
+      ready.eventsReady >= 1 &&
+      ready.smokeQuitReady >= 1 &&
+      ready.flagReady >= 1 &&
+      ready.killPlaneReady >= 1,
+    // Synthetic move_up displaced the player through the camera-relative controller
+    // (move_and_slide + the global-position immediate read prove the whole chain).
+    playerMovedOnInput: displacement > 1.0,
+    // Headless rAF throttles to ~15 ticks/s; 40 ticks proves sustained physics.
+    physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    // travel(Idle/Move) + particle toggles + blink timers flow as queued commands.
+    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
+    crossingsAdvanced: peak.crossings > ready.crossings,
+    fullTeardownToZero: settled.liveHandles === 0,
+    // Godot runs every physics tick before the idle/_process pass inside one rAF
+    // iteration; the bridge counts any same-tick physics-after-process dispatch.
+    physicsOrderingDeterministic: (settled.physicsAfterProcess ?? 0) === 0,
+    noCallbackFaults:
+      peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready.mode === "charactercontroller",
+      outcome: ready.mode === "charactercontroller" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      physicsProcessCalls: peak.physicsCalls,
+      appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(displacement.toFixed(3)),
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+    },
+    boundaryErrors,
+  };
+}
+
+function seedFrom(snap) {
+  return {
+    physicsCalls: snap.physicsCalls,
+    appliedCommands: snap.appliedCommands,
+    maxLiveHandles: snap.liveHandles,
+    crossings: snap.crossings,
+  };
+}

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -153,7 +153,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol11: protocolVersion === 11,
+    protocol12: protocolVersion === 12,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -137,7 +137,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol11: protocolVersion === 11,
+    protocol12: protocolVersion === 12,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -227,7 +227,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol11: firstRun.settled.protocol === 11 && secondRun.settled.protocol === 11,
+    protocol12: firstRun.settled.protocol === 12 && secondRun.settled.protocol === 12,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol11: protocolVersion === 11,
+    protocol12: protocolVersion === 12,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol11: protocolVersion === 11,
+    protocol12: protocolVersion === 12,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -121,7 +121,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol11: protocolVersion === 11,
+    protocol12: protocolVersion === 12,
     sceneReady: ready.mainReady >= 1,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -22,9 +22,10 @@ import { runWeb3d } from "./demos/web3d.mjs";
 import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
+import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -199,7 +200,21 @@ async function main() {
         ],
       });
 
-    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
+    // Trusted keyboard input: WebDriver key-source state persists across
+    // performActions calls, so a down-only action holds the key until keyUp.
+    const keys = (type, value) =>
+      command("input.performActions", {
+        context,
+        actions: [
+          {
+            type: "key",
+            id: "keyboard",
+            actions: [{ type: type === "down" ? "keyDown" : "keyUp", value }],
+          },
+        ],
+      });
+
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -21,9 +21,10 @@ import { runWeb3d } from "./demos/web3d.mjs";
 import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
+import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -27,6 +27,7 @@ val extraWebScriptSourceRoot: File? =
                     "platformer" -> "kanamaWebPlatformerProjectDir"
                     "squash" -> "kanamaWebSquashProjectDir"
                     "fps" -> "kanamaWebFpsProjectDir"
+                    "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
                     else -> null
                 }
             projectDirProperty
@@ -127,6 +128,10 @@ val webSquashStaging = layout.buildDirectory.dir("web-squash/godot-project")
 val webFpsSourceProject =
     providers.gradleProperty("kanamaWebFpsProjectDir").orNull?.let(rootProject::file)
 val webFpsStaging = layout.buildDirectory.dir("web-fps/godot-project")
+val webCharacterSourceProject =
+    providers.gradleProperty("kanamaWebCharactercontrollerProjectDir").orNull
+        ?.let(rootProject::file)
+val webCharacterStaging = layout.buildDirectory.dir("web-charactercontroller/godot-project")
 val webMatch3ImportLog = layout.buildDirectory.file("reports/web-match3-import.log")
 val webMatch3ImportOutput = ByteArrayOutputStream()
 val webGameplayCoverage = layout.buildDirectory.file("reports/web-gameplay-coverage.json")
@@ -1610,6 +1615,163 @@ tasks.register<Exec>("exportWebMatch3") {
 
 val webScriptsBundle = layout.buildDirectory.dir("web-scripts")
 val webExportRoot = layout.buildDirectory.dir("web-export")
+tasks.register("stageWebCharactercontrollerProject") {
+    group = "verification"
+    description = "Stages the 3D character-controller tutorial with generated Web proxies (60e)."
+    dependsOn("kspKotlinWasmJs", "generateWebGameplayCoverage")
+    webCharacterSourceProject?.let(inputs::dir)
+    inputs.dir(webSpikeAssets)
+    inputs.dir(webProxyResources)
+    inputs.file(webGameplayCoverage)
+    outputs.dir(webCharacterStaging)
+
+    doLast {
+        val sourceProject =
+            webCharacterSourceProject
+                ?: error(
+                    "Pass -PkanamaWebCharactercontrollerProjectDir=" +
+                        "/absolute/path/to/kanama-demos/godot-4-3d-character-controller-tutorial"
+                )
+        check(sourceProject.resolve("game.tscn").isFile) {
+            "Character-controller project not found: $sourceProject"
+        }
+
+        val stagingDir = webCharacterStaging.get().asFile
+        delete(stagingDir)
+        copy {
+            from(sourceProject) {
+                exclude(".git/**")
+                exclude(".godot/**")
+                exclude(".gradle/**")
+                exclude(".kotlin/**")
+                exclude("build/**")
+                exclude("web/**")
+                exclude("kotlin-src/**")
+                exclude("android/**")
+                exclude("lesson_reference/*.kt")
+                exclude("addons/kanama_tools/**")
+                exclude("addons/kanama/**")
+                exclude("export_presets.cfg")
+            }
+            into(stagingDir)
+        }
+        // The demo ships Android/iOS presets; the Web export needs the canonical Web preset.
+        copy {
+            from(webSpikeSourceProject.file("export_presets.cfg"))
+            into(stagingDir)
+        }
+        copy {
+            from(webProxyResources)
+            include("*.gd")
+            into(stagingDir.resolve("kanama-web/generated"))
+        }
+        copy {
+            from(webProxyResources)
+            include("KanamaWebProxyManifest.generated.tsv")
+            include("KanamaWebProtocol.generated.json")
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webSpikeAssets)
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webGameplayCoverage)
+            into(stagingDir.resolve("kanama-web"))
+        }
+
+        val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
+        val expectedSources =
+            setOf(
+                    "Events",
+                    "Flag3D",
+                    "FlagReachedScreen",
+                    "FreelookCamera3D",
+                    "Game",
+                    "KillPlane3D",
+                    "Player3DTemplate",
+                    "SmokeQuit",
+                    "SophiaSkin",
+                )
+                .map { "res://kotlin-src/$it.kt" }
+                .toSet()
+        val mappings =
+            manifest
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") }
+                .map { it.split('\t').let { c -> c[0] to c[1] } }
+                .filter { (sourcePath, _) -> sourcePath in expectedSources }
+                .toMap()
+        check(mappings.keys == expectedSources) {
+            "Character-controller Web proxy mappings incomplete: " +
+                "missing=${expectedSources - mappings.keys}"
+        }
+
+        fileTree(stagingDir) {
+                include("project.godot")
+                include("**/*.tscn")
+                include("**/*.tres")
+            }
+            .files
+            .forEach { stagedFile ->
+                val original = stagedFile.readText()
+                var rewritten =
+                    mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
+                        text.replace(sourcePath, proxyPath)
+                    }
+                // Godot resolves Script ext_resources by UID before path; strip the UID from
+                // rewritten references so the text path wins (platformer precedent).
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
+                if (rewritten != original) stagedFile.writeText(rewritten)
+                check(!rewritten.contains("res://kotlin-src/")) {
+                    "Unmapped Kotlin attachment remains in staged file: $stagedFile"
+                }
+            }
+
+        // The tutorial targets the Mobile renderer (with a mobile gl_compatibility override);
+        // the Web template only runs the Compatibility renderer, so pin it explicitly
+        // (FPS/squash precedent).
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val mobileFeature = "config/features=PackedStringArray(\"4.7\", \"Mobile\")"
+        val mobileRenderer = "renderer/rendering_method.mobile=\"gl_compatibility\""
+        check(stagedProjectText.contains(mobileFeature)) {
+            "Character-controller renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(mobileRenderer)) {
+            "Character-controller mobile renderer setting changed; update the staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    mobileFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    mobileRenderer,
+                    "renderer/rendering_method=\"gl_compatibility\"\n$mobileRenderer",
+                )
+        )
+
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        shell.writeText(
+            shell.readText()
+                .replace(
+                    pageStart,
+                    "$pageStart\n      globalThis.KanamaWebMode = \"charactercontroller\";",
+                )
+        )
+    }
+}
+
 val webDemo = providers.gradleProperty("kanamaWebDemo").orElse("match3")
 
 // The single renderer/thread contract for the Kotlin/Wasm preview backend.
@@ -1706,9 +1868,10 @@ fun stageTaskFor(demo: String): String =
         "platformer" -> "stageWebPlatformerProject"
         "squash" -> "stageWebSquashProject"
         "fps" -> "stageWebFpsProject"
+        "charactercontroller" -> "stageWebCharactercontrollerProject"
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller)"
             )
     }
 
@@ -1721,9 +1884,10 @@ fun stagingDirFor(demo: String): File =
         "platformer" -> webPlatformerStaging.get().asFile
         "squash" -> webSquashStaging.get().asFile
         "fps" -> webFpsStaging.get().asFile
+        "charactercontroller" -> webCharacterStaging.get().asFile
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller)"
             )
     }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -1,0 +1,65 @@
+@file:OptIn(InternalKanamaBackendApi::class)
+
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.backend.AnimationStateMachinePlaybackBackendContractProbe
+import net.multigesture.kanama.backend.AudioStreamPlayer3DBackendContractProbe
+import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
+import net.multigesture.kanama.backend.InternalKanamaBackendApi
+import net.multigesture.kanama.backend.NodeBackendContractProbe
+import net.multigesture.kanama.web.WebObjectId
+
+/**
+ * Web API surface for the 3D character-controller tutorial (Task 60e corpus).
+ *
+ * Shared Godot classes live in [WebGodotApi]/[WebPlatformerApi]/[WebFpsApi]; the AnimationTree
+ * state-machine and positional-audio surface the tutorial drives lives here and is scanned by the
+ * fail-loud Web gameplay coverage gate.
+ */
+
+/** AnimationTree state-machine playback resolved through the mixer's parameter object. */
+class AnimationNodeStateMachinePlayback internal constructor(godotObject: GodotHandle) :
+  GodotObject(godotObject) {
+  /** Queue a transition to a named state (reset_on_teleport baked to Godot's default). */
+  fun travel(state: String) {
+    AnimationStateMachinePlaybackBackendContractProbe(backendHandle).travel(state)
+  }
+}
+
+/** AnimationPlayer/AnimationTree base: the tutorial drives an AnimationTree state machine. */
+class AnimationMixer(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
+  /** Resolve the playback object behind a `parameters/.../playback` property. */
+  fun getStateMachinePlayback(path: String): AnimationNodeStateMachinePlayback =
+    GodotObjectBackendContractProbe(backendHandle).getObjectProperty(path)?.let { handle ->
+      AnimationNodeStateMachinePlayback(WebObjectId(handle.backendToken().toInt()))
+    } ?: error("AnimationMixer parameter '$path' is not an AnimationNodeStateMachinePlayback")
+
+  /** Double-valued blend parameter write (the run tilt add_amount). */
+  fun setParameter(path: String, value: Double) {
+    GodotObjectBackendContractProbe(backendHandle).setIndexedDouble(path, value)
+  }
+
+  object Signals {
+    const val animationFinished: String = "animation_finished"
+  }
+}
+
+/** Positional 3D audio (footsteps/jump/land on the tutorial player). */
+class AudioStreamPlayer3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  fun play(fromPosition: Double = 0.0) {
+    AudioStreamPlayer3DBackendContractProbe(backendHandle).play(fromPosition)
+  }
+
+  fun stop() {
+    AudioStreamPlayer3DBackendContractProbe(backendHandle).stop()
+  }
+}
+
+/** Enable or disable the node's physics processing (the tutorial pauses the player on win). */
+fun Node.setPhysicsProcess(enable: Boolean) {
+  NodeBackendContractProbe(backendHandle).setPhysicsProcess(enable)
+}
+
+/** World-space rotation basis derived from the synchronous global-rotation read (scale-1 rigs). */
+val Node3D.globalBasis: Basis
+  get() = Basis.fromEuler(globalRotation)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -58,6 +58,11 @@ open class GodotObject internal constructor(internal val backendHandle: BackendG
       Node2DBackendContractProbe(backendHandle).emitSignal(signal, (args[0] as Long).toInt())
       return
     }
+    if (args.size == 1 && args[0] is GodotObject) {
+      SignalBackendContractProbe(backendHandle)
+        .emitObject(signal, (args[0] as GodotObject).backendHandle)
+      return
+    }
     if (args.size == 1 && args[0] is Vector2i) {
       val value = args[0] as Vector2i
       SignalBackendContractProbe(backendHandle)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -56,7 +56,8 @@ internal object WebSignalCallbackRegistry {
     val ownerHandle: Int,
     val sourceHandle: Int,
     val oneShot: Boolean,
-    val callback: () -> Unit,
+    val callback: (() -> Unit)? = null,
+    val objectCallback: ((Int) -> Unit)? = null,
   )
 
   private var nextId = 1
@@ -73,7 +74,19 @@ internal object WebSignalCallbackRegistry {
   ): Int {
     check(nextId > 0) { "Kanama Web signal callback registry exhausted" }
     val id = nextId++
-    entries[id] = Entry(ownerHandle, sourceHandle, oneShot, callback)
+    entries[id] = Entry(ownerHandle, sourceHandle, oneShot, callback = callback)
+    return id
+  }
+
+  fun registerObject(
+    ownerHandle: Int,
+    sourceHandle: Int,
+    oneShot: Boolean,
+    callback: (Int) -> Unit,
+  ): Int {
+    check(nextId > 0) { "Kanama Web signal callback registry exhausted" }
+    val id = nextId++
+    entries[id] = Entry(ownerHandle, sourceHandle, oneShot, objectCallback = callback)
     return id
   }
 
@@ -90,12 +103,28 @@ internal object WebSignalCallbackRegistry {
   }
 
   fun dispatch(ownerHandle: Int, id: Int) {
+    val entry = requireEntry(ownerHandle, id)
+    val callback =
+      entry.callback ?: error("Kanama Web signal callback id=$id expects an emitted object")
+    if (entry.oneShot) entries.remove(id)
+    callback()
+  }
+
+  fun dispatchObject(ownerHandle: Int, id: Int, argHandle: Int) {
+    val entry = requireEntry(ownerHandle, id)
+    val callback =
+      entry.objectCallback
+        ?: error("Kanama Web signal callback id=$id does not accept an emitted object")
+    if (entry.oneShot) entries.remove(id)
+    callback(argHandle)
+  }
+
+  private fun requireEntry(ownerHandle: Int, id: Int): Entry {
     val entry = entries[id] ?: error("Stale Kanama Web signal callback id=$id")
     check(entry.ownerHandle == ownerHandle) {
       "Kanama Web signal callback id=$id belongs to handle=${entry.ownerHandle}, not $ownerHandle"
     }
-    if (entry.oneShot) entries.remove(id)
-    entry.callback()
+    return entry
   }
 }
 
@@ -134,8 +163,8 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
     flags: Long = 0L,
     callback: () -> Unit,
   ): Long {
-    require(argumentCount == 0) {
-      "Kanama Web signal lambda callbacks currently support zero emitted arguments"
+    require(argumentCount in 0..1) {
+      "Kanama Web signal lambda callbacks currently support at most one emitted argument"
     }
     val callbackId =
       WebSignalCallbackRegistry.register(
@@ -144,12 +173,39 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
         oneShot = flags and GodotObject.CONNECT_ONE_SHOT != 0L,
         callback,
       )
+    val dispatchMethod =
+      if (argumentCount == 0) "_kanama_web_signal_dispatch0" else "_kanama_web_signal_dispatch1"
+    val result =
+      SignalBackendContractProbe(owner.backendHandle)
+        .connectBound(target.backendHandle, name, dispatchMethod, callbackId.toLong(), flags)
+    if (result != 0L) WebSignalCallbackRegistry.unregister(callbackId)
+    return result
+  }
+
+  /**
+   * Connects a one-argument object signal (e.g. body_entered). The emitted Godot object arrives
+   * wrapped as [GodotObject]; resolve a Kanama script via kotlinScriptInstance or re-type it with a
+   * wrapper constructor.
+   */
+  fun connectObject(
+    target: GodotObject,
+    flags: Long = 0L,
+    callback: (GodotObject) -> Unit,
+  ): Long {
+    val callbackId =
+      WebSignalCallbackRegistry.registerObject(
+        target.handle.value,
+        owner.handle.value,
+        oneShot = flags and GodotObject.CONNECT_ONE_SHOT != 0L,
+      ) { argHandle ->
+        callback(GodotObject(WebObjectId(argHandle)))
+      }
     val result =
       SignalBackendContractProbe(owner.backendHandle)
         .connectBound(
           target.backendHandle,
           name,
-          "_kanama_web_signal_dispatch0",
+          "_kanama_web_signal_dispatch_object",
           callbackId.toLong(),
           flags,
         )
@@ -159,8 +215,8 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
 
   /** Suspends until this signal fires once (a one-shot connection resumes the coroutine). */
   suspend fun await(target: GodotObject, argumentCount: Int = 0) {
-    require(argumentCount == 0) {
-      "Kanama Web signal await currently supports zero emitted arguments"
+    require(argumentCount in 0..1) {
+      "Kanama Web signal await currently supports at most one emitted argument"
     }
     suspendCancellableCoroutine { continuation ->
       connect(target, argumentCount, GodotObject.CONNECT_ONE_SHOT) {
@@ -430,6 +486,8 @@ object Input {
     InputActionBackendContractProbe.setMouseMode(mode)
   }
 
+  fun getMouseMode(): Long = InputActionBackendContractProbe.getMouseMode()
+
   /**
    * Composed from two get_axis reads (deadzone-normalized identically for digital keys, the
    * only inputs the Web demos drive), clamped to unit length like Godot's get_vector.
@@ -439,9 +497,16 @@ object Input {
     positiveX: String,
     negativeY: String,
     positiveY: String,
+    deadzone: Double = -1.0,
   ): Vector2 {
     val vector = Vector2(getAxis(negativeX, positiveX), getAxis(negativeY, positiveY))
     val length = vector.length()
+    if (deadzone >= 0.0) {
+      // Godot's deadzone remap: inside the deadzone reads zero, outside rescales to [0, 1].
+      if (length <= deadzone) return Vector2.ZERO
+      if (length > 1.0) return vector / length
+      return vector * ((length - deadzone) / (1.0 - deadzone) / length)
+    }
     return if (length > 1.0) vector / length else vector
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -98,12 +98,27 @@ open class Node3D(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()
     Node3DBackendContractProbe(backendHandle).rotateY(angle)
   }
 
-  /** The node's world-space position, read synchronously (parented nodes differ from local). */
-  val globalPosition: Vector3
+  /** The node's world-space position; reads and writes cross synchronously. */
+  var globalPosition: Vector3
     get() =
       Node3DBackendContractProbe(backendHandle).getGlobalPosition().let {
         Vector3(it.x, it.y, it.z)
       }
+    set(value) {
+      Node3DBackendContractProbe(backendHandle)
+        .setGlobalPosition(GodotVector3(value.x.toFloat(), value.y.toFloat(), value.z.toFloat()))
+    }
+
+  /** The node's world-space Euler rotation; reads and writes cross synchronously. */
+  var globalRotation: Vector3
+    get() =
+      Node3DBackendContractProbe(backendHandle).getGlobalRotation().let {
+        Vector3(it.x, it.y, it.z)
+      }
+    set(value) {
+      Node3DBackendContractProbe(backendHandle)
+        .setGlobalRotation(GodotVector3(value.x.toFloat(), value.y.toFloat(), value.z.toFloat()))
+    }
 }
 
 class GPUParticles3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject) {
@@ -174,7 +189,11 @@ class CharacterBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
 }
 
 /** 3D area monitor: emits body_entered when a physics body overlaps (coin/trigger pickups). */
-open class Area3D(godotObject: GodotHandle) : Node3D(godotObject)
+open class Area3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  object Signals {
+    const val bodyEntered: String = "body_entered"
+  }
+}
 
 open class VisualInstance3D(godotObject: GodotHandle) : Node3D(godotObject)
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -67,7 +67,26 @@ data class Vector3(val x: Double, val y: Double, val z: Double) {
 
   fun length(): Double = sqrt(x * x + y * y + z * z)
 
+  fun lengthSquared(): Double = x * x + y * y + z * z
+
   fun dot(other: Vector3): Double = x * other.x + y * other.y + z * other.z
+
+  fun cross(other: Vector3): Vector3 =
+    Vector3(y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x)
+
+  /** Signed angle to [to] around [axis] (Godot's signed_angle_to). */
+  fun signedAngleTo(to: Vector3, axis: Vector3): Double {
+    val crossTo = cross(to)
+    val unsigned = atan2(crossTo.length(), dot(to))
+    return if (crossTo.dot(axis) < 0.0) -unsigned else unsigned
+  }
+
+  /** Move toward [to] by at most [delta] (Godot's move_toward). */
+  fun moveToward(to: Vector3, delta: Double): Vector3 {
+    val difference = to - this
+    val len = difference.length()
+    return if (len <= delta || len < 1e-8) to else this + difference / len * delta
+  }
 
   fun withX(value: Number): Vector3 = Vector3(value.toDouble(), y, z)
 
@@ -110,6 +129,9 @@ data class Vector3(val x: Double, val y: Double, val z: Double) {
     val UP = Vector3(0.0, 1.0, 0.0)
     val DOWN = Vector3(0.0, -1.0, 0.0)
     val FORWARD = Vector3(0.0, 0.0, -1.0)
+    val BACK = Vector3(0.0, 0.0, 1.0)
+    val LEFT = Vector3(-1.0, 0.0, 0.0)
+    val RIGHT = Vector3(1.0, 0.0, 0.0)
   }
 }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -453,6 +453,14 @@ fun kanamaWebDispatchSignal0(objectId: Int, callbackId: Int): Int {
 }
 
 @JsExport
+fun kanamaWebDispatchSignalObject(objectId: Int, callbackId: Int, argHandle: Int): Int {
+  return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch_object") {
+    WebSignalCallbackRegistry.dispatchObject(objectId, callbackId, argHandle)
+    1
+  }
+}
+
+@JsExport
 fun kanamaWebLoadPositionSnapshot(objectId: Int, x: Double, y: Double): Int {
   loadWebPositionSnapshot(objectId, x, y)
   return 1

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -31,6 +31,9 @@ internal fun immediateWebConstructObject(className: String): Int =
 internal fun immediateWebNodeLookup(objectId: Int, path: String): Int =
   js("globalThis.KanamaWebBridge.immediateNodeLookup(objectId, path)")
 
+internal fun immediateWebPropertyObjectQuery(objectId: Int, name: String): Int =
+  js("globalThis.KanamaWebBridge.immediatePropertyObjectQuery(objectId, name)")
+
 internal fun immediateWebPackedSceneInstantiate(resourceId: Int, editState: Int): Int =
   js("globalThis.KanamaWebBridge.immediatePackedSceneInstantiate(resourceId, editState)")
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -72,7 +72,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97))
+    require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144))
     val objectId = receiver.webId()
     commands.appendBoolMutation(descriptor.opcode, objectId, value)
     when (descriptor.opcode) {
@@ -93,7 +93,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     }
     when (descriptor.executionMode) {
       GodotExecutionMode.QUEUED_MUTATION -> {
-        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99))
+        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146))
         commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
@@ -372,7 +372,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(47, 57, 66, 128))
+    require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
     commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
   }
 
@@ -411,7 +411,11 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
     commands.flush()
-    return registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
+    return when (descriptor.opcode) {
+      17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
+      149 -> registerReturnedBrowserObject(immediateWebPropertyObjectQuery(receiver.webId(), path))
+      else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
+    }
   }
 
   override fun invokeLongRetHandle(
@@ -750,7 +754,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138))
+        require(descriptor.opcode in setOf(113, 123, 124, 138, 141))
         commands.flush()
         GodotVector3(
           immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
@@ -770,17 +774,32 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     value: GodotVector3,
   ) {
     requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
     val objectId = receiver.webId()
-    commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
-    when (descriptor.opcode) {
-      74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
-      76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
-      78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
-      88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
-      101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
-      118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
-      else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
+    when (descriptor.executionMode) {
+      GodotExecutionMode.QUEUED_MUTATION -> {
+        commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
+        when (descriptor.opcode) {
+          74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
+          76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
+          78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
+          88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
+          101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
+          118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
+          else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
+        }
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(142, 143))
+        commands.flush()
+        // Three Float32 components packed into one query string (unit separator); the
+        // applier writes the global transform and re-pushes the node's snapshot.
+        val packed = listOf(value.x, value.y, value.z).joinToString("")
+        check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {
+          "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+        }
+      }
+      GodotExecutionMode.SNAPSHOT_READ ->
+        error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")
     }
   }
 
@@ -836,7 +855,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(103, 132))
+    require(descriptor.opcode in setOf(103, 132, 151))
     require(doubleValue.isFinite())
     commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
   }
@@ -949,6 +968,37 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     commands.flush()
     return registerReturnedBrowserObject(
       immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)
+    )
+  }
+
+  override fun invokeNoArgsRetLongSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 145)
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "").toLong()
+  }
+
+  override fun invokeStringNameObjectRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 148)
+    commands.flush()
+    // Signal name and object handle packed into one query string (unit separator);
+    // the applier resolves the object from the shared handle dictionary and emits.
+    return immediateWebObjectQuery(
+      descriptor.opcode,
+      receiver.webId(),
+      name + "" + value.webId().toString(),
     )
   }
 

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 11;
+  const KANAMA_WEB_PROTOCOL_VERSION = 12;
 
   function commandWordCount(opcode) {
     if (
@@ -18,7 +18,8 @@
       opcode === 58 ||
       opcode === 59 ||
       opcode === 63 ||
-      opcode === 64
+      opcode === 64 ||
+      opcode === 147
     ) return 2;
     if (
       opcode === 14 ||
@@ -32,6 +33,7 @@
       opcode === 129 ||
       opcode === 130 ||
       opcode === 140 ||
+      opcode === 150 ||
       opcode === 66
     ) return 3;
     if (
@@ -60,6 +62,8 @@
       opcode === 97 ||
       opcode === 99 ||
       opcode === 105 ||
+      opcode === 144 ||
+      opcode === 146 ||
       opcode === 1000
     ) return 4;
     if (
@@ -72,7 +76,8 @@
       opcode === 88 ||
       opcode === 101 ||
       opcode === 103 ||
-      opcode === 132
+      opcode === 132 ||
+      opcode === 151
     ) return 5;
     if (opcode === 32) return 6;
     if (opcode === 6) return 9;
@@ -234,6 +239,8 @@
     squashSmokeQuitHandle: 0,
     fpsSmokeHandle: 0,
     fpsPlayerHandle: 0,
+    charSmokeQuitHandle: 0,
+    charPlayerHandle: 0,
     // _physics_process/_process ordering evidence (Task 60d): Godot's iteration runs all
     // physics ticks BEFORE the idle/_process pass inside one requestAnimationFrame callback,
     // so a physics dispatch AFTER a process dispatch within the same rAF tick would be an
@@ -1159,6 +1166,22 @@
       }
       return this.immediateResourceReleaseResult;
     },
+    immediatePropertyObjectQuery(handle, name) {
+      // Object-valued property read (opcode 149): the proxy resolves receiver.get(name),
+      // registers the result under the proposed slot (or an existing/script handle), and
+      // publishes the winning handle through the object-query integer channel.
+      const owner = this.ownerForHandle(handle);
+      const callback = this.callbackFor(this.objectQueryCallbacks, handle, "Godot object query");
+      const resultHandle = this.allocateBrowserHandle("Object", owner);
+      this.immediateLongResult = null;
+      callback(149, handle, `${name}\u001f${resultHandle}`);
+      const result = this.immediateLongResult;
+      if (!Number.isInteger(result)) {
+        throw new Error("Godot property object query callback did not publish a result");
+      }
+      if (result !== resultHandle) this.releaseBrowserHandle(resultHandle, "Object");
+      return result;
+    },
     immediateNodeLookup(handle, path) {
       const owner = this.ownerForHandle(handle);
       const callback = this.callbackFor(this.nodeLookupCallbacks, handle, "Godot node lookup");
@@ -1486,6 +1509,15 @@
         }
       }
       return this.immediateConnectResult;
+    },
+    dispatchSignalObject(handle, callbackId, argHandle) {
+      return this.invoke(
+        handle,
+        "_kanama_web_signal_dispatch_object",
+        `callback#${callbackId}`,
+        () => this.api.kanamaWebDispatchSignalObject(handle, callbackId, argHandle),
+        0,
+      );
     },
     dispatchSignal0(handle, callbackId) {
       const result = this.invoke(
@@ -1863,6 +1895,14 @@
       }
       if (this.mode === "fps" && scriptName.endsWith(".Player")) {
         this.fpsPlayerHandle = handle;
+      }
+      if (this.mode === "charactercontroller" && scriptName.endsWith(".SmokeQuit")) {
+        // The driver calls SmokeQuit.smoke_teardown (method#1) to free the Events autoload
+        // and the scene root, draining live handles to zero.
+        this.charSmokeQuitHandle = handle;
+      }
+      if (this.mode === "charactercontroller" && scriptName.endsWith(".Player3DTemplate")) {
+        this.charPlayerHandle = handle;
       }
       if (this.mode === "match3") {
         this.match3ScriptNamesByHandle.set(handle, scriptName);


### PR DESCRIPTION
Continues the task-60 Web corpus: the godot-4-3d-character-controller-tutorial is fully playable on the Web backend (paired demos PR: kanama-demos#18).

## What's here

- **Families 141-151** (protocol 11 -> 12): `get_global_rotation` / `set_global_position` / `set_global_rotation` (immediate packed-vec3 through the object-query channel with a synchronous Node3D snapshot refresh), `Node.set_physics_process`, `Input.mouse_mode` read (new `NOARGS_RET_LONG_SINGLETON` shape), `AudioStreamPlayer3D.play/stop`, `Object.emit_signal(Object)` (new `STRINGNAME_OBJECT_RET_INT` shape riding the object-query channel with a packed name/handle payload), `Object.get` restricted to object-valued properties (rides `NODEPATH_RET_HANDLE` with a new `immediatePropertyObjectQuery` bridge lookup -- the AnimationTree state-machine playback carrier), `AnimationNodeStateMachinePlayback.travel`, and `Object.set_indexed(double)` (blend parameters).
- **Object-carrying signal lambdas**: `connect(argumentCount = 1)` (proxy drops the argument, rides the zero-arg Kotlin path) and `connectObject` (the emitted Godot object crosses as a script-or-transient handle through the new `dispatchSignalObject` channel, mirroring the registered-function OBJECT rule); `await` accepts one argument; `GodotObject.emitSignal` carries object arguments (the tutorial's kill-plane event forwards the touching body).
- **Bug found by the port**: exported Boolean `@ScriptProperty` values were unsettable on every Web script -- the proxy pushes bools through the long channel (1/0) but the generated registry long-setter only had INT arms (`SophiaSkin.blink` tripped it).
- **Trusted `keys` input primitive** in the Chrome (CDP `dispatchKeyEvent` with `key`+`text`) and Firefox (BiDi `input.performActions` key source; state persists so a down-only action holds) smoke transports. Synthetic DOM KeyboardEvents turned out to stall headless Firefox's rAF (one physics tick in nine seconds) -- real per-engine input is required.
- **charactercontroller.mjs smoke**: proves real movement by reading the player's global position through the immediate Vector3 channel before/after a held `w` -- 14.85 units displacement on both engines -- plus teardown-to-zero (SmokeQuit frees the Events autoload before the root) and the standard ordering/callback checks.

## Validation

- charactercontroller wrapper-PASS on Chrome AND Firefox (displacement 14.85, `liveAfterTeardown=0`, 0 callback errors).
- All seven prior demos re-exported at protocol 12 and wrapper-PASS on both engines (16/16 smokes green).
- Played headless-Chrome session: Sophia runs (dust trail), jumps, AnimationTree states transition; screenshots verified.
- Drift gates (`generate_web_backend.py --check`, contract `--check`), processor + contract tests, gameplay-coverage gate, ktfmt, desktop jar, scaffold self-test: all green.
- Safari deliberately skipped (standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
