### PR TITLE
Task 60g: Starter-Kit-Racing runs on Web — sphere-racer surface, families 197-201

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -2159,4 +2159,59 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val RIGIDBODY3D_GET_ANGULAR_VELOCITY =
+    GodotCallDescriptor(
+      opcode = 197,
+      className = "RigidBody3D",
+      methodName = "get_angular_velocity",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_SET_ANGULAR_VELOCITY =
+    GodotCallDescriptor(
+      opcode = 198,
+      className = "RigidBody3D",
+      methodName = "set_angular_velocity",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_GET_VOLUME_DB =
+    GodotCallDescriptor(
+      opcode = 199,
+      className = "AudioStreamPlayer3D",
+      methodName = "get_volume_db",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_SET_VOLUME_DB =
+    GodotCallDescriptor(
+      opcode = 200,
+      className = "AudioStreamPlayer3D",
+      methodName = "set_volume_db",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val AUDIOSTREAMPLAYER3D_GET_PITCH_SCALE =
+    GodotCallDescriptor(
+      opcode = 201,
+      className = "AudioStreamPlayer3D",
+      methodName = "get_pitch_scale",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -752,11 +752,25 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine("      ${scriptIndex + 1} -> when (propertyId) {")
       input.model.properties.forEachIndexed { propertyIndex, property ->
         val wrapper = property.objectWrapperFqName
+        val customScript = property.customScriptFqName
         if (property.type == TypeMapping.OBJECT && property.isMutable && wrapper != null) {
           val wrapped =
             if (property.nullable) "handle?.let { $wrapper(it) }"
             else
               "$wrapper(checkNotNull(handle) { \"Property ${property.godotName} is not nullable\" })"
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = $wrapped"
+          )
+        } else if (
+          property.type == TypeMapping.OBJECT && property.isMutable && customScript != null
+        ) {
+          // Custom-script node exports resolve to the hydrated Kotlin instance.
+          val resolved =
+            "handle?.let { net.multigesture.kanama.web.webScriptInstance(it.value) as? $customScript }"
+          val wrapped =
+            if (property.nullable) resolved
+            else
+              "checkNotNull($resolved) { \"Property ${property.godotName} is not a hydrated $customScript\" }"
           appendLine(
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = $wrapped"
           )
@@ -1391,6 +1405,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\telif opcode == 158 and target_object is AudioStreamPlayer3D:")
     appendLine(
       "\t\t\t(target_object as AudioStreamPlayer3D).pitch_scale = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 200 and target_object is AudioStreamPlayer3D:")
+    appendLine(
+      "\t\t\t(target_object as AudioStreamPlayer3D).volume_db = bytes.decode_double(offset + 8)"
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
@@ -2436,6 +2456,16 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine(
       "\t\t\tresult = value.emit_signal(StringName(emit_string_parts[0]), emit_string_parts[1])"
     )
+    appendLine("\t\telif opcode == 198 and value is RigidBody3D:")
+    appendLine("\t\t\tvar angular_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as RigidBody3D).angular_velocity = Vector3(angular_parts[0], angular_parts[1], angular_parts[2])"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 199 and value is AudioStreamPlayer3D:")
+    appendLine("\t\t\tresult = int(round((value as AudioStreamPlayer3D).volume_db * 1000.0))")
+    appendLine("\t\telif opcode == 201 and value is AudioStreamPlayer3D:")
+    appendLine("\t\t\tresult = int(round((value as AudioStreamPlayer3D).pitch_scale * 1000.0))")
     appendLine("\t\telif opcode == 190:")
     appendLine("\t\t\tresult = int(OS.shell_open(String(args[2])))")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
@@ -2480,6 +2510,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as ShapeCast3D).target_position")
     appendLine("\telif opcode == 178 and value is NavigationAgent3D:")
     appendLine("\t\tresult = (value as NavigationAgent3D).get_next_path_position()")
+    appendLine("\telif opcode == 197 and value is RigidBody3D:")
+    appendLine("\t\tresult = (value as RigidBody3D).angular_velocity")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -239,6 +239,11 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     194: {"ret": "node"},
     195: {},
     196: {},
+    197: {},
+    198: {},
+    199: {},
+    200: {},
+    201: {},
 }
 
 
@@ -1161,11 +1166,12 @@ _DOUBLE_SNAPSHOT_HOOK = {"lifetime": "webLifetimeSnapshot", "rotation": "webRota
 
 
 def body_NOARGS_RET_DOUBLE(calls):
-    lines = [
-        f"require(descriptor.executionMode == {_SNAPSHOT})",
-        "return when (descriptor.opcode) {",
-    ]
-    for c in calls:
+    snapshot = [c for c in calls if c.execution_mode.value == "SNAPSHOT_READ"]
+    immediate = [c for c in calls if c.execution_mode.value == "IMMEDIATE_RESULT"]
+    lines = ["return when (descriptor.executionMode) {"]
+    lines.append(f"{_SNAPSHOT} ->")
+    lines.append("when (descriptor.opcode) {")
+    for c in snapshot:
         hook = _DOUBLE_SNAPSHOT_HOOK[WEB_POLICY[c.opcode]["double_snapshot"]]
         lines.append(f"{c.opcode} -> {hook}(receiver.webId())")
     lines += [
@@ -1175,6 +1181,20 @@ def body_NOARGS_RET_DOUBLE(calls):
         '"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +',
         '"object handle=${receiver.webId()}"',
         ")",
+    ]
+    if immediate:
+        lines += [
+            f"{_IMMEDIATE} -> {{",
+            f"require({_opcode_guard(immediate)})",
+            "commands.flush()",
+            "// Scaled by 1000 through the shared integer object-query transport.",
+            'immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") / 1000.0',
+            "}",
+        ]
+    lines += [
+        f"{_QUEUED} ->",
+        'error("Double return cannot use queued execution for opcode=${descriptor.opcode}")',
+        "}",
     ]
     return lines
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -3078,6 +3078,80 @@
       "descriptorName": "OBJECT_EMIT_SIGNAL_STRING",
       "semantics": "Emit a signal carrying one String argument (weapon_switched -> WeaponUi).",
       "introducedBy": "60f-third-person"
+    },
+    {
+      "opcode": 197,
+      "className": "RigidBody3D",
+      "methodName": "get_angular_velocity",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "semantics": "Fresh angular velocity of a physics-driven body (sphere-racer drive train).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "executionMode": "IMMEDIATE_RESULT",
+      "introducedBy": "60g-racing"
+    },
+    {
+      "opcode": 198,
+      "className": "RigidBody3D",
+      "methodName": "set_angular_velocity",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "shape": "VECTOR3_ARG",
+      "semantics": "Write the sphere's angular velocity (packed three-float immediate).",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "executionMode": "IMMEDIATE_RESULT",
+      "introducedBy": "60g-racing"
+    },
+    {
+      "opcode": 199,
+      "className": "AudioStreamPlayer3D",
+      "methodName": "get_volume_db",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_DOUBLE",
+      "semantics": "Current positional volume (engine-lerped audio effects read-modify-write).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "executionMode": "IMMEDIATE_RESULT",
+      "introducedBy": "60g-racing"
+    },
+    {
+      "opcode": 200,
+      "className": "AudioStreamPlayer3D",
+      "methodName": "set_volume_db",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Queue a positional volume write.",
+      "scope": "class",
+      "returnType": "void",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60g-racing"
+    },
+    {
+      "opcode": 201,
+      "className": "AudioStreamPlayer3D",
+      "methodName": "get_pitch_scale",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_DOUBLE",
+      "semantics": "Current pitch scale (engine-lerped audio effects read-modify-write).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "executionMode": "IMMEDIATE_RESULT",
+      "introducedBy": "60g-racing"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -31,9 +31,10 @@ import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
+import { runRacing } from "./demos/racing.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -1,0 +1,260 @@
+// demos/racing.mjs -- third-person controller play + teardown assertions for the
+// Web smoke.
+//
+// The demo boots PAUSED behind its instructions page: the driver first dispatches
+// SmokeQuit.smoke_resume (method#1) to press through, then holds move_up via the trusted
+// per-engine key transport and PROVES movement by reading the player's global position
+// through the bridge's immediate Vector3 channel (opcode 138). Enemy AI is self-evidencing
+// while the world runs (beetle-bot navigation, bee-bot bobbing). smoke_teardown (method#2)
+// releases the scene caches and frees the root, draining every live handle to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[racing ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        playerHandle: bridge.racingViewHandle,
+        smokeQuitHandle: bridge.racingSmokeHandle,
+        vehicleHandle: bridge.racingVehicleHandle,
+        readyCount: bridge.readyCount,
+        vehicleReady: classCount(".Vehicle"),
+        viewReady: classCount(".View"),
+        smokeReady: classCount(".Smoke"),
+        physicsCalls: bridge.physicsProcessCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        physicsAfterProcess: bridge.physicsAfterProcessSameTick ?? 0,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+// The player's world position through the immediate no-args Vector3 channel
+// (opcode 138 = Node3D.get_global_position on the player's script handle).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.racingViewHandle;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(`physics=${snap.physicsCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} errs=${snap.callbackErrors}`);
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runRacing({ url, evaluate, navigate, deadline }) {
+  // Engine-level action injection (ops 86/87) instead of browser key events: the first
+  // browser input gesture stalls the headless-Firefox main thread for the whole hold
+  // (audio-context resume), freezing physics under it.
+  const keyDown = () =>
+    evaluate(
+      'globalThis.KanamaWebBridge.immediateObjectQuery(86, globalThis.KanamaWebBridge.racingSmokeHandle, "forward"); true',
+    );
+  const keyUp = () =>
+    evaluate(
+      'globalThis.KanamaWebBridge.immediateObjectQuery(87, globalThis.KanamaWebBridge.racingSmokeHandle, "forward"); true',
+    );
+
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?racing=${Date.now()}`);
+
+  // Generous first-load window for the track import.
+  const readyDeadline = Math.min(deadline, Date.now() + 120_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "racing" &&
+      snap.protocol > 0 &&
+      snap.vehicleReady >= 1 &&
+      snap.viewReady >= 1 &&
+      snap.smokeReady >= 1 &&
+      snap.playerHandle > 0 &&
+      snap.smokeQuitHandle > 0
+    ) {
+      ready = snap;
+      break;
+    }
+    await delay(250);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm third-person controller did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`ready: readyCount=${ready.readyCount} playerHandle=${ready.playerHandle} protocol=${ready.protocol}`);
+
+  // Racing has no pause page: let physics settle before the movement baseline.
+  const resumed = await observe(
+    evaluate,
+    { ...seedFrom(ready), callbackErrors: 0 },
+    3_000,
+    deadline,
+    (snap) => snap.physicsCalls >= ready.physicsCalls + 30,
+  );
+  const baseline = resumed.last ?? ready;
+  const startPosition = await playerPosition(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
+
+  // Hold move_up for a FIXED wall-time (no early exit: the tick rate races past any
+  // physics-count predicate before the first observe sample, cutting the hold short —
+  // played sessions with a fixed 3s hold consistently cover ~8 units).
+  // Warm-up drive: the FIRST drive compiles the drift-trail particle shaders, which
+  // freezes the software-GL main thread for several seconds on Firefox. Press briefly,
+  // then wait for physics to flow again before taking the measured baseline.
+  await keyDown();
+  await observe(evaluate, { ...seedFrom(baseline), callbackErrors: 0 }, 2_000, deadline, null);
+  await keyUp();
+  const warm = await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    12_000,
+    deadline,
+    (snap, p) => snap.physicsCalls >= p.physicsCalls && snap.physicsCalls > baseline.physicsCalls + 120,
+  );
+  const measured = warm.last ?? baseline;
+  const measuredStart = await playerPosition(evaluate);
+
+  await keyDown();
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(measured), callbackErrors: 0 },
+    3_000,
+    deadline,
+    null,
+  );
+  await keyUp();
+  const runPosition = await playerPosition(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? baseline;
+  const measureFrom = measuredStart ?? startPosition;
+  const displacement = runPosition
+    ? Math.hypot(runPosition.x - measureFrom.x, runPosition.z - measureFrom.z)
+    : 0;
+  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
+
+  // Full teardown: smoke_teardown (method#1) frees the root; every node exits the tree
+  // and releases its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.racingSmokeHandle, 1); true",
+  );
+  const teardown = await observe(evaluate, peak, 12_000, deadline, (snap) => snap.liveHandles === 0);
+  const settled = teardown.last ?? atPeak;
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} errs=${settled.callbackErrors}`);
+
+  const protocolVersion = ready.protocol;
+  const checks = {
+    modeRacing: ready.mode === "racing",
+    protocol13: protocolVersion === 13,
+    sceneScriptsReady:
+      ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
+    // Held forward drove the sphere racer; the camera rig followed it.
+    playerMovedOnInput: displacement > 1.0,
+    physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
+    crossingsAdvanced: peak.crossings > baseline.crossings,
+    fullTeardownToZero: settled.liveHandles === 0,
+    physicsOrderingDeterministic: (settled.physicsAfterProcess ?? 0) === 0,
+    noCallbackFaults:
+      peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready.mode === "racing",
+      outcome: ready.mode === "racing" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      physicsProcessCalls: peak.physicsCalls,
+      appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(displacement.toFixed(3)),
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+    },
+    boundaryErrors,
+  };
+}
+
+function seedFrom(snap) {
+  return {
+    physicsCalls: snap.physicsCalls,
+    appliedCommands: snap.appliedCommands,
+    maxLiveHandles: snap.liveHandles,
+    crossings: snap.crossings,
+  };
+}

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -24,9 +24,10 @@ import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
+import { runRacing } from "./demos/racing.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -23,9 +23,10 @@ import { runSquash } from "./demos/squash.mjs";
 import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
+import { runRacing } from "./demos/racing.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -29,6 +29,7 @@ val extraWebScriptSourceRoot: File? =
                     "fps" -> "kanamaWebFpsProjectDir"
                     "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
                     "thirdperson" -> "kanamaWebThirdpersonProjectDir"
+                    "racing" -> "kanamaWebRacingProjectDir"
                     else -> null
                 }
             projectDirProperty
@@ -136,6 +137,9 @@ val webCharacterStaging = layout.buildDirectory.dir("web-charactercontroller/god
 val webThirdpersonSourceProject =
     providers.gradleProperty("kanamaWebThirdpersonProjectDir").orNull?.let(rootProject::file)
 val webThirdpersonStaging = layout.buildDirectory.dir("web-thirdperson/godot-project")
+val webRacingSourceProject =
+    providers.gradleProperty("kanamaWebRacingProjectDir").orNull?.let(rootProject::file)
+val webRacingStaging = layout.buildDirectory.dir("web-racing/godot-project")
 val webMatch3ImportLog = layout.buildDirectory.file("reports/web-match3-import.log")
 val webMatch3ImportOutput = ByteArrayOutputStream()
 val webGameplayCoverage = layout.buildDirectory.file("reports/web-gameplay-coverage.json")
@@ -1776,6 +1780,142 @@ tasks.register("stageWebCharactercontrollerProject") {
     }
 }
 
+tasks.register("stageWebRacingProject") {
+    group = "verification"
+    description = "Stages Starter-Kit-Racing with generated Web proxies (Task 60g)."
+    dependsOn("kspKotlinWasmJs", "generateWebGameplayCoverage")
+    webRacingSourceProject?.let(inputs::dir)
+    inputs.dir(webSpikeAssets)
+    inputs.dir(webProxyResources)
+    inputs.file(webGameplayCoverage)
+    outputs.dir(webRacingStaging)
+
+    doLast {
+        val sourceProject =
+            webRacingSourceProject
+                ?: error(
+                    "Pass -PkanamaWebRacingProjectDir=/absolute/path/to/kanama-demos/Starter-Kit-Racing"
+                )
+        check(sourceProject.resolve("scenes/main.tscn").isFile) {
+            "Racing project not found: $sourceProject"
+        }
+
+        val stagingDir = webRacingStaging.get().asFile
+        delete(stagingDir)
+        copy {
+            from(sourceProject) {
+                exclude(".git/**")
+                exclude(".godot/**")
+                exclude(".gradle/**")
+                exclude(".kotlin/**")
+                exclude("build/**")
+                exclude("web/**")
+                exclude("kotlin-src/**")
+                exclude("android/**")
+                exclude("addons/kanama_tools/**")
+                exclude("addons/kanama/**")
+                exclude("export_presets.cfg")
+            }
+            into(stagingDir)
+        }
+        copy {
+            from(webSpikeSourceProject.file("export_presets.cfg"))
+            into(stagingDir)
+        }
+        copy {
+            from(webProxyResources)
+            include("*.gd")
+            into(stagingDir.resolve("kanama-web/generated"))
+        }
+        copy {
+            from(webProxyResources)
+            include("KanamaWebProxyManifest.generated.tsv")
+            include("KanamaWebProtocol.generated.json")
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webSpikeAssets)
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webGameplayCoverage)
+            into(stagingDir.resolve("kanama-web"))
+        }
+
+        val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
+        val expectedSources =
+            setOf("Smoke", "Vehicle", "VehicleMotorcycle", "View")
+                .map { "res://kotlin-src/$it.kt" }
+                .toSet()
+        val mappings =
+            manifest
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") }
+                .map { it.split('\t').let { c -> c[0] to c[1] } }
+                .filter { (sourcePath, _) -> sourcePath in expectedSources }
+                .toMap()
+        check(mappings.keys == expectedSources) {
+            "Racing Web proxy mappings incomplete: missing=${expectedSources - mappings.keys}"
+        }
+
+        fileTree(stagingDir) {
+                include("project.godot")
+                include("**/*.tscn")
+                include("**/*.tres")
+            }
+            .files
+            .forEach { stagedFile ->
+                val original = stagedFile.readText()
+                var rewritten =
+                    mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
+                        text.replace(sourcePath, proxyPath)
+                    }
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
+                if (rewritten != original) stagedFile.writeText(rewritten)
+                check(!rewritten.contains("res://kotlin-src/")) {
+                    "Unmapped Kotlin attachment remains in staged file: $stagedFile"
+                }
+            }
+
+        // Forward+ project with a gl_compatibility mobile override: pin Compatibility.
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val forwardFeature = "config/features=PackedStringArray(\"4.7\", \"Forward Plus\")"
+        val mobileRenderer = "renderer/rendering_method.mobile=\"gl_compatibility\""
+        check(stagedProjectText.contains(forwardFeature)) {
+            "Racing renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(mobileRenderer)) {
+            "Racing mobile renderer setting changed; update the staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    forwardFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    mobileRenderer,
+                    "renderer/rendering_method=\"gl_compatibility\"\n$mobileRenderer",
+                )
+        )
+
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        shell.writeText(
+            shell.readText()
+                .replace(pageStart, "$pageStart\n      globalThis.KanamaWebMode = \"racing\";")
+        )
+    }
+}
+
 tasks.register("stageWebThirdpersonProject") {
     group = "verification"
     description = "Stages the third-person controller with generated Web proxies (Task 60f)."
@@ -2044,9 +2184,10 @@ fun stageTaskFor(demo: String): String =
         "fps" -> "stageWebFpsProject"
         "charactercontroller" -> "stageWebCharactercontrollerProject"
         "thirdperson" -> "stageWebThirdpersonProject"
+        "racing" -> "stageWebRacingProject"
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing)"
             )
     }
 
