### PR TITLE
Fix #106: GDScript static typing against Kanama @GlobalClass classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable user-facing changes will be recorded here.
 This project uses a Keep a Changelog-style format and follows semantic
 versioning once public releases begin.
 
+## Unreleased
+
+### Fixed
+
+- GDScript can now statically type against Kanama `@GlobalClass` script classes
+  (issue #106): `@export var x: CustomResource` plus
+  `var copy: CustomResource = x` no longer fails with "Cannot assign a value of
+  type res://CustomResource.kt … with specified type res://CustomResource.kt".
+  The `.kt` resource loader pre-set the script's path inside `_load`, which made
+  the engine's post-load `set_path()` early-return without registering the
+  script in ResourceCache — so every `load()` of the same `.kt` produced a
+  distinct Script object, and GDScript's analyzer (which compares script types
+  by identity) rejected the class as its own type. The loader now leaves path
+  assignment to ResourceLoader, and `KanamaScript` implements
+  `_inherits_script` (same script object, or same bound Kotlin class) instead
+  of always answering `false`, so typed containers such as
+  `Array[CustomResource]` also match. Runtime smoke now pins the reported
+  shape: typed member + typed local assignment, `is` check, load identity, and
+  a property round-trip.
+
 ## 0.4.0 - 2026-07-24
 
 ### Added

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -339,7 +339,9 @@ class Weapon(val godotObject: MemorySegment) {
 
 `@GlobalClass` registers `Weapon` in the editor's global class list: it shows
 up in the Create New Resource dialog, its `.tres` instances match typed export
-slots, and another script can export `Weapon?` or `List<Weapon>` — Kanama
+slots, GDScript can statically type against it (`@export var w: Weapon`,
+`var copy: Weapon = w`, `w is Weapon`), and another script can export
+`Weapon?` or `List<Weapon>` — Kanama
 resolves the live Kotlin resource script instances when reading the property;
 values (including nested resource slots like `swingSound`) round-trip through
 `.tscn`/`.tres` storage.

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -1,5 +1,10 @@
 extends Node
 
+# issue #106 — the exact reported shape: an exported member statically typed as a
+# Kanama @GlobalClass. Regressing the loader's ResourceCache registration makes
+# scripts like this fail to parse, which kills every check in this file.
+@export var typed_custom_res: SmokeResource = null
+
 var _kanama_smoke_reload_requested := false
 
 func _on_pinged(value: int) -> void:
@@ -70,6 +75,7 @@ func _ready() -> void:
 		_kanama_dictionary_nullable_value_smoke()
 		_kanama_malformed_property_matrix_smoke()
 		_kanama_classdb_script_class_smoke()
+		_kanama_typed_global_class_smoke()
 		var replace_smoke_scene = $ScriptNode.replace_smoke_scene()
 		print("[kanama:gd] kt script replace_smoke_scene = ", replace_smoke_scene)
 		if not replace_smoke_scene:
@@ -393,6 +399,27 @@ func _kanama_classdb_script_class_smoke() -> void:
 	if not (kanama_can and kanama_instantiate_null and gdscript_can \
 			and gdscript_instantiate_null and recipe_works):
 		push_error("Kanama ClassDB script-class parity failed")
+
+func _kanama_typed_global_class_smoke() -> void:
+	# issue #106 — GDScript static typing against a Kanama @GlobalClass. The loader must
+	# leave path assignment to ResourceLoader: pre-setting the path kept every load() of
+	# the same .kt out of ResourceCache, so the analyzer saw a distinct Script object per
+	# reference and rejected `var t: SmokeResource = value` ("Cannot assign a value of
+	# type res://SmokeResource.kt ... with specified type res://SmokeResource.kt").
+	var same_load := load("res://SmokeResource.kt") == load("res://SmokeResource.kt")
+	var member_copy: SmokeResource = typed_custom_res  # parse-time member shape (stays null)
+	var built = ClassDB.instantiate("Resource")
+	built.set_script(load("res://SmokeResource.kt"))
+	# Runtime typed assignment + `is` both walk the same script identity the analyzer uses.
+	var typed: SmokeResource = built
+	typed.payload = "issue106"
+	var is_check := built is SmokeResource
+	var roundtrip = typed.payload == "issue106"
+	print("[kanama:gd] kt script typed_global_class same_load=", same_load,
+		" member_null=", member_copy == null, " typed=", typed != null,
+		" is_check=", is_check, " roundtrip=", roundtrip)
+	if not (same_load and member_copy == null and typed != null and is_check and roundtrip):
+		push_error("Kanama typed global class smoke failed")
 
 func _kanama_dictionary_nullable_value_smoke() -> void:
 	$ScriptNode.smoke_nullable_scalar_map = {"a": null, "b": 2}

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -154,6 +154,11 @@ check "kt script dictionary nullable_value null_preserved=true wrong_nulled=true
 # ClassDB pair (can_instantiate=true, instantiate=null: script classes aren't engine classes),
 # and the supported base-Resource + set_script construction recipe works.
 check "kt script classdb_parity kanama_can=true kanama_instantiate_null=true gdscript_can=true gdscript_instantiate_null=true recipe_works=true"
+# issue #106 — GDScript static typing against a Kanama @GlobalClass: same_load proves the
+# loaded .kt Script is ResourceCache-cached (one object per path), and the typed member/local
+# assignments plus `is` prove the analyzer and VM accept the class as its own type. The loader
+# must not pre-set the script path in _load; doing so regresses all five to a parse error.
+check "kt script typed_global_class same_load=true member_null=true typed=true is_check=true roundtrip=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"

--- a/src/main/kotlin/binding/KanamaResourceFormatLoader.kt
+++ b/src/main/kotlin/binding/KanamaResourceFormatLoader.kt
@@ -44,10 +44,6 @@ object KanamaResourceFormatLoader {
   private const val RESOURCELOADER_ADD_LOADER_HASH = 2896595483L
   private const val RESOURCELOADER_REMOVE_LOADER_HASH = 405397102L
   private const val PROJECTSETTINGS_GLOBALIZE_PATH_HASH = 3135753539L
-  private const val RESOURCE_SET_PATH_CACHE_HASH = 83702148L
-  private const val RESOURCE_SET_PATH_HASH = 83702148L
-  private const val RESOURCE_TAKE_OVER_PATH_HASH = 83702148L
-  private const val RESOURCE_GET_PATH_HASH = 201670096L
 
   fun register(library: MemorySegment) {
     getRecognizedExtensionsNameValue = GodotStrings.stringNameStorage("_get_recognized_extensions")
@@ -266,22 +262,13 @@ object KanamaResourceFormatLoader {
     System.err.println("[kanama:kt] ResourceFormatLoader._load path=$path")
 
     val scriptObj = KanamaScript.constructUnbound()
-    // Make this behave like a true external script resource in editor UI.
-    val setPathCacheBind =
-      ObjectCalls.getMethodBind("Resource", "set_path_cache", RESOURCE_SET_PATH_CACHE_HASH)
-    val setPathBind = ObjectCalls.getMethodBind("Resource", "set_path", RESOURCE_SET_PATH_HASH)
-    val takeOverPathBind =
-      ObjectCalls.getMethodBind("Resource", "take_over_path", RESOURCE_TAKE_OVER_PATH_HASH)
-    if (setPathCacheBind.address() != 0L)
-      ObjectCalls.ptrcallWithStringArg(setPathCacheBind, scriptObj, path)
-    if (setPathBind.address() != 0L) ObjectCalls.ptrcallWithStringArg(setPathBind, scriptObj, path)
-    if (takeOverPathBind.address() != 0L)
-      ObjectCalls.ptrcallWithStringArg(takeOverPathBind, scriptObj, path)
-    val getPathBind = ObjectCalls.getMethodBind("Resource", "get_path", RESOURCE_GET_PATH_HASH)
-    if (getPathBind.address() != 0L) {
-      val resolvedPath = ObjectCalls.ptrcallNoArgsRetString(getPathBind, scriptObj)
-      System.err.println("[kanama:kt] ResourceFormatLoader._load script path=$resolvedPath")
-    }
+    // issue #106 — do not set the script's path here. ResourceLoader assigns the
+    // path itself right after _load returns, and that engine-side set_path() is
+    // what registers the script in ResourceCache (it also honors cache_mode).
+    // Pre-setting the path made Resource::set_path() early-return without
+    // registering, so every load of the same .kt minted a distinct Script and
+    // GDScript's analyzer (which compares script types by identity) rejected
+    // assignments of a custom class to its own type.
     val script = KanamaScript.byObjectAddress(scriptObj.address())
     if (script != null) {
       script.sourceCode = readScriptSource(path) ?: "class $basename"

--- a/src/main/kotlin/binding/KanamaScript.kt
+++ b/src/main/kotlin/binding/KanamaScript.kt
@@ -292,7 +292,7 @@ class KanamaScript(
       getGlobalNameStub =
         Upcalls.stub(KanamaScript::class.java, "callGetGlobalName", virtualType, virtualDesc)
       inheritsScriptStub =
-        Upcalls.stub(KanamaScript::class.java, "callBoolFalse", virtualType, virtualDesc)
+        Upcalls.stub(KanamaScript::class.java, "callInheritsScript", virtualType, virtualDesc)
       instanceHasStub =
         Upcalls.stub(KanamaScript::class.java, "callInstanceHas", virtualType, virtualDesc)
       hasSourceCodeStub =
@@ -1013,6 +1013,30 @@ class KanamaScript(
       val script = ObjectRegistry.get(handle) as? KanamaScript
       val name = script?.globalName ?: ""
       GodotStrings.initStringName(rRet.reinterpret(8), name)
+    }
+
+    @JvmStatic
+    fun callInheritsScript(instance: MemorySegment, args: MemorySegment, rRet: MemorySegment) {
+      // issue #106 — _inherits_script(script: Script) -> bool. Kanama has no
+      // script-to-script inheritance, so the relation is "same script type":
+      // the same Script object, or another KanamaScript bound to the same
+      // Kotlin class. Typed containers (Array[X]) and the editor consult this.
+      val self = ObjectRegistry.get(instance.address()) as? KanamaScript
+      // Object* argument arrives as type-ptr (Object**); dereference twice.
+      val objectTypePtr = args.reinterpret(8).get(ADDRESS, 0)
+      val otherObject =
+        if (objectTypePtr.address() != 0L) {
+          objectTypePtr.reinterpret(8).get(ADDRESS, 0)
+        } else {
+          MemorySegment.NULL
+        }
+      val other = if (otherObject.address() != 0L) byObjectAddress(otherObject.address()) else null
+      val inherits =
+        self != null &&
+          other != null &&
+          (other === self ||
+            (self.kotlinClassName.isNotEmpty() && self.kotlinClassName == other.kotlinClassName))
+      rRet.reinterpret(1).set(JAVA_BYTE, 0, if (inherits) 1.toByte() else 0.toByte())
     }
 
     @JvmStatic


### PR DESCRIPTION
Fixes #106.

## Symptom

```
Parse Error: Cannot assign a value of type res://CustomResource.kt to variable "copiedCustomRes" with specified type res://CustomResource.kt.
```

A `@ScriptClass(attachTo = "Resource") @GlobalClass` class could be used as an `@export` type, but any statically typed assignment (`var copy: CustomResource = customRes`) failed at parse time — the class was rejected as its own type.

## Root cause

`KanamaResourceFormatLoader.callLoad` pre-set the script's resource path inside `_load` (`set_path_cache` + `set_path` + `take_over_path`). Godot registers a loaded resource in `ResourceCache` via the `set_path()` call **it** makes right after `_load` returns — but `Resource::set_path()` early-returns when `path_cache` already equals the path, so the script never entered the cache (`set_path_cache` sets the path without registering; the two subsequent calls and the engine's own call all short-circuited).

Consequence: every `ResourceLoader::load()` of the same `.kt` ran a full load and minted a **distinct** Script object (visible as two `Loading resource: res://CustomResource.kt` lines in one analyzer pass). GDScript's analyzer resolves each named-type reference through `ResourceLoader::load(path)` and compares script types **by object identity** (`gdscript_analyzer.cpp`, `is_type_compatible`), so the two references to `CustomResource` were different types with the same display name.

## Fix

- **Loader** (`KanamaResourceFormatLoader.kt`): stop setting the path in `_load`. The engine assigns the path after `_load` returns, which both registers the ResourceCache entry and honors `cache_mode` (REUSE/REPLACE/IGNORE).
- **`KanamaScript`**: implement `_inherits_script` — true for the same script object or another `KanamaScript` bound to the same Kotlin class — replacing the hard-wired `false`. Typed containers (`Array[CustomResource]`) and editor checks consult this after the identity short-circuit.

## Validation

- Reporter's MVP shape reproduced pre-fix and passes post-fix on Godot 4.7-stable (macOS): typed member, typed local assignment, `is` check, `load() == load()` identity, property round-trip (`unit_name = "issue106"`).
- New permanent coverage: `example_project/main.gd` gains an `@export var typed_custom_res: SmokeResource` member plus `_kanama_typed_global_class_smoke()` (typed local assign, `is`, load identity, round-trip), gated by a new `check` line in `scripts/runtime_smoke.sh`.
- `./scripts/local_ci.sh` PASS end-to-end (JVM tests, audits, runtime smoke, @Tool smoke, both hot-reload smokes — relevant because cached scripts are now reused across loads).
- `mkdocs build --strict` clean.
- iOS/Web runtimes have no `.kt` ResourceFormatLoader of their own — the bug is desktop-binding-only.

Note for the reporter (worth mentioning when closing): exported Kotlin properties surface under engine naming, so `unitName` is `resource.unit_name` from GDScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)