### PR TITLE
Task 64: script-surface parity — class_name on object exports + Script-virtuals audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,17 @@ generated wrappers and focused policy fixes over ad hoc hand wrappers.
 - Do not claim platform support unless the matching smoke path has passed.
 - Do not treat package zips as proof of exported-game support; desktop kits
   validate editor/runtime onboarding.
+- In GDExtension callbacks, never pre-empt work the engine performs after the
+  callback returns — path assignment, ResourceCache registration, ownership
+  transfer. Precedent: issue #106, where the `.kt` loader pre-set the script
+  path inside `_load`, the engine's registering `set_path()` early-returned,
+  and every load minted a distinct Script ("cannot assign X to X").
+- When adding an engine-facing surface (Script/ScriptLanguage virtual, property
+  metadata field, loader behavior), pair the Kanama fixture with the equivalent
+  GDScript construct in a smoke parity probe (the
+  `_kanama_classdb_script_class_smoke` / `_kanama_typed_global_class_smoke`
+  pattern), and never leave a virtual returning a constant without a comment
+  arguing why the constant is correct.
 
 ## Looks Wrong But Isn't
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ versioning once public releases begin.
 
 ### Fixed
 
+- Object-typed Kotlin exports now carry `PropertyInfo.class_name` (task 64,
+  follow-up to issue #106): a `@ScriptProperty var x: SmokeResource?` (or an
+  engine wrapper slot like `AudioStream?`) previously reported an empty
+  `class_name`, so typed GDScript degraded `node.smoke_resource` to plain
+  `Object`/`Resource` (no safe static typing or completion). Both metadata
+  paths emit it now — the generated instance property list
+  (`ClassDB.PropertySpec` → `GDExtensionPropertyInfo`) and the script-level
+  dictionaries (`PropertyInfo.from_dict`). Also replaces the always-true
+  `_is_placeholder_fallback_enabled` stub with GDScript-parity semantics
+  (fallback only for a script that failed to bind), and documents why the
+  remaining constant-returning Script/ScriptLanguage virtuals are correct as
+  constants. Runtime smoke asserts `class_name` on both paths plus a statically
+  typed member read.
 - GDScript can now statically type against Kanama `@GlobalClass` script classes
   (issue #106): `@export var x: CustomResource` plus
   `var copy: CustomResource = x` no longer fails with "Cannot assign a value of

--- a/example_project/main.gd
+++ b/example_project/main.gd
@@ -415,10 +415,33 @@ func _kanama_typed_global_class_smoke() -> void:
 	typed.payload = "issue106"
 	var is_check := built is SmokeResource
 	var roundtrip = typed.payload == "issue106"
+	# task 64 — PropertyInfo.class_name on Kotlin object-typed exports. Both metadata
+	# paths must carry it: the instance property list (generated PropertySpec ->
+	# GDExtensionPropertyInfo) and the script-level list (generated dictionaries ->
+	# PropertyInfo.from_dict). GDScript's analyzer types `hs.smoke_resource` from
+	# class_name; empty degraded it to plain Resource in typed GDScript.
+	var hs: HelloScript = $ScriptNode
+	hs.smoke_resource = typed
+	var typed_member: SmokeResource = hs.smoke_resource
+	var member_matches := typed_member == typed
+	hs.smoke_resource = null
+	var instance_class_name := ""
+	for p in ($ScriptNode as Node).get_property_list():
+		if p.name == "smoke_resource":
+			instance_class_name = str(p.get("class_name", ""))
+	var script_class_name := ""
+	for p in load("res://HelloScript.kt").get_script_property_list():
+		if p.name == "smoke_resource":
+			script_class_name = str(p.get("class_name", ""))
 	print("[kanama:gd] kt script typed_global_class same_load=", same_load,
 		" member_null=", member_copy == null, " typed=", typed != null,
-		" is_check=", is_check, " roundtrip=", roundtrip)
-	if not (same_load and member_copy == null and typed != null and is_check and roundtrip):
+		" is_check=", is_check, " roundtrip=", roundtrip,
+		" member_matches=", member_matches,
+		" instance_class_name=", instance_class_name == "SmokeResource",
+		" script_class_name=", script_class_name == "SmokeResource")
+	if not (same_load and member_copy == null and typed != null and is_check and roundtrip \
+			and member_matches and instance_class_name == "SmokeResource" \
+			and script_class_name == "SmokeResource"):
 		push_error("Kanama typed global class smoke failed")
 
 func _kanama_dictionary_nullable_value_smoke() -> void:

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -2043,6 +2043,10 @@ private const val PROPERTY_USAGE_CATEGORY = 128
 private const val PROPERTY_USAGE_SUBGROUP = 256
 private const val PROPERTY_USAGE_EDITOR = 4
 private const val PROPERTY_HINT_TOOL_BUTTON = 39