@@ -2061,9 +2202,10 @@ fun stagingDirFor(demo: String): File =
         "fps" -> webFpsStaging.get().asFile
         "charactercontroller" -> webCharacterStaging.get().asFile
         "thirdperson" -> webThirdpersonStaging.get().asFile
+        "racing" -> webRacingStaging.get().asFile
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing)"
             )
     }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -103,6 +103,26 @@ class AudioStreamPlayer3D(godotObject: GodotHandle) : Node3D(godotObject) {
       backendHandle,
     )
 
+  fun getVolumeDb(): Double =
+    GodotBackendCalls.invokeNoArgsRetDouble(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_GET_VOLUME_DB,
+      backendHandle,
+    )
+
+  fun setVolumeDb(volumeDb: Double) {
+    GodotBackendCalls.invokeDoubleArg(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_SET_VOLUME_DB,
+      backendHandle,
+      volumeDb,
+    )
+  }
+
+  fun getPitchScale(): Double =
+    GodotBackendCalls.invokeNoArgsRetDouble(
+      InitialGodotCallDescriptors.AUDIOSTREAMPLAYER3D_GET_PITCH_SCALE,
+      backendHandle,
+    )
+
   object Signals {
     const val finished: String = "finished"
   }
@@ -178,6 +198,22 @@ open class RigidBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
   fun show() {
     visible = true
   }
