### PR TITLE
Task 60f: third-person controller runs on Web — RigidBody3D carrier, families 152-196, protocol 13

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -71,6 +71,12 @@ enum class GodotCallShape {
   CALLABLE_RET_HANDLE,
   NOARGS_RET_LONG_SINGLETON,
   STRINGNAME_OBJECT_RET_INT,
+  VECTOR3_RET_HANDLE,
+  NOARGS_RET_HANDLE_LIST,
+  LONG_RET_VECTOR3,
+  STRINGNAME_RET_DOUBLE_SINGLETON,
+  STRINGNAME_VECTOR3_VECTOR3_ARG,
+  CALLABLE_DOUBLE_RANGE_RET_HANDLE,
 }
 
 @InternalKanamaBackendApi
@@ -544,6 +550,70 @@ interface GodotBackendSpi {
     name: String,
     value: GodotHandle,
   ): Int {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Motion sweep returning the first collision as a closeable handle. */
+  fun invokeVector3RetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3,
+  ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Handle-list query (overlapping scripted bodies). */
+  fun invokeNoArgsRetHandleList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<GodotHandle> {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Indexed Vector3 query (shape-cast collision points). */
+  fun invokeLongRetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): GodotVector3 {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Singleton double query keyed by one name (raw strength, float settings). */
+  fun invokeStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ): Double {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Dynamic method dispatch carrying two Vector3 arguments. */
+  fun invokeStringNameVector3Vector3Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    first: GodotVector3,
+    second: GodotVector3,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Method tween over an interpolated double range. */
+  fun invokeCallableDoubleRangeRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    method: String,
+    fromValue: Double,
+    toValue: Double,
+    duration: Double,
+  ): GodotHandle? {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -1192,6 +1262,97 @@ object GodotBackendCalls {
       receiver,
       name,
       value,
+    )
+  }
+
+  fun invokeVector3RetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotVector3,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.VECTOR3_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeVector3RetHandle(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+    )
+  }
+
+  fun invokeNoArgsRetHandleList(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+  ): List<GodotHandle> {
+    requireShape(descriptor, GodotCallShape.NOARGS_RET_HANDLE_LIST)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeNoArgsRetHandleList(descriptor, resolve(selected, descriptor), receiver)
+  }
+
+  fun invokeLongRetVector3(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: Long,
+  ): GodotVector3 {
+    requireShape(descriptor, GodotCallShape.LONG_RET_VECTOR3)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeLongRetVector3(descriptor, resolve(selected, descriptor), receiver, value)
+  }
+
+  fun invokeStringNameRetDoubleSingleton(descriptor: GodotCallDescriptor, value: String): Double {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_RET_DOUBLE_SINGLETON)
+    val selected = requireBackend()
+    return selected.invokeStringNameRetDoubleSingleton(
+      descriptor,
+      resolve(selected, descriptor),
+      value,
+    )
+  }
+
+  fun invokeStringNameVector3Vector3Arg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    first: GodotVector3,
+    second: GodotVector3,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_VECTOR3_VECTOR3_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeStringNameVector3Vector3Arg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      first,
+      second,
+    )
+  }
+
+  fun invokeCallableDoubleRangeRetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    method: String,
+    fromValue: Double,
+    toValue: Double,
+    duration: Double,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.CALLABLE_DOUBLE_RANGE_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeCallableDoubleRangeRetHandle(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      target,
+      method,
+      fromValue,
+      toValue,
+      duration,
     )
   }
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -76,6 +76,7 @@ enum class GodotCallShape {
   LONG_RET_VECTOR3,
   STRINGNAME_RET_DOUBLE_SINGLETON,
   STRINGNAME_VECTOR3_VECTOR3_ARG,
+  STRINGNAME_STRING_RET_INT,
   CALLABLE_DOUBLE_RANGE_RET_HANDLE,
 }
 
@@ -614,6 +615,17 @@ interface GodotBackendSpi {
     toValue: Double,
     duration: Double,
   ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Signal emission carrying one String argument. */
+  fun invokeStringNameStringRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: String,
+  ): Int {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -1329,6 +1341,24 @@ object GodotBackendCalls {
       name,
       first,
       second,
+    )
+  }
+
+  fun invokeStringNameStringRetInt(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    value: String,
+  ): Int {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_STRING_RET_INT)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeStringNameStringRetInt(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      value,
     )
   }
 