+// task 64 — mirrored from the model-builder companion for the emitter scope;
+// the hints whose hint_string is exactly the property's class name.
+private const val PROPERTY_HINT_RESOURCE_TYPE = 17
+private const val PROPERTY_HINT_NODE_TYPE = 34
 
 private val kotlinStringLiteralPattern = "\"(?:\\\\.|[^\"\\\\])*\""
 
@@ -3659,8 +3663,26 @@ internal class ScriptCodeEmitter(
 
   private fun scriptPropertySpecExpression(p: ScriptPropertyModel): String {
     val declaredType = scriptPropertyDeclaredVariantType(p)
-    return "ClassDB.PropertySpec(\"${kotlinStringLiteral(p.godotName)}\", VariantType.$declaredType, ${p.hint}, \"${kotlinStringLiteral(p.hintString)}\", ${p.usage})"
+    val className = scriptPropertyClassName(p)
+    val classNameArg = if (className.isEmpty()) "" else ", \"${kotlinStringLiteral(className)}\""
+    return "ClassDB.PropertySpec(\"${kotlinStringLiteral(p.godotName)}\", VariantType.$declaredType, ${p.hint}, \"${kotlinStringLiteral(p.hintString)}\", ${p.usage}$classNameArg)"
   }
+
+  // task 64 — PropertyInfo.class_name for object-typed exports. GDScript's
+  // analyzer resolves a property's static type from class_name (hint_string is
+  // inspector-only); leaving it empty typed Kotlin-exported object properties
+  // as plain Object/Resource in typed GDScript. For RESOURCE_TYPE/NODE_TYPE
+  // hints the hint string is exactly the class name (engine wrapper class or
+  // @GlobalClass simple name), so reuse it.
+  private fun scriptPropertyClassName(p: ScriptPropertyModel): String =
+    if (
+      p.type == TypeMapping.OBJECT &&
+        (p.hint == PROPERTY_HINT_RESOURCE_TYPE || p.hint == PROPERTY_HINT_NODE_TYPE)
+    ) {
+      p.hintString
+    } else {
+      ""
+    }
 
   private fun toolButtonPropertySpecExpression(button: ToolButtonModel): String =
     "ClassDB.PropertySpec(\"${kotlinStringLiteral(button.propertyName)}\", VariantType.CALLABLE, $PROPERTY_HINT_TOOL_BUTTON, \"${kotlinStringLiteral(button.hintString)}\", $PROPERTY_USAGE_EDITOR)"
@@ -3670,7 +3692,10 @@ internal class ScriptCodeEmitter(
 
   private fun scriptPropertyDictionaryExpression(p: ScriptPropertyModel): String {
     val declaredType = scriptPropertyDeclaredVariantType(p)
-    return "mapOf(\"name\" to \"${kotlinStringLiteral(p.godotName)}\", \"type\" to VariantType.$declaredType.id, \"hint\" to ${p.hint}, \"hint_string\" to \"${kotlinStringLiteral(p.hintString)}\", \"usage\" to ${p.usage})"
+    val className = scriptPropertyClassName(p)
+    val classNameEntry =
+      if (className.isEmpty()) "" else ", \"class_name\" to \"${kotlinStringLiteral(className)}\""
+    return "mapOf(\"name\" to \"${kotlinStringLiteral(p.godotName)}\", \"type\" to VariantType.$declaredType.id, \"hint\" to ${p.hint}, \"hint_string\" to \"${kotlinStringLiteral(p.hintString)}\", \"usage\" to ${p.usage}$classNameEntry)"
   }
 
   private fun toolButtonPropertyDictionaryExpression(button: ToolButtonModel): String =

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -348,7 +348,7 @@ if ! rg -q 'ClassDB\.PropertySpec\("Runtime", VariantType\.NIL, 0, "", 256\)' "$
   echo "[local_ci] generated script-property export subgroup is missing" >&2
   exit 1
 fi
-if ! rg -q 'ClassDB\.PropertySpec\("smoke_scene", VariantType\.OBJECT, 17, "PackedScene", 6\)' "$hello_script_registrar"; then
+if ! rg -q 'ClassDB\.PropertySpec\("smoke_scene", VariantType\.OBJECT, 17, "PackedScene", 6, "PackedScene"\)' "$hello_script_registrar"; then
   echo "[local_ci] generated script-property PackedScene export metadata is missing" >&2
   exit 1
 fi
@@ -356,7 +356,7 @@ if ! rg -q 'ClassDB\.PropertySpec\("smoke_textures", VariantType\.ARRAY, 23, "24
   echo "[local_ci] generated script-property typed Texture2D array metadata is missing" >&2
   exit 1
 fi
-if ! rg -q 'ClassDB\.PropertySpec\("smoke_resource", VariantType\.OBJECT, 17, "SmokeResource", 6\)' "$hello_script_registrar"; then
+if ! rg -q 'ClassDB\.PropertySpec\("smoke_resource", VariantType\.OBJECT, 17, "SmokeResource", 6, "SmokeResource"\)' "$hello_script_registrar"; then
   echo "[local_ci] generated script-property custom Resource metadata is missing" >&2
   exit 1
 fi
@@ -365,7 +365,7 @@ if ! rg -q 'ClassDB\.PropertySpec\("smoke_resources", VariantType\.ARRAY, 23, "2
   exit 1
 fi
 resource_owner_registrar="$(find_project_script_registrar "ResourceOwnerSmokeScriptRegistrar.kt")"
-if ! rg -q 'ClassDB\.PropertySpec\("smoke_resource", VariantType\.OBJECT, 17, "SmokeResource", 6\)' "$resource_owner_registrar"; then
+if ! rg -q 'ClassDB\.PropertySpec\("smoke_resource", VariantType\.OBJECT, 17, "SmokeResource", 6, "SmokeResource"\)' "$resource_owner_registrar"; then
   echo "[local_ci] generated script-property custom Resource metadata is missing" >&2
   exit 1
 fi

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -158,7 +158,10 @@ check "kt script classdb_parity kanama_can=true kanama_instantiate_null=true gds
 # loaded .kt Script is ResourceCache-cached (one object per path), and the typed member/local
 # assignments plus `is` prove the analyzer and VM accept the class as its own type. The loader
 # must not pre-set the script path in _load; doing so regresses all five to a parse error.
-check "kt script typed_global_class same_load=true member_null=true typed=true is_check=true roundtrip=true"
+# task 64 — PropertyInfo.class_name on object-typed Kotlin exports, both metadata paths
+# (instance PropertySpec structs and script-level dictionaries), plus a statically typed
+# member read (`var m: SmokeResource = hs.smoke_resource` on a typed HelloScript var).
+check "kt script typed_global_class same_load=true member_null=true typed=true is_check=true roundtrip=true member_matches=true instance_class_name=true script_class_name=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"

--- a/src/main/kotlin/binding/KanamaScript.kt
+++ b/src/main/kotlin/binding/KanamaScript.kt
@@ -203,9 +203,9 @@ class KanamaScript(
     private lateinit var getMembersStub: MemorySegment
     private lateinit var instanceCreateStub: MemorySegment
     private lateinit var isToolStub: MemorySegment
-    private lateinit var boolTrueStub: MemorySegment
+    private lateinit var isPlaceholderFallbackEnabledStub: MemorySegment
     private lateinit var boolFalseStub:
-      MemorySegment // shared by is_tool / is_abstract / is_placeholder_fallback_enabled
+      MemorySegment // shared by _editor_can_reload_from_file / _is_abstract
     private lateinit var getDocClassNameStub: MemorySegment
     private lateinit var emptyArrayStub: MemorySegment
     private lateinit var emptyDictionaryStub: MemorySegment
@@ -279,6 +279,11 @@ class KanamaScript(
       val virtualDesc = FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS)
 
       isValidStub = Upcalls.stub(KanamaScript::class.java, "callIsValid", virtualType, virtualDesc)
+      // task 64 — always false is engine parity, not an omission: the Script base
+      // class hard-codes editor_can_reload_from_file() to false ("Reloading is
+      // handled in a special way", core script_language.h) because script reloads
+      // flow through the script language, not generic Resource reload-from-file.
+      // Kanama's reload path is the build/sync pipeline (see the hot-reload smokes).
       editorCanReloadFromFileStub =
         Upcalls.stub(KanamaScript::class.java, "callBoolFalse", virtualType, virtualDesc)
       canInstantiateStub =
@@ -323,8 +328,13 @@ class KanamaScript(
       getMembersStub =
         Upcalls.stub(KanamaScript::class.java, "callGetMembers", virtualType, virtualDesc)
       isToolStub = Upcalls.stub(KanamaScript::class.java, "callIsTool", virtualType, virtualDesc)
-      boolTrueStub =
-        Upcalls.stub(KanamaScript::class.java, "callBoolTrue", virtualType, virtualDesc)
+      isPlaceholderFallbackEnabledStub =
+        Upcalls.stub(
+          KanamaScript::class.java,
+          "callIsPlaceholderFallbackEnabled",
+          virtualType,
+          virtualDesc,
+        )
       boolFalseStub =
         Upcalls.stub(KanamaScript::class.java, "callBoolFalse", virtualType, virtualDesc)
       getDocClassNameStub =
@@ -953,6 +963,9 @@ class KanamaScript(
         getMembersNameValue -> getMembersStub
         instanceCreateNameValue -> instanceCreateStub
         getDocClassNameNameValue -> getDocClassNameStub
+        // task 64 — optional editor metadata, empty by design: Kanama does not
+        // generate in-editor class documentation or per-class icons. The editor
+        // treats an empty doc array / icon path as "none" (no error path).
         getDocumentationNameValue -> emptyArrayStub
         getClassIconPathNameValue -> emptyStringStub
         hasMethodNameValue -> hasMethodStub
@@ -967,8 +980,12 @@ class KanamaScript(
         getScriptSignalListNameValue -> getScriptSignalListStub
         getMemberLineNameValue -> getMemberLineStub
         isToolNameValue -> isToolStub
+        // task 64 — Kanama has no abstract script classes (no annotation surface
+        // declares one), matching the is_abstract=false the language reports in
+        // its _get_global_class_name dictionary. Revisit both together if
+        // abstract @ScriptClass support is ever added.
         isAbstractNameValue -> boolFalseStub
-        isPlaceholderFallbackEnabledNameValue -> boolTrueStub
+        isPlaceholderFallbackEnabledNameValue -> isPlaceholderFallbackEnabledStub
         else -> MemorySegment.NULL
       }
     }
@@ -990,6 +1007,11 @@ class KanamaScript(
 
     @JvmStatic
     fun callGetBaseScript(instance: MemorySegment, args: MemorySegment, rRet: MemorySegment) {
+      // task 64 — always NULL by design: Kanama scripts have no script-to-script
+      // inheritance (a @ScriptClass attaches directly to an engine class, reported
+      // via _get_instance_base_type). The analyzer/VM walk get_base_script() when
+      // comparing script types, so a base chain must never be invented here;
+      // same-type equality is answered by _inherits_script (issue #106).
       rRet.reinterpret(8).set(ADDRESS, 0, MemorySegment.NULL)
     }
 
@@ -1348,8 +1370,23 @@ class KanamaScript(
     }
 
     @JvmStatic
-    fun callBoolTrue(instance: MemorySegment, args: MemorySegment, rRet: MemorySegment) {
-      rRet.reinterpret(1).set(JAVA_BYTE, 0, 1.toByte())
+    fun callIsPlaceholderFallbackEnabled(
+      instance: MemorySegment,
+      args: MemorySegment,
+      rRet: MemorySegment,
+    ) {
+      // task 64 — mirror GDScript's semantics: placeholder fallback is the
+      // data-preservation mode for a *broken* script (GDScript enables it only
+      // when compilation fails), so report it exactly when this script failed to
+      // bind a Kotlin template (no factory). A healthy non-@Tool script in the
+      // editor still gets a normal placeholder with default-value behavior.
+      // Today the engine only consults this through its own
+      // PlaceHolderScriptInstance, which extension scripts never use (Kanama
+      // supplies its own placeholder via _placeholder_instance_create), so the
+      // value is inert — this keeps it honest if that ever changes.
+      val script = ObjectRegistry.get(instance.address()) as? KanamaScript
+      val broken = script?.factory == null
+      rRet.reinterpret(1).set(JAVA_BYTE, 0, if (broken) 1.toByte() else 0.toByte())
     }
 
     /**

--- a/src/main/kotlin/binding/KanamaScriptLanguage.kt
+++ b/src/main/kotlin/binding/KanamaScriptLanguage.kt
@@ -561,6 +561,12 @@ object KanamaScriptLanguage {
       getCommentDelimitersNameValue -> commentDelimitersStub
       getDocCommentDelimitersNameValue -> docCommentDelimitersStub
       getStringDelimitersNameValue -> stringDelimitersStub
+      // task 64 — deliberately-constant language surfaces, not omissions: no
+      // script templates or GDScript-style public functions/annotations/
+      // constants to advertise (Kanama scripts are compiled Kotlin), no
+      // in-engine debugger locals/members/globals or profiler integration
+      // (empty dict / 0 rows = "nothing recorded"), and the external editor is
+      // not overridden (the kanama_tools plugin handles .kt editing flows).
       getBuiltInTemplatesNameValue,
       getPublicFunctionsNameValue,
       getPublicAnnotationsNameValue -> emptyArrayStub

--- a/src/main/kotlin/binding/runtime/ClassDB.kt
+++ b/src/main/kotlin/binding/runtime/ClassDB.kt
@@ -232,6 +232,10 @@ object ClassDB {
     val hint: Int = 0,
     val hintString: String = "",
     val usage: Int = PROPERTY_USAGE_DEFAULT,
+    // task 64 — the property's class for OBJECT-typed slots (RESOURCE_TYPE/
+    // NODE_TYPE hints). GDScript's analyzer types the property from this, not
+    // from hint_string; empty means "plain Object" in typed GDScript.
+    val className: String = "",
   )
 
   /**
@@ -246,7 +250,15 @@ object ClassDB {
     val arr = GodotFFI.arena.allocate(propertyInfo, specs.size.toLong())
     specs.forEachIndexed { i, spec ->
       val slot = arr.asSlice(i * propertyInfo.byteSize(), propertyInfo)
-      fillPropertyInfo(slot, spec.name, spec.type, spec.hint, spec.hintString, spec.usage)
+      fillPropertyInfo(
+        slot,
+        spec.name,
+        spec.type,
+        spec.hint,
+        spec.hintString,
+        spec.usage,
+        spec.className,
+      )
     }
     return arr
   }
@@ -293,14 +305,18 @@ object ClassDB {
     hint: Int = 0,
     hintString: String = "",
     usage: Int = PROPERTY_USAGE_DEFAULT,
+    className: String = "",
   ) {
     val nameSegment =
       if (name.isEmpty()) GodotStrings.emptyStringName else GodotStrings.makeStringName(name)
     val hintStringSegment =
       if (hintString.isEmpty()) GodotStrings.emptyString else GodotStrings.makeString(hintString)
+    val classNameSegment =
+      if (className.isEmpty()) GodotStrings.emptyStringName
+      else GodotStrings.makeStringName(className)
     slot.set(JAVA_INT, pTypeOff, type.id)
     slot.set(ADDRESS, pNameOff, nameSegment)
-    slot.set(ADDRESS, pClassNameOff, GodotStrings.emptyStringName)
+    slot.set(ADDRESS, pClassNameOff, classNameSegment)
     slot.set(JAVA_INT, pHintOff, hint)
     slot.set(ADDRESS, pHintStringOff, hintStringSegment)
     slot.set(JAVA_INT, pUsageOff, usage)


### PR DESCRIPTION
Follow-up to #106 / #107. Issue #106 stayed invisible for a year because its failure mode was silent — the engine consulted a surface Kanama filled with a constant/empty value and nothing failed loudly until a user wrote typed GDScript. This PR closes the two remaining gaps of that species found during the #106 investigation, and adds standing guardrails.

## 1. `PropertyInfo.class_name` on object-typed Kotlin exports

A `@ScriptProperty var x: SmokeResource?` (or an engine wrapper slot like `AudioStream?`) reported an empty `class_name`, relying on `hint_string` alone. GDScript's analyzer types member accesses from `class_name` — so `hs.smoke_resource` degraded to plain `Object`/`Resource` in typed GDScript (downcast-only, no safe static typing). Both metadata paths now emit it for `OBJECT`-typed properties with `PROPERTY_HINT_RESOURCE_TYPE`/`NODE_TYPE` hints (where the hint string is exactly the class name):

- generated instance property lists: `ClassDB.PropertySpec` gains `className` (default `""`), threaded into `GDExtensionPropertyInfo.class_name`;
- script-level dictionaries: the generated `mapOf(...)` entries gain `"class_name"` (consumed by `PropertyInfo::from_dict`).

No `ScriptModelJson` change (derived from existing hint + hint_string), so no schema bump. The pinned `PropertySpec` patterns in `local_ci.sh` are updated per the drift rule.

## 2. Constant-stubbed Script/ScriptLanguage virtuals audit

- `_is_placeholder_fallback_enabled` was hard-wired `true`; it now mirrors GDScript's semantics — fallback (data-preservation for a broken script) only when the script failed to bind a Kotlin template. Today the value is inert for extension scripts (the engine only consults it via its own `PlaceHolderScriptInstance`, and Kanama supplies its own placeholders), which the comment records — this keeps it honest if that ever changes.
- Every remaining constant-returning virtual now carries a justification comment: `_editor_can_reload_from_file=false` is engine parity (Godot's own `Script` base hard-codes false — reload flows through the language), `_get_base_script=NULL` because Kanama has no script→script inheritance (same-type equality lives in `_inherits_script`, #106), `_is_abstract=false` matching the global-class dictionary, empty documentation/icon and debugger/profiler/template language surfaces by design.
- Removes the now-unused `boolTrueStub`/`callBoolTrue`.

## 3. Guardrails

AGENTS.md Repository Rules gain: (a) *never pre-empt work the engine performs after a GDExtension callback returns* (path assignment, ResourceCache registration, ownership transfer — #106 precedent), and (b) every new engine-facing surface gets a GDScript parity probe, and no virtual may return a constant without an argued comment.

## Validation

- `_kanama_typed_global_class_smoke` extended: `class_name == "SmokeResource"` asserted on **both** metadata paths, plus a statically typed member read (`var hs: HelloScript = $ScriptNode; var m: SmokeResource = hs.smoke_resource`) with value round-trip; gated in `runtime_smoke.sh`.
- `./scripts/local_ci.sh` PASS end-to-end on macOS/Godot 4.7-stable (JVM tests, audits, runtime/@Tool/both hot-reload smokes).
- `mkdocs build --strict` clean.

**Known scope cut:** iOS's script property descriptor bridge (`kanama_ios_runtime_script_resource_property_*`) has no `class_name` channel; mirroring this on iOS needs a new C bridge entry plus a device smoke — recorded in the task 64 spec as a follow-up rather than silently claimed. Web/desktop registrar codegen is shared; web-runtime compiles green in the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)