### PR TITLE
iOS mirror: PropertyInfo.class_name on object-typed exports (task 64 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ versioning once public releases begin.
 
 ### Fixed
 
+- iOS now mirrors the object-typed export `class_name` fix (task 64 follow-up):
+  the script property descriptor bridge gained a
+  `kanama_ios_runtime_script_resource_property_class_name` entry (same
+  RESOURCE_TYPE/NODE_TYPE policy as desktop) and the shim caches per-property
+  StringNames and emits them in the instance property list, so GDScript on an
+  iOS export sees e.g. `class_name=AudioStream` instead of empty. Validated on
+  an iPhone 15 Pro via the user-script visual smoke, which now asserts the
+  engine-visible `class_name` from GDScript (reported through a Kotlin
+  `@RegisterFunction`, since Godot-level `print()` does not reach the device
+  console) and doubles as a GDScript→Kotlin String/bool call-dispatch check.
 - Object-typed Kotlin exports now carry `PropertyInfo.class_name` (task 64,
   follow-up to issue #106): a `@ScriptProperty var x: SmokeResource?` (or an
   engine wrapper slot like `AudioStream?`) previously reported an empty

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/ios/KanamaIosRuntime.kt
@@ -252,6 +252,27 @@ internal object KanamaIosRuntime {
   fun scriptResourcePropertyUsage(handle: Long, propertyIndex: Int): Int =
     scriptResources[handle]?.descriptor?.properties?.getOrNull(propertyIndex)?.usage ?: 6
 
+  // task 64 iOS mirror — PropertyInfo.class_name for object-typed exports.
+  // Same policy as the desktop generator (KanamaProcessor.scriptPropertyClassName):
+  // for OBJECT-typed properties with RESOURCE_TYPE(17)/NODE_TYPE(34) hints the
+  // hint string is exactly the class name. GDScript's analyzer types member
+  // accesses from class_name; empty degrades them to plain Object/Resource.
+  fun scriptResourcePropertyClassName(handle: Long, propertyIndex: Int): String {
+    val property =
+      scriptResources[handle]?.descriptor?.properties?.getOrNull(propertyIndex) ?: return ""
+    val objectVariantType = 24
+    val resourceTypeHint = 17
+    val nodeTypeHint = 34
+    return if (
+      property.variantType == objectVariantType &&
+        (property.hint == resourceTypeHint || property.hint == nodeTypeHint)
+    ) {
+      property.hintString
+    } else {
+      ""
+    }
+  }
+
   fun scriptResourceSignalCount(handle: Long): Int =
     scriptResources[handle]?.descriptor?.signals?.size ?: 0
 
@@ -701,6 +722,21 @@ fun kanamaIosRuntimeScriptResourcePropertyHintString(
 @CName("kanama_ios_runtime_script_resource_property_usage")
 fun kanamaIosRuntimeScriptResourcePropertyUsage(scriptHandle: Long, propertyIndex: Int): Int =
   KanamaIosRuntime.scriptResourcePropertyUsage(scriptHandle, propertyIndex)
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
+@CName("kanama_ios_runtime_script_resource_property_class_name")
+fun kanamaIosRuntimeScriptResourcePropertyClassName(
+  scriptHandle: Long,
+  propertyIndex: Int,
+  buffer: CPointer<ByteVar>?,
+  bufferSize: Int,
+) {
+  writeCString(
+    KanamaIosRuntime.scriptResourcePropertyClassName(scriptHandle, propertyIndex),
+    buffer,
+    bufferSize,
+  )
+}
 
 @OptIn(ExperimentalNativeApi::class)
 @CName("kanama_ios_runtime_script_resource_signal_count")

--- a/ios/bootstrap/kanama_ios_shim.c
+++ b/ios/bootstrap/kanama_ios_shim.c
@@ -62,6 +62,15 @@ extern int32_t kanama_ios_runtime_script_resource_property_usage(
     int64_t script_handle,
     int32_t property_index
 );
+/* task 64 iOS mirror — PropertyInfo.class_name for object-typed exports (empty
+ * for everything else). GDScript types member accesses from class_name; the
+ * Kotlin side applies the same RESOURCE_TYPE/NODE_TYPE policy as desktop. */
+extern void kanama_ios_runtime_script_resource_property_class_name(
+    int64_t script_handle,
+    int32_t property_index,
+    char *buffer,
+    int32_t buffer_size
+);
 extern int32_t kanama_ios_runtime_script_resource_signal_count(int64_t script_handle);
 extern void kanama_ios_runtime_script_resource_signal_name(
     int64_t script_handle,
@@ -228,6 +237,7 @@ typedef struct {
     int32_t *script_property_types;
     int32_t *script_property_hints;
     uint64_t *script_property_hint_strings;
+    uint64_t *script_property_class_names; /* StringName storage; task 64 iOS mirror */
     int32_t *script_property_usages;
     int32_t script_property_count;
     uint64_t *script_signal_names;
@@ -1316,20 +1326,24 @@ static void kanama_ios_script_resource_init_metadata(KanamaIosExtensionInstance 
         instance->script_property_types = calloc((size_t)property_count, sizeof(int32_t));
         instance->script_property_hints = calloc((size_t)property_count, sizeof(int32_t));
         instance->script_property_hint_strings = calloc((size_t)property_count, sizeof(uint64_t));
+        instance->script_property_class_names = calloc((size_t)property_count, sizeof(uint64_t));
         instance->script_property_usages = calloc((size_t)property_count, sizeof(int32_t));
         if (instance->script_property_names == NULL || instance->script_property_types == NULL ||
             instance->script_property_hints == NULL ||
             instance->script_property_hint_strings == NULL ||
+            instance->script_property_class_names == NULL ||
             instance->script_property_usages == NULL) {
             free(instance->script_property_names);
             free(instance->script_property_types);
             free(instance->script_property_hints);
             free(instance->script_property_hint_strings);
+            free(instance->script_property_class_names);
             free(instance->script_property_usages);
             instance->script_property_names = NULL;
             instance->script_property_types = NULL;
             instance->script_property_hints = NULL;
             instance->script_property_hint_strings = NULL;
+            instance->script_property_class_names = NULL;
             instance->script_property_usages = NULL;
             return;
         }
@@ -1358,6 +1372,20 @@ static void kanama_ios_script_resource_init_metadata(KanamaIosExtensionInstance 
             instance->script_property_usages[i] = kanama_ios_runtime_script_resource_property_usage(
                 instance->script_handle, i);
             kanama_ios_init_string(&instance->script_property_hint_strings[i], property_hint_string);
+            /* task 64 iOS mirror — non-empty only for object-typed exports
+             * (RESOURCE_TYPE/NODE_TYPE hints); StringName, unlike hint_string. */
+            char property_class_name[512];
+            property_class_name[0] = '\0';
+            kanama_ios_runtime_script_resource_property_class_name(
+                instance->script_handle,
+                i,
+                property_class_name,
+                (int32_t)sizeof(property_class_name)
+            );
+            if (property_class_name[0] != '\0') {
+                kanama_ios_init_string_name(
+                    &instance->script_property_class_names[i], property_class_name);
+            }
             if (property_name[0] == '\0') {
                 continue;
             }
@@ -1456,6 +1484,12 @@ static void kanama_ios_script_resource_clear_metadata(KanamaIosExtensionInstance
         }
         free(instance->script_property_hint_strings);
     }
+    if (instance->script_property_class_names != NULL) {
+        for (int32_t i = 0; i < instance->script_property_count; i++) {
+            kanama_ios_destroy_string_name(&instance->script_property_class_names[i]);
+        }
+        free(instance->script_property_class_names);
+    }
     free(instance->script_property_usages);
     if (instance->script_signal_names != NULL) {
         for (int32_t i = 0; i < instance->script_signal_count; i++) {
@@ -1483,6 +1517,7 @@ static void kanama_ios_script_resource_clear_metadata(KanamaIosExtensionInstance
     instance->script_property_types = NULL;
     instance->script_property_hints = NULL;
     instance->script_property_hint_strings = NULL;
+    instance->script_property_class_names = NULL;
     instance->script_property_usages = NULL;
     instance->script_property_count = 0;
     instance->script_signal_names = NULL;
@@ -7034,7 +7069,12 @@ static const GDExtensionPropertyInfo *kanama_ios_script_instance_get_property_li
     for (int32_t i = 0; i < n; i++) {
         list[i].type = (GDExtensionVariantType)instance->script->script_property_types[i];
         list[i].name = (GDExtensionStringNamePtr)&instance->script->script_property_names[i];
-        list[i].class_name = (GDExtensionStringNamePtr)&g_kanama_ios_empty_string_storage;
+        /* task 64 iOS mirror — real class_name for object-typed exports so typed
+         * GDScript resolves them as their class; zeroed slot = keep empty fallback. */
+        list[i].class_name = (instance->script->script_property_class_names != NULL
+                && instance->script->script_property_class_names[i] != 0)
+            ? (GDExtensionStringNamePtr)&instance->script->script_property_class_names[i]
+            : (GDExtensionStringNamePtr)&g_kanama_ios_empty_string_storage;
         list[i].hint = instance->script->script_property_hints != NULL
             ? (uint32_t)instance->script->script_property_hints[i]
             : 0;

--- a/scripts/ios_visual_smoke.sh
+++ b/scripts/ios_visual_smoke.sh
@@ -569,7 +569,7 @@ elif [[ "$kanama_script_probe" -eq 1 ]]; then
 EOF
 elif [[ "$kanama_user_script_probe" -eq 1 ]]; then
   status_text="Waiting for Kanama iOS project script"
-  scene_header='[gd_scene load_steps=4 format=3]'
+  scene_header='[gd_scene load_steps=5 format=3]'
   script_resource_line='[ext_resource type="Script" path="res://kotlin-src/IosSmokeScript.kt" id="1_probe"]'
   status_script_line='script = ExtResource("1_probe")'
   # @ScriptProperty end-to-end checks: the scene stores a NodePath plus task-39 narrow-scalar,
@@ -588,9 +588,11 @@ import net.multigesture.kanama.annotations.OnShortcutInput
 import net.multigesture.kanama.annotations.OnUnhandledInput
 import net.multigesture.kanama.annotations.OnUnhandledKeyInput
 import net.multigesture.kanama.annotations.OverrideVirtual
+import net.multigesture.kanama.annotations.RegisterFunction
 import net.multigesture.kanama.api.GodotObject
 import net.multigesture.kanama.annotations.ScriptClass
 import net.multigesture.kanama.annotations.ScriptProperty
+import net.multigesture.kanama.api.AudioStream
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.Label
 import net.multigesture.kanama.api.ClassDB
@@ -638,6 +640,20 @@ class IosSmokeScript(godotObject: MemorySegment) : KanamaScript<Label>(godotObje
 
     @ScriptProperty
     var probeTags: List<String> = emptyList()
+
+    // task 64 iOS mirror — an object-typed export (RESOURCE_TYPE hint). The
+    // class_name probe below asserts the engine-visible PropertyInfo carries
+    // class_name=AudioStream (not empty) through the new bridge + shim path.
+    @ScriptProperty
+    var smokeStream: AudioStream? = null
+
+    // Called by scripts/class_name_probe.gd with what GDScript saw in the
+    // engine-visible property list; println is the only channel that streams
+    // from a device build (Godot print()/printerr() do not).
+    @RegisterFunction("report_class_name")
+    fun reportClassName(streamClassName: String, viewEmpty: Boolean) {
+        println("[kanama][ios][kn] property class_name smoke_stream=$streamClassName view_empty=$viewEmpty")
+    }
 
     private var processedFrames = 0
     private var sawUnhandledInput = false
@@ -887,8 +903,29 @@ class ReplicationProbe(godotObject: MemorySegment) :
     }
 }
 EOF
-  probe_extra_resources=$'[ext_resource type="Script" path="res://kotlin-src/ProcessDisableProbe.kt" id="2_pdp"]\n[ext_resource type="Script" path="res://kotlin-src/ReplicationProbe.kt" id="3_rep"]'
-  probe_extra_nodes=$'[node name="ProcessDisableProbe" type="Node" parent="."]\nscript = ExtResource("2_pdp")\n\n[node name="ReplicationProbe" type="MultiplayerSynchronizer" parent="."]\nscript = ExtResource("3_rep")'
+  # task 64 iOS mirror — GDScript-side reader of the engine-visible PropertyInfo:
+  # asserts the object-typed export advertises class_name (empty before the shim
+  # cached real StringNames) while a value-typed export stays empty.
+  mkdir -p "$project_dir/scripts"
+  cat >"$project_dir/scripts/class_name_probe.gd" <<'EOF'
+extends Node
+
+func _ready() -> void:
+	var target := get_node("../Status")
+	var stream_class := ""
+	var view_class := "unset"
+	for p in target.get_property_list():
+		if p.name == "smoke_stream":
+			stream_class = str(p.get("class_name", ""))
+		elif p.name == "view":
+			view_class = str(p.get("class_name", ""))
+	# Godot-level print()/printerr() never reaches the devicectl console on a
+	# device build (only raw C/Kotlin writes stream), so hand the result to the
+	# Kotlin script and let it println — the channel every other probe uses.
+	target.call("report_class_name", stream_class, view_class == "")
+EOF
+  probe_extra_resources=$'[ext_resource type="Script" path="res://kotlin-src/ProcessDisableProbe.kt" id="2_pdp"]\n[ext_resource type="Script" path="res://kotlin-src/ReplicationProbe.kt" id="3_rep"]\n[ext_resource type="Script" path="res://scripts/class_name_probe.gd" id="4_cnp"]'
+  probe_extra_nodes=$'[node name="ProcessDisableProbe" type="Node" parent="."]\nscript = ExtResource("2_pdp")\n\n[node name="ReplicationProbe" type="MultiplayerSynchronizer" parent="."]\nscript = ExtResource("3_rep")\n\n[node name="ClassNameProbe" type="Node" parent="."]\nscript = ExtResource("4_cnp")'
 elif [[ "$godot_fps_probe" -eq 1 ]]; then
   status_text="Running pure Godot iOS FPS smoke"
   launch_sleep=12
@@ -2649,6 +2686,15 @@ if [[ "$kanama_user_script_probe" -eq 1 ]]; then
     echo "[ios_visual_smoke] replication: MultiplayerSynchronizer @ScriptProperty read-back round-tripped"
   else
     echo "[ios_visual_smoke] replication probe failed: value-type @ScriptProperty read back wrong via engine" >&2
+    exit 1
+  fi
+  # task 64 iOS mirror — PropertyInfo.class_name on object-typed exports: GDScript reads the
+  # engine-visible property list and must see class_name=AudioStream on smoke_stream (the new
+  # bridge + shim StringName cache) while the value-typed `view` stays empty.
+  if rg -q 'property class_name smoke_stream=AudioStream view_empty=true' "$stderr_log" "$stdout_log"; then
+    echo "[ios_visual_smoke] object-typed @ScriptProperty class_name delivered (task 64 iOS mirror)"
+  else
+    echo "[ios_visual_smoke] class_name probe failed: object-typed export missing PropertyInfo.class_name" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Closes the deliberate scope cut recorded in #108: the iOS script property descriptor bridge had no `class_name` channel, so typed GDScript in iOS exports still saw object-typed Kotlin exports as plain `Object`/`Resource` while desktop/Android carried the real class since #108.

## Changes

- **ios-runtime**: new `scriptResourcePropertyClassName` accessor applying the same policy as the desktop generator (`OBJECT` type + `RESOURCE_TYPE`/`NODE_TYPE` hint ⇒ hint string is exactly the class name), exported as `kanama_ios_runtime_script_resource_property_class_name`.
- **shim** (`kanama_ios_shim.c`): a per-property StringName cache (alloc/fill/teardown mirroring the existing hint-string plumbing) now feeds `GDExtensionPropertyInfo.class_name` in the instance property list; a zeroed slot keeps the previous empty fallback, so non-object properties are byte-for-byte unchanged.
- **`ios_visual_smoke.sh`** (user-script probe): adds an `AudioStream?` export plus a GDScript `ClassNameProbe` node that reads the engine-visible property list and asserts `class_name smoke_stream=AudioStream` with a value-typed export staying empty. The result is reported through a Kotlin `@RegisterFunction` because Godot-level `print()`/`printerr()` never reaches the devicectl console on a device build — only raw C/Kotlin writes stream (now documented in the probe). The check doubles as GDScript→Kotlin String/bool call-dispatch coverage.

An engine wrapper type (`AudioStream`) is used rather than a custom `@GlobalClass` resource on purpose: the `class_name` mechanism is identical, and iOS global-class registration is a separate surface that shouldn't be silently coupled into this assertion.

## Validation

- Full `scripts/ios_visual_smoke.sh --kanama-user-script-probe --physical-device` run **PASS on iPhone 15 Pro (iOS 26.5)** — the new class_name assertion plus all standing probes (task 39 conversions, task 46b lifecycle, task 47 replication read-back, value-type NodePath delivery, arg-bearing callV dispatch).
- `check_ios_no_silent_stubs.py` PASS; `ktfmtFormat` clean.
- No desktop/Android/Web code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)