@@ -2149,6 +2179,14 @@ class SignalBackendContractProbe(private val handle: GodotHandle) {
   fun emitObject(name: String, value: GodotHandle): Int =
     GodotBackendCalls.invokeStringNameObjectRetInt(
       InitialGodotCallDescriptors.OBJECT_EMIT_SIGNAL_OBJECT,
+      handle,
+      name,
+      value,
+    )
+
+  fun emitString(name: String, value: String): Int =
+    GodotBackendCalls.invokeStringNameStringRetInt(
+      InitialGodotCallDescriptors.OBJECT_EMIT_SIGNAL_STRING,
       handle,
       name,
       value,

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -50,6 +50,7 @@ enum class GodotCallShape {
   NOARGS_RET_STRING_ARRAY,
   STRINGNAME_ARG,
   STRINGNAME_BOOL_ARG,
+  LONG_BOOL_ARG,
   STRINGNAME_STRINGNAME_ARG,
   STRINGNAME_VECTOR2I_RET_INT,
   NOARGS_RET_COLOR,
@@ -350,6 +351,16 @@ interface GodotBackendSpi {
     callSite: GodotCallSite,
     receiver: GodotHandle,
     name: String,
+    value: Boolean,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  fun invokeLongBoolArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    layer: Long,
     value: Boolean,
   ) {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
@@ -943,6 +954,18 @@ object GodotBackendCalls {
       name,
       value,
     )
+  }
+
+  fun invokeLongBoolArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    layer: Long,
+    value: Boolean,
+  ) {
+    requireShape(descriptor, GodotCallShape.LONG_BOOL_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeLongBoolArg(descriptor, resolve(selected, descriptor), receiver, layer, value)
   }
 
   fun invokeStringNameStringNameArg(
@@ -1592,6 +1615,52 @@ class AudioStreamPlayer3DBackendContractProbe(private val handle: GodotHandle) {
   fun stop() {
     GodotBackendCalls.invokeNoArgsVoid(InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_STOP, handle)
   }
+
+  fun setPitchScale(scale: Double) {
+    GodotBackendCalls.invokeDoubleArg(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_SET_PITCH_SCALE,
+      handle,
+      scale,
+    )
+  }
+}
+
+/** Rigid-body dynamics slice (the third-person controller's destructible-box shards). */
+@InternalKanamaBackendApi
+class RigidBody3DBackendContractProbe(private val handle: GodotHandle) {
+  fun setFreezeEnabled(frozen: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.RIGIDBODY3D_SET_FREEZE_ENABLED,
+      handle,
+      frozen,
+    )
+  }
+
+  fun setSleeping(sleeping: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.RIGIDBODY3D_SET_SLEEPING,
+      handle,
+      sleeping,
+    )
+  }
+
+  fun applyForce(force: GodotVector3, position: GodotVector3) {
+    GodotBackendCalls.invokeVector3Vector3Arg(
+      InitialGodotCallDescriptors.RIGIDBODY3D_APPLY_FORCE,
+      handle,
+      force,
+      position,
+    )
+  }
+
+  fun setCollisionMaskValue(layer: Long, value: Boolean) {
+    GodotBackendCalls.invokeLongBoolArg(
+      InitialGodotCallDescriptors.COLLISIONOBJECT3D_SET_COLLISION_MASK_VALUE,
+      handle,
+      layer,
+      value,
+    )
+  }
 }
 
 /** Typed AudioStreamPlayer configuration and playback slice used by Match3's Audio autoload. */
@@ -2175,6 +2244,12 @@ class Light3DBackendContractProbe(private val handle: GodotHandle) {
  */
 @InternalKanamaBackendApi
 class CharacterBody3DBackendContractProbe(private val handle: GodotHandle) {
+  fun getWallNormal(): GodotVector3 =
+    GodotBackendCalls.invokeNoArgsRetVector3(
+      InitialGodotCallDescriptors.CHARACTERBODY3D_GET_WALL_NORMAL,
+      handle,
+    )
+
   var velocity: GodotVector3
     get() =
       GodotBackendCalls.invokeNoArgsRetVector3(

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -2137,4 +2137,26 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val NODE3D_IS_VISIBLE =
+    GodotCallDescriptor(
+      opcode = 195,
+      className = "Node3D",
+      methodName = "is_visible",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_EMIT_SIGNAL_STRING =
+    GodotCallDescriptor(
+      opcode = 196,
+      className = "Object",
+      methodName = "emit_signal",
+      hash = 4047867050L,
+      shape = GodotCallShape.STRINGNAME_STRING_RET_INT,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -1741,4 +1741,389 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.QUEUED_MUTATION,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val RIGIDBODY3D_APPLY_IMPULSE =
+    GodotCallDescriptor(
+      opcode = 159,
+      className = "RigidBody3D",
+      methodName = "apply_impulse",
+      hash = 2754756483L,
+      shape = GodotCallShape.VECTOR3_VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_APPLY_CENTRAL_IMPULSE =
+    GodotCallDescriptor(
+      opcode = 160,
+      className = "RigidBody3D",
+      methodName = "apply_central_impulse",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_SET_GRAVITY_SCALE =
+    GodotCallDescriptor(
+      opcode = 161,
+      className = "RigidBody3D",
+      methodName = "set_gravity_scale",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_SET_LOCK_ROTATION_ENABLED =
+    GodotCallDescriptor(
+      opcode = 162,
+      className = "RigidBody3D",
+      methodName = "set_lock_rotation_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PHYSICSBODY3D_SET_AXIS_LOCK =
+    GodotCallDescriptor(
+      opcode = 163,
+      className = "PhysicsBody3D",
+      methodName = "set_axis_lock",
+      hash = 1787895195L,
+      shape = GodotCallShape.LONG_BOOL_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val COLLISIONOBJECT3D_SET_COLLISION_LAYER_VALUE =
+    GodotCallDescriptor(
+      opcode = 164,
+      className = "CollisionObject3D",
+      methodName = "set_collision_layer_value",
+      hash = 300928843L,
+      shape = GodotCallShape.LONG_BOOL_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PHYSICSBODY3D_ADD_COLLISION_EXCEPTION_WITH =
+    GodotCallDescriptor(
+      opcode = 165,
+      className = "PhysicsBody3D",
+      methodName = "add_collision_exception_with",
+      hash = 1078189570L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PHYSICSBODY3D_MOVE_AND_COLLIDE =
+    GodotCallDescriptor(
+      opcode = 166,
+      className = "PhysicsBody3D",
+      methodName = "move_and_collide",
+      hash = 3208792678L,
+      shape = GodotCallShape.VECTOR3_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AREA3D_GET_OVERLAPPING_BODIES =
+    GodotCallDescriptor(
+      opcode = 167,
+      className = "Area3D",
+      methodName = "get_overlapping_bodies",
+      hash = 3995934104L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE_LIST,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENETREE_SET_PAUSE =
+    GodotCallDescriptor(
+      opcode = 168,
+      className = "SceneTree",
+      methodName = "set_pause",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_SET_PROCESS =
+    GodotCallDescriptor(
+      opcode = 169,
+      className = "Node",
+      methodName = "set_process",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SPRINGARM3D_ADD_EXCLUDED_OBJECT =
+    GodotCallDescriptor(
+      opcode = 170,
+      className = "SpringArm3D",
+      methodName = "add_excluded_object",
+      hash = 2722037293L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RAYCAST3D_ADD_EXCEPTION =
+    GodotCallDescriptor(
+      opcode = 171,
+      className = "RayCast3D",
+      methodName = "add_exception",
+      hash = 1976431078L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHAPECAST3D_GET_COLLISION_COUNT =
+    GodotCallDescriptor(
+      opcode = 172,
+      className = "ShapeCast3D",
+      methodName = "get_collision_count",
+      hash = 3905245786L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHAPECAST3D_GET_COLLISION_POINT =
+    GodotCallDescriptor(
+      opcode = 173,
+      className = "ShapeCast3D",
+      methodName = "get_collision_point",
+      hash = 711720468L,
+      shape = GodotCallShape.LONG_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHAPECAST3D_GET_COLLIDER =
+    GodotCallDescriptor(
+      opcode = 174,
+      className = "ShapeCast3D",
+      methodName = "get_collider",
+      hash = 3332903315L,
+      shape = GodotCallShape.LONG_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHAPECAST3D_SET_TARGET_POSITION =
+    GodotCallDescriptor(
+      opcode = 175,
+      className = "ShapeCast3D",
+      methodName = "set_target_position",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHAPECAST3D_GET_TARGET_POSITION =
+    GodotCallDescriptor(
+      opcode = 176,
+      className = "ShapeCast3D",
+      methodName = "get_target_position",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NAVIGATIONAGENT3D_SET_TARGET_POSITION =
+    GodotCallDescriptor(
+      opcode = 177,
+      className = "NavigationAgent3D",
+      methodName = "set_target_position",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NAVIGATIONAGENT3D_GET_NEXT_PATH_POSITION =
+    GodotCallDescriptor(
+      opcode = 178,
+      className = "NavigationAgent3D",
+      methodName = "get_next_path_position",
+      hash = 3783033775L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NAVIGATIONAGENT3D_IS_TARGET_REACHED =
+    GodotCallDescriptor(
+      opcode = 179,
+      className = "NavigationAgent3D",
+      methodName = "is_target_reached",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONMIXER_SET_ACTIVE =
+    GodotCallDescriptor(
+      opcode = 180,
+      className = "AnimationMixer",
+      methodName = "set_active",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONPLAYER_STOP =
+    GodotCallDescriptor(
+      opcode = 181,
+      className = "AnimationPlayer",
+      methodName = "stop",
+      hash = 107499316L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONPLAYER_SEEK =
+    GodotCallDescriptor(
+      opcode = 182,
+      className = "AnimationPlayer",
+      methodName = "seek",
+      hash = 1807872683L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONPLAYER_SET_DEFAULT_BLEND_TIME =
+    GodotCallDescriptor(
+      opcode = 183,
+      className = "AnimationPlayer",
+      methodName = "set_default_blend_time",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONMIXER_GET_ANIMATION =
+    GodotCallDescriptor(
+      opcode = 184,
+      className = "AnimationMixer",
+      methodName = "get_animation",
+      hash = 2933122410L,
+      shape = GodotCallShape.NODEPATH_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATION_SET_LOOP_MODE =
+    GodotCallDescriptor(
+      opcode = 185,
+      className = "Animation",
+      methodName = "set_loop_mode",
+      hash = 3155355575L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_GET_ACTION_RAW_STRENGTH =
+    GodotCallDescriptor(
+      opcode = 186,
+      className = "Input",
+      methodName = "get_action_raw_strength",
+      hash = 801543509L,
+      shape = GodotCallShape.STRINGNAME_RET_DOUBLE_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PROJECTSETTINGS_GET_SETTING_DOUBLE =
+    GodotCallDescriptor(
+      opcode = 187,
+      className = "ProjectSettings",
+      methodName = "get_setting",
+      hash = 223050753L,
+      shape = GodotCallShape.STRINGNAME_RET_DOUBLE_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_IS_PLAYING =
+    GodotCallDescriptor(
+      opcode = 188,
+      className = "AudioStreamPlayer3D",
+      methodName = "is_playing",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHINSTANCE3D_CLEAR_SURFACE_OVERRIDE_MATERIAL =
+    GodotCallDescriptor(
+      opcode = 189,
+      className = "MeshInstance3D",
+      methodName = "set_surface_override_material",
+      hash = 3671737478L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OS_SHELL_OPEN =
+    GodotCallDescriptor(
+      opcode = 190,
+      className = "OS",
+      methodName = "shell_open",
+      hash = 166001499L,
+      shape = GodotCallShape.STRINGNAME_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_CALL_VECTOR3_VECTOR3 =
+    GodotCallDescriptor(
+      opcode = 191,
+      className = "Object",
+      methodName = "call",
+      hash = 3400424181L,
+      shape = GodotCallShape.STRINGNAME_VECTOR3_VECTOR3_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val TWEEN_TWEEN_METHOD =
+    GodotCallDescriptor(
+      opcode = 192,
+      className = "Tween",
+      methodName = "tween_method",
+      hash = 2337877153L,
+      shape = GodotCallShape.CALLABLE_DOUBLE_RANGE_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
+    )
+
+  val OBJECT_DISCONNECT =
+    GodotCallDescriptor(
+      opcode = 193,
+      className = "Object",
+      methodName = "disconnect",
+      hash = 1874754934L,
+      shape = GodotCallShape.STRINGNAME_BOUND_CALLABLE_LONG_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -1664,4 +1664,81 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.QUEUED_MUTATION,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val RIGIDBODY3D_SET_FREEZE_ENABLED =
+    GodotCallDescriptor(
+      opcode = 152,
+      className = "RigidBody3D",
+      methodName = "set_freeze_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_SET_SLEEPING =
+    GodotCallDescriptor(
+      opcode = 153,
+      className = "RigidBody3D",
+      methodName = "set_sleeping",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_APPLY_FORCE =
+    GodotCallDescriptor(
+      opcode = 154,
+      className = "RigidBody3D",
+      methodName = "apply_force",
+      hash = 2754756483L,
+      shape = GodotCallShape.VECTOR3_VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val COLLISIONOBJECT3D_SET_COLLISION_MASK_VALUE =
+    GodotCallDescriptor(
+      opcode = 155,
+      className = "CollisionObject3D",
+      methodName = "set_collision_mask_value",
+      hash = 300928843L,
+      shape = GodotCallShape.LONG_BOOL_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CHARACTERBODY3D_GET_WALL_NORMAL =
+    GodotCallDescriptor(
+      opcode = 156,
+      className = "CharacterBody3D",
+      methodName = "get_wall_normal",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONPLAYER_IS_PLAYING =
+    GodotCallDescriptor(
+      opcode = 157,
+      className = "AnimationPlayer",
+      methodName = "is_playing",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_SET_PITCH_SCALE =
+    GodotCallDescriptor(
+      opcode = 158,
+      className = "AudioStreamPlayer3D",
+      methodName = "set_pitch_scale",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -2126,4 +2126,15 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val VIEWPORT_GET_CAMERA_3D =
+    GodotCallDescriptor(
+      opcode = 194,
+      className = "Viewport",
+      methodName = "get_camera_3d",
+      hash = 2285090890L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -253,8 +253,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendVector3PropertySetter()
     appendObjectPropertySetter()
     appendObjectArrayPropertySetter()
+    appendStringArrayPropertySetter()
     appendLongMethodDispatcher()
     appendLongVoidMethodDispatcher()
+    appendStringMethodDispatcher()
     appendVector2iMethodDispatcher()
     appendObjectMethodDispatcher()
     appendObjectObjectLongMethodDispatcher()
@@ -500,6 +502,33 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine()
   }
 
+  private fun StringBuilder.appendStringMethodDispatcher() {
+    appendLine(
+      "  fun callString(scriptId: Int, methodId: Int, script: KanamaWebScript, value: String) {"
+    )
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (methodId) {")
+      input.model.methods.forEachIndexed { methodIndex, method ->
+        if (
+          method.returnType == null &&
+            method.args.size == 1 &&
+            method.args.single().type == TypeMapping.STRING
+        ) {
+          appendLine(
+            "        ${methodIndex + 1} -> (script as ${input.model.simpleName}).${method.kotlinName}(value)"
+          )
+        }
+      }
+      appendLine("        else -> unknown(\"method\", methodId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine("  }")
+    appendLine()
+  }
+
   private fun StringBuilder.appendLongVoidMethodDispatcher() {
     appendLine(
       "  fun callLongVoid(scriptId: Int, methodId: Int, script: KanamaWebScript, value: Long) {"
@@ -730,6 +759,31 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
               "$wrapper(checkNotNull(handle) { \"Property ${property.godotName} is not nullable\" })"
           appendLine(
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = $wrapped"
+          )
+        }
+      }
+      appendLine("        else -> unknown(\"property\", propertyId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine("  }")
+    appendLine()
+  }
+
+  private fun StringBuilder.appendStringArrayPropertySetter() {
+    appendLine(
+      "  fun setStringArrayProperty(scriptId: Int, propertyId: Int, script: KanamaWebScript, values: List<String>) {"
+    )
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (propertyId) {")
+      input.model.properties.forEachIndexed { propertyIndex, property ->
+        if (
+          property.type == TypeMapping.ARRAY && property.isMutable && property.arrayElementString
+        ) {
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = values"
           )
         }
       }
@@ -986,6 +1040,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           )
         }
         TypeMapping.ARRAY -> {
+          if (property.arrayElementString) {
+            appendLine(
+              "\t_kanama_bridge.setStringArrayProperty(_kanama_handle, ${index + 1}, \"\\u001f\".join(${property.godotName}))"
+            )
+            return@forEachIndexed
+          }
           appendLine("\tvar property_handles_${index + 1}: String = \"\"")
           appendLine("\tfor property_value in ${property.godotName}:")
           appendLine("\t\tvar property_value_handle := 0")
@@ -1175,6 +1235,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine("\t\t\tvar target: Node2D = self")
       appendLine("\t\t\ttarget.position = Vector2(float(last_value % 640), target.position.y)")
     }
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 1000 and target_object != null:")
+    appendLine("\t\t\t# Frame marker for a script processed under another owner's proxy")
+    appendLine("\t\t\t# (instantiated nodes flush through their creator): consume it.")
+    appendLine("\t\t\tlast_value = bytes.decode_s32(offset + 8)")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
     appendLine("\t\telif opcode == 3 and target_object is Node2D:")
@@ -2363,6 +2429,13 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\telif opcode == 188 and value is AudioStreamPlayer3D:")
     appendLine("\t\t\tresult = int((value as AudioStreamPlayer3D).is_playing())")
+    appendLine("\t\telif opcode == 195 and value is Node3D:")
+    appendLine("\t\t\tresult = int((value as Node3D).is_visible())")
+    appendLine("\t\telif opcode == 196 and value != null:")
+    appendLine("\t\t\tvar emit_string_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tresult = value.emit_signal(StringName(emit_string_parts[0]), emit_string_parts[1])"
+    )
     appendLine("\t\telif opcode == 190:")
     appendLine("\t\t\tresult = int(OS.shell_open(String(args[2])))")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
@@ -2460,6 +2533,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           method.args.single().type == TypeMapping.INT -> {
           val arg = method.args.single()
           appendLine("\t_kanama_bridge.callLongVoid(_kanama_handle, ${index + 1}, ${arg.name})")
+        }
+        method.returnType == null &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.STRING -> {
+          val arg = method.args.single()
+          appendLine("\t_kanama_bridge.callString(_kanama_handle, ${index + 1}, ${arg.name})")
         }
         method.returnType == null &&
           method.args.size == 1 &&

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -8,7 +8,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 12
+    const val PROTOCOL_VERSION = 13
     const val PROTOCOL_SCHEMA_VERSION = 1
   }
 
@@ -1314,6 +1314,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t(target_object as AudioStreamPlayer3D).stop()")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 152 and target_object is RigidBody3D:")
+    appendLine("\t\t\t(target_object as RigidBody3D).freeze = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 153 and target_object is RigidBody3D:")
+    appendLine("\t\t\t(target_object as RigidBody3D).sleeping = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 158 and target_object is AudioStreamPlayer3D:")
+    appendLine(
+      "\t\t\t(target_object as AudioStreamPlayer3D).pitch_scale = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
     appendLine("\t\telif opcode == 46 and target_object is AudioStreamPlayer:")
     appendLine("\t\t\tvar stream_handle := bytes.decode_s32(offset + 8)")
     appendLine(
@@ -2105,6 +2119,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tif result == 0:")
     appendLine("\t\t\t\t\tresult = int(get_parts[1])")
     appendLine("\t\t\t\t\t_kanama_object_handles[result] = got")
+    appendLine("\t\telif opcode == 154 and value is RigidBody3D:")
+    appendLine("\t\t\tvar force_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as RigidBody3D).apply_force(Vector3(force_parts[0], force_parts[1], force_parts[2]), Vector3(force_parts[3], force_parts[4], force_parts[5]))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 155 and value is CollisionObject3D:")
+    appendLine("\t\t\tvar mask_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as CollisionObject3D).set_collision_mask_value(int(mask_parts[0]), mask_parts[1] == \"1\")"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 157 and value is AnimationPlayer:")
+    appendLine("\t\t\tresult = int((value as AnimationPlayer).is_playing())")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2139,6 +2167,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as Node3D).global_position")
     appendLine("\telif opcode == 141 and value is Node3D:")
     appendLine("\t\tresult = (value as Node3D).global_rotation")
+    appendLine("\telif opcode == 156 and value is CharacterBody3D:")
+    appendLine("\t\tresult = (value as CharacterBody3D).get_wall_normal()")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1328,6 +1328,97 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 161 and target_object is RigidBody3D:")
+    appendLine(
+      "\t\t\t(target_object as RigidBody3D).gravity_scale = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 162 and target_object is RigidBody3D:")
+    appendLine(
+      "\t\t\t(target_object as RigidBody3D).lock_rotation = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 165 and target_object is PhysicsBody3D:")
+    appendLine("\t\t\tvar exception_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar exception_node: Node = _kanama_object_handles.get(exception_handle) as Node"
+    )
+    appendLine("\t\t\tif exception_node != null:")
+    appendLine(
+      "\t\t\t\t(target_object as PhysicsBody3D).add_collision_exception_with(exception_node)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 168 and target_object is SceneTree:")
+    appendLine("\t\t\t(target_object as SceneTree).paused = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 169 and target_object is Node:")
+    appendLine("\t\t\t(target_object as Node).set_process(bytes.decode_s32(offset + 8) != 0)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 170 and target_object is SpringArm3D:")
+    appendLine("\t\t\tvar excluded_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar excluded: CollisionObject3D = _kanama_object_handles.get(excluded_handle) as CollisionObject3D"
+    )
+    appendLine("\t\t\tif excluded != null:")
+    appendLine("\t\t\t\t# The RID never crosses the boundary; it is derived applier-side.")
+    appendLine("\t\t\t\t(target_object as SpringArm3D).add_excluded_object(excluded.get_rid())")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 171 and target_object is RayCast3D:")
+    appendLine("\t\t\tvar ray_exception_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar ray_exception: CollisionObject3D = _kanama_object_handles.get(ray_exception_handle) as CollisionObject3D"
+    )
+    appendLine("\t\t\tif ray_exception != null:")
+    appendLine("\t\t\t\t(target_object as RayCast3D).add_exception(ray_exception)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 180 and target_object is AnimationMixer:")
+    appendLine("\t\t\t(target_object as AnimationMixer).active = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 181 and target_object is AnimationPlayer:")
+    appendLine("\t\t\t(target_object as AnimationPlayer).stop()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 182 and target_object is AnimationPlayer:")
+    appendLine(
+      "\t\t\t(target_object as AnimationPlayer).seek(bytes.decode_double(offset + 8), true)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 183 and target_object is AnimationPlayer:")
+    appendLine(
+      "\t\t\t(target_object as AnimationPlayer).playback_default_blend_time = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 185 and target_object is Animation:")
+    appendLine("\t\t\t(target_object as Animation).loop_mode = bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 189 and target_object is MeshInstance3D:")
+    appendLine("\t\t\t# Material baked null: this family only clears surface overrides.")
+    appendLine(
+      "\t\t\t(target_object as MeshInstance3D).set_surface_override_material(bytes.decode_s32(offset + 8), null)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 191 and target_object != null:")
+    appendLine("\t\t\tvar dyn_method_id := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\tvar dyn_method := String(_kanama_bridge.resolveCommandStringName(dyn_method_id))"
+    )
+    appendLine(
+      "\t\t\ttarget_object.call(StringName(dyn_method), Vector3(bytes.decode_float(offset + 12), bytes.decode_float(offset + 16), bytes.decode_float(offset + 20)), Vector3(bytes.decode_float(offset + 24), bytes.decode_float(offset + 28), bytes.decode_float(offset + 32)))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 36")
     appendLine("\t\telif opcode == 46 and target_object is AudioStreamPlayer:")
     appendLine("\t\t\tvar stream_handle := bytes.decode_s32(offset + 8)")
     appendLine(
@@ -1876,6 +1967,63 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tif result_handle == 0:")
     appendLine("\t\t\t\t\t_kanama_object_handles[proposed_child] = child_node")
     appendLine("\t\t\t\t\tresult_handle = proposed_child")
+    appendLine("\telif opcode == 166:")
+    appendLine(
+      "\t\tvar sweep_body: Object = self if receiver_handle == _kanama_handle else _kanama_object_handles.get(receiver_handle)"
+    )
+    appendLine("\t\tif sweep_body is PhysicsBody3D:")
+    appendLine("\t\t\tvar proposed_sweep_handle := int(args[2])")
+    appendLine("\t\t\tvar motion_parts := String(args[3]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar sweep := (sweep_body as PhysicsBody3D).move_and_collide(Vector3(motion_parts[0], motion_parts[1], motion_parts[2]))"
+    )
+    appendLine("\t\t\tif sweep != null:")
+    appendLine("\t\t\t\t_kanama_object_handles[proposed_sweep_handle] = sweep")
+    appendLine("\t\t\t\tresult_handle = proposed_sweep_handle")
+    appendLine("\t\t\tif sweep_body is Node3D:")
+    appendLine("\t\t\t\tvar swept := sweep_body as Node3D")
+    appendLine(
+      "\t\t\t\t_kanama_bridge.refreshNode3DSnapshot(receiver_handle, swept.position.x, swept.position.y, swept.position.z, swept.rotation.x, swept.rotation.y, swept.rotation.z, swept.scale.x, swept.scale.y, swept.scale.z)"
+    )
+    appendLine("\telif opcode == 174:")
+    appendLine(
+      "\t\tvar shape_cast: Object = self if receiver_handle == _kanama_handle else _kanama_object_handles.get(receiver_handle)"
+    )
+    appendLine("\t\tif shape_cast is ShapeCast3D:")
+    appendLine(
+      "\t\t\tvar shape_hit: Object = (shape_cast as ShapeCast3D).get_collider(int(args[3]))"
+    )
+    appendLine("\t\t\tif shape_hit != null:")
+    appendLine("\t\t\t\tif shape_hit.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\t\t\t\tvar shape_hit_script := int(shape_hit.call(\"_kanama_ensure_created\"))")
+    appendLine("\t\t\t\t\tif shape_hit_script != 0:")
+    appendLine("\t\t\t\t\t\t_kanama_object_handles[shape_hit_script] = shape_hit")
+    appendLine("\t\t\t\t\t\tresult_handle = shape_hit_script")
+    appendLine("\t\t\t\tif result_handle == 0:")
+    appendLine("\t\t\t\t\tfor existing_hit_handle in _kanama_object_handles:")
+    appendLine("\t\t\t\t\t\tif is_same(_kanama_object_handles[existing_hit_handle], shape_hit):")
+    appendLine("\t\t\t\t\t\t\tresult_handle = int(existing_hit_handle)")
+    appendLine("\t\t\t\t\t\t\tbreak")
+    appendLine("\t\t\t\tif result_handle == 0:")
+    appendLine("\t\t\t\t\t_kanama_object_handles[int(args[2])] = shape_hit")
+    appendLine("\t\t\t\t\tresult_handle = int(args[2])")
+    appendLine("\telif opcode == 192 and receiver is Tween:")
+    appendLine("\t\tvar method_proposed := int(args[2])")
+    appendLine(
+      "\t\tvar method_target: Object = self if int(args[3]) == _kanama_handle else _kanama_object_handles.get(int(args[3]))"
+    )
+    appendLine("\t\tif method_target != null:")
+    appendLine(
+      "\t\t\tvar method_tweener := (receiver as Tween).tween_method(Callable(method_target, StringName(String(args[4]))), float(args[5]), float(args[6]), float(args[7]))"
+    )
+    appendLine("\t\t\tif method_tweener != null:")
+    appendLine("\t\t\t\t_kanama_object_handles[method_proposed] = method_tweener")
+    appendLine(
+      "\t\t\t\tvar method_children: Array = _kanama_tween_children.get(receiver_handle, [])"
+    )
+    appendLine("\t\t\t\tmethod_children.append(method_proposed)")
+    appendLine("\t\t\t\t_kanama_tween_children[receiver_handle] = method_children")
+    appendLine("\t\t\t\tresult_handle = method_proposed")
     appendLine("\telif opcode == 111:")
     appendLine(
       "\t\tvar slide_body: Object = self if receiver_handle == _kanama_handle else _kanama_object_handles.get(receiver_handle)"
@@ -1942,7 +2090,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvar callable := Callable(target, StringName(String(args[3])))")
     appendLine("\t\tif args.size() > 5:")
     appendLine("\t\t\tcallable = callable.bind(int(args[5]))")
-    appendLine("\t\tresult = source.connect(StringName(String(args[1])), callable, int(args[4]))")
+    appendLine("\t\tif int(args[4]) == -1:")
+    appendLine("\t\t\t# flags -1 selects disconnect for the same bound callable shape.")
+    appendLine("\t\t\tsource.disconnect(StringName(String(args[1])), callable)")
+    appendLine("\t\t\tresult = OK")
+    appendLine("\t\telse:")
+    appendLine("\t\t\tresult = source.connect(StringName(String(args[1])), callable, int(args[4]))")
     appendLine("\t_kanama_bridge.recordImmediateConnectResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2119,6 +2272,24 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tif result == 0:")
     appendLine("\t\t\t\t\tresult = int(get_parts[1])")
     appendLine("\t\t\t\t\t_kanama_object_handles[result] = got")
+    appendLine("\t\telif opcode == 184 and value is AnimationMixer:")
+    appendLine("\t\t\tvar anim_get_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar named_animation: Animation = (value as AnimationMixer).get_animation(StringName(anim_get_parts[0]))"
+    )
+    appendLine("\t\t\tif named_animation == null:")
+    appendLine("\t\t\t\tresult = 0")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\tresult = 0")
+    appendLine("\t\t\t\tfor existing_anim_handle in _kanama_object_handles:")
+    appendLine(
+      "\t\t\t\t\tif is_same(_kanama_object_handles[existing_anim_handle], named_animation):"
+    )
+    appendLine("\t\t\t\t\t\tresult = int(existing_anim_handle)")
+    appendLine("\t\t\t\t\t\tbreak")
+    appendLine("\t\t\t\tif result == 0:")
+    appendLine("\t\t\t\t\tresult = int(anim_get_parts[1])")
+    appendLine("\t\t\t\t\t_kanama_object_handles[result] = named_animation")
     appendLine("\t\telif opcode == 154 and value is RigidBody3D:")
     appendLine("\t\t\tvar force_parts := String(args[2]).split_floats(\"\\u001f\")")
     appendLine(
@@ -2133,6 +2304,65 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 157 and value is AnimationPlayer:")
     appendLine("\t\t\tresult = int((value as AnimationPlayer).is_playing())")
+    appendLine("\t\telif opcode == 160 and value is RigidBody3D:")
+    appendLine("\t\t\tvar central_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as RigidBody3D).apply_central_impulse(Vector3(central_parts[0], central_parts[1], central_parts[2]))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 163 and value is PhysicsBody3D:")
+    appendLine("\t\t\tvar axis_lock_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as PhysicsBody3D).set_axis_lock(int(axis_lock_parts[0]), axis_lock_parts[1] == \"1\")"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 164 and value is CollisionObject3D:")
+    appendLine("\t\t\tvar layer_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as CollisionObject3D).set_collision_layer_value(int(layer_parts[0]), layer_parts[1] == \"1\")"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 167 and value is Area3D:")
+    appendLine("\t\t\tvar overlapping := (value as Area3D).get_overlapping_bodies()")
+    appendLine("\t\t\tvar packed_handles := PackedStringArray()")
+    appendLine("\t\t\tfor overlapping_body in overlapping:")
+    appendLine("\t\t\t\tif overlapping_body.has_method(\"_kanama_ensure_created\"):")
+    appendLine(
+      "\t\t\t\t\tvar overlap_script := int(overlapping_body.call(\"_kanama_ensure_created\"))"
+    )
+    appendLine("\t\t\t\t\tif overlap_script != 0:")
+    appendLine("\t\t\t\t\t\t_kanama_object_handles[overlap_script] = overlapping_body")
+    appendLine("\t\t\t\t\t\tpacked_handles.append(str(overlap_script))")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(packed_handles))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 172 and value is ShapeCast3D:")
+    appendLine("\t\t\tresult = (value as ShapeCast3D).get_collision_count()")
+    appendLine("\t\telif opcode == 175 and value is ShapeCast3D:")
+    appendLine("\t\t\tvar cast_target_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as ShapeCast3D).target_position = Vector3(cast_target_parts[0], cast_target_parts[1], cast_target_parts[2])"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 177 and value is NavigationAgent3D:")
+    appendLine("\t\t\tvar nav_target_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as NavigationAgent3D).target_position = Vector3(nav_target_parts[0], nav_target_parts[1], nav_target_parts[2])"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 179 and value is NavigationAgent3D:")
+    appendLine("\t\t\tresult = int((value as NavigationAgent3D).is_target_reached())")
+    appendLine("\t\telif opcode == 186:")
+    appendLine(
+      "\t\t\tresult = int(round(Input.get_action_raw_strength(StringName(String(args[2]))) * 1000.0))"
+    )
+    appendLine("\t\telif opcode == 187:")
+    appendLine(
+      "\t\t\tresult = int(round(float(ProjectSettings.get_setting(String(args[2]), 0.0)) * 1000.0))"
+    )
+    appendLine("\t\telif opcode == 188 and value is AudioStreamPlayer3D:")
+    appendLine("\t\t\tresult = int((value as AudioStreamPlayer3D).is_playing())")
+    appendLine("\t\telif opcode == 190:")
+    appendLine("\t\t\tresult = int(OS.shell_open(String(args[2])))")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2169,6 +2399,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as Node3D).global_rotation")
     appendLine("\telif opcode == 156 and value is CharacterBody3D:")
     appendLine("\t\tresult = (value as CharacterBody3D).get_wall_normal()")
+    appendLine("\telif opcode == 173 and value is ShapeCast3D:")
+    appendLine("\t\tresult = (value as ShapeCast3D).get_collision_point(int(args[2]))")
+    appendLine("\telif opcode == 176 and value is ShapeCast3D:")
+    appendLine("\t\tresult = (value as ShapeCast3D).target_position")
+    appendLine("\telif opcode == 178 and value is NavigationAgent3D:")
+    appendLine("\t\tresult = (value as NavigationAgent3D).get_next_path_position()")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1827,6 +1827,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvalue = receiver.get_parent()")
     appendLine("\telif opcode == 81 and receiver is WorldEnvironment:")
     appendLine("\t\tvalue = (receiver as WorldEnvironment).environment")
+    appendLine("\telif opcode == 194 and receiver is Viewport:")
+    appendLine("\t\tvalue = (receiver as Viewport).get_camera_3d()")
     appendLine("\telif opcode == 112 and receiver is KinematicCollision3D:")
     appendLine("\t\tvalue = (receiver as KinematicCollision3D).get_collider()")
     appendLine("\telif opcode == 114 and receiver is Node:")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -72,7 +72,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 12"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 13"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -410,7 +410,7 @@ class WebScriptCodeEmitterTest {
     )
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 12"))
+    assertTrue(protocol.contains("\"protocolVersion\": 13"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -421,7 +421,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=12\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=13\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -236,6 +236,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     191: {},
     192: {},
     193: {},
+    194: {"ret": "node"},
 }
 
 

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -194,6 +194,13 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     149: {},
     150: {},
     151: {},
+    152: {},
+    153: {},
+    154: {},
+    155: {},
+    156: {},
+    157: {},
+    158: {},
 }
 
 
@@ -442,6 +449,24 @@ def body_STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON(calls):
         "// returned scaled by 1000 through the shared object-query transport.",
         'return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), '
         'first + "\\u001f" + second) / 1000.0',
+    ]
+
+
+def body_LONG_BOOL_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Layer number and flag packed into one query string (unit separator).",
+        "check(",
+        "immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'layer.toString() + "\u001f" + (if (value) "1" else "0"),',
+        ") == 1",
+        ") {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
+        "}",
     ]
 
 
@@ -1216,6 +1241,10 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ["receiver: GodotHandle", "name: String", "value: Boolean"],
         "",
     ),
+    "LONG_BOOL_ARG": (
+        ["receiver: GodotHandle", "layer: Long", "value: Boolean"],
+        "",
+    ),
     "STRINGNAME_STRINGNAME_ARG": (
         ["receiver: GodotHandle", "first: String", "second: String"],
         "",
@@ -1306,6 +1335,7 @@ EMIT_ORDER = [
     "OBJECT_ARG",
     "STRINGNAME_ARG",
     "STRINGNAME_BOOL_ARG",
+    "LONG_BOOL_ARG",
     "STRINGNAME_STRINGNAME_ARG",
     "NODEPATH_RET_HANDLE",
     "LONG_RET_HANDLE",

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -201,6 +201,41 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     156: {},
     157: {},
     158: {},
+    159: {},
+    160: {},
+    161: {},
+    162: {},
+    163: {},
+    164: {},
+    165: {},
+    166: {},
+    167: {},
+    168: {},
+    169: {},
+    170: {},
+    171: {},
+    172: {},
+    173: {},
+    174: {"ret": "existing"},
+    175: {},
+    176: {},
+    177: {},
+    178: {},
+    179: {},
+    180: {},
+    181: {},
+    182: {},
+    183: {},
+    184: {},
+    185: {},
+    186: {},
+    187: {},
+    188: {},
+    189: {},
+    190: {},
+    191: {},
+    192: {},
+    193: {},
 }
 
 
@@ -449,6 +484,95 @@ def body_STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON(calls):
         "// returned scaled by 1000 through the shared object-query transport.",
         'return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), '
         'first + "\\u001f" + second) / 1000.0',
+    ]
+
+
+def body_VECTOR3_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Motion packed as three floats; the bridge allocates the collision slot and the",
+        "// applier registers the KinematicCollision3D under it (null collision returns 0).",
+        "return registerReturnedBrowserObject(",
+        "immediateWebMoveAndCollide(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'listOf(value.x, value.y, value.z).joinToString("\u001f"),',
+        ")",
+        ")",
+    ]
+
+
+def body_NOARGS_RET_HANDLE_LIST(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// The applier packs the SCRIPT handles of scripted overlapping bodies (unit",
+        "// separator); bodies without Kanama scripts are omitted by contract.",
+        'return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")',
+        ".split('\u001f')",
+        ".filter { it.isNotEmpty() }",
+        ".map { GodotHandle.fromBackendToken(it.toLong()) }",
+    ]
+
+
+def body_LONG_RET_VECTOR3(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "return GodotVector3(",
+        "immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),",
+        "immediateWebNoArgsVector3Y().toFloat(),",
+        "immediateWebNoArgsVector3Z().toFloat(),",
+        ")",
+    ]
+
+
+def body_STRINGNAME_RET_DOUBLE_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Scaled by 1000 through the shared integer object-query transport.",
+        "return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /",
+        "1000.0",
+    ]
+
+
+def body_STRINGNAME_VECTOR3_VECTOR3_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_QUEUED})",
+        f"require({_opcode_guard(calls)})",
+        "commands.appendStringNameVector3Vector3Mutation(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "name,",
+        "first,",
+        "second,",
+        ")",
+    ]
+
+
+def body_CALLABLE_DOUBLE_RANGE_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "return registerReturnedBrowserObject(",
+        "immediateWebTweenMethod(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "target.webId(),",
+        "method,",
+        "fromValue,",
+        "toValue,",
+        "duration,",
+        ")",
+        ")",
     ]
 
 
@@ -724,6 +848,13 @@ def body_OBJECT_ARG(calls):
                 "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }",
                 "}",
             ]
+        elif op in (165, 170, 171):
+            lines += [
+                f"{op} -> {{",
+                f"require(descriptor.executionMode == {_QUEUED})",
+                "checkNotNull(value)",
+                "}",
+            ]
         else:
             raise GenerationError(f"OBJECT_ARG opcode {op} has no emitter arm")
     lines += [
@@ -741,8 +872,11 @@ def body_NODEPATH_RET_HANDLE(calls):
         "commands.flush()",
         "return when (descriptor.opcode) {",
         "17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))",
-        "149 ->",
-        "registerReturnedBrowserObject(immediateWebPropertyObjectQuery(receiver.webId(), path))",
+        "149,",
+        "184 ->",
+        "registerReturnedBrowserObject(",
+        "immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)",
+        ")",
         'else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")',
         "}",
     ]
@@ -864,7 +998,9 @@ def body_STRINGNAME_BOUND_CALLABLE_LONG_RET_LONG(calls):
         "require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
         "require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
         "commands.flush()",
-        "return immediateWebConnectBound(",
+        "return when (descriptor.opcode) {",
+        "34 ->",
+        "immediateWebConnectBound(",
         "receiver.webId(),",
         "signal,",
         "target.webId(),",
@@ -873,6 +1009,17 @@ def body_STRINGNAME_BOUND_CALLABLE_LONG_RET_LONG(calls):
         "flags.toInt(),",
         ")",
         ".toLong()",
+        "193 ->",
+        "immediateWebDisconnectBound(",
+        "receiver.webId(),",
+        "signal,",
+        "target.webId(),",
+        "method,",
+        "boundValue.toInt(),",
+        ")",
+        ".toLong()",
+        'else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")',
+        "}",
     ]
 
 
@@ -1245,6 +1392,36 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ["receiver: GodotHandle", "layer: Long", "value: Boolean"],
         "",
     ),
+    "VECTOR3_RET_HANDLE": (
+        ["receiver: GodotHandle", "value: GodotVector3"],
+        "GodotHandle?",
+    ),
+    "NOARGS_RET_HANDLE_LIST": (["receiver: GodotHandle"], "List<GodotHandle>"),
+    "LONG_RET_VECTOR3": (
+        ["receiver: GodotHandle", "value: Long"],
+        "GodotVector3",
+    ),
+    "STRINGNAME_RET_DOUBLE_SINGLETON": (["value: String"], "Double"),
+    "STRINGNAME_VECTOR3_VECTOR3_ARG": (
+        [
+            "receiver: GodotHandle",
+            "name: String",
+            "first: GodotVector3",
+            "second: GodotVector3",
+        ],
+        "",
+    ),
+    "CALLABLE_DOUBLE_RANGE_RET_HANDLE": (
+        [
+            "receiver: GodotHandle",
+            "target: GodotHandle",
+            "method: String",
+            "fromValue: Double",
+            "toValue: Double",
+            "duration: Double",
+        ],
+        "GodotHandle?",
+    ),
     "STRINGNAME_STRINGNAME_ARG": (
         ["receiver: GodotHandle", "first: String", "second: String"],
         "",
@@ -1304,6 +1481,8 @@ _WORD_CASE = {
     "BOUND": "Bound",
     "SINGLETON": "Singleton",
     "ARRAY": "Array",
+    "LIST": "List",
+    "RANGE": "Range",
 }
 
 
@@ -1336,6 +1515,12 @@ EMIT_ORDER = [
     "STRINGNAME_ARG",
     "STRINGNAME_BOOL_ARG",
     "LONG_BOOL_ARG",
+    "VECTOR3_RET_HANDLE",
+    "NOARGS_RET_HANDLE_LIST",
+    "LONG_RET_VECTOR3",
+    "STRINGNAME_RET_DOUBLE_SINGLETON",
+    "STRINGNAME_VECTOR3_VECTOR3_ARG",
+    "CALLABLE_DOUBLE_RANGE_RET_HANDLE",
     "STRINGNAME_STRINGNAME_ARG",
     "NODEPATH_RET_HANDLE",
     "LONG_RET_HANDLE",

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -216,7 +216,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     171: {},
     172: {},
     173: {},
-    174: {"ret": "existing"},
+    174: {"ret": "indexed_node"},
     175: {},
     176: {},
     177: {},
@@ -237,6 +237,8 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     192: {},
     193: {},
     194: {"ret": "node"},
+    195: {},
+    196: {},
 }
 
 
@@ -541,6 +543,20 @@ def body_STRINGNAME_RET_DOUBLE_SINGLETON(calls):
         "// Scaled by 1000 through the shared integer object-query transport.",
         "return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /",
         "1000.0",
+    ]
+
+
+def body_STRINGNAME_STRING_RET_INT(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Signal name and String argument packed into one query (unit separator).",
+        "return immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'name + "\u001f" + value,',
+        ")",
     ]
 
 
@@ -905,6 +921,16 @@ def body_LONG_RET_HANDLE(calls):
     node_ops = [c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "node"]
     existing_ops = [c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "existing"]
     collision_ops = [c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "collision"]
+    indexed_node_ops = [
+        c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "indexed_node"
+    ]
+    for op in indexed_node_ops:
+        lines.append(f"{op} ->")
+        lines.append(
+            "registerReturnedNode("
+            "immediateWebIndexedObjectLookup(descriptor.opcode, receiver.webId(), value.toInt())"
+            ")"
+        )
     for op in node_ops:
         lines.append(f"{op} ->")
         lines.append(
@@ -1403,6 +1429,10 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         "GodotVector3",
     ),
     "STRINGNAME_RET_DOUBLE_SINGLETON": (["value: String"], "Double"),
+    "STRINGNAME_STRING_RET_INT": (
+        ["receiver: GodotHandle", "name: String", "value: String"],
+        "Int",
+    ),
     "STRINGNAME_VECTOR3_VECTOR3_ARG": (
         [
             "receiver: GodotHandle",
@@ -1521,6 +1551,7 @@ EMIT_ORDER = [
     "LONG_RET_VECTOR3",
     "STRINGNAME_RET_DOUBLE_SINGLETON",
     "STRINGNAME_VECTOR3_VECTOR3_ARG",
+    "STRINGNAME_STRING_RET_INT",
     "CALLABLE_DOUBLE_RANGE_RET_HANDLE",
     "STRINGNAME_STRINGNAME_ARG",
     "NODEPATH_RET_HANDLE",

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -2455,6 +2455,580 @@
       "returnOwnership": "BORROWED",
       "semantics": "Queue a pitch-scale write (randomized footstep/destroy pitches).",
       "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 159,
+      "className": "RigidBody3D",
+      "methodName": "apply_impulse",
+      "hash": 2754756483,
+      "arguments": [
+        "Vector3",
+        "Vector3"
+      ],
+      "shape": "VECTOR3_VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Apply a positioned impulse (packed six-float immediate; bot knockback).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 160,
+      "className": "RigidBody3D",
+      "methodName": "apply_central_impulse",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "shape": "VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Apply a central impulse (packed three-float immediate; coin launch).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 161,
+      "className": "RigidBody3D",
+      "methodName": "set_gravity_scale",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue a gravity-scale write (defeated bots start falling).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 162,
+      "className": "RigidBody3D",
+      "methodName": "set_lock_rotation_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue unlocking rotation (defeated beetle-bot tumbles).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 163,
+      "className": "PhysicsBody3D",
+      "methodName": "set_axis_lock",
+      "hash": 1787895195,
+      "arguments": [
+        "enum::PhysicsServer3D.BodyAxis",
+        "bool"
+      ],
+      "shape": "LONG_BOOL_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Toggle one body-axis lock (packed axis/value immediate).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 164,
+      "className": "CollisionObject3D",
+      "methodName": "set_collision_layer_value",
+      "hash": 300928843,
+      "arguments": [
+        "int",
+        "bool"
+      ],
+      "shape": "LONG_BOOL_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Toggle one collision-layer bit (packed layer/value immediate; coin pickup delay).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 165,
+      "className": "PhysicsBody3D",
+      "methodName": "add_collision_exception_with",
+      "hash": 1078189570,
+      "arguments": [
+        "Node"
+      ],
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue a pairwise collision exception (coin follows its collector; grenade skips the thrower).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 166,
+      "className": "PhysicsBody3D",
+      "methodName": "move_and_collide",
+      "hash": 3208792678,
+      "arguments": [
+        "Vector3",
+        "bool",
+        "float",
+        "bool",
+        "int"
+      ],
+      "returnType": "KinematicCollision3D",
+      "shape": "VECTOR3_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Move by a motion vector and return the first collision as a closeable handle (trailing arguments baked to Godot defaults).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 167,
+      "className": "Area3D",
+      "methodName": "get_overlapping_bodies",
+      "hash": 3995934104,
+      "arguments": [],
+      "returnType": "typedarray::Node3D",
+      "shape": "NOARGS_RET_HANDLE_LIST",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Overlapping physics bodies as script handles (bodies without Kanama scripts are omitted; the explosion filters to scripted damageables).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 168,
+      "className": "SceneTree",
+      "methodName": "set_pause",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue pausing/unpausing the tree (the demo boots paused behind its menu).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 169,
+      "className": "Node",
+      "methodName": "set_process",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue toggling idle processing (bullet pool parks recycled bullets).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 170,
+      "className": "SpringArm3D",
+      "methodName": "add_excluded_object",
+      "hash": 2722037293,
+      "arguments": [
+        "RID"
+      ],
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue excluding a collision object from the spring-arm probe; the RID never crosses the boundary \u2014 the applier derives it from the passed object handle.",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 171,
+      "className": "RayCast3D",
+      "methodName": "add_exception",
+      "hash": 1976431078,
+      "arguments": [
+        "CollisionObject3D"
+      ],
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue excluding a collision object from the ray (camera aim skips its anchor).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 172,
+      "className": "ShapeCast3D",
+      "methodName": "get_collision_count",
+      "hash": 3905245786,
+      "arguments": [],
+      "returnType": "int",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Number of shape-cast hits this tick (ground-height probe).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 173,
+      "className": "ShapeCast3D",
+      "methodName": "get_collision_point",
+      "hash": 711720468,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "Vector3",
+      "shape": "LONG_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "World-space hit point by index through the indexed Vector3 query.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 174,
+      "className": "ShapeCast3D",
+      "methodName": "get_collider",
+      "hash": 3332903315,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "Object",
+      "shape": "LONG_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "The indexed hit object as an existing tracked handle (script-or-known, node-lookup rule).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 175,
+      "className": "ShapeCast3D",
+      "methodName": "set_target_position",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "shape": "VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Aim the cast (packed three-float immediate; the launcher re-aims per tick and reads back).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 176,
+      "className": "ShapeCast3D",
+      "methodName": "get_target_position",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "The cast's local target vector (synchronous read-after-write).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 177,
+      "className": "NavigationAgent3D",
+      "methodName": "set_target_position",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "shape": "VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Set the navigation goal (packed three-float immediate before the path query).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 178,
+      "className": "NavigationAgent3D",
+      "methodName": "get_next_path_position",
+      "hash": 3783033775,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Next path waypoint (beetle-bot steering).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 179,
+      "className": "NavigationAgent3D",
+      "methodName": "is_target_reached",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Whether the agent finished its path.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 180,
+      "className": "AnimationMixer",
+      "methodName": "set_active",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue activating the mixer (skins enable their AnimationTree on ready).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 181,
+      "className": "AnimationPlayer",
+      "methodName": "stop",
+      "hash": 107499316,
+      "arguments": [
+        "bool"
+      ],
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue stopping playback (keep_state baked to Godot's default false).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 182,
+      "className": "AnimationPlayer",
+      "methodName": "seek",
+      "hash": 1807872683,
+      "arguments": [
+        "float",
+        "bool",
+        "bool"
+      ],
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue seeking to a time with update baked true (bot flight rewind).",
+      "descriptorName": "ANIMATIONPLAYER_SEEK",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 183,
+      "className": "AnimationPlayer",
+      "methodName": "set_default_blend_time",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue the default cross-animation blend time.",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 184,
+      "className": "AnimationMixer",
+      "methodName": "get_animation",
+      "hash": 2933122410,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Animation",
+      "shape": "NODEPATH_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Resolve a named Animation resource to a tracked handle (loop-mode forcing).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 185,
+      "className": "Animation",
+      "methodName": "set_loop_mode",
+      "hash": 3155355575,
+      "arguments": [
+        "enum::Animation.LoopMode"
+      ],
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue a loop-mode write on a resolved Animation resource.",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 186,
+      "scope": "singleton",
+      "className": "Input",
+      "methodName": "get_action_raw_strength",
+      "hash": 801543509,
+      "arguments": [
+        "StringName",
+        "bool"
+      ],
+      "returnType": "float",
+      "shape": "STRINGNAME_RET_DOUBLE_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Raw action strength scaled by 1000 through the object-query transport (exact_match baked false).",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 187,
+      "scope": "singleton",
+      "className": "ProjectSettings",
+      "methodName": "get_setting",
+      "hash": 223050753,
+      "arguments": [
+        "String",
+        "Variant"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_RET_DOUBLE_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Float-valued project setting scaled by 1000 (default-gravity read).",
+      "descriptorName": "PROJECTSETTINGS_GET_SETTING_DOUBLE",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 188,
+      "className": "AudioStreamPlayer3D",
+      "methodName": "is_playing",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Whether the positional stream is playing (bullet recycle stop guard).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 189,
+      "className": "MeshInstance3D",
+      "methodName": "set_surface_override_material",
+      "hash": 3671737478,
+      "arguments": [
+        "int",
+        "Material"
+      ],
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue clearing one surface override (material baked null \u2014 bee-bot teardown).",
+      "descriptorName": "MESHINSTANCE3D_CLEAR_SURFACE_OVERRIDE_MATERIAL",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 190,
+      "scope": "singleton",
+      "className": "OS",
+      "methodName": "shell_open",
+      "hash": 166001499,
+      "arguments": [
+        "String"
+      ],
+      "returnType": "enum::Error",
+      "shape": "STRINGNAME_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Open a URL (the browser opens a new tab; menu link buttons).",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 191,
+      "className": "Object",
+      "methodName": "call",
+      "hash": 3400424181,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_VECTOR3_VECTOR3_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "isVararg": true,
+      "typedVarargTail": [
+        "Vector3",
+        "Vector3"
+      ],
+      "semantics": "Queue a dynamic damage(impact, force) dispatch (interned method + six doubles; the Variant return is discarded).",
+      "descriptorName": "OBJECT_CALL_VECTOR3_VECTOR3",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 192,
+      "className": "Tween",
+      "methodName": "tween_method",
+      "hash": 2337877153,
+      "arguments": [
+        "Callable",
+        "Variant",
+        "Variant",
+        "float"
+      ],
+      "returnType": "MethodTweener",
+      "shape": "CALLABLE_DOUBLE_RANGE_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "RETAINED_REFCOUNTED",
+      "semantics": "Tween a registered method with an interpolated double (coin follow); the Callable binds to the owning script's proxy method.",
+      "scope": "class",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 193,
+      "className": "Object",
+      "methodName": "disconnect",
+      "hash": 1874754934,
+      "arguments": [
+        "StringName",
+        "Callable"
+      ],
+      "shape": "STRINGNAME_BOUND_CALLABLE_LONG_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Disconnect a bound signal-dispatch callable (bots drop their detection hooks on defeat).",
+      "descriptorName": "OBJECT_DISCONNECT",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60f-third-person"
     }
   ],
   "compositions": [

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -2345,6 +2345,116 @@
       "semantics": "Queue a double-valued indexed property write (AnimationTree blend parameters like the run tilt).",
       "introducedBy": "60e-corpus",
       "descriptorName": "OBJECT_SET_INDEXED_DOUBLE"
+    },
+    {
+      "opcode": 152,
+      "scope": "class",
+      "className": "RigidBody3D",
+      "methodName": "set_freeze_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue freezing/unfreezing a rigid body (destroyed-box shards wake by unfreezing).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 153,
+      "scope": "class",
+      "className": "RigidBody3D",
+      "methodName": "set_sleeping",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue waking/sleeping a rigid body.",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 154,
+      "scope": "class",
+      "className": "RigidBody3D",
+      "methodName": "apply_force",
+      "hash": 2754756483,
+      "arguments": [
+        "Vector3",
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_VECTOR3_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Apply a positioned continuous force (packed six-float immediate; shards fly).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 155,
+      "scope": "class",
+      "className": "CollisionObject3D",
+      "methodName": "set_collision_mask_value",
+      "hash": 300928843,
+      "arguments": [
+        "int",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "LONG_BOOL_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle one collision-mask layer (packed layer/value immediate).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 156,
+      "scope": "class",
+      "className": "CharacterBody3D",
+      "methodName": "get_wall_normal",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Wall normal from the last move_and_slide (anti-stuck nudge).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 157,
+      "scope": "class",
+      "className": "AnimationPlayer",
+      "methodName": "is_playing",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Whether an animation is currently playing (melee attack gate).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 158,
+      "scope": "class",
+      "className": "AudioStreamPlayer3D",
+      "methodName": "set_pitch_scale",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a pitch-scale write (randomized footstep/destroy pitches).",
+      "introducedBy": "60f-third-person"
     }
   ],
   "compositions": [

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -3029,6 +3029,20 @@
       "returnType": "void",
       "returnOwnership": "BORROWED",
       "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 194,
+      "scope": "class",
+      "className": "Viewport",
+      "methodName": "get_camera_3d",
+      "hash": 2285090890,
+      "arguments": [],
+      "returnType": "Camera3D",
+      "shape": "NOARGS_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "The viewport's active 3D camera as a tracked handle (grenade aim tilt).",
+      "introducedBy": "60f-third-person"
     }
   ],
   "compositions": [

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -3043,6 +3043,41 @@
       "returnOwnership": "BORROWED",
       "semantics": "The viewport's active 3D camera as a tracked handle (grenade aim tilt).",
       "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 195,
+      "scope": "class",
+      "className": "Node3D",
+      "methodName": "is_visible",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Node3D visibility read (the grenade launcher gates its aim tick on it).",
+      "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 196,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "emit_signal",
+      "hash": 4047867050,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "enum::Error",
+      "shape": "STRINGNAME_STRING_RET_INT",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "isVararg": true,
+      "typedVarargTail": [
+        "String"
+      ],
+      "descriptorName": "OBJECT_EMIT_SIGNAL_STRING",
+      "semantics": "Emit a signal carrying one String argument (weapon_switched -> WeaponUi).",
+      "introducedBy": "60f-third-person"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -30,9 +30,10 @@ import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
+import { runThirdperson } from "./demos/thirdperson.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -153,6 +153,9 @@ async function main() {
       if (message.id) {
         const callback = pendingCalls.get(message.id);
         pendingCalls.delete(message.id);
+        // A reply can outlive its per-call timeout (which already rejected and
+        // removed the entry); a late response must not crash the driver.
+        if (!callback) return;
         if (message.error) callback.reject(new Error(JSON.stringify(message.error)));
         else callback.resolve(message.result);
         return;

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -178,7 +178,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -153,7 +153,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -137,7 +137,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -227,7 +227,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol12: firstRun.settled.protocol === 12 && secondRun.settled.protocol === 12,
+    protocol13: firstRun.settled.protocol === 13 && secondRun.settled.protocol === 13,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -1,0 +1,258 @@
+// demos/thirdperson.mjs -- third-person controller play + teardown assertions for the
+// Web smoke.
+//
+// The demo boots PAUSED behind its instructions page: the driver first dispatches
+// SmokeQuit.smoke_resume (method#1) to press through, then holds move_up via the trusted
+// per-engine key transport and PROVES movement by reading the player's global position
+// through the bridge's immediate Vector3 channel (opcode 138). Enemy AI is self-evidencing
+// while the world runs (beetle-bot navigation, bee-bot bobbing). smoke_teardown (method#2)
+// releases the scene caches and frees the root, draining every live handle to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[thirdperson ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        playerHandle: bridge.tpPlayerHandle,
+        smokeQuitHandle: bridge.tpSmokeQuitHandle,
+        demoPageHandle: bridge.tpDemoPageHandle,
+        readyCount: bridge.readyCount,
+        playerReady: classCount(".Player"),
+        demoPageReady: classCount(".DemoPage"),
+        cameraReady: classCount(".CameraController"),
+        skinReady: classCount(".CharacterSkin"),
+        beeReady: classCount(".BeeBot"),
+        beetleReady: classCount(".BeetleBot"),
+        boxReady: classCount(".Box"),
+        smokeQuitReady: classCount(".SmokeQuit"),
+        physicsCalls: bridge.physicsProcessCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        physicsAfterProcess: bridge.physicsAfterProcessSameTick ?? 0,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+// The player's world position through the immediate no-args Vector3 channel
+// (opcode 138 = Node3D.get_global_position on the player's script handle).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.tpPlayerHandle;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(`physics=${snap.physicsCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} errs=${snap.callbackErrors}`);
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runThirdperson({ url, evaluate, navigate, keys, deadline }) {
+  const keyDown = keys ? () => keys("down", "w") : () => { throw new Error("thirdperson needs the keys transport"); };
+  const keyUp = keys ? () => keys("up", "w") : () => {};
+
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?thirdperson=${Date.now()}`);
+
+  // The 100 MB level takes longer to fetch/import than the small demos.
+  const readyDeadline = Math.min(deadline, Date.now() + 120_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "thirdperson" &&
+      snap.protocol > 0 &&
+      snap.playerReady >= 1 &&
+      snap.demoPageReady >= 1 &&
+      snap.cameraReady >= 1 &&
+      snap.skinReady >= 1 &&
+      snap.beeReady >= 1 &&
+      snap.beetleReady >= 1 &&
+      snap.boxReady >= 1 &&
+      snap.smokeQuitReady >= 1 &&
+      snap.playerHandle > 0 &&
+      snap.smokeQuitHandle > 0
+    ) {
+      ready = snap;
+      break;
+    }
+    await delay(250);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm third-person controller did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`ready: readyCount=${ready.readyCount} playerHandle=${ready.playerHandle} protocol=${ready.protocol}`);
+
+  // The demo boots paused behind its instructions page; physics must be still.
+  const pausedBefore = (await snapshot(evaluate))?.physicsCalls ?? 0;
+
+  // Press through the page (SmokeQuit.smoke_resume, method#1) and wait for physics.
+  trace("smoke_resume");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpSmokeQuitHandle, 1); true",
+  );
+  const resumed = await observe(
+    evaluate,
+    { ...seedFrom(ready), callbackErrors: 0 },
+    8_000,
+    deadline,
+    (snap) => snap.physicsCalls >= pausedBefore + 30,
+  );
+  const baseline = resumed.last ?? ready;
+  const startPosition = await playerPosition(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
+
+  // Hold move_up: the camera-relative controller accelerates, the skin state machine
+  // travels, the detection areas light up as the player passes the first beetle.
+  await keyDown();
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    6_000,
+    deadline,
+    (snap, p) => p.physicsCalls >= baseline.physicsCalls + 150,
+  );
+  await keyUp();
+  const runPosition = await playerPosition(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? baseline;
+  const displacement = runPosition
+    ? Math.hypot(runPosition.x - startPosition.x, runPosition.z - startPosition.z)
+    : 0;
+  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
+
+  // Full teardown: smoke_teardown (method#2) releases the scene caches and frees the
+  // root; every node exits the tree and releases its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpSmokeQuitHandle, 2); true",
+  );
+  const teardown = await observe(evaluate, peak, 12_000, deadline, (snap) => snap.liveHandles === 0);
+  const settled = teardown.last ?? atPeak;
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} errs=${settled.callbackErrors}`);
+
+  const protocolVersion = ready.protocol;
+  const checks = {
+    modeThirdperson: ready.mode === "thirdperson",
+    protocol13: protocolVersion === 13,
+    sceneScriptsReady:
+      ready.playerReady >= 1 &&
+      ready.demoPageReady >= 1 &&
+      ready.cameraReady >= 1 &&
+      ready.skinReady >= 1 &&
+      ready.beeReady >= 1 &&
+      ready.beetleReady >= 1 &&
+      ready.boxReady >= 1,
+    // The pause page held the world still until smoke_resume unpaused it.
+    bootPausedThenResumed: ready.physicsCalls === 0 && baseline.physicsCalls > 0,
+    // Synthetic move_up displaced the player through the camera-relative controller.
+    playerMovedOnInput: displacement > 1.0,
+    physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
+    crossingsAdvanced: peak.crossings > baseline.crossings,
+    fullTeardownToZero: settled.liveHandles === 0,
+    physicsOrderingDeterministic: (settled.physicsAfterProcess ?? 0) === 0,
+    noCallbackFaults:
+      peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready.mode === "thirdperson",
+      outcome: ready.mode === "thirdperson" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      physicsProcessCalls: peak.physicsCalls,
+      appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(displacement.toFixed(3)),
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+    },
+    boundaryErrors,
+  };
+}
+
+function seedFrom(snap) {
+  return {
+    physicsCalls: snap.physicsCalls,
+    appliedCommands: snap.appliedCommands,
+    maxLiveHandles: snap.liveHandles,
+    crossings: snap.crossings,
+  };
+}

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -150,15 +150,16 @@ export async function runThirdperson({ url, evaluate, navigate, keys, deadline }
   if (!startPosition) throw new Error("could not read the player's global position");
   trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
 
-  // Hold move_up: the camera-relative controller accelerates, the skin state machine
-  // travels, the detection areas light up as the player passes the first beetle.
+  // Hold move_up for a FIXED wall-time (no early exit: the tick rate races past any
+  // physics-count predicate before the first observe sample, cutting the hold short —
+  // played sessions with a fixed 3s hold consistently cover ~8 units).
   await keyDown();
   const gameplay = await observe(
     evaluate,
     { ...seedFrom(baseline), callbackErrors: 0 },
-    6_000,
+    3_000,
     deadline,
-    (snap, p) => p.physicsCalls >= baseline.physicsCalls + 150,
+    null,
   );
   await keyUp();
   const runPosition = await playerPosition(evaluate);

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -121,7 +121,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol12: protocolVersion === 12,
+    protocol13: protocolVersion === 13,
     sceneReady: ready.mainReady >= 1,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -23,9 +23,10 @@ import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
+import { runThirdperson } from "./demos/thirdperson.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -22,9 +22,10 @@ import { runPlatformer } from "./demos/platformer.mjs";
 import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
+import { runThirdperson } from "./demos/thirdperson.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1861,6 +1861,7 @@ tasks.register("stageWebThirdpersonProject") {
                     "GrassScatter",
                     "Grenade",
                     "GrenadeLauncher",
+                    "GrenadeVisual",
                     "Icone",
                     "JumpingPad",
                     "LinkButton",

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -28,6 +28,7 @@ val extraWebScriptSourceRoot: File? =
                     "squash" -> "kanamaWebSquashProjectDir"
                     "fps" -> "kanamaWebFpsProjectDir"
                     "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
+                    "thirdperson" -> "kanamaWebThirdpersonProjectDir"
                     else -> null
                 }
             projectDirProperty
@@ -132,6 +133,9 @@ val webCharacterSourceProject =
     providers.gradleProperty("kanamaWebCharactercontrollerProjectDir").orNull
         ?.let(rootProject::file)
 val webCharacterStaging = layout.buildDirectory.dir("web-charactercontroller/godot-project")
+val webThirdpersonSourceProject =
+    providers.gradleProperty("kanamaWebThirdpersonProjectDir").orNull?.let(rootProject::file)
+val webThirdpersonStaging = layout.buildDirectory.dir("web-thirdperson/godot-project")
 val webMatch3ImportLog = layout.buildDirectory.file("reports/web-match3-import.log")
 val webMatch3ImportOutput = ByteArrayOutputStream()
 val webGameplayCoverage = layout.buildDirectory.file("reports/web-gameplay-coverage.json")
@@ -1772,6 +1776,175 @@ tasks.register("stageWebCharactercontrollerProject") {
     }
 }
 
+tasks.register("stageWebThirdpersonProject") {
+    group = "verification"
+    description = "Stages the third-person controller with generated Web proxies (Task 60f)."
+    dependsOn("kspKotlinWasmJs", "generateWebGameplayCoverage")
+    webThirdpersonSourceProject?.let(inputs::dir)
+    inputs.dir(webSpikeAssets)
+    inputs.dir(webProxyResources)
+    inputs.file(webGameplayCoverage)
+    outputs.dir(webThirdpersonStaging)
+
+    doLast {
+        val sourceProject =
+            webThirdpersonSourceProject
+                ?: error(
+                    "Pass -PkanamaWebThirdpersonProjectDir=" +
+                        "/absolute/path/to/kanama-demos/godot-4-3d-third-person-controller"
+                )
+        check(sourceProject.resolve("main.tscn").isFile) {
+            "Third-person project not found: $sourceProject"
+        }
+
+        val stagingDir = webThirdpersonStaging.get().asFile
+        delete(stagingDir)
+        copy {
+            from(sourceProject) {
+                exclude(".git/**")
+                exclude(".godot/**")
+                exclude(".gradle/**")
+                exclude(".kotlin/**")
+                exclude("build/**")
+                exclude("web/**")
+                exclude("kotlin-src/**")
+                exclude("android/**")
+                exclude("addons/kanama_tools/**")
+                exclude("addons/kanama/**")
+                exclude("export_presets.cfg")
+            }
+            into(stagingDir)
+        }
+        copy {
+            from(webSpikeSourceProject.file("export_presets.cfg"))
+            into(stagingDir)
+        }
+        copy {
+            from(webProxyResources)
+            include("*.gd")
+            into(stagingDir.resolve("kanama-web/generated"))
+        }
+        copy {
+            from(webProxyResources)
+            include("KanamaWebProxyManifest.generated.tsv")
+            include("KanamaWebProtocol.generated.json")
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webSpikeAssets)
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webGameplayCoverage)
+            into(stagingDir.resolve("kanama-web"))
+        }
+
+        val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
+        val expectedSources =
+            setOf(
+                    "BeeBot",
+                    "BeeRoot",
+                    "BeetleBot",
+                    "BeetlebotSkin",
+                    "Box",
+                    "Bullet",
+                    "CameraController",
+                    "CameraMode",
+                    "CharacterSkin",
+                    "Coin",
+                    "CoinModel",
+                    "CoinsContainer",
+                    "DeathPlane",
+                    "DemoPage",
+                    "DestroyedBox",
+                    "FullScreenHandler",
+                    "GrassScatter",
+                    "Grenade",
+                    "GrenadeLauncher",
+                    "Icone",
+                    "JumpingPad",
+                    "LinkButton",
+                    "MeleeAttackArea",
+                    "Player",
+                    "SmokePuff",
+                    "SmokeQuit",
+                    "WeaponUi",
+                )
+                .map { "res://kotlin-src/$it.kt" }
+                .toSet()
+        val mappings =
+            manifest
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") }
+                .map { it.split('\t').let { c -> c[0] to c[1] } }
+                .filter { (sourcePath, _) -> sourcePath in expectedSources }
+                .toMap()
+        check(mappings.keys == expectedSources) {
+            "Third-person Web proxy mappings incomplete: missing=${expectedSources - mappings.keys}"
+        }
+
+        fileTree(stagingDir) {
+                include("project.godot")
+                include("**/*.tscn")
+                include("**/*.tres")
+            }
+            .files
+            .forEach { stagedFile ->
+                val original = stagedFile.readText()
+                var rewritten =
+                    mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
+                        text.replace(sourcePath, proxyPath)
+                    }
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
+                if (rewritten != original) stagedFile.writeText(rewritten)
+                check(!rewritten.contains("res://kotlin-src/")) {
+                    "Unmapped Kotlin attachment remains in staged file: $stagedFile"
+                }
+            }
+
+        // Forward+ project: pin the Compatibility renderer for the Web template (FPS precedent).
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val forwardFeature = "config/features=PackedStringArray(\"4.7\", \"Forward Plus\")"
+        val mobileRenderer = "renderer/rendering_method.mobile=\"mobile\""
+        check(stagedProjectText.contains(forwardFeature)) {
+            "Third-person renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(mobileRenderer)) {
+            "Third-person mobile renderer setting changed; update the staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    forwardFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    mobileRenderer,
+                    "renderer/rendering_method=\"gl_compatibility\"\n" +
+                        "renderer/rendering_method.mobile=\"gl_compatibility\"",
+                )
+        )
+
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        shell.writeText(
+            shell.readText()
+                .replace(
+                    pageStart,
+                    "$pageStart\n      globalThis.KanamaWebMode = \"thirdperson\";",
+                )
+        )
+    }
+}
+
 val webDemo = providers.gradleProperty("kanamaWebDemo").orElse("match3")
 
 // The single renderer/thread contract for the Kotlin/Wasm preview backend.
@@ -1869,9 +2042,10 @@ fun stageTaskFor(demo: String): String =
         "squash" -> "stageWebSquashProject"
         "fps" -> "stageWebFpsProject"
         "charactercontroller" -> "stageWebCharactercontrollerProject"
+        "thirdperson" -> "stageWebThirdpersonProject"
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson)"
             )
     }
 
@@ -1885,9 +2059,10 @@ fun stagingDirFor(demo: String): File =
         "squash" -> webSquashStaging.get().asFile
         "fps" -> webFpsStaging.get().asFile
         "charactercontroller" -> webCharacterStaging.get().asFile
+        "thirdperson" -> webThirdpersonStaging.get().asFile
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson)"
             )
     }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -25,10 +25,19 @@ import net.multigesture.kanama.web.WebObjectId
 /** AnimationTree state-machine playback resolved through the mixer's parameter object. */
 class AnimationNodeStateMachinePlayback internal constructor(godotObject: GodotHandle) :
   GodotObject(godotObject) {
+  private var lastTravelled: String = ""
+
   /** Queue a transition to a named state (reset_on_teleport baked to Godot's default). */
   fun travel(state: String) {
+    lastTravelled = state
     AnimationStateMachinePlaybackBackendContractProbe(backendHandle).travel(state)
   }
+
+  /**
+   * Web adaptation: the last travelled state, tracked client-side (the engine node may still
+   * be mid-transition; the corpus only compares against its own travel targets).
+   */
+  fun getCurrentNode(): String = lastTravelled
 }
 
 /** AnimationPlayer/AnimationTree base: the tutorial drives an AnimationTree state machine. */
@@ -43,6 +52,28 @@ class AnimationMixer(godotObject: GodotHandle) : Node(godotObject.toBackendHandl
   fun setParameter(path: String, value: Double) {
     GodotObjectBackendContractProbe(backendHandle).setIndexedDouble(path, value)
   }
+
+  /** Long parameters (one-shot requests) ride the double family; Godot coerces Variants. */
+  fun setParameter(path: String, value: Long) {
+    GodotObjectBackendContractProbe(backendHandle).setIndexedDouble(path, value.toDouble())
+  }
+
+  fun setActive(active: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.ANIMATIONMIXER_SET_ACTIVE,
+      backendHandle,
+      active,
+    )
+  }
+
+  /** Resolve a named Animation resource to a tracked handle (loop-mode forcing). */
+  fun getAnimation(name: String): Animation? =
+    GodotBackendCalls.invokeNodePathRetHandle(
+        InitialGodotCallDescriptors.ANIMATIONMIXER_GET_ANIMATION,
+        backendHandle,
+        name,
+      )
+      ?.let { Animation(WebObjectId(it.backendToken().toInt())) }
 
   object Signals {
     const val animationFinished: String = "animation_finished"
@@ -62,6 +93,12 @@ class AudioStreamPlayer3D(godotObject: GodotHandle) : Node3D(godotObject) {
   fun setPitchScale(scale: Double) {
     AudioStreamPlayer3DBackendContractProbe(backendHandle).setPitchScale(scale)
   }
+
+  fun isPlaying(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_IS_PLAYING,
+      backendHandle,
+    )
 
   object Signals {
     const val finished: String = "finished"
@@ -95,6 +132,45 @@ open class RigidBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
   fun setCollisionMaskValue(layer: Long, value: Boolean) {
     RigidBody3DBackendContractProbe(backendHandle).setCollisionMaskValue(layer, value)
   }
+
+  fun applyImpulse(impulse: Vector3, position: Vector3 = Vector3.ZERO) {
+    GodotBackendCalls.invokeVector3Vector3Arg(
+      InitialGodotCallDescriptors.RIGIDBODY3D_APPLY_IMPULSE,
+      backendHandle,
+      GodotVector3(impulse.x.toFloat(), impulse.y.toFloat(), impulse.z.toFloat()),
+      GodotVector3(position.x.toFloat(), position.y.toFloat(), position.z.toFloat()),
+    )
+  }
+
+  fun applyCentralImpulse(impulse: Vector3) {
+    GodotBackendCalls.invokeVector3Arg(
+      InitialGodotCallDescriptors.RIGIDBODY3D_APPLY_CENTRAL_IMPULSE,
+      backendHandle,
+      GodotVector3(impulse.x.toFloat(), impulse.y.toFloat(), impulse.z.toFloat()),
+    )
+  }
+
+  /** Write-only on Web. */
+  var gravityScale: Double
+    get() = unsupportedWebGameplayFamily("RigidBody3D.get_gravity_scale")
+    set(value) {
+      GodotBackendCalls.invokeDoubleArg(
+        InitialGodotCallDescriptors.RIGIDBODY3D_SET_GRAVITY_SCALE,
+        backendHandle,
+        value,
+      )
+    }
+
+  /** Write-only on Web. */
+  var lockRotation: Boolean
+    get() = unsupportedWebGameplayFamily("RigidBody3D.is_lock_rotation_enabled")
+    set(value) {
+      GodotBackendCalls.invokeBoolArg(
+        InitialGodotCallDescriptors.RIGIDBODY3D_SET_LOCK_ROTATION_ENABLED,
+        backendHandle,
+        value,
+      )
+    }
 
   fun show() {
     visible = true

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -30,6 +30,9 @@ class AnimationNodeStateMachinePlayback internal constructor(godotObject: GodotH
   /** Queue a transition to a named state (reset_on_teleport baked to Godot's default). */
   fun travel(state: String) {
     lastTravelled = state
+    // Children free before parents during scene teardown: a dying skin's playback handle
+    // may already be released while its owner still forwards states (Tween.kill precedent).
+    if (!isWebBrowserHandleLive(handle.value)) return
     AnimationStateMachinePlaybackBackendContractProbe(backendHandle).travel(state)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -4,9 +4,14 @@ package net.multigesture.kanama.api
 
 import net.multigesture.kanama.backend.AnimationStateMachinePlaybackBackendContractProbe
 import net.multigesture.kanama.backend.AudioStreamPlayer3DBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
+import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 import net.multigesture.kanama.backend.NodeBackendContractProbe
+import net.multigesture.kanama.backend.RigidBody3DBackendContractProbe
+import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebObjectId
 
 /**
@@ -52,6 +57,47 @@ class AudioStreamPlayer3D(godotObject: GodotHandle) : Node3D(godotObject) {
 
   fun stop() {
     AudioStreamPlayer3DBackendContractProbe(backendHandle).stop()
+  }
+
+  fun setPitchScale(scale: Double) {
+    AudioStreamPlayer3DBackendContractProbe(backendHandle).setPitchScale(scale)
+  }
+
+  object Signals {
+    const val finished: String = "finished"
+  }
+}
+
+/** Dynamic rigid body (the third-person controller's destructible-box shards). */
+open class RigidBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
+  /** Write-only on Web: shards flip freeze off to enter simulation. */
+  var freeze: Boolean
+    get() = unsupportedWebGameplayFamily("RigidBody3D.is_freeze_enabled")
+    set(value) {
+      RigidBody3DBackendContractProbe(backendHandle).setFreezeEnabled(value)
+    }
+
+  /** Write-only on Web: shards clear sleeping so the force applies immediately. */
+  var sleeping: Boolean
+    get() = unsupportedWebGameplayFamily("RigidBody3D.is_sleeping")
+    set(value) {
+      RigidBody3DBackendContractProbe(backendHandle).setSleeping(value)
+    }
+
+  fun applyForce(force: Vector3, position: Vector3 = Vector3.ZERO) {
+    RigidBody3DBackendContractProbe(backendHandle)
+      .applyForce(
+        GodotVector3(force.x.toFloat(), force.y.toFloat(), force.z.toFloat()),
+        GodotVector3(position.x.toFloat(), position.y.toFloat(), position.z.toFloat()),
+      )
+  }
+
+  fun setCollisionMaskValue(layer: Long, value: Boolean) {
+    RigidBody3DBackendContractProbe(backendHandle).setCollisionMaskValue(layer, value)
+  }
+
+  fun show() {
+    visible = true
   }
 }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
@@ -3,6 +3,7 @@
 package net.multigesture.kanama.api
 
 import net.multigesture.kanama.backend.AnimatedSprite3DBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
 import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.InputEventMouseMotionBackendContractProbe
@@ -11,6 +12,7 @@ import net.multigesture.kanama.backend.NodeBackendContractProbe
 import net.multigesture.kanama.backend.RayCast3DBackendContractProbe
 import net.multigesture.kanama.backend.TextureRectBackendContractProbe
 import net.multigesture.kanama.backend.VisualInstance3DBackendContractProbe
+import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebObjectId
@@ -79,7 +81,27 @@ class MeshInstance3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject)
   fun setLayerMask(mask: Long) {
     VisualInstance3DBackendContractProbe(backendHandle).setLayerMask(mask)
   }
+
+  /** Web supports only clearing an override (material baked null in the family). */
+  fun setSurfaceOverrideMaterial(surface: Long, material: Nothing?) {
+    NodeBackendContractProbe(backendHandle) // keep receiver-liveness semantics uniform
+    GodotBackendCalls.invokeLongArg(
+      net.multigesture.kanama.backend.InitialGodotCallDescriptors
+        .MESHINSTANCE3D_CLEAR_SURFACE_OVERRIDE_MATERIAL,
+      backendHandle,
+      surface,
+    )
+  }
 }
+
+/** Button base tier for the demo menu; pressed rides the shared connect flow. */
+open class BaseButton(godotObject: GodotHandle) : Control(godotObject) {
+  object Signals {
+    const val pressed: String = "pressed"
+  }
+}
+
+class TextureButton(godotObject: GodotHandle) : BaseButton(godotObject)
 
 /** Crosshair rect (FPS HUD): texture is write-only on Web. */
 class TextureRect(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle()) {
@@ -108,49 +130,9 @@ class InputEventMouseMotion private constructor(godotObject: GodotHandle) :
   }
 }
 
-/** Godot-order (YXZ) rotation basis derived from Euler angles — enough for the FPS's
- * camera-relative movement on scale-1 bodies; not a general Transform3D. */
-class Basis private constructor(private val rows: Array<DoubleArray>) {
-  operator fun times(v: Vector3): Vector3 =
-    Vector3(
-      rows[0][0] * v.x + rows[0][1] * v.y + rows[0][2] * v.z,
-      rows[1][0] * v.x + rows[1][1] * v.y + rows[1][2] * v.z,
-      rows[2][0] * v.x + rows[2][1] * v.y + rows[2][2] * v.z,
-    )
+/** The FPS-era pure-Kotlin Basis now lives with the value types; same YXZ math. */
 
-  /** Rotation-only basis: the inverse is the transpose. */
-  fun inverse(): Basis =
-    Basis(
-      arrayOf(
-        doubleArrayOf(rows[0][0], rows[1][0], rows[2][0]),
-        doubleArrayOf(rows[0][1], rows[1][1], rows[2][1]),
-        doubleArrayOf(rows[0][2], rows[1][2], rows[2][2]),
-      )
-    )
 
-  companion object {
-    /** Godot's default Euler order YXZ: R = Ry * Rx * Rz. */
-    fun fromEuler(euler: Vector3): Basis {
-      val cx = kotlin.math.cos(euler.x)
-      val sx = kotlin.math.sin(euler.x)
-      val cy = kotlin.math.cos(euler.y)
-      val sy = kotlin.math.sin(euler.y)
-      val cz = kotlin.math.cos(euler.z)
-      val sz = kotlin.math.sin(euler.z)
-      return Basis(
-        arrayOf(
-          doubleArrayOf(cy * cz + sy * sx * sz, -cy * sz + sy * sx * cz, sy * cx),
-          doubleArrayOf(cx * sz, cx * cz, -sx),
-          doubleArrayOf(-sy * cz + cy * sx * sz, sy * sz + cy * sx * cz, cy * cx),
-        )
-      )
-    }
-  }
-}
-
-/** The node's rotation basis derived from the mirrored rotation snapshot (scale-1 bodies). */
-val Node3D.basis: Basis
-  get() = Basis.fromEuler(rotation)
 
 /** get_children/find_children walks backed by get_child_count + get_child. */
 fun Node.getChildren(): List<GodotObject> {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -175,6 +175,10 @@ open class CanvasItem internal constructor(backendHandle: BackendGodotHandle) : 
     Node2DBackendContractProbe(backendHandle).queueRedraw()
   }
 
+  fun setVisible(value: Boolean) {
+    CanvasItemBackendContractProbe(backendHandle).setVisible(value)
+  }
+
   fun show() {
     CanvasItemBackendContractProbe(backendHandle).setVisible(true)
   }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -25,6 +25,7 @@ import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector2i
 import net.multigesture.kanama.web.KanamaWebScript
 import net.multigesture.kanama.web.WebObjectId
+import net.multigesture.kanama.web.webScriptInstance
 
 @RequiresOptIn(
   level = RequiresOptIn.Level.WARNING,
@@ -298,6 +299,22 @@ object GD {
     require(from <= to)
     val range = to - from + 1
     return from + (randi().toULong() % range.toULong()).toLong()
+  }
+
+  /** Normally-distributed random (Box-Muller over the engine-seeded randf). */
+  fun randfn(mean: Double, deviation: Double): Double {
+    val u1 = randf().coerceAtLeast(1e-12)
+    val u2 = randf()
+    val gaussian =
+      kotlin.math.sqrt(-2.0 * kotlin.math.ln(u1)) * kotlin.math.cos(2.0 * kotlin.math.PI * u2)
+    return mean + deviation * gaussian
+  }
+
+  /** Web adaptation: liveness of the tracked script/browser handle. */
+  fun isInstanceValid(instance: GodotObject?): Boolean {
+    if (instance == null) return false
+    val handle = instance.handle.value
+    return webScriptInstance(handle) != null || isWebBrowserHandleLive(handle)
   }
 
   fun randfRange(from: Double, to: Double): Double {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -59,6 +59,11 @@ open class GodotObject internal constructor(internal val backendHandle: BackendG
       Node2DBackendContractProbe(backendHandle).emitSignal(signal, (args[0] as Long).toInt())
       return
     }
+    if (args.size == 1 && args[0] is String) {
+      SignalBackendContractProbe(backendHandle)
+        .emitString(signal, args[0] as String)
+      return
+    }
     if (args.size == 1 && args[0] is GodotObject) {
       SignalBackendContractProbe(backendHandle)
         .emitObject(signal, (args[0] as GodotObject).backendHandle)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -144,6 +144,19 @@ object Mathf {
 
   fun lerp(from: Double, to: Double, weight: Double): Double = from + (to - from) * weight
 
+  fun inverseLerp(from: Double, to: Double, value: Double): Double =
+    if (to == from) 0.0 else (value - from) / (to - from)
+
+  fun sqrt(value: Double): Double = kotlin.math.sqrt(value)
+
+  fun min(a: Double, b: Double): Double = kotlin.math.min(a, b)
+
+  fun min(a: Long, b: Long): Long = kotlin.math.min(a, b)
+
+  fun max(a: Double, b: Double): Double = kotlin.math.max(a, b)
+
+  fun isEqualApprox(a: Double, b: Double): Boolean = kotlin.math.abs(a - b) < 1e-6
+
   /** Godot's angle_lerp / lerp_angle: interpolate the shortest arc between two angles (radians). */
   fun lerpAngle(from: Double, to: Double, weight: Double): Double {
     val difference = (to - from) % TAU
@@ -191,7 +204,7 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
     target: GodotObject,
     flags: Long = 0L,
     callback: (GodotObject) -> Unit,
-  ): Long {
+  ): SignalConnection? {
     val callbackId =
       WebSignalCallbackRegistry.registerObject(
         target.handle.value,
@@ -209,8 +222,11 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
           callbackId.toLong(),
           flags,
         )
-    if (result != 0L) WebSignalCallbackRegistry.unregister(callbackId)
-    return result
+    if (result != 0L) {
+      WebSignalCallbackRegistry.unregister(callbackId)
+      return null
+    }
+    return SignalConnection(owner, name, target, callbackId)
   }
 
   /** Suspends until this signal fires once (a one-shot connection resumes the coroutine). */
@@ -223,6 +239,32 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
         if (continuation.isActive) continuation.resume(Unit)
       }
     }
+  }
+}
+
+/** A live bound connection; [close] disconnects and releases the Kotlin callback. */
+class SignalConnection
+internal constructor(
+  private val source: GodotObject,
+  private val name: String,
+  private val target: GodotObject,
+  private val callbackId: Int,
+) {
+  private var closed = false
+
+  fun close() {
+    if (closed) return
+    closed = true
+    GodotBackendCalls.invokeStringNameBoundCallableLongRetLong(
+      InitialGodotCallDescriptors.OBJECT_DISCONNECT,
+      source.backendHandle,
+      name,
+      target.backendHandle,
+      "_kanama_web_signal_dispatch_object",
+      callbackId.toLong(),
+      -1L,
+    )
+    WebSignalCallbackRegistry.unregister(callbackId)
   }
 }
 
@@ -408,6 +450,19 @@ class Tween internal constructor(backendHandle: BackendGodotHandle) : GodotObjec
     TweenBackendContractProbe(backendHandle).tweenCallback(target.backendHandle, method)
   }
 
+  /** Tween a registered method with an interpolated double (the Callable binds proxy-side). */
+  fun tweenMethod(target: GodotObject, method: String, from: Double, to: Double, duration: Double) {
+    GodotBackendCalls.invokeCallableDoubleRangeRetHandle(
+      InitialGodotCallDescriptors.TWEEN_TWEEN_METHOD,
+      backendHandle,
+      target.backendHandle,
+      method,
+      from,
+      to,
+      duration,
+    )
+  }
+
   private fun wrapSelf(returned: net.multigesture.kanama.backend.GodotHandle?): Tween {
     check(returned != null && returned.backendToken() == backendHandle.backendToken()) {
       "Tween fluent call did not return its receiver"
@@ -510,6 +565,13 @@ object Input {
     return if (length > 1.0) vector / length else vector
   }
 
+  /** exact_match baked false; x1000 integer transport. */
+  fun getActionRawStrength(action: String): Double =
+    GodotBackendCalls.invokeStringNameRetDoubleSingleton(
+      InitialGodotCallDescriptors.INPUT_GET_ACTION_RAW_STRENGTH,
+      action,
+    )
+
   fun getAxis(negativeAction: String, positiveAction: String): Double =
     GodotBackendCalls.invokeStringNameStringNameRetDoubleSingleton(
       InitialGodotCallDescriptors.INPUT_GET_AXIS,
@@ -525,6 +587,14 @@ class SceneTree internal constructor(backendHandle: BackendGodotHandle) : GodotO
 
   fun callGroup(group: String, method: String) {
     SceneTreeBackendContractProbe(backendHandle).callGroup(group, method)
+  }
+
+  fun setPaused(paused: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      InitialGodotCallDescriptors.SCENETREE_SET_PAUSE,
+      backendHandle,
+      paused,
+    )
   }
 
   fun reloadCurrentScene() {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -274,6 +274,14 @@ inline fun <reified T : Any> GodotObject.kotlinScriptInstance(): T? =
 class Area2D(godotObject: GodotHandle) : Node2D(godotObject)
 
 class Viewport(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
+  /** The active 3D camera as a tracked handle. */
+  fun getCamera3D(): Camera3D? =
+    GodotBackendCalls.invokeNoArgsRetHandle(
+        InitialGodotCallDescriptors.VIEWPORT_GET_CAMERA_3D,
+        backendHandle,
+      )
+      ?.let { Camera3D(WebObjectId(it.backendToken().toInt())) }
+
   fun getVisibleRect(): Rect2 =
     ViewportBackendContractProbe(backendHandle).visibleRect.let { rect ->
       Rect2(

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -151,6 +151,9 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
       customBlend,
     )
   }
+
+  fun isPlaying(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(D.ANIMATIONPLAYER_IS_PLAYING, backendHandle)
 }
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())
@@ -177,6 +180,12 @@ class CharacterBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
   fun isOnFloor(): Boolean = CharacterBody3DBackendContractProbe(backendHandle).isOnFloor()
 
   fun isOnCeiling(): Boolean = CharacterBody3DBackendContractProbe(backendHandle).isOnCeiling()
+
+  /** Wall normal from the last move_and_slide (anti-stuck nudge). */
+  fun getWallNormal(): Vector3 =
+    CharacterBody3DBackendContractProbe(backendHandle).getWallNormal().let {
+      Vector3(it.x, it.y, it.z)
+    }
 
   fun getSlideCollisionCount(): Long =
     CharacterBody3DBackendContractProbe(backendHandle).getSlideCollisionCount()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -173,6 +173,11 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
       seconds,
     )
   }
+
+  /** AnimationPlayer is an AnimationMixer engine-side; rides the same family. */
+  fun getAnimation(name: String): Animation? =
+    GodotBackendCalls.invokeNodePathRetHandle(D.ANIMATIONMIXER_GET_ANIMATION, backendHandle, name)
+      ?.let { Animation(WebObjectId(it.backendToken().toInt())) }
 }
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())
@@ -220,6 +225,7 @@ class CharacterBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
 open class Area3D(godotObject: GodotHandle) : Node3D(godotObject) {
   object Signals {
     const val bodyEntered: String = "body_entered"
+    const val bodyExited: String = "body_exited"
   }
 }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -154,6 +154,25 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
 
   fun isPlaying(): Boolean =
     GodotBackendCalls.invokeNoArgsRetBool(D.ANIMATIONPLAYER_IS_PLAYING, backendHandle)
+
+  /** keep_state baked to Godot's default false. */
+  fun stop() {
+    GodotBackendCalls.invokeNoArgsVoid(D.ANIMATIONPLAYER_STOP, backendHandle)
+  }
+
+  /** update baked true (the only value the corpus passes). */
+  fun seek(seconds: Double, update: Boolean = true) {
+    require(update) { "Web AnimationPlayer.seek bakes update=true" }
+    GodotBackendCalls.invokeDoubleArg(D.ANIMATIONPLAYER_SEEK, backendHandle, seconds)
+  }
+
+  fun setDefaultBlendTime(seconds: Double) {
+    GodotBackendCalls.invokeDoubleArg(
+      D.ANIMATIONPLAYER_SET_DEFAULT_BLEND_TIME,
+      backendHandle,
+      seconds,
+    )
+  }
 }
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())
@@ -267,6 +286,13 @@ class WorldEnvironment(godotObject: GodotHandle) : Node(godotObject.toBackendHan
 
 object OS {
   fun hasFeature(tagName: String): Boolean = OSBackendContractProbe.hasFeature(tagName)
+
+  /** Web ships the release template; debug-gated tooling stays off. */
+  fun isDebugBuild(): Boolean = false
+
+  fun shellOpen(url: String) {
+    GodotBackendCalls.invokeStringNameArgSingleton(D.OS_SHELL_OPEN, url)
+  }
 }
 
 object RenderingServer {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
@@ -61,6 +61,15 @@ fun Node3D.lookAt(target: Vector3, up: Vector3 = Vector3.UP) {
   lookAtFromPosition(globalPosition, target, up)
 }
 
+/** Node3D visibility read (synchronous immediate). */
+fun Node3D.isVisible(): Boolean =
+  GodotBackendCalls.invokeNoArgsRetBool(D.NODE3D_IS_VISIBLE, backendHandle)
+
+/** Godot's rotate_object_local: right-multiply the local basis by an axis-angle rotation. */
+fun Node3D.rotateObjectLocal(axis: Vector3, angle: Double) {
+  basis = basis * Basis.fromAxisAngle(axis, angle)
+}
+
 private fun Vector3.toGodot(): GodotVector3 = GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
 
 private fun GodotVector3.toApi(): Vector3 = Vector3(x, y, z)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
@@ -1,0 +1,234 @@
+@file:OptIn(InternalKanamaBackendApi::class)
+
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.backend.GodotBackendCalls
+import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
+import net.multigesture.kanama.backend.InternalKanamaBackendApi
+import net.multigesture.kanama.types.Transform3D
+import net.multigesture.kanama.types.Vector3
+import net.multigesture.kanama.web.WebObjectId
+
+/**
+ * Web API surface for the third-person controller (Task 60f).
+ *
+ * Transform composition is pure Kotlin over the mirrored position/rotation/scale snapshots:
+ * the engine side only ever sees decomposed property writes. Global transforms assume
+ * unit global scale (true for every rig in the corpus; only the character's rotation root
+ * carries a local scale).
+ */
+
+/** FPS-era alias: the pure-Kotlin Basis moved in with the value types. */
+typealias Basis = net.multigesture.kanama.types.Basis
+
+private fun composeBasis(rotation: Vector3, scale: Vector3): Basis {
+  val rotationBasis = Basis.fromEuler(rotation)
+  // Node basis = R * S: columns scaled (Godot composes scale on the right of rotation).
+  return Basis(
+    rotationBasis.getColumn(0) * scale.x,
+    rotationBasis.getColumn(1) * scale.y,
+    rotationBasis.getColumn(2) * scale.z,
+  )
+}
+
+/** The node's local rotation+scale basis; writes decompose to the two snapshot families. */
+var Node3D.basis: Basis
+  get() = composeBasis(rotation, scale)
+  set(value) {
+    rotation = value.getEuler()
+    scale = value.getScale()
+  }
+
+/** The node's local transform (basis + origin over the mirrored snapshots). */
+var Node3D.transform: Transform3D
+  get() = Transform3D(basis, position)
+  set(value) {
+    position = value.origin
+    basis = value.basis
+  }
+
+/** The node's world transform; rotation/origin cross synchronously, global scale assumed 1. */
+var Node3D.globalTransform: Transform3D
+  get() = Transform3D(Basis.fromEuler(globalRotation), globalPosition)
+  set(value) {
+    globalPosition = value.origin
+    globalRotation = value.basis.getEuler()
+  }
+
+/** Orient -Z at [target] from the current position (rides look_at_from_position). */
+fun Node3D.lookAt(target: Vector3, up: Vector3 = Vector3.UP) {
+  lookAtFromPosition(globalPosition, target, up)
+}
+
+private fun Vector3.toGodot(): GodotVector3 = GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
+
+private fun GodotVector3.toApi(): Vector3 = Vector3(x, y, z)
+
+/** First collision of a motion sweep; close it when done (KinematicCollision3D rule). */
+fun PhysicsBody3D.moveAndCollide(motion: Vector3): KinematicCollision3D? =
+  GodotBackendCalls.invokeVector3RetHandle(
+      D.PHYSICSBODY3D_MOVE_AND_COLLIDE,
+      backendHandle,
+      motion.toGodot(),
+    )
+    ?.let { KinematicCollision3D(it) }
+
+fun PhysicsBody3D.addCollisionExceptionWith(body: GodotObject) {
+  GodotBackendCalls.invokeObjectArg(
+    D.PHYSICSBODY3D_ADD_COLLISION_EXCEPTION_WITH,
+    backendHandle,
+    body.backendHandle,
+  )
+}
+
+fun PhysicsBody3D.setAxisLock(axis: Long, lock: Boolean) {
+  GodotBackendCalls.invokeLongBoolArg(D.PHYSICSBODY3D_SET_AXIS_LOCK, backendHandle, axis, lock)
+}
+
+/** PhysicsServer3D.BodyAxis constants (PhysicsBody3D.set_axis_lock). */
+object BodyAxis {
+  const val ANGULAR_X: Long = 8L
+  const val ANGULAR_Y: Long = 16L
+  const val ANGULAR_Z: Long = 32L
+}
+
+fun CollisionObject3D.setCollisionLayerValue(layer: Long, value: Boolean) {
+  GodotBackendCalls.invokeLongBoolArg(
+    D.COLLISIONOBJECT3D_SET_COLLISION_LAYER_VALUE,
+    backendHandle,
+    layer,
+    value,
+  )
+}
+
+/** CollisionObject3D alias tier for the third-person port (layer/mask + exceptions). */
+typealias CollisionObject3D = PhysicsBody3D
+
+/** 3D shape sweep node (ground probe + grenade aim). Reads are synchronous immediates. */
+class ShapeCast3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  var targetPosition: Vector3
+    get() =
+      GodotBackendCalls.invokeNoArgsRetVector3(D.SHAPECAST3D_GET_TARGET_POSITION, backendHandle)
+        .toApi()
+    set(value) {
+      GodotBackendCalls.invokeVector3Arg(
+        D.SHAPECAST3D_SET_TARGET_POSITION,
+        backendHandle,
+        value.toGodot(),
+      )
+    }
+
+  fun getCollisionCount(): Long =
+    GodotBackendCalls.invokeNoArgsRetLong(D.SHAPECAST3D_GET_COLLISION_COUNT, backendHandle)
+
+  fun getCollisionPoint(index: Long): Vector3 =
+    GodotBackendCalls.invokeLongRetVector3(D.SHAPECAST3D_GET_COLLISION_POINT, backendHandle, index)
+      .toApi()
+
+  /** The indexed hit as an existing tracked handle (script-or-known, node-lookup rule). */
+  fun getCollider(index: Long): GodotObject? =
+    GodotBackendCalls.invokeLongRetHandle(D.SHAPECAST3D_GET_COLLIDER, backendHandle, index)?.let {
+      GodotObject(WebObjectId(it.backendToken().toInt()))
+    }
+}
+
+/** Navigation agent (beetle-bot pathing); requires a baked navmesh in the exported level. */
+class NavigationAgent3D(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
+  var targetPosition: Vector3
+    get() = unsupportedWebGameplayFamily("NavigationAgent3D.get_target_position")
+    set(value) {
+      GodotBackendCalls.invokeVector3Arg(
+        D.NAVIGATIONAGENT3D_SET_TARGET_POSITION,
+        backendHandle,
+        value.toGodot(),
+      )
+    }
+
+  fun getNextPathPosition(): Vector3 =
+    GodotBackendCalls.invokeNoArgsRetVector3(
+        D.NAVIGATIONAGENT3D_GET_NEXT_PATH_POSITION,
+        backendHandle,
+      )
+      .toApi()
+
+  fun isTargetReached(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(D.NAVIGATIONAGENT3D_IS_TARGET_REACHED, backendHandle)
+}
+
+/**
+ * Camera collision arm. Web adaptation: exclusion takes the collision OBJECT (the applier
+ * derives the RID engine-side; RIDs never cross the boundary).
+ */
+class SpringArm3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  fun addExcludedObject(body: GodotObject) {
+    GodotBackendCalls.invokeObjectArg(
+      D.SPRINGARM3D_ADD_EXCLUDED_OBJECT,
+      backendHandle,
+      body.backendHandle,
+    )
+  }
+}
+
+fun RayCast3D.addException(body: GodotObject) {
+  GodotBackendCalls.invokeObjectArg(D.RAYCAST3D_ADD_EXCEPTION, backendHandle, body.backendHandle)
+}
+
+/** Position marker (grenade launch point) — pure transform surface. */
+class Marker3D(godotObject: GodotHandle) : Node3D(godotObject)
+
+/** Grass scatter host: the Web port keeps the node inert (no MultiMesh introspection yet). */
+class MultiMeshInstance3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject)
+
+/** Animation resource resolved through AnimationMixer.get_animation. */
+class Animation internal constructor(godotObject: GodotHandle) : GodotObject(godotObject) {
+  fun setLoopMode(mode: Long) {
+    GodotBackendCalls.invokeLongArg(D.ANIMATION_SET_LOOP_MODE, backendHandle, mode)
+  }
+
+  companion object {
+    const val LOOP_LINEAR: Long = 1L
+  }
+}
+
+/** Overlapping scripted bodies (bodies without Kanama scripts are omitted by contract). */
+fun Area3D.getOverlappingBodies(): List<GodotObject> =
+  GodotBackendCalls.invokeNoArgsRetHandleList(D.AREA3D_GET_OVERLAPPING_BODIES, backendHandle).map {
+    GodotObject(WebObjectId(it.backendToken().toInt()))
+  }
+
+/** Dynamic two-Vector3 dispatch (the corpus's damage(impact, force) convention). */
+fun GodotObject.call(method: String, first: Vector3, second: Vector3) {
+  GodotBackendCalls.invokeStringNameVector3Vector3Arg(
+    D.OBJECT_CALL_VECTOR3_VECTOR3,
+    backendHandle,
+    method,
+    first.toGodot(),
+    second.toGodot(),
+  )
+}
+
+fun Node.setProcess(enable: Boolean) {
+  GodotBackendCalls.invokeBoolArg(D.NODE_SET_PROCESS, backendHandle, enable)
+}
+
+/** Web no-ops: generated proxies dispatch input only to scripts that declare handlers. */
+fun Node.setProcessInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+
+fun Node.setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+
+object ProjectSettings {
+  /** Float-valued setting read (x1000 integer transport; millis precision). */
+  fun getSettingDouble(name: String): Double =
+    GodotBackendCalls.invokeStringNameRetDoubleSingleton(
+      D.PROJECTSETTINGS_GET_SETTING_DOUBLE,
+      name,
+    )
+}
+
+object Time {
+  private val origin = kotlin.time.TimeSource.Monotonic.markNow()
+
+  /** Web adaptation: a Kotlin monotonic clock (only relative time is consumed). */
+  fun getTicksMsec(): Long = origin.elapsedNow().inWholeMilliseconds
+}

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -248,6 +248,20 @@ class Basis internal constructor(internal val m: DoubleArray) {
       m[6] * v.x + m[7] * v.y + m[8] * v.z,
     )
 
+  /** Row-major matrix product (this applied after [other] in xform order). */
+  operator fun times(other: Basis): Basis {
+    val a = m
+    val b = other.m
+    val out = DoubleArray(9)
+    for (row in 0..2) {
+      for (col in 0..2) {
+        out[row * 3 + col] =
+          a[row * 3] * b[col] + a[row * 3 + 1] * b[3 + col] + a[row * 3 + 2] * b[6 + col]
+      }
+    }
+    return Basis(out)
+  }
+
   /** Rotation-only inverse: the transpose. */
   fun inverse(): Basis = transposed()
 
@@ -351,6 +365,27 @@ class Basis internal constructor(internal val m: DoubleArray) {
           -sy * cz + cy * sx * sz,
           sy * sz + cy * sx * cz,
           cy * cx,
+        )
+      )
+    }
+
+    /** Rodrigues rotation matrix about (unit) [axis] by [angle] radians. */
+    fun fromAxisAngle(axis: Vector3, angle: Double): Basis {
+      val a = axis.normalized()
+      val c = cos(angle)
+      val s = sin(angle)
+      val t = 1.0 - c
+      return Basis(
+        doubleArrayOf(
+          t * a.x * a.x + c,
+          t * a.x * a.y - s * a.z,
+          t * a.x * a.z + s * a.y,
+          t * a.x * a.y + s * a.z,
+          t * a.y * a.y + c,
+          t * a.y * a.z - s * a.x,
+          t * a.x * a.z - s * a.y,
+          t * a.y * a.z + s * a.x,
+          t * a.z * a.z + c,
         )
       )
     }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -49,6 +49,8 @@ data class Vector2(val x: Double, val y: Double) {
   companion object {
     val ZERO = Vector2(0.0, 0.0)
     val ONE = Vector2(1.0, 1.0)
+    val RIGHT = Vector2(1.0, 0.0)
+    val DOWN = Vector2(0.0, 1.0)
   }
 }
 
@@ -68,6 +70,15 @@ data class Vector3(val x: Double, val y: Double, val z: Double) {
   fun length(): Double = sqrt(x * x + y * y + z * z)
 
   fun lengthSquared(): Double = x * x + y * y + z * z
+
+  operator fun unaryMinus(): Vector3 = Vector3(-x, -y, -z)
+
+  fun distanceTo(other: Vector3): Double = (other - this).length()
+
+  fun distanceSquaredTo(other: Vector3): Double = (other - this).lengthSquared()
+
+  /** Godot's bounce: reflect off the plane with (unit) normal [normal]. */
+  fun bounce(normal: Vector3): Vector3 = this - normal * (2.0 * dot(normal))
 
   fun dot(other: Vector3): Double = x * other.x + y * other.y + z * other.z
 
@@ -142,5 +153,239 @@ data class Color(val r: Float, val g: Float, val b: Float, val a: Float = 1.0f)
 data class Vector2i(val x: Int, val y: Int) {
   companion object {
     val ZERO = Vector2i(0, 0)
+  }
+}
+
+/** Rotation quaternion backing Basis decomposition and slerp (Godot layout: x, y, z, w). */
+data class Quaternion(val x: Double, val y: Double, val z: Double, val w: Double) {
+  fun normalized(): Quaternion {
+    val len = sqrt(x * x + y * y + z * z + w * w)
+    return if (len > 0.0) Quaternion(x / len, y / len, z / len, w / len) else IDENTITY
+  }
+
+  /** Spherical interpolation along the shortest arc (Godot's slerp). */
+  fun slerp(to: Quaternion, weight: Double): Quaternion {
+    var cosom = x * to.x + y * to.y + z * to.z + w * to.w
+    var target = to
+    if (cosom < 0.0) {
+      cosom = -cosom
+      target = Quaternion(-to.x, -to.y, -to.z, -to.w)
+    }
+    val scale0: Double
+    val scale1: Double
+    if (1.0 - cosom > 1e-6) {
+      val omega = kotlin.math.acos(cosom)
+      val sinom = sin(omega)
+      scale0 = sin((1.0 - weight) * omega) / sinom
+      scale1 = sin(weight * omega) / sinom
+    } else {
+      scale0 = 1.0 - weight
+      scale1 = weight
+    }
+    return Quaternion(
+      scale0 * x + scale1 * target.x,
+      scale0 * y + scale1 * target.y,
+      scale0 * z + scale1 * target.z,
+      scale0 * w + scale1 * target.w,
+    )
+  }
+
+  companion object {
+    val IDENTITY = Quaternion(0.0, 0.0, 0.0, 1.0)
+  }
+}
+
+/**
+ * 3x3 basis over row-major storage (rows match Godot's internal layout: xform(v) dots rows with v;
+ * the x/y/z axes are COLUMNS). Pure Kotlin — composes from the mirrored rotation/scale snapshots
+ * without an engine crossing.
+ */
+class Basis internal constructor(internal val m: DoubleArray) {
+  init {
+    require(m.size == 9)
+  }
+
+  /** Godot's axis constructor: [xAxis]/[yAxis]/[zAxis] are the matrix COLUMNS. */
+  constructor(
+    xAxis: Vector3,
+    yAxis: Vector3,
+    zAxis: Vector3,
+  ) : this(
+    doubleArrayOf(xAxis.x, yAxis.x, zAxis.x, xAxis.y, yAxis.y, zAxis.y, xAxis.z, yAxis.z, zAxis.z)
+  )
+
+  constructor(
+    quaternion: Quaternion
+  ) : this(
+    quaternion.normalized().let { q ->
+      val xx = q.x * q.x
+      val yy = q.y * q.y
+      val zz = q.z * q.z
+      val xy = q.x * q.y
+      val xz = q.x * q.z
+      val yz = q.y * q.z
+      val wx = q.w * q.x
+      val wy = q.w * q.y
+      val wz = q.w * q.z
+      doubleArrayOf(
+        1.0 - 2.0 * (yy + zz),
+        2.0 * (xy - wz),
+        2.0 * (xz + wy),
+        2.0 * (xy + wz),
+        1.0 - 2.0 * (xx + zz),
+        2.0 * (yz - wx),
+        2.0 * (xz - wy),
+        2.0 * (yz + wx),
+        1.0 - 2.0 * (xx + yy),
+      )
+    }
+  )
+
+  operator fun times(v: Vector3): Vector3 =
+    Vector3(
+      m[0] * v.x + m[1] * v.y + m[2] * v.z,
+      m[3] * v.x + m[4] * v.y + m[5] * v.z,
+      m[6] * v.x + m[7] * v.y + m[8] * v.z,
+    )
+
+  /** Rotation-only inverse: the transpose. */
+  fun inverse(): Basis = transposed()
+
+  fun transposed(): Basis =
+    Basis(doubleArrayOf(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]))
+
+  fun getColumn(index: Int): Vector3 = Vector3(m[index], m[3 + index], m[6 + index])
+
+  /** Column lengths signed by the determinant (Godot's get_scale). */
+  fun getScale(): Vector3 {
+    val detSign = if (determinant() < 0.0) -1.0 else 1.0
+    return Vector3(
+      detSign * getColumn(0).length(),
+      detSign * getColumn(1).length(),
+      detSign * getColumn(2).length(),
+    )
+  }
+
+  fun determinant(): Double =
+    m[0] * (m[4] * m[8] - m[5] * m[7]) - m[1] * (m[3] * m[8] - m[5] * m[6]) +
+      m[2] * (m[3] * m[7] - m[4] * m[6])
+
+  /** Godot's scaled(): rows scaled componentwise (scale applied on the left). */
+  fun scaled(scale: Vector3): Basis =
+    Basis(
+      doubleArrayOf(
+        m[0] * scale.x,
+        m[1] * scale.x,
+        m[2] * scale.x,
+        m[3] * scale.y,
+        m[4] * scale.y,
+        m[5] * scale.y,
+        m[6] * scale.z,
+        m[7] * scale.z,
+        m[8] * scale.z,
+      )
+    )
+
+  /** Columns normalized (drops scale; assumes no shear — node transforms in these demos). */
+  fun orthonormalized(): Basis {
+    val x = getColumn(0).normalized()
+    val y = getColumn(1).normalized()
+    val z = getColumn(2).normalized()
+    return Basis(x, y, z)
+  }
+
+  /** Rotation quaternion of the orthonormalized basis (Shepperd's method). */
+  fun getRotationQuaternion(): Quaternion {
+    val ortho = orthonormalized()
+    val r = (if (ortho.determinant() < 0.0) ortho.scaled(Vector3(-1, -1, -1)) else ortho).m
+    val trace = r[0] + r[4] + r[8]
+    val raw =
+      if (trace > 0.0) {
+        val s = sqrt(trace + 1.0) * 2.0
+        Quaternion((r[7] - r[5]) / s, (r[2] - r[6]) / s, (r[3] - r[1]) / s, 0.25 * s)
+      } else if (r[0] > r[4] && r[0] > r[8]) {
+        val s = sqrt(1.0 + r[0] - r[4] - r[8]) * 2.0
+        Quaternion(0.25 * s, (r[1] + r[3]) / s, (r[2] + r[6]) / s, (r[7] - r[5]) / s)
+      } else if (r[4] > r[8]) {
+        val s = sqrt(1.0 + r[4] - r[0] - r[8]) * 2.0
+        Quaternion((r[1] + r[3]) / s, 0.25 * s, (r[5] + r[7]) / s, (r[2] - r[6]) / s)
+      } else {
+        val s = sqrt(1.0 + r[8] - r[0] - r[4]) * 2.0
+        Quaternion((r[2] + r[6]) / s, (r[5] + r[7]) / s, 0.25 * s, (r[3] - r[1]) / s)
+      }
+    return raw.normalized()
+  }
+
+  /** Euler angles in Godot's default YXZ order (inverse of [fromEuler]). */
+  fun getEuler(): Vector3 {
+    val r = orthonormalized().m
+    val sx = -r[5]
+    return if (sx > 0.999999) {
+      Vector3(kotlin.math.PI / 2.0, atan2(r[3], r[0]), 0.0)
+    } else if (sx < -0.999999) {
+      Vector3(-kotlin.math.PI / 2.0, atan2(r[3], r[0]), 0.0)
+    } else {
+      Vector3(kotlin.math.asin(sx), atan2(r[2], r[8]), atan2(r[3], r[4]))
+    }
+  }
+
+  companion object {
+    val IDENTITY = Basis(doubleArrayOf(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+
+    /** Godot's default Euler order YXZ: R = Ry * Rx * Rz. */
+    fun fromEuler(euler: Vector3): Basis {
+      val cx = cos(euler.x)
+      val sx = sin(euler.x)
+      val cy = cos(euler.y)
+      val sy = sin(euler.y)
+      val cz = cos(euler.z)
+      val sz = sin(euler.z)
+      return Basis(
+        doubleArrayOf(
+          cy * cz + sy * sx * sz,
+          -cy * sz + sy * sx * cz,
+          sy * cx,
+          cx * sz,
+          cx * cz,
+          -sx,
+          -sy * cz + cy * sx * sz,
+          sy * sz + cy * sx * cz,
+          cy * cx,
+        )
+      )
+    }
+
+    /** Godot's looking_at basis: -Z oriented at [direction], [up] as the vertical hint. */
+    fun lookingAt(direction: Vector3, up: Vector3 = Vector3.UP): Basis {
+      val z = -direction.normalized()
+      val x = up.cross(z).normalized()
+      val y = z.cross(x)
+      return Basis(x, y, z)
+    }
+  }
+}
+
+/** Basis + origin. Pure Kotlin — the engine side sees only the decomposed writes. */
+data class Transform3D(val basis: Basis, val origin: Vector3) {
+  /** Godot's xform: rotate/scale then translate. */
+  operator fun times(v: Vector3): Vector3 = basis * v + origin
+
+  fun withBasis(newBasis: Basis): Transform3D = Transform3D(newBasis, origin)
+
+  fun withOrigin(newOrigin: Vector3): Transform3D = Transform3D(basis, newOrigin)
+
+  /** Keeps the origin; orients -Z at [target] (Godot's looking_at). */
+  fun lookingAt(target: Vector3, up: Vector3 = Vector3.UP): Transform3D =
+    Transform3D(Basis.lookingAt(target - origin, up), origin)
+
+  /** Godot's interpolate_with: slerp rotation, lerp scale and origin. */
+  fun interpolateWith(other: Transform3D, weight: Double): Transform3D {
+    val rotation = basis.getRotationQuaternion().slerp(other.basis.getRotationQuaternion(), weight)
+    val scale = basis.getScale().lerp(other.basis.getScale(), weight)
+    return Transform3D(Basis(rotation).scaled(scale), origin.lerp(other.origin, weight))
+  }
+
+  companion object {
+    val IDENTITY = Transform3D(Basis.IDENTITY, Vector3.ZERO)
   }
 }

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -298,6 +298,20 @@ fun kanamaWebSetObjectProperty(objectId: Int, propertyId: Int, value: Int): Int 
 }
 
 @JsExport
+fun kanamaWebSetStringArrayProperty(objectId: Int, propertyId: Int, encodedValues: String): Int {
+  val values = encodedValues.takeIf { it.isNotEmpty() }?.split('\u001f') ?: emptyList()
+  return webCallbackBoundary(objectId, "property_set", "property", propertyId) { record ->
+    KanamaWebProjectRegistry.setStringArrayProperty(
+      record.scriptId,
+      propertyId,
+      record.script,
+      values,
+    )
+    1
+  }
+}
+
+@JsExport
 fun kanamaWebSetObjectArrayProperty(objectId: Int, propertyId: Int, encodedValues: String): Int {
   val values =
     encodedValues.takeIf { it.isNotEmpty() }?.split(',')?.map(String::toInt)?.toIntArray()
@@ -310,6 +324,15 @@ fun kanamaWebSetObjectArrayProperty(objectId: Int, propertyId: Int, encodedValue
       record.script,
       values,
     )
+    1
+  }
+}
+
+@JsExport
+fun kanamaWebCallString(objectId: Int, methodId: Int, value: String): Int {
+  return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
+    KanamaWebProjectRegistry.callString(record.scriptId, methodId, record.script, value)
+    commands.flush()
     1
   }
 }

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -40,6 +40,9 @@ internal fun immediateWebMoveAndCollide(opcode: Int, objectId: Int, packed: Stri
 internal fun immediateWebStringQuery(opcode: Int, objectId: Int, value: String): String =
   js("globalThis.KanamaWebBridge.immediateStringQuery(opcode, objectId, value)")
 
+internal fun immediateWebIndexedObjectLookup(opcode: Int, objectId: Int, index: Int): Int =
+  js("globalThis.KanamaWebBridge.immediateIndexedObjectLookup(opcode, objectId, index)")
+
 internal fun immediateWebIndexedVector3X(opcode: Int, objectId: Int, index: Int): Double =
   js("globalThis.KanamaWebBridge.immediateIndexedVector3X(opcode, objectId, index)")
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -31,8 +31,41 @@ internal fun immediateWebConstructObject(className: String): Int =
 internal fun immediateWebNodeLookup(objectId: Int, path: String): Int =
   js("globalThis.KanamaWebBridge.immediateNodeLookup(objectId, path)")
 
-internal fun immediateWebPropertyObjectQuery(objectId: Int, name: String): Int =
-  js("globalThis.KanamaWebBridge.immediatePropertyObjectQuery(objectId, name)")
+internal fun immediateWebPropertyObjectQuery(opcode: Int, objectId: Int, name: String): Int =
+  js("globalThis.KanamaWebBridge.immediatePropertyObjectQuery(opcode, objectId, name)")
+
+internal fun immediateWebMoveAndCollide(opcode: Int, objectId: Int, packed: String): Int =
+  js("globalThis.KanamaWebBridge.immediateMoveAndCollide(opcode, objectId, packed)")
+
+internal fun immediateWebStringQuery(opcode: Int, objectId: Int, value: String): String =
+  js("globalThis.KanamaWebBridge.immediateStringQuery(opcode, objectId, value)")
+
+internal fun immediateWebIndexedVector3X(opcode: Int, objectId: Int, index: Int): Double =
+  js("globalThis.KanamaWebBridge.immediateIndexedVector3X(opcode, objectId, index)")
+
+internal fun immediateWebDisconnectBound(
+  objectId: Int,
+  signal: String,
+  targetId: Int,
+  method: String,
+  boundValue: Int,
+): Int =
+  js(
+    "globalThis.KanamaWebBridge.immediateDisconnectBound(objectId, signal, targetId, method, boundValue)"
+  )
+
+internal fun immediateWebTweenMethod(
+  opcode: Int,
+  tweenId: Int,
+  targetId: Int,
+  method: String,
+  fromValue: Double,
+  toValue: Double,
+  duration: Double,
+): Int =
+  js(
+    "globalThis.KanamaWebBridge.immediateTweenMethod(opcode, tweenId, targetId, method, fromValue, toValue, duration)"
+  )
 
 internal fun immediateWebPackedSceneInstantiate(resourceId: Int, editState: Int): Int =
   js("globalThis.KanamaWebBridge.immediatePackedSceneInstantiate(resourceId, editState)")

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
@@ -1,4 +1,7 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
+@file:OptIn(
+  ExperimentalWasmJsInterop::class,
+  net.multigesture.kanama.backend.InternalKanamaBackendApi::class,
+)
 
 package net.multigesture.kanama.web
 
@@ -113,6 +116,25 @@ internal class WebCommandBuffer(capacity: Int) {
     words[offset + 2] = internWebCommandStringName(value)
   }
 
+  fun appendStringNameVector3Vector3Mutation(
+    opcode: Int,
+    objectHandle: Int,
+    name: String,
+    first: net.multigesture.kanama.backend.GodotVector3,
+    second: net.multigesture.kanama.backend.GodotVector3,
+  ) {
+    val offset = reserve(WORDS_STRINGNAME_VECTOR3_VECTOR3)
+    words[offset] = opcode
+    words[offset + 1] = objectHandle
+    words[offset + 2] = internWebCommandStringName(name)
+    words[offset + 3] = first.x.toBits()
+    words[offset + 4] = first.y.toBits()
+    words[offset + 5] = first.z.toBits()
+    words[offset + 6] = second.x.toBits()
+    words[offset + 7] = second.y.toBits()
+    words[offset + 8] = second.z.toBits()
+  }
+
   fun appendStringNameBoolMutation(opcode: Int, objectHandle: Int, name: String, value: Boolean) {
     val offset = reserve(WORDS_SCALAR_OR_VECTOR)
     words[offset] = opcode
@@ -224,6 +246,7 @@ internal class WebCommandBuffer(capacity: Int) {
     const val WORDS_LONG_DOUBLE = 5
     const val WORDS_STRINGNAME_DOUBLE = 5
     const val WORDS_COLOR = 6
+    const val WORDS_STRINGNAME_VECTOR3_VECTOR3 = 9
     const val WORDS_DRAW_TEXTURE = 9
     const val MAX_WORDS_PER_COMMAND = WORDS_DRAW_TEXTURE
     // The benchmark contributes 10,000 data mutations plus one phase-control mutation (redraw).

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -72,7 +72,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144))
+    require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153))
     val objectId = receiver.webId()
     commands.appendBoolMutation(descriptor.opcode, objectId, value)
     when (descriptor.opcode) {
@@ -93,7 +93,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     }
     when (descriptor.executionMode) {
       GodotExecutionMode.QUEUED_MUTATION -> {
-        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146))
+        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158))
         commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
@@ -387,6 +387,29 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
     require(descriptor.opcode == 67)
     commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
+  }
+
+  override fun invokeLongBoolArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    layer: Long,
+    value: Boolean,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 155)
+    commands.flush()
+    // Layer number and flag packed into one query string (unit separator).
+    check(
+      immediateWebObjectQuery(
+        descriptor.opcode,
+        receiver.webId(),
+        layer.toString() + "" + (if (value) "1" else "0"),
+      ) == 1
+    ) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
   }
 
   override fun invokeStringNameStringNameArg(
@@ -754,7 +777,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138, 141))
+        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156))
         commands.flush()
         GodotVector3(
           immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
@@ -888,7 +911,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 108)
+    require(descriptor.opcode in setOf(108, 154))
     commands.flush()
     // Six Float32 components are packed into one query string (unit separator); the applier
     // re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -21,10 +21,10 @@ import net.multigesture.kanama.backend.InternalKanamaBackendApi
  * Kotlin/Wasm backend dispatch: opcode routing, execution-mode guards, and JS-bridge codec calls.
  *
  * Generated from scripts/platform_backend_calls.json + the Web-local policy in
- * scripts/generate_web_backend.py. Web-only state (property snapshots, browser handle-kind tracking,
- * free-time cache clearing) lives hand-written in WebBackendBookkeeping.kt and is reached through its
- * hooks; the js(...) transport primitives live hand-written in WebBackendTransport.kt. See
- * docs/contributing/web-internals.md ("Backend-dispatch codegen").
+ * scripts/generate_web_backend.py. Web-only state (property snapshots, browser handle-kind
+ * tracking, free-time cache clearing) lives hand-written in WebBackendBookkeeping.kt and is reached
+ * through its hooks; the js(...) transport primitives live hand-written in WebBackendTransport.kt.
+ * See docs/contributing/web-internals.md ("Backend-dispatch codegen").
  */
 internal object WebCommonGodotBackend : GodotBackendSpi {
   override fun requireLive(handle: GodotHandle) {
@@ -37,1143 +37,1163 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   override fun resolve(descriptor: GodotCallDescriptor): GodotCallSite =
     GodotCallSite.fromBackendToken(descriptor.opcode.toLong())
 
-override fun invokeBoolRetInt(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Boolean,
-): Int {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush() // explicit ordering barrier for mutations issued before this result
-return immediateWebChildCount(receiver.webId(), value)
-}
+  override fun invokeBoolRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Boolean,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush() // explicit ordering barrier for mutations issued before this result
+    return immediateWebChildCount(receiver.webId(), value)
+  }
 
-override fun invokeBoolRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Boolean,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return existingReturnedObject(
-receiver,
-immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
-)
-}
+  override fun invokeBoolRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Boolean,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return existingReturnedObject(
+      receiver,
+      immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
+    )
+  }
 
-override fun invokeBoolArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Boolean,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180))
-val objectId = receiver.webId()
-commands.appendBoolMutation(descriptor.opcode, objectId, value)
-when (descriptor.opcode) {
-43 -> webWriteEmittingSnapshot(objectId, value)
-else -> {}
-}
-}
+  override fun invokeBoolArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Boolean,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(
+      descriptor.opcode in
+        setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180)
+    )
+    val objectId = receiver.webId()
+    commands.appendBoolMutation(descriptor.opcode, objectId, value)
+    when (descriptor.opcode) {
+      43 -> webWriteEmittingSnapshot(objectId, value)
+      else -> {}
+    }
+  }
 
-override fun invokeDoubleArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Double,
-) {
-requireOpcode(descriptor, callSite)
-require(value.isFinite()) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
-}
-when (descriptor.executionMode) {
-GodotExecutionMode.QUEUED_MUTATION -> {
-require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
-commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
-}
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-require(descriptor.opcode in setOf(65, 107, 109))
-commands.flush()
-when (descriptor.opcode) {
-65 -> immediateWebSetProgressRatio(receiver.webId(), value)
-107 -> immediateWebSetProgressRatio3D(receiver.webId(), value)
-109 -> immediateWebRotateY(receiver.webId(), value)
-else -> error("Unsupported Web immediate Double opcode=${descriptor.opcode}")
-}
-}
-GodotExecutionMode.SNAPSHOT_READ ->
-error("Double argument cannot use snapshot execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeDoubleArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Double,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(value.isFinite()) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
+    }
+    when (descriptor.executionMode) {
+      GodotExecutionMode.QUEUED_MUTATION -> {
+        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
+        commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(65, 107, 109))
+        commands.flush()
+        when (descriptor.opcode) {
+          65 -> immediateWebSetProgressRatio(receiver.webId(), value)
+          107 -> immediateWebSetProgressRatio3D(receiver.webId(), value)
+          109 -> immediateWebRotateY(receiver.webId(), value)
+          else -> error("Unsupported Web immediate Double opcode=${descriptor.opcode}")
+        }
+      }
+      GodotExecutionMode.SNAPSHOT_READ ->
+        error("Double argument cannot use snapshot execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeLongArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Long,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
-require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
-}
-commands.appendLongMutation(descriptor.opcode, receiver.webId(), value)
-}
+  override fun invokeLongArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
+    }
+    commands.appendLongMutation(descriptor.opcode, receiver.webId(), value)
+  }
 
-override fun invokeNoArgsRetVector2(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): GodotVector2 {
-requireOpcode(descriptor, callSite)
-return when (descriptor.executionMode) {
-GodotExecutionMode.SNAPSHOT_READ ->
-when (descriptor.opcode) {
-2 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.POSITION)
-29 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.SCALE)
-else -> null
-}
-?: error(
-"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-"object handle=${receiver.webId()}"
-)
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-commands.flush()
-GodotVector2(
-immediateWebNoArgsVector2X(descriptor.opcode, receiver.webId()).toFloat(),
-immediateWebNoArgsVector2Y().toFloat(),
-)
-}
-GodotExecutionMode.QUEUED_MUTATION ->
-error("Vector2 return cannot use queued execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeNoArgsRetVector2(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): GodotVector2 {
+    requireOpcode(descriptor, callSite)
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.SNAPSHOT_READ ->
+        when (descriptor.opcode) {
+          2 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.POSITION)
+          29 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.SCALE)
+          else -> null
+        }
+          ?: error(
+            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+              "object handle=${receiver.webId()}"
+          )
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        commands.flush()
+        GodotVector2(
+          immediateWebNoArgsVector2X(descriptor.opcode, receiver.webId()).toFloat(),
+          immediateWebNoArgsVector2Y().toFloat(),
+        )
+      }
+      GodotExecutionMode.QUEUED_MUTATION ->
+        error("Vector2 return cannot use queued execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeVector2Arg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotVector2,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-val objectId = receiver.webId()
-commands.appendVector2Mutation(descriptor.opcode, objectId, value.x, value.y)
-when (descriptor.opcode) {
-3 -> webWriteVector2Snapshot(objectId, WebVector2Slot.POSITION, value)
-30 -> webWriteVector2Snapshot(objectId, WebVector2Slot.SCALE, value)
-60 -> {}
-else -> error("Unsupported Web Vector2 mutation opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeVector2Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector2,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    val objectId = receiver.webId()
+    commands.appendVector2Mutation(descriptor.opcode, objectId, value.x, value.y)
+    when (descriptor.opcode) {
+      3 -> webWriteVector2Snapshot(objectId, WebVector2Slot.POSITION, value)
+      30 -> webWriteVector2Snapshot(objectId, WebVector2Slot.SCALE, value)
+      60 -> {}
+      else -> error("Unsupported Web Vector2 mutation opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeNoArgsRetRect2(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): GodotRect2 {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-return webViewportRectSnapshot(receiver.webId())
-?: error("Missing Web viewport snapshot for object handle=${receiver.webId()}")
-}
+  override fun invokeNoArgsRetRect2(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): GodotRect2 {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+    return webViewportRectSnapshot(receiver.webId())
+      ?: error("Missing Web viewport snapshot for object handle=${receiver.webId()}")
+  }
 
-override fun invokeNoArgsVoid(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-) {
-requireOpcode(descriptor, callSite)
-val objectId = receiver.webId()
-when (descriptor.executionMode) {
-GodotExecutionMode.QUEUED_MUTATION -> {
-commands.appendNoArgsMutation(descriptor.opcode, objectId)
-if (descriptor.opcode == 15) onWebQueueFree(objectId)
-}
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-commands.flush()
-when (descriptor.opcode) {
-37 ->
-check(immediateWebTweenNoArgs(descriptor.opcode, objectId) == 1) {
-"Kanama Web Tween.kill failed for handle=$objectId"
-}
-120 ->
-check(immediateWebObjectQuery(120, objectId, "") == 1) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-}
-else -> error("Unsupported Web immediate void opcode=${descriptor.opcode}")
-}
-}
-GodotExecutionMode.SNAPSHOT_READ ->
-error("Void call cannot use snapshot execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeNoArgsVoid(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ) {
+    requireOpcode(descriptor, callSite)
+    val objectId = receiver.webId()
+    when (descriptor.executionMode) {
+      GodotExecutionMode.QUEUED_MUTATION -> {
+        commands.appendNoArgsMutation(descriptor.opcode, objectId)
+        if (descriptor.opcode == 15) onWebQueueFree(objectId)
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        commands.flush()
+        when (descriptor.opcode) {
+          37 ->
+            check(immediateWebTweenNoArgs(descriptor.opcode, objectId) == 1) {
+              "Kanama Web Tween.kill failed for handle=$objectId"
+            }
+          120 ->
+            check(immediateWebObjectQuery(120, objectId, "") == 1) {
+              "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+            }
+          else -> error("Unsupported Web immediate void opcode=${descriptor.opcode}")
+        }
+      }
+      GodotExecutionMode.SNAPSHOT_READ ->
+        error("Void call cannot use snapshot execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeTexture2DVector2ColorArgs(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-texture: GodotHandle,
-position: GodotVector2,
-modulate: GodotColor,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-requireWebBrowserHandle(texture.webId(), WebBrowserHandleKind.RESOURCE)
-drawCommands.appendDrawTexture(
-descriptor.opcode,
-receiver.webId(),
-texture.webId(),
-position.x,
-position.y,
-modulate.r,
-modulate.g,
-modulate.b,
-modulate.a,
-)
-}
+  override fun invokeTexture2DVector2ColorArgs(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    texture: GodotHandle,
+    position: GodotVector2,
+    modulate: GodotColor,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    requireWebBrowserHandle(texture.webId(), WebBrowserHandleKind.RESOURCE)
+    drawCommands.appendDrawTexture(
+      descriptor.opcode,
+      receiver.webId(),
+      texture.webId(),
+      position.x,
+      position.y,
+      modulate.r,
+      modulate.g,
+      modulate.b,
+      modulate.a,
+    )
+  }
 
-override fun invokeStringStringLongRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-first: String,
-second: String,
-value: Long,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-return registerLoadedResource(immediateWebResourceLoad(first, second, value.toInt()))
-}
+  override fun invokeStringStringLongRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    first: String,
+    second: String,
+    value: Long,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return registerLoadedResource(immediateWebResourceLoad(first, second, value.toInt()))
+  }
 
-override fun invokeUtilityNoArgsVoid(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-WebRandom.randomize()
-}
+  override fun invokeUtilityNoArgsVoid(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    WebRandom.randomize()
+  }
 
-override fun invokeUtilityNoArgsRetLong(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-): Long {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-return WebRandom.randi()
-}
+  override fun invokeUtilityNoArgsRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    return WebRandom.randi()
+  }
 
-override fun invokeUtilityNoArgsRetDouble(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-): Double {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-return WebRandom.randf()
-}
+  override fun invokeUtilityNoArgsRetDouble(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    return WebRandom.randf()
+  }
 
-override fun invokeStringNameIntRetInt(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-name: String,
-value: Int,
-): Int {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebEmitSignal(receiver.webId(), name, value)
-}
+  override fun invokeStringNameIntRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: Int,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebEmitSignal(receiver.webId(), name, value)
+  }
 
-override fun invokeStringNameRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-value: String,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return registerConstructedNode(immediateWebConstructObject(value), value)
-}
+  override fun invokeStringNameRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return registerConstructedNode(immediateWebConstructObject(value), value)
+  }
 
-override fun invokeStringNameRetInt(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: String,
-): Int {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebEmitSignalNoArgs(receiver.webId(), value)
-}
+  override fun invokeStringNameRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebEmitSignalNoArgs(receiver.webId(), value)
+  }
 
-override fun invokeObjectBoolLongArgs(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-objectValue: GodotHandle,
-boolValue: Boolean,
-longValue: Long,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-requireWebNodeHandle(objectValue.webId())
-commands.appendObjectBoolLongArgs(
-descriptor.opcode,
-receiver.webId(),
-objectValue.webId(),
-boolValue,
-longValue,
-)
-}
+  override fun invokeObjectBoolLongArgs(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    objectValue: GodotHandle,
+    boolValue: Boolean,
+    longValue: Long,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    requireWebNodeHandle(objectValue.webId())
+    commands.appendObjectBoolLongArgs(
+      descriptor.opcode,
+      receiver.webId(),
+      objectValue.webId(),
+      boolValue,
+      longValue,
+    )
+  }
 
-override fun invokeObjectArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotHandle?,
-) {
-requireOpcode(descriptor, callSite)
-when (descriptor.opcode) {
-14 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-requireWebNodeHandle(checkNotNull(value).webId())
-}
-16 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-webWriteTextureSnapshot(receiver.webId(), value?.webId() ?: 0)
-}
-46 -> {
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-}
-130 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-}
-165 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-checkNotNull(value)
-}
-170 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-checkNotNull(value)
-}
-171 -> {
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-checkNotNull(value)
-}
-else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
-}
-commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
-if (descriptor.opcode == 46) commands.flush()
-}
+  override fun invokeObjectArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotHandle?,
+  ) {
+    requireOpcode(descriptor, callSite)
+    when (descriptor.opcode) {
+      14 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        requireWebNodeHandle(checkNotNull(value).webId())
+      }
+      16 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+        webWriteTextureSnapshot(receiver.webId(), value?.webId() ?: 0)
+      }
+      46 -> {
+        require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+      }
+      130 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+      }
+      165 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
+      170 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
+      171 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
+      else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
+    }
+    commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
+    if (descriptor.opcode == 46) commands.flush()
+  }
 