+
+  /** Fresh engine-side angular velocity (the sphere racer's drive train). */
+  var angularVelocity: Vector3
+    get() =
+      GodotBackendCalls.invokeNoArgsRetVector3(
+          InitialGodotCallDescriptors.RIGIDBODY3D_GET_ANGULAR_VELOCITY,
+          backendHandle,
+        )
+        .let { Vector3(it.x, it.y, it.z) }
+    set(value) {
+      GodotBackendCalls.invokeVector3Arg(
+        InitialGodotCallDescriptors.RIGIDBODY3D_SET_ANGULAR_VELOCITY,
+        backendHandle,
+        GodotVector3(value.x.toFloat(), value.y.toFloat(), value.z.toFloat()),
+      )
+    }
 }
 
 /** Enable or disable the node's physics processing (the tutorial pauses the player on win). */

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -333,6 +333,12 @@ object GD {
 
   fun lerpf(from: Double, to: Double, weight: Double): Double = Mathf.lerp(from, to, weight)
 
+  fun signf(value: Double): Double = if (value > 0.0) 1.0 else if (value < 0.0) -1.0 else 0.0
+
+  /** Godot's remap: linear map of [value] from [istart, istop] onto [ostart, ostop]. */
+  fun remap(value: Double, istart: Double, istop: Double, ostart: Double, ostop: Double): Double =
+    ostart + (ostop - ostart) * ((value - istart) / (istop - istart))
+
   fun clampf(value: Double, min: Double, max: Double): Double = Mathf.clamp(value, min, max)
 
   fun lerpAngle(from: Double, to: Double, weight: Double): Double =

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
@@ -235,6 +235,9 @@ object ProjectSettings {
     )
 }
 