-override fun invokeStringNameArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: String,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
-commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
-}
+  override fun invokeStringNameArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
+    commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
+  }
 
-override fun invokeStringNameBoolArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-name: String,
-value: Boolean,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode == 67)
-commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
-}
+  override fun invokeStringNameBoolArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: Boolean,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 67)
+    commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
+  }
 
-override fun invokeLongBoolArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-layer: Long,
-value: Boolean,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode in setOf(155, 163, 164))
-commands.flush()
-// Layer number and flag packed into one query string (unit separator).
-check(
-immediateWebObjectQuery(
-descriptor.opcode,
-receiver.webId(),
-layer.toString() + "" + (if (value) "1" else "0"),
-) == 1
-) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-}
-}
+  override fun invokeLongBoolArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    layer: Long,
+    value: Boolean,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(155, 163, 164))
+    commands.flush()
+    // Layer number and flag packed into one query string (unit separator).
+    check(
+      immediateWebObjectQuery(
+        descriptor.opcode,
+        receiver.webId(),
+        layer.toString() + "" + (if (value) "1" else "0"),
+      ) == 1
+    ) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
+  }
 
-override fun invokeVector3RetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotVector3,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 166)
-commands.flush()
-// Motion packed as three floats; the bridge allocates the collision slot and the
-// applier registers the KinematicCollision3D under it (null collision returns 0).
-return registerReturnedBrowserObject(
-immediateWebMoveAndCollide(
-descriptor.opcode,
-receiver.webId(),
-listOf(value.x, value.y, value.z).joinToString(""),
-)
-)
-}
+  override fun invokeVector3RetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 166)
+    commands.flush()
+    // Motion packed as three floats; the bridge allocates the collision slot and the
+    // applier registers the KinematicCollision3D under it (null collision returns 0).
+    return registerReturnedBrowserObject(
+      immediateWebMoveAndCollide(
+        descriptor.opcode,
+        receiver.webId(),
+        listOf(value.x, value.y, value.z).joinToString(""),
+      )
+    )
+  }
 
-override fun invokeNoArgsRetHandleList(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): List<GodotHandle> {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 167)
-commands.flush()
-// The applier packs the SCRIPT handles of scripted overlapping bodies (unit
-// separator); bodies without Kanama scripts are omitted by contract.
-return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
-.split('')
-.filter { it.isNotEmpty() }
-.map { GodotHandle.fromBackendToken(it.toLong()) }
-}
+  override fun invokeNoArgsRetHandleList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<GodotHandle> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 167)
+    commands.flush()
+    // The applier packs the SCRIPT handles of scripted overlapping bodies (unit
+    // separator); bodies without Kanama scripts are omitted by contract.
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
+      .split('')
+      .filter { it.isNotEmpty() }
+      .map { GodotHandle.fromBackendToken(it.toLong()) }
+  }
 
-override fun invokeLongRetVector3(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Long,
-): GodotVector3 {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 173)
-require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-return GodotVector3(
-immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),
-immediateWebNoArgsVector3Y().toFloat(),
-immediateWebNoArgsVector3Z().toFloat(),
-)
-}
+  override fun invokeLongRetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): GodotVector3 {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 173)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return GodotVector3(
+      immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),
+      immediateWebNoArgsVector3Y().toFloat(),
+      immediateWebNoArgsVector3Z().toFloat(),
+    )
+  }
 
-override fun invokeStringNameRetDoubleSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-value: String,
-): Double {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode in setOf(186, 187))
-commands.flush()
-// Scaled by 1000 through the shared integer object-query transport.
-return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
-1000.0
-}
+  override fun invokeStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(186, 187))
+    commands.flush()
+    // Scaled by 1000 through the shared integer object-query transport.
+    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
+      1000.0
+  }
 
-override fun invokeStringNameVector3Vector3Arg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-name: String,
-first: GodotVector3,
-second: GodotVector3,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode == 191)
-commands.appendStringNameVector3Vector3Mutation(
-descriptor.opcode,
-receiver.webId(),
-name,
-first,
-second,
-)
-}
+  override fun invokeStringNameVector3Vector3Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    first: GodotVector3,
+    second: GodotVector3,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 191)
+    commands.appendStringNameVector3Vector3Mutation(
+      descriptor.opcode,
+      receiver.webId(),
+      name,
+      first,
+      second,
+    )
+  }
 
-override fun invokeCallableDoubleRangeRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-target: GodotHandle,
-method: String,
-fromValue: Double,
-toValue: Double,
-duration: Double,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 192)
-commands.flush()
-return registerReturnedBrowserObject(
-immediateWebTweenMethod(
-descriptor.opcode,
-receiver.webId(),
-target.webId(),
-method,
-fromValue,
-toValue,
-duration,
-)
-)
-}
+  override fun invokeStringNameStringRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: String,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 196)
+    commands.flush()
+    // Signal name and String argument packed into one query (unit separator).
+    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), name + "" + value)
+  }
 