+/** Web adaptation: the corpus runs the default 60 Hz fixed physics tick. */
+fun Node.getPhysicsProcessDeltaTime(): Double = 1.0 / 60.0
+
 object Time {
   private val origin = kotlin.time.TimeSource.Monotonic.markNow()
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -270,6 +270,30 @@ class Basis internal constructor(internal val m: DoubleArray) {
 
   fun getColumn(index: Int): Vector3 = Vector3(m[index], m[3 + index], m[6 + index])
 
+  /** Godot's basis.x/y/z axis properties (matrix COLUMNS). */
+  val x: Vector3
+    get() = getColumn(0)
+
+  val y: Vector3
+    get() = getColumn(1)
+
+  val z: Vector3
+    get() = getColumn(2)
+
+  fun withX(axis: Vector3): Basis = withColumn(0, axis)
+
+  fun withY(axis: Vector3): Basis = withColumn(1, axis)
+
+  fun withZ(axis: Vector3): Basis = withColumn(2, axis)
+
+  private fun withColumn(index: Int, axis: Vector3): Basis {
+    val out = m.copyOf()
+    out[index] = axis.x
+    out[3 + index] = axis.y
+    out[6 + index] = axis.z
+    return Basis(out)
+  }
+
   /** Column lengths signed by the determinant (Godot's get_scale). */
   fun getScale(): Vector3 {
     val detSign = if (determinant() < 0.0) -1.0 else 1.0
@@ -408,6 +432,8 @@ data class Transform3D(val basis: Basis, val origin: Vector3) {
   fun withBasis(newBasis: Basis): Transform3D = Transform3D(newBasis, origin)
 
   fun withOrigin(newOrigin: Vector3): Transform3D = Transform3D(basis, newOrigin)
+
+  fun orthonormalized(): Transform3D = Transform3D(basis.orthonormalized(), origin)
 
   /** Keeps the origin; orients -Z at [target] (Godot's looking_at). */
   fun lookingAt(target: Vector3, up: Vector3 = Vector3.UP): Transform3D =

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -96,7 +96,9 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     }
     when (descriptor.executionMode) {
       GodotExecutionMode.QUEUED_MUTATION -> {
-        require(descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183))
+        require(
+          descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183, 200)
+        )
         commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
@@ -789,16 +791,26 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     receiver: GodotHandle,
   ): Double {
     requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    return when (descriptor.opcode) {
-      45 -> webLifetimeSnapshot(receiver.webId())
-      70 -> webRotationSnapshot(receiver.webId())
-      else -> null
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.SNAPSHOT_READ ->
+        when (descriptor.opcode) {
+          45 -> webLifetimeSnapshot(receiver.webId())
+          70 -> webRotationSnapshot(receiver.webId())
+          else -> null
+        }
+          ?: error(
+            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+              "object handle=${receiver.webId()}"
+          )
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(199, 201))
+        commands.flush()
+        // Scaled by 1000 through the shared integer object-query transport.
+        immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") / 1000.0
+      }
+      GodotExecutionMode.QUEUED_MUTATION ->
+        error("Double return cannot use queued execution for opcode=${descriptor.opcode}")
     }
-      ?: error(
-        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-          "object handle=${receiver.webId()}"
-      )
   }
 
   override fun invokeNoArgsRetLong(
@@ -946,7 +958,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178))
+        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178, 197))
         commands.flush()
         GodotVector3(
           immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
@@ -981,7 +993,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         }
       }
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(142, 143, 160, 175, 177))
+        require(descriptor.opcode in setOf(142, 143, 160, 175, 177, 198))
         commands.flush()
         // Three Float32 components packed into one query string (unit separator); the
         // applier writes the global transform and re-pushes the node's snapshot.

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -80,6 +80,7 @@
       opcode === 180 ||
       opcode === 182 ||
       opcode === 183 ||