-override fun invokeStringNameStringNameArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-first: String,
-second: String,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode in setOf(68, 105))
-commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
-}
+  override fun invokeCallableDoubleRangeRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    method: String,
+    fromValue: Double,
+    toValue: Double,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 192)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenMethod(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        method,
+        fromValue,
+        toValue,
+        duration,
+      )
+    )
+  }
 
-override fun invokeNodePathRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-path: String,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return when (descriptor.opcode) {
-17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
-149,
-184 ->
-registerReturnedBrowserObject(
-immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)
-)
-else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeStringNameStringNameArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: String,
+    second: String,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode in setOf(68, 105))
+    commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
+  }
 
-override fun invokeLongRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: Long,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-return when (descriptor.opcode) {
-18 ->
-registerReturnedNode(immediateWebPackedSceneInstantiate(receiver.webId(), value.toInt()))
-41,
-42,
-135,
-174 ->
-existingReturnedObject(
-receiver,
-immediateWebTweenLongRetObject(descriptor.opcode, receiver.webId(), value.toInt()),
-)
-111 ->
-registerReturnedBrowserObject(immediateWebSlideCollision(receiver.webId(), value.toInt()))
-133 ->
-registerReturnedNode(immediateWebNodeChild(receiver.webId(), value.toInt()))
-else -> error("Unsupported Web Long-return-handle opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeNodePathRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    path: String,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return when (descriptor.opcode) {
+      17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
+      149,
+      184 ->
+        registerReturnedBrowserObject(
+          immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)
+        )
+      else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeNoArgsRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-return when (descriptor.executionMode) {
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-commands.flush()
-val token = immediateWebNoArgsObject(descriptor.opcode, receiver.webId())
-when (descriptor.opcode) {
-19 -> registerReturnedNode(token)
-36 -> registerReturnedBrowserObject(token)
-51 -> registerReturnedBrowserObject(token)
-71 -> registerReturnedBrowserObject(token)
-73 -> registerReturnedNode(token)
-81 -> registerReturnedBrowserObject(token)
-112 -> registerReturnedNode(token)
-114 -> registerReturnedNode(token)
-122 -> registerReturnedNode(token)
-194 -> registerReturnedNode(token)
-else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
-}
-}
-GodotExecutionMode.SNAPSHOT_READ -> {
-require(descriptor.opcode == 33)
-val objectId = receiver.webId()
-val textureId =
-webTextureSnapshot(objectId)
-?: error("Missing Web Sprite2D.get_texture snapshot for object handle=$objectId")
-textureId.takeIf { it > 0 }?.let { GodotHandle.fromBackendToken(it.toLong()) }
-}
-GodotExecutionMode.QUEUED_MUTATION ->
-error("Handle return cannot use queued execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeLongRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return when (descriptor.opcode) {
+      174 ->
+        registerReturnedNode(
+          immediateWebIndexedObjectLookup(descriptor.opcode, receiver.webId(), value.toInt())
+        )
+      18 ->
+        registerReturnedNode(immediateWebPackedSceneInstantiate(receiver.webId(), value.toInt()))
+      41,
+      42,
+      135 ->
+        existingReturnedObject(
+          receiver,
+          immediateWebTweenLongRetObject(descriptor.opcode, receiver.webId(), value.toInt()),
+        )
+      111 ->
+        registerReturnedBrowserObject(immediateWebSlideCollision(receiver.webId(), value.toInt()))
+      133 -> registerReturnedNode(immediateWebNodeChild(receiver.webId(), value.toInt()))
+      else -> error("Unsupported Web Long-return-handle opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeObjectLongVector2Args(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-objectValue: GodotHandle?,
-longValue: Long,
-vectorValue: GodotVector2,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-commands.flush()
-immediateWebSetCustomMouseCursor(
-requireActiveWebScriptHandle(),
-objectValue?.webId() ?: 0,
-longValue.toInt(),
-vectorValue.x.toDouble(),
-vectorValue.y.toDouble(),
-)
-}
+  override fun invokeNoArgsRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        commands.flush()
+        val token = immediateWebNoArgsObject(descriptor.opcode, receiver.webId())
+        when (descriptor.opcode) {
+          19 -> registerReturnedNode(token)
+          36 -> registerReturnedBrowserObject(token)
+          51 -> registerReturnedBrowserObject(token)
+          71 -> registerReturnedBrowserObject(token)
+          73 -> registerReturnedNode(token)
+          81 -> registerReturnedBrowserObject(token)
+          112 -> registerReturnedNode(token)
+          114 -> registerReturnedNode(token)
+          122 -> registerReturnedNode(token)
+          194 -> registerReturnedNode(token)
+          else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
+        }
+      }
+      GodotExecutionMode.SNAPSHOT_READ -> {
+        require(descriptor.opcode == 33)
+        val objectId = receiver.webId()
+        val textureId =
+          webTextureSnapshot(objectId)
+            ?: error("Missing Web Sprite2D.get_texture snapshot for object handle=$objectId")
+        textureId.takeIf { it > 0 }?.let { GodotHandle.fromBackendToken(it.toLong()) }
+      }
+      GodotExecutionMode.QUEUED_MUTATION ->
+        error("Handle return cannot use queued execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeStringNameCallableLongRetLong(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-signal: String,
-target: GodotHandle,
-method: String,
-flags: Long,
-): Long {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-return immediateWebConnect(receiver.webId(), signal, target.webId(), method, flags.toInt())
-.toLong()
-}
+  override fun invokeObjectLongVector2Args(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    objectValue: GodotHandle?,
+    longValue: Long,
+    vectorValue: GodotVector2,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+    commands.flush()
+    immediateWebSetCustomMouseCursor(
+      requireActiveWebScriptHandle(),
+      objectValue?.webId() ?: 0,
+      longValue.toInt(),
+      vectorValue.x.toDouble(),
+      vectorValue.y.toDouble(),
+    )
+  }
 
-override fun invokeStringNameBoundCallableLongRetLong(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-signal: String,
-target: GodotHandle,
-method: String,
-boundValue: Long,
-flags: Long,
-): Long {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-return when (descriptor.opcode) {
-34 ->
-immediateWebConnectBound(
-receiver.webId(),
-signal,
-target.webId(),
-method,
-boundValue.toInt(),
-flags.toInt(),
-)
-.toLong()
-193 ->
-immediateWebDisconnectBound(
-receiver.webId(),
-signal,
-target.webId(),
-method,
-boundValue.toInt(),
-)
-.toLong()
-else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeStringNameCallableLongRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    signal: String,
+    target: GodotHandle,
+    method: String,
+    flags: Long,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return immediateWebConnect(receiver.webId(), signal, target.webId(), method, flags.toInt())
+      .toLong()
+  }
 
-override fun invokeStringNameRetBool(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: String,
-): Boolean {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value) != 0
-}
+  override fun invokeStringNameBoundCallableLongRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    signal: String,
+    target: GodotHandle,
+    method: String,
+    boundValue: Long,
+    flags: Long,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return when (descriptor.opcode) {
+      34 ->
+        immediateWebConnectBound(
+            receiver.webId(),
+            signal,
+            target.webId(),
+            method,
+            boundValue.toInt(),
+            flags.toInt(),
+          )
+          .toLong()
+      193 ->
+        immediateWebDisconnectBound(
+            receiver.webId(),
+            signal,
+            target.webId(),
+            method,
+            boundValue.toInt(),
+          )
+          .toLong()
+      else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeStringNameRetBoolSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-value: String,
-): Boolean {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) != 0
-}
+  override fun invokeStringNameRetBool(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+  ): Boolean {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value) != 0
+  }
 
-override fun invokeNoArgsRetBool(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): Boolean {
-requireOpcode(descriptor, callSite)
-return when (descriptor.executionMode) {
-GodotExecutionMode.SNAPSHOT_READ -> {
-require(descriptor.opcode == 44)
-webEmittingSnapshot(receiver.webId())
-?: error(
-"Missing Web GPUParticles2D.is_emitting snapshot for object handle=${receiver.webId()}"
-)
-}
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-commands.flush()
-immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") != 0
-}
-GodotExecutionMode.QUEUED_MUTATION ->
-error("Boolean return cannot use queued execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeStringNameRetBoolSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ): Boolean {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) != 0
+  }
 
-override fun invokeNoArgsRetDouble(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): Double {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-return when (descriptor.opcode) {
-45 -> webLifetimeSnapshot(receiver.webId())
-70 -> webRotationSnapshot(receiver.webId())
-else -> null
-}
-?: error(
-"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-"object handle=${receiver.webId()}"
-)
-}
+  override fun invokeNoArgsRetBool(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): Boolean {
+    requireOpcode(descriptor, callSite)
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.SNAPSHOT_READ -> {
+        require(descriptor.opcode == 44)
+        webEmittingSnapshot(receiver.webId())
+          ?: error(
+            "Missing Web GPUParticles2D.is_emitting snapshot for object handle=${receiver.webId()}"
+          )
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        commands.flush()
+        immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") != 0
+      }
+      GodotExecutionMode.QUEUED_MUTATION ->
+        error("Boolean return cannot use queued execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeNoArgsRetLong(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): Long {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "").toLong()
-}
+  override fun invokeNoArgsRetDouble(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+    return when (descriptor.opcode) {
+      45 -> webLifetimeSnapshot(receiver.webId())
+      70 -> webRotationSnapshot(receiver.webId())
+      else -> null
+    }
+      ?: error(
+        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+          "object handle=${receiver.webId()}"
+      )
+  }
 
-override fun invokeNoArgsRetStringArray(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): List<String> {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-require(descriptor.opcode == 72)
-return webAnimationNamesSnapshot(receiver.webId())
-?: error(
-"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-"object handle=${receiver.webId()}"
-)
-}
+  override fun invokeNoArgsRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "").toLong()
+  }
 
-override fun invokeStringNameVector2iRetInt(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-name: String,
-value: GodotVector2i,
-): Int {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-commands.flush()
-return immediateWebEmitSignalVector2i(receiver.webId(), name, value.x, value.y)
-}
+  override fun invokeNoArgsRetStringArray(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<String> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+    require(descriptor.opcode == 72)
+    return webAnimationNamesSnapshot(receiver.webId())
+      ?: error(
+        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+          "object handle=${receiver.webId()}"
+      )
+  }
 
-override fun invokeNoArgsRetColor(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): GodotColor {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-return webModulateSnapshot(receiver.webId())
-?: error("Missing Web CanvasItem.get_modulate snapshot for object handle=${receiver.webId()}")
-}
+  override fun invokeStringNameVector2iRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotVector2i,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return immediateWebEmitSignalVector2i(receiver.webId(), name, value.x, value.y)
+  }
 
-override fun invokeColorArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotColor,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-commands.appendColorMutation(
-descriptor.opcode,
-receiver.webId(),
-value.r,
-value.g,
-value.b,
-value.a,
-)
-webWriteModulateSnapshot(receiver.webId(), value)
-}
+  override fun invokeNoArgsRetColor(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): GodotColor {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+    return webModulateSnapshot(receiver.webId())
+      ?: error("Missing Web CanvasItem.get_modulate snapshot for object handle=${receiver.webId()}")
+  }
 
-override fun invokeObjectNodePathVector2DoubleRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-target: GodotHandle,
-property: String,
-finalValue: GodotVector2,
-duration: Double,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(duration.isFinite() && duration >= 0.0)
-commands.flush()
-return registerReturnedBrowserObject(
-immediateWebTweenPropertyVector2(
-descriptor.opcode,
-receiver.webId(),
-target.webId(),
-property,
-finalValue.x.toDouble(),
-finalValue.y.toDouble(),
-duration,
-)
-)
-}
+  override fun invokeColorArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotColor,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    commands.appendColorMutation(
+      descriptor.opcode,
+      receiver.webId(),
+      value.r,
+      value.g,
+      value.b,
+      value.a,
+    )
+    webWriteModulateSnapshot(receiver.webId(), value)
+  }
 
-override fun invokeObjectNodePathColorDoubleRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-target: GodotHandle,
-property: String,
-finalValue: GodotColor,
-duration: Double,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(duration.isFinite() && duration >= 0.0)
-commands.flush()
-return registerReturnedBrowserObject(
-immediateWebTweenPropertyColor(
-descriptor.opcode,
-receiver.webId(),
-target.webId(),
-property,
-finalValue.r.toDouble(),
-finalValue.g.toDouble(),
-finalValue.b.toDouble(),
-finalValue.a.toDouble(),
-duration,
-)
-)
-}
+  override fun invokeObjectNodePathVector2DoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: GodotVector2,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(duration.isFinite() && duration >= 0.0)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenPropertyVector2(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        property,
+        finalValue.x.toDouble(),
+        finalValue.y.toDouble(),
+        duration,
+      )
+    )
+  }
 
-override fun invokeNoArgsRetVector3(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-): GodotVector3 {
-requireOpcode(descriptor, callSite)
-return when (descriptor.executionMode) {
-GodotExecutionMode.SNAPSHOT_READ ->
-when (descriptor.opcode) {
-75 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.POSITION)
-77 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION)
-79 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.SCALE)
-89 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.VELOCITY)
-102 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION_DEGREES)
-119 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.TARGET_POSITION)
-else -> null
-}
-?: error(
-"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-"object handle=${receiver.webId()}"
-)
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
-commands.flush()
-GodotVector3(
-immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
-immediateWebNoArgsVector3Y().toFloat(),
-immediateWebNoArgsVector3Z().toFloat(),
-)
-}
-GodotExecutionMode.QUEUED_MUTATION ->
-error("Vector3 return cannot use queued execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeObjectNodePathColorDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: GodotColor,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(duration.isFinite() && duration >= 0.0)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenPropertyColor(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        property,
+        finalValue.r.toDouble(),
+        finalValue.g.toDouble(),
+        finalValue.b.toDouble(),
+        finalValue.a.toDouble(),
+        duration,
+      )
+    )
+  }
 
-override fun invokeVector3Arg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotVector3,
-) {
-requireOpcode(descriptor, callSite)
-val objectId = receiver.webId()
-when (descriptor.executionMode) {
-GodotExecutionMode.QUEUED_MUTATION -> {
-commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
-when (descriptor.opcode) {
-74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
-76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
-78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
-88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
-101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
-118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
-else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
-}
-}
-GodotExecutionMode.IMMEDIATE_RESULT -> {
-require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
-commands.flush()
-// Three Float32 components packed into one query string (unit separator); the
-// applier writes the global transform and re-pushes the node's snapshot.
-val packed =
-listOf(value.x, value.y, value.z).joinToString("")
-check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-}
-}
-GodotExecutionMode.SNAPSHOT_READ ->
-error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")
-}
-}
+  override fun invokeNoArgsRetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): GodotVector3 {
+    requireOpcode(descriptor, callSite)
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.SNAPSHOT_READ ->
+        when (descriptor.opcode) {
+          75 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.POSITION)
+          77 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION)
+          79 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.SCALE)
+          89 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.VELOCITY)
+          102 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION_DEGREES)
+          119 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.TARGET_POSITION)
+          else -> null
+        }
+          ?: error(
+            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+              "object handle=${receiver.webId()}"
+          )
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
+        commands.flush()
+        GodotVector3(
+          immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
+          immediateWebNoArgsVector3Y().toFloat(),
+          immediateWebNoArgsVector3Z().toFloat(),
+        )
+      }
+      GodotExecutionMode.QUEUED_MUTATION ->
+        error("Vector3 return cannot use queued execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeLongDoubleArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-longValue: Long,
-doubleValue: Double,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode == 84)
-require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-require(doubleValue.isFinite()) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
-}
-commands.appendLongDoubleMutation(descriptor.opcode, receiver.webId(), longValue, doubleValue)
-}
+  override fun invokeVector3Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3,
+  ) {
+    requireOpcode(descriptor, callSite)
+    val objectId = receiver.webId()
+    when (descriptor.executionMode) {
+      GodotExecutionMode.QUEUED_MUTATION -> {
+        commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
+        when (descriptor.opcode) {
+          74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
+          76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
+          78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
+          88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
+          101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
+          118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
+          else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
+        }
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
+        commands.flush()
+        // Three Float32 components packed into one query string (unit separator); the
+        // applier writes the global transform and re-pushes the node's snapshot.
+        val packed = listOf(value.x, value.y, value.z).joinToString("")
+        check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {
+          "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+        }
+      }
+      GodotExecutionMode.SNAPSHOT_READ ->
+        error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")
+    }
+  }
 
-override fun invokeNoArgsRetStringSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-): String {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-require(descriptor.opcode == 85)
-return webRenderingMethodSnapshot(requireActiveWebScriptHandle())
-?: error(
-"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-"active script handle"
-)
-}
+  override fun invokeLongDoubleArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    longValue: Long,
+    doubleValue: Double,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 84)
+    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(doubleValue.isFinite()) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
+    }
+    commands.appendLongDoubleMutation(descriptor.opcode, receiver.webId(), longValue, doubleValue)
+  }
 
-override fun invokeStringNameArgSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-value: String,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode in setOf(86, 87, 190))
-commands.flush()
-immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
-}
+  override fun invokeNoArgsRetStringSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+    require(descriptor.opcode == 85)
+    return webRenderingMethodSnapshot(requireActiveWebScriptHandle())
+      ?: error(
+        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+          "active script handle"
+      )
+  }
 
-override fun invokeStringNameDoubleArg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: String,
-doubleValue: Double,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-require(descriptor.opcode in setOf(103, 132, 151))
-require(doubleValue.isFinite())
-commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
-}
+  override fun invokeStringNameArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(86, 87, 190))
+    commands.flush()
+    immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
+  }
 
-override fun invokeStringNameStringNameRetDoubleSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-first: String,
-second: String,
-): Double {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 104)
-commands.flush()
-// Two action names are packed into one query string (unit separator) and the axis is
-// returned scaled by 1000 through the shared object-query transport.
-return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), first + "\u001f" + second) / 1000.0
-}
+  override fun invokeStringNameDoubleArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: String,
+    doubleValue: Double,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode in setOf(103, 132, 151))
+    require(doubleValue.isFinite())
+    commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
+  }
 
-override fun invokeVector3Vector3Arg(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-first: GodotVector3,
-second: GodotVector3,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode in setOf(108, 154, 159))
-commands.flush()
-// Six Float32 components are packed into one query string (unit separator); the applier
-// re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.
-val packed =
-listOf(first.x, first.y, first.z, second.x, second.y, second.z).joinToString("\u001f")
-check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
-"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-}
-}
+  override fun invokeStringNameStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    first: String,
+    second: String,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 104)
+    commands.flush()
+    // Two action names are packed into one query string (unit separator) and the axis is
+    // returned scaled by 1000 through the shared object-query transport.
+    return immediateWebObjectQuery(
+      descriptor.opcode,
+      requireActiveWebScriptHandle(),
+      first + "\u001f" + second,
+    ) / 1000.0
+  }
 
-override fun invokeLongArgSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-value: Long,
-) {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode in setOf(116, 126))
-require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-commands.flush()
-immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
-}
+  override fun invokeVector3Vector3Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: GodotVector3,
+    second: GodotVector3,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(108, 154, 159))
+    commands.flush()
+    // Six Float32 components are packed into one query string (unit separator); the applier
+    // re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.
+    val packed =
+      listOf(first.x, first.y, first.z, second.x, second.y, second.z).joinToString("\u001f")
+    check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
+  }
 
-override fun invokeObjectRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-value: GodotHandle,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 134)
-commands.flush()
-return existingReturnedObject(
-receiver,
-immediateWebTweenObjectRetObject(descriptor.opcode, receiver.webId(), value.webId()),
-)
-}
+  override fun invokeLongArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: Long,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(116, 126))
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
+  }
 
-override fun invokeObjectNodePathVector3DoubleRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-target: GodotHandle,
-property: String,
-finalValue: GodotVector3,
-duration: Double,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(duration.isFinite() && duration >= 0.0)
-commands.flush()
-return registerReturnedBrowserObject(
-immediateWebTweenPropertyVector3(
-descriptor.opcode,
-receiver.webId(),
-target.webId(),
-property,
-finalValue.x.toDouble(),
-finalValue.y.toDouble(),
-finalValue.z.toDouble(),
-duration,
-)
-)
-}
+  override fun invokeObjectRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotHandle,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 134)
+    commands.flush()
+    return existingReturnedObject(
+      receiver,
+      immediateWebTweenObjectRetObject(descriptor.opcode, receiver.webId(), value.webId()),
+    )
+  }
 
-override fun invokeCallableRetHandle(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-target: GodotHandle,
-method: String,
-): GodotHandle? {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 137)
-commands.flush()
-return registerReturnedBrowserObject(
-immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)
-)
-}
+  override fun invokeObjectNodePathVector3DoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: GodotVector3,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(duration.isFinite() && duration >= 0.0)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenPropertyVector3(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        property,
+        finalValue.x.toDouble(),
+        finalValue.y.toDouble(),
+        finalValue.z.toDouble(),
+        duration,
+      )
+    )
+  }
 
-override fun invokeNoArgsRetLongSingleton(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-): Long {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 145)
-commands.flush()
-return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")
-.toLong()
-}
+  override fun invokeCallableRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    method: String,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 137)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)
+    )
+  }
 
-override fun invokeStringNameObjectRetInt(
-descriptor: GodotCallDescriptor,
-callSite: GodotCallSite,
-receiver: GodotHandle,
-name: String,
-value: GodotHandle,
-): Int {
-requireOpcode(descriptor, callSite)
-require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-require(descriptor.opcode == 148)
-commands.flush()
-// Signal name and object handle packed into one query string (unit separator);
-// the applier resolves the object from the shared handle dictionary and emits.
-return immediateWebObjectQuery(
-descriptor.opcode,
-receiver.webId(),
-name + "" + value.webId().toString(),
-)
-}
+  override fun invokeNoArgsRetLongSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 145)
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "").toLong()
+  }
+
+  override fun invokeStringNameObjectRetInt(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ): Int {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 148)
+    commands.flush()
+    // Signal name and object handle packed into one query string (unit separator);
+    // the applier resolves the object from the shared handle dictionary and emits.
+    return immediateWebObjectQuery(
+      descriptor.opcode,
+      receiver.webId(),
+      name + "" + value.webId().toString(),
+    )
+  }
+
   private fun requireOpcode(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {
     require(callSite.backendToken() == descriptor.opcode.toLong()) {
       "Web Godot call-site opcode does not match ${descriptor.className}.${descriptor.methodName}"

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -72,7 +72,10 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153))
+    require(
+      descriptor.opcode in
+        setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180)
+    )
     val objectId = receiver.webId()
     commands.appendBoolMutation(descriptor.opcode, objectId, value)
     when (descriptor.opcode) {
@@ -93,7 +96,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     }
     when (descriptor.executionMode) {
       GodotExecutionMode.QUEUED_MUTATION -> {
-        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158))
+        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
         commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
@@ -119,7 +122,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140))
+    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
     }
@@ -358,6 +361,18 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
         value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
       }
+      165 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
+      170 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
+      171 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        checkNotNull(value)
+      }
       else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
     }
     commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
@@ -398,7 +413,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 155)
+    require(descriptor.opcode in setOf(155, 163, 164))
     commands.flush()
     // Layer number and flag packed into one query string (unit separator).
     check(
@@ -410,6 +425,123 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     ) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
     }
+  }
+
+  override fun invokeVector3RetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 166)
+    commands.flush()
+    // Motion packed as three floats; the bridge allocates the collision slot and the
+    // applier registers the KinematicCollision3D under it (null collision returns 0).
+    return registerReturnedBrowserObject(
+      immediateWebMoveAndCollide(
+        descriptor.opcode,
+        receiver.webId(),
+        listOf(value.x, value.y, value.z).joinToString(""),
+      )
+    )
+  }
+
+  override fun invokeNoArgsRetHandleList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<GodotHandle> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 167)
+    commands.flush()
+    // The applier packs the SCRIPT handles of scripted overlapping bodies (unit
+    // separator); bodies without Kanama scripts are omitted by contract.
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
+      .split('')
+      .filter { it.isNotEmpty() }
+      .map { GodotHandle.fromBackendToken(it.toLong()) }
+  }
+
+  override fun invokeLongRetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): GodotVector3 {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 173)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return GodotVector3(
+      immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),
+      immediateWebNoArgsVector3Y().toFloat(),
+      immediateWebNoArgsVector3Z().toFloat(),
+    )
+  }
+
+  override fun invokeStringNameRetDoubleSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    value: String,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(186, 187))
+    commands.flush()
+    // Scaled by 1000 through the shared integer object-query transport.
+    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
+      1000.0
+  }
+
+  override fun invokeStringNameVector3Vector3Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    first: GodotVector3,
+    second: GodotVector3,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 191)
+    commands.appendStringNameVector3Vector3Mutation(
+      descriptor.opcode,
+      receiver.webId(),
+      name,
+      first,
+      second,
+    )
+  }
+
+  override fun invokeCallableDoubleRangeRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    method: String,
+    fromValue: Double,
+    toValue: Double,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 192)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenMethod(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        method,
+        fromValue,
+        toValue,
+        duration,
+      )
+    )
   }
 
   override fun invokeStringNameStringNameArg(
@@ -436,7 +568,11 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     commands.flush()
     return when (descriptor.opcode) {
       17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
-      149 -> registerReturnedBrowserObject(immediateWebPropertyObjectQuery(receiver.webId(), path))
+      149,
+      184 ->
+        registerReturnedBrowserObject(
+          immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)
+        )
       else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
     }
   }
@@ -456,7 +592,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         registerReturnedNode(immediateWebPackedSceneInstantiate(receiver.webId(), value.toInt()))
       41,
       42,
-      135 ->
+      135,
+      174 ->
         existingReturnedObject(
           receiver,
           immediateWebTweenLongRetObject(descriptor.opcode, receiver.webId(), value.toInt()),
@@ -557,15 +694,28 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     commands.flush()
-    return immediateWebConnectBound(
-        receiver.webId(),
-        signal,
-        target.webId(),
-        method,
-        boundValue.toInt(),
-        flags.toInt(),
-      )
-      .toLong()
+    return when (descriptor.opcode) {
+      34 ->
+        immediateWebConnectBound(
+            receiver.webId(),
+            signal,
+            target.webId(),
+            method,
+            boundValue.toInt(),
+            flags.toInt(),
+          )
+          .toLong()
+      193 ->
+        immediateWebDisconnectBound(
+            receiver.webId(),
+            signal,
+            target.webId(),
+            method,
+            boundValue.toInt(),
+          )
+          .toLong()
+      else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")
+    }
   }
 
   override fun invokeStringNameRetBool(
@@ -777,7 +927,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156))
+        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
         commands.flush()
         GodotVector3(
           immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
@@ -812,7 +962,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         }
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(142, 143))
+        require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
         commands.flush()
         // Three Float32 components packed into one query string (unit separator); the
         // applier writes the global transform and re-pushes the node's snapshot.
@@ -864,7 +1014,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(86, 87))
+    require(descriptor.opcode in setOf(86, 87, 190))
     commands.flush()
     immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
   }
@@ -911,7 +1061,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(108, 154))
+    require(descriptor.opcode in setOf(108, 154, 159))
     commands.flush()
     // Six Float32 components are packed into one query string (unit separator); the applier
     // re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -21,10 +21,10 @@ import net.multigesture.kanama.backend.InternalKanamaBackendApi
  * Kotlin/Wasm backend dispatch: opcode routing, execution-mode guards, and JS-bridge codec calls.
  *
  * Generated from scripts/platform_backend_calls.json + the Web-local policy in
- * scripts/generate_web_backend.py. Web-only state (property snapshots, browser handle-kind
- * tracking, free-time cache clearing) lives hand-written in WebBackendBookkeeping.kt and is reached
- * through its hooks; the js(...) transport primitives live hand-written in WebBackendTransport.kt.
- * See docs/contributing/web-internals.md ("Backend-dispatch codegen").
+ * scripts/generate_web_backend.py. Web-only state (property snapshots, browser handle-kind tracking,
+ * free-time cache clearing) lives hand-written in WebBackendBookkeeping.kt and is reached through its
+ * hooks; the js(...) transport primitives live hand-written in WebBackendTransport.kt. See
+ * docs/contributing/web-internals.md ("Backend-dispatch codegen").
  */
 internal object WebCommonGodotBackend : GodotBackendSpi {
   override fun requireLive(handle: GodotHandle) {
@@ -37,1144 +37,1143 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   override fun resolve(descriptor: GodotCallDescriptor): GodotCallSite =
     GodotCallSite.fromBackendToken(descriptor.opcode.toLong())
 
-  override fun invokeBoolRetInt(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Boolean,
-  ): Int {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush() // explicit ordering barrier for mutations issued before this result
-    return immediateWebChildCount(receiver.webId(), value)
-  }
+override fun invokeBoolRetInt(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Boolean,
+): Int {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush() // explicit ordering barrier for mutations issued before this result
+return immediateWebChildCount(receiver.webId(), value)
+}
 
-  override fun invokeBoolRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Boolean,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return existingReturnedObject(
-      receiver,
-      immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
-    )
-  }
+override fun invokeBoolRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Boolean,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return existingReturnedObject(
+receiver,
+immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
+)
+}
 
-  override fun invokeBoolArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Boolean,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(
-      descriptor.opcode in
-        setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180)
-    )
-    val objectId = receiver.webId()
-    commands.appendBoolMutation(descriptor.opcode, objectId, value)
-    when (descriptor.opcode) {
-      43 -> webWriteEmittingSnapshot(objectId, value)
-      else -> {}
-    }
-  }
+override fun invokeBoolArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Boolean,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode in setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180))
+val objectId = receiver.webId()
+commands.appendBoolMutation(descriptor.opcode, objectId, value)
+when (descriptor.opcode) {
+43 -> webWriteEmittingSnapshot(objectId, value)
+else -> {}
+}
+}
 
-  override fun invokeDoubleArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Double,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(value.isFinite()) {
-      "Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
-    }
-    when (descriptor.executionMode) {
-      GodotExecutionMode.QUEUED_MUTATION -> {
-        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
-        commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
-      }
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(65, 107, 109))
-        commands.flush()
-        when (descriptor.opcode) {
-          65 -> immediateWebSetProgressRatio(receiver.webId(), value)
-          107 -> immediateWebSetProgressRatio3D(receiver.webId(), value)
-          109 -> immediateWebRotateY(receiver.webId(), value)
-          else -> error("Unsupported Web immediate Double opcode=${descriptor.opcode}")
-        }
-      }
-      GodotExecutionMode.SNAPSHOT_READ ->
-        error("Double argument cannot use snapshot execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeDoubleArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Double,
+) {
+requireOpcode(descriptor, callSite)
+require(value.isFinite()) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
+}
+when (descriptor.executionMode) {
+GodotExecutionMode.QUEUED_MUTATION -> {
+require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
+commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
+}
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+require(descriptor.opcode in setOf(65, 107, 109))
+commands.flush()
+when (descriptor.opcode) {
+65 -> immediateWebSetProgressRatio(receiver.webId(), value)
+107 -> immediateWebSetProgressRatio3D(receiver.webId(), value)
+109 -> immediateWebRotateY(receiver.webId(), value)
+else -> error("Unsupported Web immediate Double opcode=${descriptor.opcode}")
+}
+}
+GodotExecutionMode.SNAPSHOT_READ ->
+error("Double argument cannot use snapshot execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeLongArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Long,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
-    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
-      "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
-    }
-    commands.appendLongMutation(descriptor.opcode, receiver.webId(), value)
-  }
+override fun invokeLongArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Long,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
+require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
+}
+commands.appendLongMutation(descriptor.opcode, receiver.webId(), value)
+}
 
-  override fun invokeNoArgsRetVector2(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): GodotVector2 {
-    requireOpcode(descriptor, callSite)
-    return when (descriptor.executionMode) {
-      GodotExecutionMode.SNAPSHOT_READ ->
-        when (descriptor.opcode) {
-          2 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.POSITION)
-          29 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.SCALE)
-          else -> null
-        }
-          ?: error(
-            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-              "object handle=${receiver.webId()}"
-          )
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        commands.flush()
-        GodotVector2(
-          immediateWebNoArgsVector2X(descriptor.opcode, receiver.webId()).toFloat(),
-          immediateWebNoArgsVector2Y().toFloat(),
-        )
-      }
-      GodotExecutionMode.QUEUED_MUTATION ->
-        error("Vector2 return cannot use queued execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNoArgsRetVector2(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): GodotVector2 {
+requireOpcode(descriptor, callSite)
+return when (descriptor.executionMode) {
+GodotExecutionMode.SNAPSHOT_READ ->
+when (descriptor.opcode) {
+2 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.POSITION)
+29 -> webVector2Snapshot(receiver.webId(), WebVector2Slot.SCALE)
+else -> null
+}
+?: error(
+"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+"object handle=${receiver.webId()}"
+)
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+commands.flush()
+GodotVector2(
+immediateWebNoArgsVector2X(descriptor.opcode, receiver.webId()).toFloat(),
+immediateWebNoArgsVector2Y().toFloat(),
+)
+}
+GodotExecutionMode.QUEUED_MUTATION ->
+error("Vector2 return cannot use queued execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeVector2Arg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotVector2,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    val objectId = receiver.webId()
-    commands.appendVector2Mutation(descriptor.opcode, objectId, value.x, value.y)
-    when (descriptor.opcode) {
-      3 -> webWriteVector2Snapshot(objectId, WebVector2Slot.POSITION, value)
-      30 -> webWriteVector2Snapshot(objectId, WebVector2Slot.SCALE, value)
-      60 -> {}
-      else -> error("Unsupported Web Vector2 mutation opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeVector2Arg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotVector2,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+val objectId = receiver.webId()
+commands.appendVector2Mutation(descriptor.opcode, objectId, value.x, value.y)
+when (descriptor.opcode) {
+3 -> webWriteVector2Snapshot(objectId, WebVector2Slot.POSITION, value)
+30 -> webWriteVector2Snapshot(objectId, WebVector2Slot.SCALE, value)
+60 -> {}
+else -> error("Unsupported Web Vector2 mutation opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeNoArgsRetRect2(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): GodotRect2 {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    return webViewportRectSnapshot(receiver.webId())
-      ?: error("Missing Web viewport snapshot for object handle=${receiver.webId()}")
-  }
+override fun invokeNoArgsRetRect2(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): GodotRect2 {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+return webViewportRectSnapshot(receiver.webId())
+?: error("Missing Web viewport snapshot for object handle=${receiver.webId()}")
+}
 
-  override fun invokeNoArgsVoid(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ) {
-    requireOpcode(descriptor, callSite)
-    val objectId = receiver.webId()
-    when (descriptor.executionMode) {
-      GodotExecutionMode.QUEUED_MUTATION -> {
-        commands.appendNoArgsMutation(descriptor.opcode, objectId)
-        if (descriptor.opcode == 15) onWebQueueFree(objectId)
-      }
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        commands.flush()
-        when (descriptor.opcode) {
-          37 ->
-            check(immediateWebTweenNoArgs(descriptor.opcode, objectId) == 1) {
-              "Kanama Web Tween.kill failed for handle=$objectId"
-            }
-          120 ->
-            check(immediateWebObjectQuery(120, objectId, "") == 1) {
-              "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-            }
-          else -> error("Unsupported Web immediate void opcode=${descriptor.opcode}")
-        }
-      }
-      GodotExecutionMode.SNAPSHOT_READ ->
-        error("Void call cannot use snapshot execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNoArgsVoid(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+) {
+requireOpcode(descriptor, callSite)
+val objectId = receiver.webId()
+when (descriptor.executionMode) {
+GodotExecutionMode.QUEUED_MUTATION -> {
+commands.appendNoArgsMutation(descriptor.opcode, objectId)
+if (descriptor.opcode == 15) onWebQueueFree(objectId)
+}
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+commands.flush()
+when (descriptor.opcode) {
+37 ->
+check(immediateWebTweenNoArgs(descriptor.opcode, objectId) == 1) {
+"Kanama Web Tween.kill failed for handle=$objectId"
+}
+120 ->
+check(immediateWebObjectQuery(120, objectId, "") == 1) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+}
+else -> error("Unsupported Web immediate void opcode=${descriptor.opcode}")
+}
+}
+GodotExecutionMode.SNAPSHOT_READ ->
+error("Void call cannot use snapshot execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeTexture2DVector2ColorArgs(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    texture: GodotHandle,
-    position: GodotVector2,
-    modulate: GodotColor,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    requireWebBrowserHandle(texture.webId(), WebBrowserHandleKind.RESOURCE)
-    drawCommands.appendDrawTexture(
-      descriptor.opcode,
-      receiver.webId(),
-      texture.webId(),
-      position.x,
-      position.y,
-      modulate.r,
-      modulate.g,
-      modulate.b,
-      modulate.a,
-    )
-  }
+override fun invokeTexture2DVector2ColorArgs(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+texture: GodotHandle,
+position: GodotVector2,
+modulate: GodotColor,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+requireWebBrowserHandle(texture.webId(), WebBrowserHandleKind.RESOURCE)
+drawCommands.appendDrawTexture(
+descriptor.opcode,
+receiver.webId(),
+texture.webId(),
+position.x,
+position.y,
+modulate.r,
+modulate.g,
+modulate.b,
+modulate.a,
+)
+}
 
-  override fun invokeStringStringLongRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    first: String,
-    second: String,
-    value: Long,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    return registerLoadedResource(immediateWebResourceLoad(first, second, value.toInt()))
-  }
+override fun invokeStringStringLongRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+first: String,
+second: String,
+value: Long,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+return registerLoadedResource(immediateWebResourceLoad(first, second, value.toInt()))
+}
 
-  override fun invokeUtilityNoArgsVoid(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    WebRandom.randomize()
-  }
+override fun invokeUtilityNoArgsVoid(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+WebRandom.randomize()
+}
 
-  override fun invokeUtilityNoArgsRetLong(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-  ): Long {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    return WebRandom.randi()
-  }
+override fun invokeUtilityNoArgsRetLong(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+): Long {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+return WebRandom.randi()
+}
 
-  override fun invokeUtilityNoArgsRetDouble(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-  ): Double {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    return WebRandom.randf()
-  }
+override fun invokeUtilityNoArgsRetDouble(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+): Double {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+return WebRandom.randf()
+}
 
-  override fun invokeStringNameIntRetInt(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    name: String,
-    value: Int,
-  ): Int {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebEmitSignal(receiver.webId(), name, value)
-  }
+override fun invokeStringNameIntRetInt(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+name: String,
+value: Int,
+): Int {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebEmitSignal(receiver.webId(), name, value)
+}
 
-  override fun invokeStringNameRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    value: String,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return registerConstructedNode(immediateWebConstructObject(value), value)
-  }
+override fun invokeStringNameRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+value: String,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return registerConstructedNode(immediateWebConstructObject(value), value)
+}
 
-  override fun invokeStringNameRetInt(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: String,
-  ): Int {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebEmitSignalNoArgs(receiver.webId(), value)
-  }
+override fun invokeStringNameRetInt(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: String,
+): Int {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebEmitSignalNoArgs(receiver.webId(), value)
+}
 
-  override fun invokeObjectBoolLongArgs(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    objectValue: GodotHandle,
-    boolValue: Boolean,
-    longValue: Long,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    requireWebNodeHandle(objectValue.webId())
-    commands.appendObjectBoolLongArgs(
-      descriptor.opcode,
-      receiver.webId(),
-      objectValue.webId(),
-      boolValue,
-      longValue,
-    )
-  }
+override fun invokeObjectBoolLongArgs(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+objectValue: GodotHandle,
+boolValue: Boolean,
+longValue: Long,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+requireWebNodeHandle(objectValue.webId())
+commands.appendObjectBoolLongArgs(
+descriptor.opcode,
+receiver.webId(),
+objectValue.webId(),
+boolValue,
+longValue,
+)
+}
 
-  override fun invokeObjectArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotHandle?,
-  ) {
-    requireOpcode(descriptor, callSite)
-    when (descriptor.opcode) {
-      14 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        requireWebNodeHandle(checkNotNull(value).webId())
-      }
-      16 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-        webWriteTextureSnapshot(receiver.webId(), value?.webId() ?: 0)
-      }
-      46 -> {
-        require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-      }
-      130 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-      }
-      165 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        checkNotNull(value)
-      }
-      170 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        checkNotNull(value)
-      }
-      171 -> {
-        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-        checkNotNull(value)
-      }
-      else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
-    }
-    commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
-    if (descriptor.opcode == 46) commands.flush()
-  }
+override fun invokeObjectArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotHandle?,
+) {
+requireOpcode(descriptor, callSite)
+when (descriptor.opcode) {
+14 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+requireWebNodeHandle(checkNotNull(value).webId())
+}
+16 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+webWriteTextureSnapshot(receiver.webId(), value?.webId() ?: 0)
+}
+46 -> {
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+}
+130 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+}
+165 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+checkNotNull(value)
+}
+170 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+checkNotNull(value)
+}
+171 -> {
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+checkNotNull(value)
+}
+else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
+}
+commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
+if (descriptor.opcode == 46) commands.flush()
+}
 
-  override fun invokeStringNameArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: String,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
-    commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
-  }
+override fun invokeStringNameArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: String,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
+commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
+}
 
-  override fun invokeStringNameBoolArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    name: String,
-    value: Boolean,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode == 67)
-    commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
-  }
+override fun invokeStringNameBoolArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+name: String,
+value: Boolean,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode == 67)
+commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
+}
 
-  override fun invokeLongBoolArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    layer: Long,
-    value: Boolean,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(155, 163, 164))
-    commands.flush()
-    // Layer number and flag packed into one query string (unit separator).
-    check(
-      immediateWebObjectQuery(
-        descriptor.opcode,
-        receiver.webId(),
-        layer.toString() + "" + (if (value) "1" else "0"),
-      ) == 1
-    ) {
-      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-    }
-  }
+override fun invokeLongBoolArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+layer: Long,
+value: Boolean,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode in setOf(155, 163, 164))
+commands.flush()
+// Layer number and flag packed into one query string (unit separator).
+check(
+immediateWebObjectQuery(
+descriptor.opcode,
+receiver.webId(),
+layer.toString() + "" + (if (value) "1" else "0"),
+) == 1
+) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+}
+}
 
-  override fun invokeVector3RetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotVector3,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 166)
-    commands.flush()
-    // Motion packed as three floats; the bridge allocates the collision slot and the
-    // applier registers the KinematicCollision3D under it (null collision returns 0).
-    return registerReturnedBrowserObject(
-      immediateWebMoveAndCollide(
-        descriptor.opcode,
-        receiver.webId(),
-        listOf(value.x, value.y, value.z).joinToString(""),
-      )
-    )
-  }
+override fun invokeVector3RetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotVector3,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 166)
+commands.flush()
+// Motion packed as three floats; the bridge allocates the collision slot and the
+// applier registers the KinematicCollision3D under it (null collision returns 0).
+return registerReturnedBrowserObject(
+immediateWebMoveAndCollide(
+descriptor.opcode,
+receiver.webId(),
+listOf(value.x, value.y, value.z).joinToString(""),
+)
+)
+}
 
-  override fun invokeNoArgsRetHandleList(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): List<GodotHandle> {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 167)
-    commands.flush()
-    // The applier packs the SCRIPT handles of scripted overlapping bodies (unit
-    // separator); bodies without Kanama scripts are omitted by contract.
-    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
-      .split('')
-      .filter { it.isNotEmpty() }
-      .map { GodotHandle.fromBackendToken(it.toLong()) }
-  }
+override fun invokeNoArgsRetHandleList(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): List<GodotHandle> {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 167)
+commands.flush()
+// The applier packs the SCRIPT handles of scripted overlapping bodies (unit
+// separator); bodies without Kanama scripts are omitted by contract.
+return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
+.split('')
+.filter { it.isNotEmpty() }
+.map { GodotHandle.fromBackendToken(it.toLong()) }
+}
 
-  override fun invokeLongRetVector3(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Long,
-  ): GodotVector3 {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 173)
-    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    return GodotVector3(
-      immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),
-      immediateWebNoArgsVector3Y().toFloat(),
-      immediateWebNoArgsVector3Z().toFloat(),
-    )
-  }
+override fun invokeLongRetVector3(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Long,
+): GodotVector3 {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 173)
+require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+return GodotVector3(
+immediateWebIndexedVector3X(descriptor.opcode, receiver.webId(), value.toInt()).toFloat(),
+immediateWebNoArgsVector3Y().toFloat(),
+immediateWebNoArgsVector3Z().toFloat(),
+)
+}
 
-  override fun invokeStringNameRetDoubleSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    value: String,
-  ): Double {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(186, 187))
-    commands.flush()
-    // Scaled by 1000 through the shared integer object-query transport.
-    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
-      1000.0
-  }
+override fun invokeStringNameRetDoubleSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+value: String,
+): Double {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode in setOf(186, 187))
+commands.flush()
+// Scaled by 1000 through the shared integer object-query transport.
+return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
+1000.0
+}
 
-  override fun invokeStringNameVector3Vector3Arg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    name: String,
-    first: GodotVector3,
-    second: GodotVector3,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode == 191)
-    commands.appendStringNameVector3Vector3Mutation(
-      descriptor.opcode,
-      receiver.webId(),
-      name,
-      first,
-      second,
-    )
-  }
+override fun invokeStringNameVector3Vector3Arg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+name: String,
+first: GodotVector3,
+second: GodotVector3,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode == 191)
+commands.appendStringNameVector3Vector3Mutation(
+descriptor.opcode,
+receiver.webId(),
+name,
+first,
+second,
+)
+}
 
-  override fun invokeCallableDoubleRangeRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    target: GodotHandle,
-    method: String,
-    fromValue: Double,
-    toValue: Double,
-    duration: Double,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 192)
-    commands.flush()
-    return registerReturnedBrowserObject(
-      immediateWebTweenMethod(
-        descriptor.opcode,
-        receiver.webId(),
-        target.webId(),
-        method,
-        fromValue,
-        toValue,
-        duration,
-      )
-    )
-  }
+override fun invokeCallableDoubleRangeRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+target: GodotHandle,
+method: String,
+fromValue: Double,
+toValue: Double,
+duration: Double,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 192)
+commands.flush()
+return registerReturnedBrowserObject(
+immediateWebTweenMethod(
+descriptor.opcode,
+receiver.webId(),
+target.webId(),
+method,
+fromValue,
+toValue,
+duration,
+)
+)
+}
 
-  override fun invokeStringNameStringNameArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    first: String,
-    second: String,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(68, 105))
-    commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
-  }
+override fun invokeStringNameStringNameArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+first: String,
+second: String,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode in setOf(68, 105))
+commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
+}
 
-  override fun invokeNodePathRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    path: String,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return when (descriptor.opcode) {
-      17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
-      149,
-      184 ->
-        registerReturnedBrowserObject(
-          immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)
-        )
-      else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNodePathRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+path: String,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return when (descriptor.opcode) {
+17 -> registerReturnedNode(immediateWebNodeLookup(receiver.webId(), path))
+149,
+184 ->
+registerReturnedBrowserObject(
+immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), path)
+)
+else -> error("Unsupported Web path-to-handle opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeLongRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: Long,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    return when (descriptor.opcode) {
-      18 ->
-        registerReturnedNode(immediateWebPackedSceneInstantiate(receiver.webId(), value.toInt()))
-      41,
-      42,
-      135,
-      174 ->
-        existingReturnedObject(
-          receiver,
-          immediateWebTweenLongRetObject(descriptor.opcode, receiver.webId(), value.toInt()),
-        )
-      111 ->
-        registerReturnedBrowserObject(immediateWebSlideCollision(receiver.webId(), value.toInt()))
-      133 -> registerReturnedNode(immediateWebNodeChild(receiver.webId(), value.toInt()))
-      else -> error("Unsupported Web Long-return-handle opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeLongRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: Long,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+return when (descriptor.opcode) {
+18 ->
+registerReturnedNode(immediateWebPackedSceneInstantiate(receiver.webId(), value.toInt()))
+41,
+42,
+135,
+174 ->
+existingReturnedObject(
+receiver,
+immediateWebTweenLongRetObject(descriptor.opcode, receiver.webId(), value.toInt()),
+)
+111 ->
+registerReturnedBrowserObject(immediateWebSlideCollision(receiver.webId(), value.toInt()))
+133 ->
+registerReturnedNode(immediateWebNodeChild(receiver.webId(), value.toInt()))
+else -> error("Unsupported Web Long-return-handle opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeNoArgsRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    return when (descriptor.executionMode) {
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        commands.flush()
-        val token = immediateWebNoArgsObject(descriptor.opcode, receiver.webId())
-        when (descriptor.opcode) {
-          19 -> registerReturnedNode(token)
-          36 -> registerReturnedBrowserObject(token)
-          51 -> registerReturnedBrowserObject(token)
-          71 -> registerReturnedBrowserObject(token)
-          73 -> registerReturnedNode(token)
-          81 -> registerReturnedBrowserObject(token)
-          112 -> registerReturnedNode(token)
-          114 -> registerReturnedNode(token)
-          122 -> registerReturnedNode(token)
-          else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
-        }
-      }
-      GodotExecutionMode.SNAPSHOT_READ -> {
-        require(descriptor.opcode == 33)
-        val objectId = receiver.webId()
-        val textureId =
-          webTextureSnapshot(objectId)
-            ?: error("Missing Web Sprite2D.get_texture snapshot for object handle=$objectId")
-        textureId.takeIf { it > 0 }?.let { GodotHandle.fromBackendToken(it.toLong()) }
-      }
-      GodotExecutionMode.QUEUED_MUTATION ->
-        error("Handle return cannot use queued execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNoArgsRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+return when (descriptor.executionMode) {
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+commands.flush()
+val token = immediateWebNoArgsObject(descriptor.opcode, receiver.webId())
+when (descriptor.opcode) {
+19 -> registerReturnedNode(token)
+36 -> registerReturnedBrowserObject(token)
+51 -> registerReturnedBrowserObject(token)
+71 -> registerReturnedBrowserObject(token)
+73 -> registerReturnedNode(token)
+81 -> registerReturnedBrowserObject(token)
+112 -> registerReturnedNode(token)
+114 -> registerReturnedNode(token)
+122 -> registerReturnedNode(token)
+194 -> registerReturnedNode(token)
+else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
+}
+}
+GodotExecutionMode.SNAPSHOT_READ -> {
+require(descriptor.opcode == 33)
+val objectId = receiver.webId()
+val textureId =
+webTextureSnapshot(objectId)
+?: error("Missing Web Sprite2D.get_texture snapshot for object handle=$objectId")
+textureId.takeIf { it > 0 }?.let { GodotHandle.fromBackendToken(it.toLong()) }
+}
+GodotExecutionMode.QUEUED_MUTATION ->
+error("Handle return cannot use queued execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeObjectLongVector2Args(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    objectValue: GodotHandle?,
-    longValue: Long,
-    vectorValue: GodotVector2,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
-    commands.flush()
-    immediateWebSetCustomMouseCursor(
-      requireActiveWebScriptHandle(),
-      objectValue?.webId() ?: 0,
-      longValue.toInt(),
-      vectorValue.x.toDouble(),
-      vectorValue.y.toDouble(),
-    )
-  }
+override fun invokeObjectLongVector2Args(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+objectValue: GodotHandle?,
+longValue: Long,
+vectorValue: GodotVector2,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+commands.flush()
+immediateWebSetCustomMouseCursor(
+requireActiveWebScriptHandle(),
+objectValue?.webId() ?: 0,
+longValue.toInt(),
+vectorValue.x.toDouble(),
+vectorValue.y.toDouble(),
+)
+}
 
-  override fun invokeStringNameCallableLongRetLong(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    signal: String,
-    target: GodotHandle,
-    method: String,
-    flags: Long,
-  ): Long {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    return immediateWebConnect(receiver.webId(), signal, target.webId(), method, flags.toInt())
-      .toLong()
-  }
+override fun invokeStringNameCallableLongRetLong(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+signal: String,
+target: GodotHandle,
+method: String,
+flags: Long,
+): Long {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+return immediateWebConnect(receiver.webId(), signal, target.webId(), method, flags.toInt())
+.toLong()
+}
 
-  override fun invokeStringNameBoundCallableLongRetLong(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    signal: String,
-    target: GodotHandle,
-    method: String,
-    boundValue: Long,
-    flags: Long,
-  ): Long {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    return when (descriptor.opcode) {
-      34 ->
-        immediateWebConnectBound(
-            receiver.webId(),
-            signal,
-            target.webId(),
-            method,
-            boundValue.toInt(),
-            flags.toInt(),
-          )
-          .toLong()
-      193 ->
-        immediateWebDisconnectBound(
-            receiver.webId(),
-            signal,
-            target.webId(),
-            method,
-            boundValue.toInt(),
-          )
-          .toLong()
-      else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeStringNameBoundCallableLongRetLong(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+signal: String,
+target: GodotHandle,
+method: String,
+boundValue: Long,
+flags: Long,
+): Long {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(boundValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+return when (descriptor.opcode) {
+34 ->
+immediateWebConnectBound(
+receiver.webId(),
+signal,
+target.webId(),
+method,
+boundValue.toInt(),
+flags.toInt(),
+)
+.toLong()
+193 ->
+immediateWebDisconnectBound(
+receiver.webId(),
+signal,
+target.webId(),
+method,
+boundValue.toInt(),
+)
+.toLong()
+else -> error("Unsupported Web bound-callable opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeStringNameRetBool(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: String,
-  ): Boolean {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value) != 0
-  }
+override fun invokeStringNameRetBool(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: String,
+): Boolean {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value) != 0
+}
 
-  override fun invokeStringNameRetBoolSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    value: String,
-  ): Boolean {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) != 0
-  }
+override fun invokeStringNameRetBoolSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+value: String,
+): Boolean {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) != 0
+}
 
-  override fun invokeNoArgsRetBool(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): Boolean {
-    requireOpcode(descriptor, callSite)
-    return when (descriptor.executionMode) {
-      GodotExecutionMode.SNAPSHOT_READ -> {
-        require(descriptor.opcode == 44)
-        webEmittingSnapshot(receiver.webId())
-          ?: error(
-            "Missing Web GPUParticles2D.is_emitting snapshot for object handle=${receiver.webId()}"
-          )
-      }
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        commands.flush()
-        immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") != 0
-      }
-      GodotExecutionMode.QUEUED_MUTATION ->
-        error("Boolean return cannot use queued execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNoArgsRetBool(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): Boolean {
+requireOpcode(descriptor, callSite)
+return when (descriptor.executionMode) {
+GodotExecutionMode.SNAPSHOT_READ -> {
+require(descriptor.opcode == 44)
+webEmittingSnapshot(receiver.webId())
+?: error(
+"Missing Web GPUParticles2D.is_emitting snapshot for object handle=${receiver.webId()}"
+)
+}
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+commands.flush()
+immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") != 0
+}
+GodotExecutionMode.QUEUED_MUTATION ->
+error("Boolean return cannot use queued execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeNoArgsRetDouble(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): Double {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    return when (descriptor.opcode) {
-      45 -> webLifetimeSnapshot(receiver.webId())
-      70 -> webRotationSnapshot(receiver.webId())
-      else -> null
-    }
-      ?: error(
-        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-          "object handle=${receiver.webId()}"
-      )
-  }
+override fun invokeNoArgsRetDouble(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): Double {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+return when (descriptor.opcode) {
+45 -> webLifetimeSnapshot(receiver.webId())
+70 -> webRotationSnapshot(receiver.webId())
+else -> null
+}
+?: error(
+"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+"object handle=${receiver.webId()}"
+)
+}
 
-  override fun invokeNoArgsRetLong(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): Long {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "").toLong()
-  }
+override fun invokeNoArgsRetLong(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): Long {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "").toLong()
+}
 