+      opcode === 200 ||
       opcode === 1000
     ) return 4;
     if (
@@ -260,6 +261,9 @@
     tpSmokeQuitHandle: 0,
     tpPlayerHandle: 0,
     tpDemoPageHandle: 0,
+    racingSmokeHandle: 0,
+    racingVehicleHandle: 0,
+    racingViewHandle: 0,
     // _physics_process/_process ordering evidence (Task 60d): Godot's iteration runs all
     // physics ticks BEFORE the idle/_process pass inside one requestAnimationFrame callback,
     // so a physics dispatch AFTER a process dispatch within the same rAF tick would be an
@@ -2040,6 +2044,19 @@
       }
       if (this.mode === "thirdperson" && scriptName.endsWith(".DemoPage")) {
         this.tpDemoPageHandle = handle;
+      }
+      if (this.mode === "racing" && scriptName.endsWith(".Smoke")) {
+        // smoke_teardown (method#1) frees the scene root for the teardown assertion.
+        this.racingSmokeHandle = handle;
+      }
+      if (this.mode === "racing" && scriptName.endsWith(".Vehicle")) {
+        // The player vehicle uses the base class (trucks/motorcycle variants subclass it).
+        this.racingVehicleHandle = handle;
+      }
+      if (this.mode === "racing" && scriptName.endsWith(".View")) {
+        // The camera rig lerps toward the vehicle every tick: its root position is the
+        // driver's movement evidence (the Vehicle ROOT node intentionally never moves).
+        this.racingViewHandle = handle;
       }
       if (this.mode === "match3") {
         this.match3ScriptNamesByHandle.set(handle, scriptName);


### PR DESCRIPTION
Racing lands with a small slice: the demo is a sphere-based arcade racer (no VehicleBody3D anywhere — the corpus's last assumed physics-family gap evaporated). Paired demos PR: kanama-demos#20.

## What's here

- **Families 197-201**: `RigidBody3D.angular_velocity` read/write (fresh immediates — the sphere drive train), AudioStreamPlayer3D `get_volume_db`/`get_pitch_scale` (the NOARGS_RET_DOUBLE shape gained an immediate x1000 arm) and `set_volume_db` (engine-audio read-modify-write lerps).
- **Registry fix**: single custom-script OBJECT exports (`View.target: Vehicle?`) resolve to the hydrated Kotlin instance — the setter arm only existed for wrapper types and script arrays.
- Value types: Basis column accessors (`x`/`y`/`z` + `withX/withY/withZ`), `Transform3D.orthonormalized`; `GD.signf`/`remap`; `Node.getPhysicsProcessDeltaTime` web adaptation (fixed 60 Hz tick).
- **racing.mjs smoke** with two harness lessons baked in:
  - Input injects at ENGINE level through the `action_press`/`action_release` object-query ops — no browser input gesture, no per-engine key transport, and the page cannot stall under it.
  - The FIRST drive compiles the drift-trail particle shaders, freezing the software-GL main thread for several seconds (headless Firefox showed 4 physics ticks across a 4.5 s hold); the driver warms up one press, waits for physics to flow again, then takes the measured hold. Movement evidence is the camera rig's position — the Vehicle ROOT node never moves by design.

## Validation

- racing wrapper-PASS on Chrome (12.2 units) AND Firefox (15.4 units), `liveAfterTeardown=0`, zero callback faults.
- Played headless-Chrome session: the car drives the track from the starting grid with the camera following; screenshots verified.
- thirdperson + charactercontroller Chrome spot-regressions PASS; drift gates, processor + contract tests, coverage gate, ktfmt, desktop jar green. Safari deliberately skipped (standing instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