-  override fun invokeNoArgsRetStringArray(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): List<String> {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    require(descriptor.opcode == 72)
-    return webAnimationNamesSnapshot(receiver.webId())
-      ?: error(
-        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-          "object handle=${receiver.webId()}"
-      )
-  }
+override fun invokeNoArgsRetStringArray(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): List<String> {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+require(descriptor.opcode == 72)
+return webAnimationNamesSnapshot(receiver.webId())
+?: error(
+"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+"object handle=${receiver.webId()}"
+)
+}
 
-  override fun invokeStringNameVector2iRetInt(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    name: String,
-    value: GodotVector2i,
-  ): Int {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    commands.flush()
-    return immediateWebEmitSignalVector2i(receiver.webId(), name, value.x, value.y)
-  }
+override fun invokeStringNameVector2iRetInt(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+name: String,
+value: GodotVector2i,
+): Int {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+commands.flush()
+return immediateWebEmitSignalVector2i(receiver.webId(), name, value.x, value.y)
+}
 
-  override fun invokeNoArgsRetColor(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): GodotColor {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    return webModulateSnapshot(receiver.webId())
-      ?: error("Missing Web CanvasItem.get_modulate snapshot for object handle=${receiver.webId()}")
-  }
+override fun invokeNoArgsRetColor(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): GodotColor {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+return webModulateSnapshot(receiver.webId())
+?: error("Missing Web CanvasItem.get_modulate snapshot for object handle=${receiver.webId()}")
+}
 
-  override fun invokeColorArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotColor,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    commands.appendColorMutation(
-      descriptor.opcode,
-      receiver.webId(),
-      value.r,
-      value.g,
-      value.b,
-      value.a,
-    )
-    webWriteModulateSnapshot(receiver.webId(), value)
-  }
+override fun invokeColorArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotColor,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+commands.appendColorMutation(
+descriptor.opcode,
+receiver.webId(),
+value.r,
+value.g,
+value.b,
+value.a,
+)
+webWriteModulateSnapshot(receiver.webId(), value)
+}
 
-  override fun invokeObjectNodePathVector2DoubleRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    target: GodotHandle,
-    property: String,
-    finalValue: GodotVector2,
-    duration: Double,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(duration.isFinite() && duration >= 0.0)
-    commands.flush()
-    return registerReturnedBrowserObject(
-      immediateWebTweenPropertyVector2(
-        descriptor.opcode,
-        receiver.webId(),
-        target.webId(),
-        property,
-        finalValue.x.toDouble(),
-        finalValue.y.toDouble(),
-        duration,
-      )
-    )
-  }
+override fun invokeObjectNodePathVector2DoubleRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+target: GodotHandle,
+property: String,
+finalValue: GodotVector2,
+duration: Double,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(duration.isFinite() && duration >= 0.0)
+commands.flush()
+return registerReturnedBrowserObject(
+immediateWebTweenPropertyVector2(
+descriptor.opcode,
+receiver.webId(),
+target.webId(),
+property,
+finalValue.x.toDouble(),
+finalValue.y.toDouble(),
+duration,
+)
+)
+}
 
-  override fun invokeObjectNodePathColorDoubleRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    target: GodotHandle,
-    property: String,
-    finalValue: GodotColor,
-    duration: Double,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(duration.isFinite() && duration >= 0.0)
-    commands.flush()
-    return registerReturnedBrowserObject(
-      immediateWebTweenPropertyColor(
-        descriptor.opcode,
-        receiver.webId(),
-        target.webId(),
-        property,
-        finalValue.r.toDouble(),
-        finalValue.g.toDouble(),
-        finalValue.b.toDouble(),
-        finalValue.a.toDouble(),
-        duration,
-      )
-    )
-  }
+override fun invokeObjectNodePathColorDoubleRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+target: GodotHandle,
+property: String,
+finalValue: GodotColor,
+duration: Double,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(duration.isFinite() && duration >= 0.0)
+commands.flush()
+return registerReturnedBrowserObject(
+immediateWebTweenPropertyColor(
+descriptor.opcode,
+receiver.webId(),
+target.webId(),
+property,
+finalValue.r.toDouble(),
+finalValue.g.toDouble(),
+finalValue.b.toDouble(),
+finalValue.a.toDouble(),
+duration,
+)
+)
+}
 
-  override fun invokeNoArgsRetVector3(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-  ): GodotVector3 {
-    requireOpcode(descriptor, callSite)
-    return when (descriptor.executionMode) {
-      GodotExecutionMode.SNAPSHOT_READ ->
-        when (descriptor.opcode) {
-          75 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.POSITION)
-          77 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION)
-          79 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.SCALE)
-          89 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.VELOCITY)
-          102 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION_DEGREES)
-          119 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.TARGET_POSITION)
-          else -> null
-        }
-          ?: error(
-            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-              "object handle=${receiver.webId()}"
-          )
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
-        commands.flush()
-        GodotVector3(
-          immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
-          immediateWebNoArgsVector3Y().toFloat(),
-          immediateWebNoArgsVector3Z().toFloat(),
-        )
-      }
-      GodotExecutionMode.QUEUED_MUTATION ->
-        error("Vector3 return cannot use queued execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeNoArgsRetVector3(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+): GodotVector3 {
+requireOpcode(descriptor, callSite)
+return when (descriptor.executionMode) {
+GodotExecutionMode.SNAPSHOT_READ ->
+when (descriptor.opcode) {
+75 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.POSITION)
+77 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION)
+79 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.SCALE)
+89 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.VELOCITY)
+102 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.ROTATION_DEGREES)
+119 -> webVector3Snapshot(receiver.webId(), WebVector3Slot.TARGET_POSITION)
+else -> null
+}
+?: error(
+"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+"object handle=${receiver.webId()}"
+)
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
+commands.flush()
+GodotVector3(
+immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
+immediateWebNoArgsVector3Y().toFloat(),
+immediateWebNoArgsVector3Z().toFloat(),
+)
+}
+GodotExecutionMode.QUEUED_MUTATION ->
+error("Vector3 return cannot use queued execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeVector3Arg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotVector3,
-  ) {
-    requireOpcode(descriptor, callSite)
-    val objectId = receiver.webId()
-    when (descriptor.executionMode) {
-      GodotExecutionMode.QUEUED_MUTATION -> {
-        commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
-        when (descriptor.opcode) {
-          74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
-          76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
-          78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
-          88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
-          101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
-          118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
-          else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
-        }
-      }
-      GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
-        commands.flush()
-        // Three Float32 components packed into one query string (unit separator); the
-        // applier writes the global transform and re-pushes the node's snapshot.
-        val packed = listOf(value.x, value.y, value.z).joinToString("")
-        check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {
-          "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-        }
-      }
-      GodotExecutionMode.SNAPSHOT_READ ->
-        error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")
-    }
-  }
+override fun invokeVector3Arg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotVector3,
+) {
+requireOpcode(descriptor, callSite)
+val objectId = receiver.webId()
+when (descriptor.executionMode) {
+GodotExecutionMode.QUEUED_MUTATION -> {
+commands.appendVector3Mutation(descriptor.opcode, objectId, value.x, value.y, value.z)
+when (descriptor.opcode) {
+74 -> webWriteVector3Snapshot(objectId, WebVector3Slot.POSITION, value)
+76 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION, value)
+78 -> webWriteVector3Snapshot(objectId, WebVector3Slot.SCALE, value)
+88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
+101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
+118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
+else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
+}
+}
+GodotExecutionMode.IMMEDIATE_RESULT -> {
+require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
+commands.flush()
+// Three Float32 components packed into one query string (unit separator); the
+// applier writes the global transform and re-pushes the node's snapshot.
+val packed =
+listOf(value.x, value.y, value.z).joinToString("")
+check(immediateWebObjectQuery(descriptor.opcode, objectId, packed) == 1) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+}
+}
+GodotExecutionMode.SNAPSHOT_READ ->
+error("Vector3 argument cannot use snapshot execution for opcode=${descriptor.opcode}")
+}
+}
 
-  override fun invokeLongDoubleArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    longValue: Long,
-    doubleValue: Double,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode == 84)
-    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    require(doubleValue.isFinite()) {
-      "Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
-    }
-    commands.appendLongDoubleMutation(descriptor.opcode, receiver.webId(), longValue, doubleValue)
-  }
+override fun invokeLongDoubleArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+longValue: Long,
+doubleValue: Double,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode == 84)
+require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+require(doubleValue.isFinite()) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
+}
+commands.appendLongDoubleMutation(descriptor.opcode, receiver.webId(), longValue, doubleValue)
+}
 
-  override fun invokeNoArgsRetStringSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-  ): String {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    require(descriptor.opcode == 85)
-    return webRenderingMethodSnapshot(requireActiveWebScriptHandle())
-      ?: error(
-        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-          "active script handle"
-      )
-  }
+override fun invokeNoArgsRetStringSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+): String {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
+require(descriptor.opcode == 85)
+return webRenderingMethodSnapshot(requireActiveWebScriptHandle())
+?: error(
+"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+"active script handle"
+)
+}
 
-  override fun invokeStringNameArgSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    value: String,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(86, 87, 190))
-    commands.flush()
-    immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
-  }
+override fun invokeStringNameArgSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+value: String,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode in setOf(86, 87, 190))
+commands.flush()
+immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
+}
 
-  override fun invokeStringNameDoubleArg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: String,
-    doubleValue: Double,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(103, 132, 151))
-    require(doubleValue.isFinite())
-    commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
-  }
+override fun invokeStringNameDoubleArg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: String,
+doubleValue: Double,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+require(descriptor.opcode in setOf(103, 132, 151))
+require(doubleValue.isFinite())
+commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
+}
 
-  override fun invokeStringNameStringNameRetDoubleSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    first: String,
-    second: String,
-  ): Double {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 104)
-    commands.flush()
-    // Two action names are packed into one query string (unit separator) and the axis is
-    // returned scaled by 1000 through the shared object-query transport.
-    return immediateWebObjectQuery(
-      descriptor.opcode,
-      requireActiveWebScriptHandle(),
-      first + "\u001f" + second,
-    ) / 1000.0
-  }
+override fun invokeStringNameStringNameRetDoubleSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+first: String,
+second: String,
+): Double {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 104)
+commands.flush()
+// Two action names are packed into one query string (unit separator) and the axis is
+// returned scaled by 1000 through the shared object-query transport.
+return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), first + "\u001f" + second) / 1000.0
+}
 
-  override fun invokeVector3Vector3Arg(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    first: GodotVector3,
-    second: GodotVector3,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(108, 154, 159))
-    commands.flush()
-    // Six Float32 components are packed into one query string (unit separator); the applier
-    // re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.
-    val packed =
-      listOf(first.x, first.y, first.z, second.x, second.y, second.z).joinToString("\u001f")
-    check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
-      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
-    }
-  }
+override fun invokeVector3Vector3Arg(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+first: GodotVector3,
+second: GodotVector3,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode in setOf(108, 154, 159))
+commands.flush()
+// Six Float32 components are packed into one query string (unit separator); the applier
+// re-pushes the Node3D transform snapshot so rotation reads reflect the new orientation.
+val packed =
+listOf(first.x, first.y, first.z, second.x, second.y, second.z).joinToString("\u001f")
+check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
+"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+}
+}
 
-  override fun invokeLongArgSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    value: Long,
-  ) {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(116, 126))
-    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    commands.flush()
-    immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
-  }
+override fun invokeLongArgSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+value: Long,
+) {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode in setOf(116, 126))
+require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+commands.flush()
+immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
+}
 
-  override fun invokeObjectRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    value: GodotHandle,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 134)
-    commands.flush()
-    return existingReturnedObject(
-      receiver,
-      immediateWebTweenObjectRetObject(descriptor.opcode, receiver.webId(), value.webId()),
-    )
-  }
+override fun invokeObjectRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+value: GodotHandle,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 134)
+commands.flush()
+return existingReturnedObject(
+receiver,
+immediateWebTweenObjectRetObject(descriptor.opcode, receiver.webId(), value.webId()),
+)
+}
 
-  override fun invokeObjectNodePathVector3DoubleRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    target: GodotHandle,
-    property: String,
-    finalValue: GodotVector3,
-    duration: Double,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(duration.isFinite() && duration >= 0.0)
-    commands.flush()
-    return registerReturnedBrowserObject(
-      immediateWebTweenPropertyVector3(
-        descriptor.opcode,
-        receiver.webId(),
-        target.webId(),
-        property,
-        finalValue.x.toDouble(),
-        finalValue.y.toDouble(),
-        finalValue.z.toDouble(),
-        duration,
-      )
-    )
-  }
+override fun invokeObjectNodePathVector3DoubleRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+target: GodotHandle,
+property: String,
+finalValue: GodotVector3,
+duration: Double,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(duration.isFinite() && duration >= 0.0)
+commands.flush()
+return registerReturnedBrowserObject(
+immediateWebTweenPropertyVector3(
+descriptor.opcode,
+receiver.webId(),
+target.webId(),
+property,
+finalValue.x.toDouble(),
+finalValue.y.toDouble(),
+finalValue.z.toDouble(),
+duration,
+)
+)
+}
 
-  override fun invokeCallableRetHandle(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    target: GodotHandle,
-    method: String,
-  ): GodotHandle? {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 137)
-    commands.flush()
-    return registerReturnedBrowserObject(
-      immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)
-    )
-  }
+override fun invokeCallableRetHandle(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+target: GodotHandle,
+method: String,
+): GodotHandle? {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 137)
+commands.flush()
+return registerReturnedBrowserObject(
+immediateWebTweenCallback(descriptor.opcode, receiver.webId(), target.webId(), method)
+)
+}
 
-  override fun invokeNoArgsRetLongSingleton(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-  ): Long {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 145)
-    commands.flush()
-    return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "").toLong()
-  }
+override fun invokeNoArgsRetLongSingleton(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+): Long {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 145)
+commands.flush()
+return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")
+.toLong()
+}
 
-  override fun invokeStringNameObjectRetInt(
-    descriptor: GodotCallDescriptor,
-    callSite: GodotCallSite,
-    receiver: GodotHandle,
-    name: String,
-    value: GodotHandle,
-  ): Int {
-    requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 148)
-    commands.flush()
-    // Signal name and object handle packed into one query string (unit separator);
-    // the applier resolves the object from the shared handle dictionary and emits.
-    return immediateWebObjectQuery(
-      descriptor.opcode,
-      receiver.webId(),
-      name + "" + value.webId().toString(),
-    )
-  }
-
+override fun invokeStringNameObjectRetInt(
+descriptor: GodotCallDescriptor,
+callSite: GodotCallSite,
+receiver: GodotHandle,
+name: String,
+value: GodotHandle,
+): Int {
+requireOpcode(descriptor, callSite)
+require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+require(descriptor.opcode == 148)
+commands.flush()
+// Signal name and object handle packed into one query string (unit separator);
+// the applier resolves the object from the shared handle dictionary and emits.
+return immediateWebObjectQuery(
+descriptor.opcode,
+receiver.webId(),
+name + "" + value.webId().toString(),
+)
+}
   private fun requireOpcode(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {
     require(callSite.backendToken() == descriptor.opcode.toLong()) {
       "Web Godot call-site opcode does not match ${descriptor.className}.${descriptor.methodName}"

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -257,6 +257,9 @@
     fpsPlayerHandle: 0,
     charSmokeQuitHandle: 0,
     charPlayerHandle: 0,
+    tpSmokeQuitHandle: 0,
+    tpPlayerHandle: 0,
+    tpDemoPageHandle: 0,
     // _physics_process/_process ordering evidence (Task 60d): Godot's iteration runs all
     // physics ticks BEFORE the idle/_process pass inside one requestAnimationFrame callback,
     // so a physics dispatch AFTER a process dispatch within the same rAF tick would be an
@@ -1984,6 +1987,17 @@
       }
       if (this.mode === "charactercontroller" && scriptName.endsWith(".Player3DTemplate")) {
         this.charPlayerHandle = handle;
+      }
+      if (this.mode === "thirdperson" && scriptName.endsWith(".SmokeQuit")) {
+        // smoke_resume (method#1) presses through the boot pause; smoke_teardown (method#2)
+        // frees the scene root and drains live handles to zero.
+        this.tpSmokeQuitHandle = handle;
+      }
+      if (this.mode === "thirdperson" && scriptName.endsWith(".Player")) {
+        this.tpPlayerHandle = handle;
+      }
+      if (this.mode === "thirdperson" && scriptName.endsWith(".DemoPage")) {
+        this.tpDemoPageHandle = handle;
       }
       if (this.mode === "match3") {
         this.match3ScriptNamesByHandle.set(handle, scriptName);

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 12;
+  const KANAMA_WEB_PROTOCOL_VERSION = 13;
 
   function commandWordCount(opcode) {
     if (
@@ -64,6 +64,9 @@
       opcode === 105 ||
       opcode === 144 ||
       opcode === 146 ||
+      opcode === 152 ||
+      opcode === 153 ||
+      opcode === 158 ||
       opcode === 1000
     ) return 4;
     if (

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -612,6 +612,15 @@
         0,
       );
     },
+    setStringArrayProperty(handle, propertyId, values) {
+      return this.invoke(
+        handle,
+        "property_set",
+        `property#${propertyId}`,
+        () => this.api.kanamaWebSetStringArrayProperty(handle, propertyId, String(values)),
+        0,
+      );
+    },
     setObjectArrayProperty(handle, propertyId, values) {
       const parsedValues =
         values === "" ? [] : String(values).split(",").map((value) => Number.parseInt(value, 10));
@@ -645,6 +654,15 @@
     recordDeferredReady(scriptName) {
       this.match3DeferredReadyByClass[scriptName] =
         (this.match3DeferredReadyByClass[scriptName] ?? 0) + 1;
+    },
+    callString(handle, methodId, value) {
+      return this.invoke(
+        handle,
+        "registered_function",
+        `method#${methodId}`,
+        () => this.api.kanamaWebCallString(handle, methodId, String(value)),
+        0,
+      );
     },
     callInt(handle, methodId, value) {
       return this.invoke(
@@ -1435,6 +1453,30 @@
         toValue,
         duration,
       ]);
+    },
+    immediateIndexedObjectLookup(opcode, handle, index) {
+      // Indexed hit lookup (shape-cast colliders): node-lookup validation — the applier may
+      // return the proposed slot, an existing tracked handle, or a script handle.
+      const owner = this.ownerForHandle(handle);
+      const callback = this.callbackFor(this.tweenCallbacks, handle, "Godot indexed lookup");
+      const resultHandle = this.allocateBrowserHandle("Node", owner);
+      this.api.kanamaWebAdoptNodeHandle(resultHandle);
+      this.immediateObjectHandleResult = null;
+      callback(opcode, handle, resultHandle, index);
+      const result = this.immediateObjectHandleResult;
+      if (result !== 0 && result !== resultHandle) {
+        const scriptHandle = this.api.kanamaWebIsLive(result) === 1;
+        if (!scriptHandle && this.isBrowserHandleLive(result) !== 1) {
+          throw new Error("Godot indexed lookup returned neither its proposed nor a live handle");
+        }
+        this.api.kanamaWebDiscardNodeHandle(resultHandle);
+        this.releaseBrowserHandle(resultHandle, "Node");
+      }
+      if (result === 0) {
+        this.api.kanamaWebDiscardNodeHandle(resultHandle);
+        this.releaseBrowserHandle(resultHandle, "Node");
+      }
+      return result;
     },
     immediateSlideCollision(handle, index) {
       const owner = this.ownerForHandle(handle);

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -19,7 +19,8 @@
       opcode === 59 ||
       opcode === 63 ||
       opcode === 64 ||
-      opcode === 147
+      opcode === 147 ||
+      opcode === 181
     ) return 2;
     if (
       opcode === 14 ||
@@ -34,6 +35,11 @@
       opcode === 130 ||
       opcode === 140 ||
       opcode === 150 ||
+      opcode === 165 ||
+      opcode === 170 ||
+      opcode === 171 ||
+      opcode === 185 ||
+      opcode === 189 ||
       opcode === 66
     ) return 3;
     if (
@@ -67,6 +73,13 @@
       opcode === 152 ||
       opcode === 153 ||
       opcode === 158 ||
+      opcode === 161 ||
+      opcode === 162 ||
+      opcode === 168 ||
+      opcode === 169 ||
+      opcode === 180 ||
+      opcode === 182 ||
+      opcode === 183 ||
       opcode === 1000
     ) return 4;
     if (
@@ -83,7 +96,7 @@
       opcode === 151
     ) return 5;
     if (opcode === 32) return 6;
-    if (opcode === 6) return 9;
+    if (opcode === 6 || opcode === 191) return 9;
     throw new Error(`Unknown Kanama Web command opcode=${opcode}`);
   }
 
@@ -1169,15 +1182,15 @@
       }
       return this.immediateResourceReleaseResult;
     },
-    immediatePropertyObjectQuery(handle, name) {
-      // Object-valued property read (opcode 149): the proxy resolves receiver.get(name),
+    immediatePropertyObjectQuery(opcode, handle, name) {
+      // Object-valued property/animation read: the proxy resolves the named object,
       // registers the result under the proposed slot (or an existing/script handle), and
       // publishes the winning handle through the object-query integer channel.
       const owner = this.ownerForHandle(handle);
       const callback = this.callbackFor(this.objectQueryCallbacks, handle, "Godot object query");
       const resultHandle = this.allocateBrowserHandle("Object", owner);
       this.immediateLongResult = null;
-      callback(149, handle, `${name}\u001f${resultHandle}`);
+      callback(opcode, handle, `${name}\u001f${resultHandle}`);
       const result = this.immediateLongResult;
       if (!Number.isInteger(result)) {
         throw new Error("Godot property object query callback did not publish a result");
@@ -1354,6 +1367,71 @@
         throw new Error("Godot Tweener long callback did not return its receiver");
       }
       return handle;
+    },
+    immediateMoveAndCollide(opcode, handle, packed) {
+      // Mirrors immediateSlideCollision: the applier registers the KinematicCollision3D
+      // under the proposed slot (0 when the sweep hit nothing).
+      const owner = this.ownerForHandle(handle);
+      const callback = this.callbackFor(this.tweenCallbacks, handle, "Godot move-and-collide");
+      const resultHandle = this.allocateBrowserHandle("KinematicCollision3D", owner);
+      this.api.kanamaWebAdoptObjectHandle(resultHandle);
+      this.immediateObjectHandleResult = null;
+      callback(opcode, handle, resultHandle, packed);
+      const result = this.immediateObjectHandleResult;
+      if (result !== 0 && result !== resultHandle) {
+        throw new Error("Godot move-and-collide callback published an invalid handle");
+      }
+      if (result === 0) {
+        this.api.kanamaWebDiscardBrowserHandle(resultHandle);
+        this.releaseBrowserHandle(resultHandle, "KinematicCollision3D");
+      }
+      return result;
+    },
+    immediateStringQuery(opcode, handle, value) {
+      const callback = this.callbackFor(this.objectQueryCallbacks, handle, "Godot object query");
+      this.immediateStringResult = null;
+      callback(opcode, handle, value);
+      if (typeof this.immediateStringResult !== "string") {
+        throw new Error("Godot string query callback did not publish a string result");
+      }
+      return this.immediateStringResult;
+    },
+    recordImmediateStringResult(value) {
+      this.immediateStringResult = String(value);
+    },
+    immediateIndexedVector3X(opcode, handle, index) {
+      const callback = this.callbackFor(
+        this.noArgsVector3Callbacks,
+        handle,
+        "Godot indexed Vector3",
+      );
+      this.immediateVector3Result = null;
+      callback(opcode, handle, index);
+      if (
+        this.immediateVector3Result === null ||
+        !Number.isFinite(this.immediateVector3Result.x)
+      ) {
+        throw new Error("Godot indexed Vector3 callback did not publish a finite result");
+      }
+      return this.immediateVector3Result.x;
+    },
+    immediateDisconnectBound(handle, signal, targetHandle, method, boundValue) {
+      const router = this.activeOwnerHandle || targetHandle;
+      const callback = this.callbackFor(this.connectCallbacks, router, "Godot bound disconnect");
+      this.immediateConnectResult = null;
+      // flags slot carries -1 to select the disconnect arm in the shared connect callback.
+      callback(handle, signal, targetHandle, method, -1, boundValue);
+      if (!Number.isInteger(this.immediateConnectResult)) {
+        throw new Error("Godot bound disconnect callback did not publish a result");
+      }
+      return this.immediateConnectResult;
+    },
+    immediateTweenMethod(opcode, tweenHandle, targetHandle, method, fromValue, toValue, duration) {
+      return this.immediateTweenProperty(opcode, tweenHandle, targetHandle, method, [
+        fromValue,
+        toValue,
+        duration,
+      ]);
     },
     immediateSlideCollision(handle, index) {
       const owner = this.ownerForHandle(handle);


### PR DESCRIPTION
The RigidBody3D carrier lands: the godot-4-3d-third-person-controller is fully playable on the Web backend (paired demos PR: kanama-demos#19). This closes the last unclaimed task-60 physics family group.

## What's here

- **Families 152-196** (protocol 12 -> 13, 45 new opcodes, 8 new shapes): RigidBody3D dynamics (`apply_impulse`/`apply_central_impulse`/`apply_force`, freeze/sleeping, gravity scale, rotation + per-axis locks, collision layer/mask bits, pairwise exceptions), `move_and_collide` returning a closeable KinematicCollision3D, `Area3D.get_overlapping_bodies` (packed script-handle list), the full ShapeCast3D surface (count/point/collider-by-index/target RW), NavigationAgent3D pathing, `SceneTree.set_pause`, `Node.set_process`, SpringArm3D/RayCast exclusions (RIDs are derived applier-side and never cross the boundary), AnimationMixer activation + `get_animation` -> `Animation.set_loop_mode`, AnimationPlayer stop/seek/blend-time, `Input.get_action_raw_strength` + float ProjectSettings reads, dynamic `call(method, Vector3, Vector3)`, `Tween.tween_method` over a proxy-bound Callable, **signal disconnect** (`SignalConnection.close`, flags -1 selects the disconnect arm of the shared connect flow), `emit_signal(String)`, `Viewport.get_camera_3d`, `Node3D.is_visible`.
- **Pure-Kotlin Transform3D/Basis/Quaternion** in the web value types (YXZ Euler round-trip, column construction, axis-angle, matrix product, quaternion slerp, scale decomposition). `Node3D.transform`/`basis`/`globalTransform` compose from the mirrored snapshots and decompose back to property writes; the engine only ever sees the existing families.
- **Framework bugs found by the port, root-fixed**: exported `List<String>` properties emitted the object-hydration loop on String elements (broke every proxy parse); registered functions taking a single String had no dispatch arm; the opcode-1000 frame marker faulted when an instantiated node's `_process` flushed under its creator-owner proxy (pooled bullets); `ShapeCast3D.get_collider` needed node-lookup registration semantics rather than the fluent-tween receiver check; state-machine `travel` on a freed playback handle now no-ops (children free before parents; Tween.kill precedent).
- **thirdperson.mjs smoke**: presses through the boot pause via `smoke_resume`, proves movement by reading the player's global position through the immediate Vector3 channel across a fixed 3s move_up hold, and tears down to zero handles. Driver lesson baked into the code: a physics-count predicate exits a held-input window after one sample on fast engines — held input must use fixed wall-time.

## Validation

- thirdperson wrapper-PASS on Chrome (displacement 3.77) AND Firefox (10.6), `liveAfterTeardown=0`, zero callback errors.
- Played headless-Chrome session: boots paused behind the demo page, resumes, the player runs with the beetle-bot pathing after it (NavigationAgent3D) and bee-bots airborne, melee swings, teardown drains 151 handles to zero. Screenshots verified.
- All eight prior demos re-exported at protocol 13; full 18-run matrix (9 demos x Chrome+Firefox) green.
- Drift gates, processor + contract tests, gameplay-coverage gate, ktfmt, desktop jar: green. Safari deliberately skipped (standing instruction).

Known adaptations (documented in the ports): grenade trajectory trail disabled (SurfaceTool not modeled), GrassScatter inert (MeshDataTool/MultiMesh not modeled), Bullet scale-decay Curve unhydrated, debug cameras inert, pause-menu Exit resumes (a page has no app quit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
