### PR TITLE
Task 60h: Starter-Kit-City-Builder runs on Web — families 202-225, protocol 14

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -61,7 +61,7 @@ Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently **6**); startup rejects a mismatch
+`KANAMA_WEB_PROTOCOL_VERSION` (currently **14**); startup rejects a mismatch
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -78,6 +78,19 @@ enum class GodotCallShape {
   STRINGNAME_VECTOR3_VECTOR3_ARG,
   STRINGNAME_STRING_RET_INT,
   CALLABLE_DOUBLE_RANGE_RET_HANDLE,
+  VECTOR3I_LONG_LONG_ARG,
+  VECTOR3I_RET_LONG,
+  BASIS_RET_LONG,
+  NOARGS_RET_VECTOR3I_LIST,
+  LONG_OBJECT_ARG,
+  LONG_TRANSFORM3D_ARG,
+  LONG_RET_STRING,
+  LONG_RET_LONG,
+  LONG_LONG_RET_STRING,
+  LONG_LONG_RET_HANDLE,
+  VECTOR2_RET_VECTOR3,
+  OBJECT_STRING_RET_LONG_SINGLETON,
+  STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST,
 }
 
 @InternalKanamaBackendApi
@@ -120,6 +133,17 @@ data class GodotCallDescriptor(
 /** Platform-neutral immutable RGBA value used by typed draw commands. */
 @InternalKanamaBackendApi
 data class GodotColor(val r: Float, val g: Float, val b: Float, val a: Float = 1.0f)
+
+/** Platform-neutral immutable integer 3D vector used by the grid-cell families. */
+@InternalKanamaBackendApi data class GodotVector3i(val x: Int, val y: Int, val z: Int)
+
+/** Platform-neutral immutable basis as the three axis (column) vectors. */
+@InternalKanamaBackendApi
+data class GodotBasis(val x: GodotVector3, val y: GodotVector3, val z: GodotVector3)
+
+/** Platform-neutral immutable 3D transform (basis plus origin). */
+@InternalKanamaBackendApi
+data class GodotTransform3D(val basis: GodotBasis, val origin: GodotVector3)
 
 /** Typed backend SPI. No reflective or `List<Any?>` dispatch is permitted here. */
 @InternalKanamaBackendApi
@@ -626,6 +650,145 @@ interface GodotBackendSpi {
     name: String,
     value: String,
   ): Int {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Grid-cell write carrying a Vector3i position plus item and orientation indices. */
+  fun invokeVector3iLongLongArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+    first: Long,
+    second: Long,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Grid-cell integer query keyed by a Vector3i position. */
+  fun invokeVector3iRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+  ): Long {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Integer query keyed by a rotation basis (orthogonal orientation index). */
+  fun invokeBasisRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotBasis,
+  ): Long {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Vector3i-list query (occupied grid cells). */
+  fun invokeNoArgsRetVector3iList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<GodotVector3i> {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Indexed object write (mesh-library item mesh). */
+  fun invokeLongObjectArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    longValue: Long,
+    objectValue: GodotHandle,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Indexed transform write (mesh-library item transform). */
+  fun invokeLongTransform3dArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    longValue: Long,
+    value: GodotTransform3D,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Indexed string query (scene-state node type). */
+  fun invokeLongRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): String {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Indexed integer query (scene-state property count). */
+  fun invokeLongRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): Long {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Doubly indexed string query (scene-state property name). */
+  fun invokeLongLongRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): String {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Doubly indexed object query (scene-state property value; non-objects resolve null). */
+  fun invokeLongLongRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Screen-point to world-space Vector3 query (camera ray projection). */
+  fun invokeVector2RetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector2,
+  ): GodotVector3 {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Singleton resource persist (ResourceSaver.save). */
+  fun invokeObjectStringRetLongSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    resource: GodotHandle,
+    path: String,
+    flags: Long,
+  ): Long {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Descendant search returning tracked handles (Node.find_children). */
+  fun invokeStringStringBoolBoolRetHandleList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    pattern: String,
+    type: String,
+    recursive: Boolean,
+    owned: Boolean,
+  ): List<GodotHandle> {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -1359,6 +1522,210 @@ object GodotBackendCalls {
       receiver,
       name,
       value,
+    )
+  }
+
+  fun invokeVector3iLongLongArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+    first: Long,
+    second: Long,
+  ) {
+    requireShape(descriptor, GodotCallShape.VECTOR3I_LONG_LONG_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeVector3iLongLongArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+      first,
+      second,
+    )
+  }
+
+  fun invokeVector3iRetLong(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+  ): Long {
+    requireShape(descriptor, GodotCallShape.VECTOR3I_RET_LONG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeVector3iRetLong(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+    )
+  }
+
+  fun invokeBasisRetLong(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotBasis,
+  ): Long {
+    requireShape(descriptor, GodotCallShape.BASIS_RET_LONG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeBasisRetLong(descriptor, resolve(selected, descriptor), receiver, value)
+  }
+
+  fun invokeNoArgsRetVector3iList(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+  ): List<GodotVector3i> {
+    requireShape(descriptor, GodotCallShape.NOARGS_RET_VECTOR3I_LIST)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeNoArgsRetVector3iList(descriptor, resolve(selected, descriptor), receiver)
+  }
+
+  fun invokeLongObjectArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    longValue: Long,
+    objectValue: GodotHandle,
+  ) {
+    requireShape(descriptor, GodotCallShape.LONG_OBJECT_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.requireLive(objectValue)
+    selected.invokeLongObjectArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      longValue,
+      objectValue,
+    )
+  }
+
+  fun invokeLongTransform3dArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    longValue: Long,
+    value: GodotTransform3D,
+  ) {
+    requireShape(descriptor, GodotCallShape.LONG_TRANSFORM3D_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeLongTransform3dArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      longValue,
+      value,
+    )
+  }
+
+  fun invokeLongRetString(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: Long,
+  ): String {
+    requireShape(descriptor, GodotCallShape.LONG_RET_STRING)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeLongRetString(descriptor, resolve(selected, descriptor), receiver, value)
+  }
+
+  fun invokeLongRetLong(descriptor: GodotCallDescriptor, receiver: GodotHandle, value: Long): Long {
+    requireShape(descriptor, GodotCallShape.LONG_RET_LONG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeLongRetLong(descriptor, resolve(selected, descriptor), receiver, value)
+  }
+
+  fun invokeLongLongRetString(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): String {
+    requireShape(descriptor, GodotCallShape.LONG_LONG_RET_STRING)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeLongLongRetString(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      first,
+      second,
+    )
+  }
+
+  fun invokeLongLongRetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.LONG_LONG_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeLongLongRetHandle(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      first,
+      second,
+    )
+  }
+
+  fun invokeVector2RetVector3(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotVector2,
+  ): GodotVector3 {
+    requireShape(descriptor, GodotCallShape.VECTOR2_RET_VECTOR3)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeVector2RetVector3(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+    )
+  }
+
+  fun invokeObjectStringRetLongSingleton(
+    descriptor: GodotCallDescriptor,
+    resource: GodotHandle,
+    path: String,
+    flags: Long,
+  ): Long {
+    requireShape(descriptor, GodotCallShape.OBJECT_STRING_RET_LONG_SINGLETON)
+    val selected = requireBackend()
+    selected.requireLive(resource)
+    return selected.invokeObjectStringRetLongSingleton(
+      descriptor,
+      resolve(selected, descriptor),
+      resource,
+      path,
+      flags,
+    )
+  }
+
+  fun invokeStringStringBoolBoolRetHandleList(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    pattern: String,
+    type: String,
+    recursive: Boolean,
+    owned: Boolean,
+  ): List<GodotHandle> {
+    requireShape(descriptor, GodotCallShape.STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeStringStringBoolBoolRetHandleList(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      pattern,
+      type,
+      recursive,
+      owned,
     )
   }
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -2214,4 +2214,268 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val GRIDMAP_SET_MESH_LIBRARY =
+    GodotCallDescriptor(
+      opcode = 202,
+      className = "GridMap",
+      methodName = "set_mesh_library",
+      hash = 1488083439L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_SET_CELL_ITEM =
+    GodotCallDescriptor(
+      opcode = 203,
+      className = "GridMap",
+      methodName = "set_cell_item",
+      hash = 3449088946L,
+      shape = GodotCallShape.VECTOR3I_LONG_LONG_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_GET_CELL_ITEM =
+    GodotCallDescriptor(
+      opcode = 204,
+      className = "GridMap",
+      methodName = "get_cell_item",
+      hash = 3724960147L,
+      shape = GodotCallShape.VECTOR3I_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_GET_CELL_ITEM_ORIENTATION =
+    GodotCallDescriptor(
+      opcode = 205,
+      className = "GridMap",
+      methodName = "get_cell_item_orientation",
+      hash = 3724960147L,
+      shape = GodotCallShape.VECTOR3I_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_GET_ORTHOGONAL_INDEX_FROM_BASIS =
+    GodotCallDescriptor(
+      opcode = 206,
+      className = "GridMap",
+      methodName = "get_orthogonal_index_from_basis",
+      hash = 4210359952L,
+      shape = GodotCallShape.BASIS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_CLEAR =
+    GodotCallDescriptor(
+      opcode = 207,
+      className = "GridMap",
+      methodName = "clear",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val GRIDMAP_GET_USED_CELLS =
+    GodotCallDescriptor(
+      opcode = 208,
+      className = "GridMap",
+      methodName = "get_used_cells",
+      hash = 3995934104L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3I_LIST,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHLIBRARY_CREATE_ITEM =
+    GodotCallDescriptor(
+      opcode = 209,
+      className = "MeshLibrary",
+      methodName = "create_item",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHLIBRARY_SET_ITEM_MESH =
+    GodotCallDescriptor(
+      opcode = 210,
+      className = "MeshLibrary",
+      methodName = "set_item_mesh",
+      hash = 969122797L,
+      shape = GodotCallShape.LONG_OBJECT_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHLIBRARY_SET_ITEM_MESH_TRANSFORM =
+    GodotCallDescriptor(
+      opcode = 211,
+      className = "MeshLibrary",
+      methodName = "set_item_mesh_transform",
+      hash = 3616898986L,
+      shape = GodotCallShape.LONG_TRANSFORM3D_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PACKEDSCENE_GET_STATE =
+    GodotCallDescriptor(
+      opcode = 212,
+      className = "PackedScene",
+      methodName = "get_state",
+      hash = 3479783971L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENESTATE_GET_NODE_COUNT =
+    GodotCallDescriptor(
+      opcode = 213,
+      className = "SceneState",
+      methodName = "get_node_count",
+      hash = 3905245786L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENESTATE_GET_NODE_TYPE =
+    GodotCallDescriptor(
+      opcode = 214,
+      className = "SceneState",
+      methodName = "get_node_type",
+      hash = 659327637L,
+      shape = GodotCallShape.LONG_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENESTATE_GET_NODE_PROPERTY_COUNT =
+    GodotCallDescriptor(
+      opcode = 215,
+      className = "SceneState",
+      methodName = "get_node_property_count",
+      hash = 923996154L,
+      shape = GodotCallShape.LONG_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENESTATE_GET_NODE_PROPERTY_NAME =
+    GodotCallDescriptor(
+      opcode = 216,
+      className = "SceneState",
+      methodName = "get_node_property_name",
+      hash = 351665558L,
+      shape = GodotCallShape.LONG_LONG_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENESTATE_GET_NODE_PROPERTY_VALUE =
+    GodotCallDescriptor(
+      opcode = 217,
+      className = "SceneState",
+      methodName = "get_node_property_value",
+      hash = 678354945L,
+      shape = GodotCallShape.LONG_LONG_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CAMERA3D_PROJECT_RAY_ORIGIN =
+    GodotCallDescriptor(
+      opcode = 218,
+      className = "Camera3D",
+      methodName = "project_ray_origin",
+      hash = 1718073306L,
+      shape = GodotCallShape.VECTOR2_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CAMERA3D_PROJECT_RAY_NORMAL =
+    GodotCallDescriptor(
+      opcode = 219,
+      className = "Camera3D",
+      methodName = "project_ray_normal",
+      hash = 1718073306L,
+      shape = GodotCallShape.VECTOR2_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val VIEWPORT_GET_MOUSE_POSITION =
+    GodotCallDescriptor(
+      opcode = 220,
+      className = "Viewport",
+      methodName = "get_mouse_position",
+      hash = 3341600327L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR2,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_IS_ACTION_JUST_RELEASED =
+    GodotCallDescriptor(
+      opcode = 221,
+      className = "Input",
+      methodName = "is_action_just_released",
+      hash = 1558498928L,
+      shape = GodotCallShape.STRINGNAME_RET_BOOL_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RESOURCE_DUPLICATE =
+    GodotCallDescriptor(
+      opcode = 222,
+      className = "Resource",
+      methodName = "duplicate",
+      hash = 482882304L,
+      shape = GodotCallShape.BOOL_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.OWNED,
+    )
+
+  val RESOURCESAVER_SAVE =
+    GodotCallDescriptor(
+      opcode = 223,
+      className = "ResourceSaver",
+      methodName = "save",
+      hash = 2983274697L,
+      shape = GodotCallShape.OBJECT_STRING_RET_LONG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_FIND_CHILDREN =
+    GodotCallDescriptor(
+      opcode = 224,
+      className = "Node",
+      methodName = "find_children",
+      hash = 2560337219L,
+      shape = GodotCallShape.STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHINSTANCE3D_GET_MESH =
+    GodotCallDescriptor(
+      opcode = 225,
+      className = "MeshInstance3D",
+      methodName = "get_mesh",
+      hash = 1808005922L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -8,7 +8,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 13
+    const val PROTOCOL_VERSION = 14
     const val PROTOCOL_SCHEMA_VERSION = 1
   }
 
@@ -48,6 +48,16 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             appendLine("# One handle dictionary shared by every Kanama Web proxy: a handle")
             appendLine("# minted by any proxy resolves in all of them.")
             appendLine("static var handles: Dictionary = {}")
+            appendLine()
+            appendLine("# Proxy script path per Kanama script class (simple name), so a proxy can")
+            appendLine("# instantiate a scripted resource for the runtime factory crossing.")
+            appendLine("static var proxy_paths: Dictionary = {")
+            scripts.forEach { input ->
+              appendLine(
+                "\t${quote(input.model.simpleName)}: ${quote("res://kanama-web/generated/${input.model.simpleName}.gd")},"
+              )
+            }
+            appendLine("}")
           },
       )
 
@@ -250,8 +260,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLongPropertySetter()
     appendDoublePropertySetter()
     appendVector2PropertySetter()
+    appendVector2iPropertySetter()
     appendVector3PropertySetter()
     appendObjectPropertySetter()
+    appendPackedPropertyGetter()
     appendObjectArrayPropertySetter()
     appendStringArrayPropertySetter()
     appendLongMethodDispatcher()
@@ -719,6 +731,78 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine()
   }
 
+  private fun StringBuilder.appendVector2iPropertySetter() {
+    appendLine(
+      "  fun setVector2iProperty(scriptId: Int, propertyId: Int, script: KanamaWebScript, x: Int, y: Int) {"
+    )
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (propertyId) {")
+      input.model.properties.forEachIndexed { propertyIndex, property ->
+        if (property.type == TypeMapping.VECTOR2I && property.isMutable) {
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = Vector2i(x, y)"
+          )
+        }
+      }
+      appendLine("        else -> unknown(\"property\", propertyId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine("  }")
+    appendLine()
+  }
+
+  /**
+   * Current Kotlin property value packed as one string, per declared type (save-time pull). Object
+   * values pack their backend handle, script arrays comma-join element handles, string arrays join
+   * with the unit separator; the proxy parses per its declared type.
+   */
+  private fun StringBuilder.appendPackedPropertyGetter() {
+    appendLine(
+      "  fun getPackedProperty(scriptId: Int, propertyId: Int, script: KanamaWebScript): String ="
+    )
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (propertyId) {")
+      input.model.properties.forEachIndexed { propertyIndex, property ->
+        val access = "(script as ${input.model.simpleName}).${property.kotlinName}"
+        val expression =
+          when {
+            property.type == TypeMapping.STRING -> access
+            property.type == TypeMapping.INT -> "$access.toString()"
+            property.type == TypeMapping.FLOAT -> "$access.toString()"
+            property.type == TypeMapping.BOOL -> "if ($access) \"1\" else \"0\""
+            property.type == TypeMapping.VECTOR2 -> "$access.let { \"\${it.x},\${it.y}\" }"
+            property.type == TypeMapping.VECTOR2I -> "$access.let { \"\${it.x},\${it.y}\" }"
+            property.type == TypeMapping.VECTOR3 -> "$access.let { \"\${it.x},\${it.y},\${it.z}\" }"
+            property.type == TypeMapping.OBJECT && property.customScriptFqName != null ->
+              if (property.nullable) "($access?.objectId?.value ?: 0).toString()"
+              else "$access.objectId.value.toString()"
+            property.type == TypeMapping.OBJECT ->
+              if (property.nullable) "($access?.handle?.value ?: 0).toString()"
+              else "$access.handle.value.toString()"
+            property.type == TypeMapping.ARRAY && property.arrayElementString ->
+              "$access.joinToString(\"\\u001f\")"
+            property.type == TypeMapping.ARRAY && property.arrayElementCustomScriptFqName != null ->
+              "$access.joinToString(\",\") { it.objectId.value.toString() }"
+            property.type == TypeMapping.ARRAY && property.arrayElementWrapperFqName != null ->
+              "$access.joinToString(\",\") { it.handle.value.toString() }"
+            else -> null
+          }
+        if (expression != null) {
+          appendLine("        ${propertyIndex + 1} -> $expression")
+        }
+      }
+      appendLine("        else -> unknown(\"property\", propertyId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine()
+  }
+
   private fun StringBuilder.appendVector3PropertySetter() {
     appendLine(
       "  fun setVector3Property(scriptId: Int, propertyId: Int, script: KanamaWebScript, x: Double, y: Double, z: Double) {"
@@ -892,6 +976,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("var _kanama_tween_callback")
     appendLine("var _kanama_noargs_vector3_callback")
     appendLine("var _kanama_ready_dispatched: bool = false")
+    appendLine("var _kanama_pulling: bool = false")
     appendLine("var _kanama_object_handles: Dictionary = KanamaWebHandles.handles")
     appendLine("var _kanama_tween_children: Dictionary = {}")
     appendLine("var _kanama_tween_targets: Dictionary = {}")
@@ -1020,6 +1105,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           appendLine(
             "\t_kanama_bridge.setVector3Property(_kanama_handle, ${index + 1}, ${property.godotName}.x, ${property.godotName}.y, ${property.godotName}.z)"
           )
+        TypeMapping.VECTOR2I ->
+          appendLine(
+            "\t_kanama_bridge.setVector2iProperty(_kanama_handle, ${index + 1}, ${property.godotName}.x, ${property.godotName}.y)"
+          )
         TypeMapping.OBJECT -> {
           appendLine("\tvar property_handle_${index + 1}: int = 0")
           appendLine("\tif ${property.godotName} != null:")
@@ -1086,6 +1175,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
     appendLine("\treturn _kanama_handle")
     appendLine()
+    appendPullProperties(model)
     appendLine("func _ready() -> void:")
     appendLine("\tif _kanama_ensure_created() == 0 or _kanama_ready_dispatched:")
     appendLine("\t\treturn")
@@ -1563,6 +1653,17 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 202 and target_object is GridMap:")
+    appendLine("\t\t\tvar library_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\t(target_object as GridMap).mesh_library = null if library_handle == 0 else _kanama_object_handles.get(library_handle) as MeshLibrary"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 209 and target_object is MeshLibrary:")
+    appendLine("\t\t\t(target_object as MeshLibrary).create_item(bytes.decode_s32(offset + 8))")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
     appendLine("\t\telif opcode == 132 and target_object != null:")
     appendLine(
       "\t\t\tvar damage_method := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
@@ -1785,6 +1886,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\tif resource == null:")
     appendLine("\t\t_kanama_bridge.recordImmediateResourceHandle(0)")
     appendLine("\t\treturn 0")
+    appendLine("\t# A Kanama-scripted resource resolves to its script handle so the Kotlin side")
+    appendLine("\t# can reach the hydrated instance (node-lookup rule for loads).")
+    appendLine("\tif resource.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\tvar loaded_script_handle := int(resource.call(\"_kanama_ensure_created\"))")
+    appendLine("\t\tif loaded_script_handle != 0:")
+    appendLine("\t\t\t_kanama_object_handles[loaded_script_handle] = resource")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateResourceHandle(loaded_script_handle)")
+    appendLine("\t\t\treturn loaded_script_handle")
     appendLine("\t_kanama_object_handles[resource_handle] = resource")
     appendLine("\t_kanama_bridge.recordImmediateResourceHandle(resource_handle)")
     appendLine("\treturn resource_handle")
@@ -1813,7 +1922,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\tvar object_handle := int(args[0])")
     appendLine("\tvar requested_class := String(args[1])")
     appendLine("\tvar value: Object = ClassDB.instantiate(requested_class)")
-    appendLine("\tif value == null or not value is Node:")
+    appendLine("\t# Nodes and Resources both construct here (MeshLibrary is a Resource); only a")
+    appendLine("\t# failed instantiation refuses the proposed handle.")
+    appendLine("\tif value == null:")
     appendLine("\t\t_kanama_bridge.recordImmediateConstructHandle(0)")
     appendLine("\t\treturn 0")
     appendLine("\t_kanama_object_handles[object_handle] = value")
@@ -1915,6 +2026,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvalue = (receiver as WorldEnvironment).environment")
     appendLine("\telif opcode == 194 and receiver is Viewport:")
     appendLine("\t\tvalue = (receiver as Viewport).get_camera_3d()")
+    appendLine("\telif opcode == 212 and receiver is PackedScene:")
+    appendLine("\t\tvalue = (receiver as PackedScene).get_state()")
+    appendLine("\telif opcode == 225 and receiver is MeshInstance3D:")
+    appendLine("\t\tvalue = (receiver as MeshInstance3D).mesh")
     appendLine("\telif opcode == 112 and receiver is KinematicCollision3D:")
     appendLine("\t\tvalue = (receiver as KinematicCollision3D).get_collider()")
     appendLine("\telif opcode == 114 and receiver is Node:")
@@ -2468,6 +2583,144 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int(round((value as AudioStreamPlayer3D).pitch_scale * 1000.0))")
     appendLine("\t\telif opcode == 190:")
     appendLine("\t\t\tresult = int(OS.shell_open(String(args[2])))")
+    appendLine("\t\telif opcode == 0:")
+    appendLine("\t\t\t# Reserved runtime crossing (not a contract opcode): instantiate a Kanama")
+    appendLine("\t\t\t# scripted resource by class simple name and hydrate its Kotlin instance.")
+    appendLine(
+      "\t\t\tvar instantiate_path: String = KanamaWebHandles.proxy_paths.get(String(args[2]), \"\")"
+    )
+    appendLine("\t\t\tif instantiate_path != \"\":")
+    appendLine("\t\t\t\tvar instantiate_script = load(instantiate_path)")
+    appendLine(
+      "\t\t\t\tvar created = instantiate_script.new() if instantiate_script != null else null"
+    )
+    appendLine("\t\t\t\tif created != null and created.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\t\t\t\tresult = int(created.call(\"_kanama_ensure_created\"))")
+    appendLine("\t\t\t\t\tif result != 0:")
+    appendLine("\t\t\t\t\t\t_kanama_object_handles[result] = created")
+    appendLine("\t\telif opcode == 203 and value is GridMap:")
+    appendLine("\t\t\tvar cell_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as GridMap).set_cell_item(Vector3i(int(cell_parts[0]), int(cell_parts[1]), int(cell_parts[2])), int(cell_parts[3]), int(cell_parts[4]))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 204 and value is GridMap:")
+    appendLine("\t\t\tvar get_cell_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tresult = (value as GridMap).get_cell_item(Vector3i(int(get_cell_parts[0]), int(get_cell_parts[1]), int(get_cell_parts[2])))"
+    )
+    appendLine("\t\telif opcode == 205 and value is GridMap:")
+    appendLine("\t\t\tvar orient_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tresult = (value as GridMap).get_cell_item_orientation(Vector3i(int(orient_parts[0]), int(orient_parts[1]), int(orient_parts[2])))"
+    )
+    appendLine("\t\telif opcode == 206 and value is GridMap:")
+    appendLine("\t\t\tvar basis_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\tresult = (value as GridMap).get_orthogonal_index_from_basis(Basis(Vector3(basis_parts[0], basis_parts[1], basis_parts[2]), Vector3(basis_parts[3], basis_parts[4], basis_parts[5]), Vector3(basis_parts[6], basis_parts[7], basis_parts[8])))"
+    )
+    appendLine("\t\telif opcode == 207 and value is GridMap:")
+    appendLine("\t\t\t(value as GridMap).clear()")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 208 and value is GridMap:")
+    appendLine("\t\t\tvar used_cells := (value as GridMap).get_used_cells()")
+    appendLine("\t\t\tvar packed_cells := PackedStringArray()")
+    appendLine("\t\t\tfor used_cell in used_cells:")
+    appendLine(
+      "\t\t\t\tpacked_cells.append(\"%d,%d,%d\" % [used_cell.x, used_cell.y, used_cell.z])"
+    )
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(packed_cells))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 210 and value is MeshLibrary:")
+    appendLine("\t\t\tvar item_mesh_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar item_mesh: Mesh = _kanama_object_handles.get(int(item_mesh_parts[1])) as Mesh"
+    )
+    appendLine("\t\t\tif item_mesh != null:")
+    appendLine("\t\t\t\t(value as MeshLibrary).set_item_mesh(int(item_mesh_parts[0]), item_mesh)")
+    appendLine("\t\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 211 and value is MeshLibrary:")
+    appendLine("\t\t\tvar item_transform_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar item_basis := Basis(Vector3(item_transform_parts[1], item_transform_parts[2], item_transform_parts[3]), Vector3(item_transform_parts[4], item_transform_parts[5], item_transform_parts[6]), Vector3(item_transform_parts[7], item_transform_parts[8], item_transform_parts[9]))"
+    )
+    appendLine(
+      "\t\t\t(value as MeshLibrary).set_item_mesh_transform(int(item_transform_parts[0]), Transform3D(item_basis, Vector3(item_transform_parts[10], item_transform_parts[11], item_transform_parts[12])))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 213 and value is SceneState:")
+    appendLine("\t\t\tresult = (value as SceneState).get_node_count()")
+    appendLine("\t\telif opcode == 214 and value is SceneState:")
+    appendLine(
+      "\t\t\t_kanama_bridge.recordImmediateStringResult(String((value as SceneState).get_node_type(int(String(args[2])))))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 215 and value is SceneState:")
+    appendLine("\t\t\tresult = (value as SceneState).get_node_property_count(int(String(args[2])))")
+    appendLine("\t\telif opcode == 216 and value is SceneState:")
+    appendLine("\t\t\tvar prop_name_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\t_kanama_bridge.recordImmediateStringResult(String((value as SceneState).get_node_property_name(int(prop_name_parts[0]), int(prop_name_parts[1]))))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 217 and value is SceneState:")
+    appendLine("\t\t\tvar prop_value_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar prop_variant: Variant = (value as SceneState).get_node_property_value(int(prop_value_parts[0]), int(prop_value_parts[1]))"
+    )
+    appendLine("\t\t\tvar prop_object: Object = prop_variant if prop_variant is Object else null")
+    appendLine("\t\t\tif prop_object != null:")
+    appendLine("\t\t\t\tresult = int(prop_value_parts[2])")
+    appendLine("\t\t\t\t_kanama_object_handles[result] = prop_object")
+    appendLine("\t\telif opcode == 221:")
+    appendLine("\t\t\tresult = int(Input.is_action_just_released(StringName(String(args[2]))))")
+    appendLine("\t\telif opcode == 222 and value is Resource:")
+    appendLine("\t\t\tvar duplicate_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar duplicated: Resource = (value as Resource).duplicate(duplicate_parts[0] == \"1\")"
+    )
+    appendLine("\t\t\tif duplicated != null:")
+    appendLine("\t\t\t\tresult = int(duplicate_parts[1])")
+    appendLine("\t\t\t\t_kanama_object_handles[result] = duplicated")
+    appendLine("\t\telif opcode == 223:")
+    appendLine("\t\t\tvar save_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar save_handle := int(save_parts[0])")
+    appendLine(
+      "\t\t\tvar save_target: Object = self if save_handle == _kanama_handle else _kanama_object_handles.get(save_handle)"
+    )
+    appendLine("\t\t\tif save_target == null or not (save_target is Resource):")
+    appendLine("\t\t\t\tresult = ERR_INVALID_PARAMETER")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\t# Property flow is engine-to-Kotlin at hydration; pull the current Kotlin")
+    appendLine("\t\t\t\t# values into the scripted resource graph before serializing.")
+    appendLine("\t\t\t\tif save_target.has_method(\"_kanama_pull_properties\"):")
+    appendLine("\t\t\t\t\tsave_target.call(\"_kanama_pull_properties\")")
+    appendLine(
+      "\t\t\t\tresult = ResourceSaver.save(save_target as Resource, save_parts[1], int(save_parts[2]))"
+    )
+    appendLine("\t\telif opcode == 224 and value is Node:")
+    appendLine("\t\t\tvar find_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar found := (value as Node).find_children(find_parts[0], find_parts[1], find_parts[2] == \"1\", find_parts[3] == \"1\")"
+    )
+    appendLine("\t\t\tvar found_handles := PackedStringArray()")
+    appendLine("\t\t\tfor found_node in found:")
+    appendLine("\t\t\t\tvar found_handle := 0")
+    appendLine("\t\t\t\tif found_node.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\t\t\t\tfound_handle = int(found_node.call(\"_kanama_ensure_created\"))")
+    appendLine("\t\t\t\tif found_handle == 0:")
+    appendLine("\t\t\t\t\tfor existing_found in _kanama_object_handles:")
+    appendLine("\t\t\t\t\t\tif is_same(_kanama_object_handles[existing_found], found_node):")
+    appendLine("\t\t\t\t\t\t\tfound_handle = int(existing_found)")
+    appendLine("\t\t\t\t\t\t\tbreak")
+    appendLine("\t\t\t\tif found_handle == 0:")
+    appendLine(
+      "\t\t\t\t\tfound_handle = int(_kanama_bridge.allocateFoundNodeHandle(_kanama_handle))"
+    )
+    appendLine("\t\t\t\t_kanama_object_handles[found_handle] = found_node")
+    appendLine("\t\t\t\tfound_handles.append(str(found_handle))")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(found_handles))")
+    appendLine("\t\t\tresult = 1")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2482,6 +2735,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as CanvasItem).get_local_mouse_position()")
     appendLine("\telif opcode == 127 and value is InputEventMouseMotion:")
     appendLine("\t\tresult = (value as InputEventMouseMotion).relative")
+    appendLine("\telif opcode == 220 and value is Viewport:")
+    appendLine("\t\tresult = (value as Viewport).get_mouse_position()")
     appendLine("\t_kanama_bridge.recordImmediateVector2(result.x, result.y)")
     appendLine("\treturn 1")
     appendLine()
@@ -2510,6 +2765,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as ShapeCast3D).target_position")
     appendLine("\telif opcode == 178 and value is NavigationAgent3D:")
     appendLine("\t\tresult = (value as NavigationAgent3D).get_next_path_position()")
+    appendLine("\telif opcode == 218 and value is Camera3D:")
+    appendLine(
+      "\t\tresult = (value as Camera3D).project_ray_origin(Vector2(float(args[2]), float(args[3])))"
+    )
+    appendLine("\telif opcode == 219 and value is Camera3D:")
+    appendLine(
+      "\t\tresult = (value as Camera3D).project_ray_normal(Vector2(float(args[2]), float(args[3])))"
+    )
     appendLine("\telif opcode == 197 and value is RigidBody3D:")
     appendLine("\t\tresult = (value as RigidBody3D).angular_velocity")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
@@ -2681,6 +2944,101 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
 
   private fun gdType(arg: ArgModel): String =
     arg.objectWrapperFqName?.let(::gdObjectType) ?: gdType(arg.type)
+
+  /**
+   * Engine-side pull of the current Kotlin property values (save-time sync). Property flow is
+   * normally engine-to-Kotlin at hydration; ResourceSaver.save must serialize what the Kotlin
+   * instance holds NOW, so the save applier calls this before saving. Recurses into scripted
+   * object/array elements; the reentry flag guards resource cycles.
+   */
+  private fun StringBuilder.appendPullProperties(model: ScriptModel) {
+    appendLine("func _kanama_pull_properties() -> void:")
+    appendLine("\tif _kanama_handle == 0 or _kanama_pulling:")
+    appendLine("\t\treturn")
+    appendLine("\t_kanama_pulling = true")
+    model.properties.forEachIndexed { index, property ->
+      val id = index + 1
+      val name = property.godotName
+      val packed = "_kanama_packed_$id"
+      val supported =
+        when (property.type) {
+          TypeMapping.STRING,
+          TypeMapping.INT,
+          TypeMapping.FLOAT,
+          TypeMapping.BOOL,
+          TypeMapping.VECTOR2,
+          TypeMapping.VECTOR2I,
+          TypeMapping.VECTOR3 -> true
+          TypeMapping.OBJECT ->
+            property.customScriptFqName != null || property.objectWrapperFqName != null
+          TypeMapping.ARRAY ->
+            property.arrayElementString ||
+              property.arrayElementCustomScriptFqName != null ||
+              property.arrayElementWrapperFqName != null
+          else -> false
+        }
+      if (!supported) {
+        appendLine("\t# ${property.godotName}: unsupported pull type, left as-is")
+        return@forEachIndexed
+      }
+      appendLine("\tvar $packed := String(_kanama_bridge.getPackedProperty(_kanama_handle, $id))")
+      when {
+        property.type == TypeMapping.STRING -> appendLine("\t$name = $packed")
+        property.type == TypeMapping.INT -> appendLine("\t$name = int($packed)")
+        property.type == TypeMapping.FLOAT -> appendLine("\t$name = float($packed)")
+        property.type == TypeMapping.BOOL -> appendLine("\t$name = $packed == \"1\"")
+        property.type == TypeMapping.VECTOR2 -> {
+          appendLine("\tvar _kanama_parts_$id := $packed.split_floats(\",\")")
+          appendLine("\t$name = Vector2(_kanama_parts_$id[0], _kanama_parts_$id[1])")
+        }
+        property.type == TypeMapping.VECTOR2I -> {
+          appendLine("\tvar _kanama_parts_$id := $packed.split(\",\")")
+          appendLine("\t$name = Vector2i(int(_kanama_parts_$id[0]), int(_kanama_parts_$id[1]))")
+        }
+        property.type == TypeMapping.VECTOR3 -> {
+          appendLine("\tvar _kanama_parts_$id := $packed.split_floats(\",\")")
+          appendLine(
+            "\t$name = Vector3(_kanama_parts_$id[0], _kanama_parts_$id[1], _kanama_parts_$id[2])"
+          )
+        }
+        property.type == TypeMapping.OBJECT -> {
+          appendLine("\tvar _kanama_pull_handle_$id := int($packed)")
+          appendLine("\tvar _kanama_pull_value_$id: Object = null")
+          appendLine("\tif _kanama_pull_handle_$id != 0:")
+          appendLine(
+            "\t\t_kanama_pull_value_$id = self if _kanama_pull_handle_$id == _kanama_handle else _kanama_object_handles.get(_kanama_pull_handle_$id)"
+          )
+          appendLine(
+            "\tif _kanama_pull_value_$id != null and _kanama_pull_value_$id.has_method(\"_kanama_pull_properties\"):"
+          )
+          appendLine("\t\t_kanama_pull_value_$id.call(\"_kanama_pull_properties\")")
+          appendLine("\t$name = _kanama_pull_value_$id as ${gdType(property)}")
+        }
+        property.type == TypeMapping.ARRAY && property.arrayElementString -> {
+          appendLine("\tif $packed == \"\":")
+          appendLine("\t\t$name.assign([])")
+          appendLine("\telse:")
+          appendLine("\t\t$name.assign($packed.split(\"\\u001f\"))")
+        }
+        property.type == TypeMapping.ARRAY -> {
+          appendLine("\tvar _kanama_rebuilt_$id: Array = []")
+          appendLine("\tfor _kanama_part in $packed.split(\",\"):")
+          appendLine("\t\tif _kanama_part == \"\":")
+          appendLine("\t\t\tcontinue")
+          appendLine("\t\tvar _kanama_element = _kanama_object_handles.get(int(_kanama_part))")
+          appendLine("\t\tif _kanama_element == null:")
+          appendLine("\t\t\tcontinue")
+          appendLine("\t\tif _kanama_element.has_method(\"_kanama_pull_properties\"):")
+          appendLine("\t\t\t_kanama_element.call(\"_kanama_pull_properties\")")
+          appendLine("\t\t_kanama_rebuilt_$id.append(_kanama_element)")
+          appendLine("\t$name.assign(_kanama_rebuilt_$id)")
+        }
+        else -> error("unreachable pull arm for ${property.godotName}")
+      }
+    }
+    appendLine("\t_kanama_pulling = false")
+    appendLine()
+  }
 
   private fun gdType(property: ScriptPropertyModel): String =
     when {

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -72,7 +72,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 13"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 14"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -410,7 +410,7 @@ class WebScriptCodeEmitterTest {
     )
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 13"))
+    assertTrue(protocol.contains("\"protocolVersion\": 14"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -421,7 +421,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=13\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=14\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -244,6 +244,30 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     199: {},
     200: {},
     201: {},
+    202: {},
+    203: {},
+    204: {},
+    205: {},
+    206: {},
+    207: {},
+    208: {},
+    209: {},
+    210: {},
+    211: {},
+    212: {"ret": "browser"},
+    213: {},
+    214: {},
+    215: {},
+    216: {},
+    217: {"ret": "browser"},
+    218: {},
+    219: {},
+    220: {},
+    221: {},
+    222: {"ret": "browser"},
+    223: {},
+    224: {},
+    225: {"ret": "browser"},
 }
 
 
@@ -324,14 +348,39 @@ def body_BOOL_RET_INT(calls):
 
 
 def body_BOOL_RET_HANDLE(calls):
-    return [
+    tween = [c for c in calls if WEB_POLICY[c.opcode].get("ret") != "browser"]
+    browser = [c for c in calls if WEB_POLICY[c.opcode].get("ret") == "browser"]
+    lines = [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
         "commands.flush()",
-        "return existingReturnedObject(",
-        "receiver,",
-        "immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),",
-        ")",
+        "return when (descriptor.opcode) {",
     ]
+    if tween:
+        lines.append(",\n".join(str(c.opcode) for c in tween) + " ->")
+        lines += [
+            "existingReturnedObject(",
+            "receiver,",
+            "immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),",
+            ")",
+        ]
+    for c in browser:
+        lines.append(f"{c.opcode} ->")
+        lines += [
+            "// The Boolean rides the property-object-query string; the bridge appends the",
+            "// proposed handle and the applier registers the duplicate under it.",
+            "registerReturnedBrowserObject(",
+            "immediateWebPropertyObjectQuery(",
+            "descriptor.opcode,",
+            "receiver.webId(),",
+            'if (value) "1" else "0",',
+            ")",
+            ")",
+        ]
+    lines += [
+        'else -> error("Unsupported Web Boolean-return-handle opcode=${descriptor.opcode}")',
+        "}",
+    ]
+    return lines
 
 
 def body_BOOL_ARG(calls):
@@ -877,6 +926,15 @@ def body_OBJECT_ARG(calls):
                 "checkNotNull(value)",
                 "}",
             ]
+        elif op == 202:
+            lines += [
+                "202 -> {",
+                f"require(descriptor.executionMode == {_QUEUED})",
+                "// The MeshLibrary was constructed via ClassDB.instantiate, so it is",
+                "// registered under the NODE kind like every constructed handle.",
+                "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }",
+                "}",
+            ]
         else:
             raise GenerationError(f"OBJECT_ARG opcode {op} has no emitter arm")
     lines += [
@@ -1315,6 +1373,237 @@ def body_OBJECT_NODEPATH_COLOR_DOUBLE_RET_HANDLE(calls):
     ]
 
 
+def body_VECTOR3I_LONG_LONG_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Cell position plus item/orientation packed as five integers (unit separator).",
+        "val packed =",
+        'listOf(value.x, value.y, value.z, first.toInt(), second.toInt()).joinToString("\\u001f")',
+        "check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
+        "}",
+    ]
+
+
+def body_VECTOR3I_RET_LONG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Cell position packed as three integers; the result (INVALID_CELL_ITEM = -1",
+        "// included) rides the shared integer object-query transport.",
+        "return immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'listOf(value.x, value.y, value.z).joinToString(""),',
+        ")",
+        ".toLong()",
+    ]
+
+
+def body_BASIS_RET_LONG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Nine Float32 components packed column-major (x, y, z axes; unit separator).",
+        "val packed =",
+        "listOf(",
+        "value.x.x,",
+        "value.x.y,",
+        "value.x.z,",
+        "value.y.x,",
+        "value.y.y,",
+        "value.y.z,",
+        "value.z.x,",
+        "value.z.y,",
+        "value.z.z,",
+        ")",
+        '.joinToString("")',
+        "return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed).toLong()",
+    ]
+
+
+def body_NOARGS_RET_VECTOR3I_LIST(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// The applier packs one comma-joined integer triple per cell (unit separator).",
+        'return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")',
+        ".split('')",
+        ".filter { it.isNotEmpty() }",
+        ".map { triple ->",
+        "val parts = triple.split(',')",
+        "GodotVector3i(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())",
+        "}",
+    ]
+
+
+def body_LONG_OBJECT_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "requireWebBrowserHandle(objectValue.webId(), WebBrowserHandleKind.OBJECT)",
+        "commands.flush()",
+        "// Item index and object handle packed into one query string (unit separator).",
+        "check(",
+        "immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'longValue.toString() + "" + objectValue.webId().toString(),',
+        ") == 1",
+        ") {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
+        "}",
+    ]
+
+
+def body_LONG_TRANSFORM3D_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Item index plus twelve Float32 transform components (basis columns then origin).",
+        "val packed =",
+        "listOf(",
+        "longValue.toInt().toFloat(),",
+        "value.basis.x.x,",
+        "value.basis.x.y,",
+        "value.basis.x.z,",
+        "value.basis.y.x,",
+        "value.basis.y.y,",
+        "value.basis.y.z,",
+        "value.basis.z.x,",
+        "value.basis.z.y,",
+        "value.basis.z.z,",
+        "value.origin.x,",
+        "value.origin.y,",
+        "value.origin.z,",
+        ")",
+        '.joinToString("")',
+        "check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
+        "}",
+    ]
+
+
+def body_LONG_RET_STRING(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "return immediateWebStringQuery(descriptor.opcode, receiver.webId(), value.toString())",
+    ]
+
+
+def body_LONG_RET_LONG(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value.toString())",
+        ".toLong()",
+    ]
+
+
+def body_LONG_LONG_RET_STRING(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Both indices packed into one query string (unit separator).",
+        "return immediateWebStringQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'first.toString() + "" + second.toString(),',
+        ")",
+    ]
+
+
+def body_LONG_LONG_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Both indices ride the property-object-query string; the bridge appends the",
+        "// proposed handle and non-object values resolve to a null handle.",
+        "return registerReturnedBrowserObject(",
+        "immediateWebPropertyObjectQuery(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        'first.toString() + "" + second.toString(),',
+        ")",
+        ")",
+    ]
+
+
+def body_VECTOR2_RET_VECTOR3(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "return GodotVector3(",
+        "immediateWebVector2ArgVector3X(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "value.x.toDouble(),",
+        "value.y.toDouble(),",
+        ")",
+        ".toFloat(),",
+        "immediateWebNoArgsVector3Y().toFloat(),",
+        "immediateWebNoArgsVector3Z().toFloat(),",
+        ")",
+    ]
+
+
+def body_OBJECT_STRING_RET_LONG_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Resource handle, destination path, and flags packed into one query string; the",
+        "// applier pulls current Kotlin property values into scripted resources first.",
+        "return immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "requireActiveWebScriptHandle(),",
+        'resource.webId().toString() + "" + path + "" + flags.toString(),',
+        ")",
+        ".toLong()",
+    ]
+
+
+def body_STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Pattern, type, and both flags packed into one query string; the applier packs the",
+        "// matches back as handles (scripted matches resolve to script handles, engine nodes",
+        "// get tracked browser handles).",
+        "val packed =",
+        'listOf(pattern, type, if (recursive) "1" else "0", if (owned) "1" else "0")',
+        '.joinToString("")',
+        "return immediateWebStringQuery(descriptor.opcode, receiver.webId(), packed)",
+        ".split('')",
+        ".filter { it.isNotEmpty() }",
+        ".map { GodotHandle.fromBackendToken(it.toLong()) }",
+    ]
+
+
 # Signature: (params-after-descriptor/callSite, return-type). `receiver` present unless noted.
 SIGNATURES: dict[str, tuple[list[str], str]] = {
     "BOOL_RET_INT": (["receiver: GodotHandle", "value: Boolean"], "Int"),
@@ -1503,6 +1792,46 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ],
         "GodotHandle?",
     ),
+    "VECTOR3I_LONG_LONG_ARG": (
+        ["receiver: GodotHandle", "value: GodotVector3i", "first: Long", "second: Long"],
+        "",
+    ),
+    "VECTOR3I_RET_LONG": (["receiver: GodotHandle", "value: GodotVector3i"], "Long"),
+    "BASIS_RET_LONG": (["receiver: GodotHandle", "value: GodotBasis"], "Long"),
+    "NOARGS_RET_VECTOR3I_LIST": (["receiver: GodotHandle"], "List<GodotVector3i>"),
+    "LONG_OBJECT_ARG": (
+        ["receiver: GodotHandle", "longValue: Long", "objectValue: GodotHandle"],
+        "",
+    ),
+    "LONG_TRANSFORM3D_ARG": (
+        ["receiver: GodotHandle", "longValue: Long", "value: GodotTransform3D"],
+        "",
+    ),
+    "LONG_RET_STRING": (["receiver: GodotHandle", "value: Long"], "String"),
+    "LONG_RET_LONG": (["receiver: GodotHandle", "value: Long"], "Long"),
+    "LONG_LONG_RET_STRING": (
+        ["receiver: GodotHandle", "first: Long", "second: Long"],
+        "String",
+    ),
+    "LONG_LONG_RET_HANDLE": (
+        ["receiver: GodotHandle", "first: Long", "second: Long"],
+        "GodotHandle?",
+    ),
+    "VECTOR2_RET_VECTOR3": (["receiver: GodotHandle", "value: GodotVector2"], "GodotVector3"),
+    "OBJECT_STRING_RET_LONG_SINGLETON": (
+        ["resource: GodotHandle", "path: String", "flags: Long"],
+        "Long",
+    ),
+    "STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST": (
+        [
+            "receiver: GodotHandle",
+            "pattern: String",
+            "type: String",
+            "recursive: Boolean",
+            "owned: Boolean",
+        ],
+        "List<GodotHandle>",
+    ),
 }
 
 
@@ -1522,6 +1851,9 @@ _WORD_CASE = {
     "VECTOR2": "Vector2",
     "VECTOR2I": "Vector2i",
     "VECTOR3": "Vector3",
+    "VECTOR3I": "Vector3i",
+    "BASIS": "Basis",
+    "TRANSFORM3D": "Transform3d",
     "STRING": "String",
     "STRINGNAME": "StringName",
     "NODEPATH": "NodePath",
@@ -1605,6 +1937,19 @@ EMIT_ORDER = [
     "CALLABLE_RET_HANDLE",
     "NOARGS_RET_LONG_SINGLETON",
     "STRINGNAME_OBJECT_RET_INT",
+    "VECTOR3I_LONG_LONG_ARG",
+    "VECTOR3I_RET_LONG",
+    "BASIS_RET_LONG",
+    "NOARGS_RET_VECTOR3I_LIST",
+    "LONG_OBJECT_ARG",
+    "LONG_TRANSFORM3D_ARG",
+    "LONG_RET_STRING",
+    "LONG_RET_LONG",
+    "LONG_LONG_RET_STRING",
+    "LONG_LONG_RET_HANDLE",
+    "VECTOR2_RET_VECTOR3",
+    "OBJECT_STRING_RET_LONG_SINGLETON",
+    "STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST",
 ]
 
 
@@ -1630,15 +1975,18 @@ package net.multigesture.kanama.web
 import kotlin.js.ExperimentalWasmJsInterop
 import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotBackendSpi
+import net.multigesture.kanama.backend.GodotBasis
 import net.multigesture.kanama.backend.GodotCallDescriptor
 import net.multigesture.kanama.backend.GodotCallSite
 import net.multigesture.kanama.backend.GodotColor
 import net.multigesture.kanama.backend.GodotExecutionMode
 import net.multigesture.kanama.backend.GodotHandle
 import net.multigesture.kanama.backend.GodotRect2
+import net.multigesture.kanama.backend.GodotTransform3D
 import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector2i
 import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.GodotVector3i
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
 /**

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -3152,6 +3152,390 @@
       "returnOwnership": "BORROWED",
       "executionMode": "IMMEDIATE_RESULT",
       "introducedBy": "60g-racing"
+    },
+    {
+      "opcode": 202,
+      "className": "GridMap",
+      "methodName": "set_mesh_library",
+      "hash": 1488083439,
+      "arguments": [
+        "MeshLibrary"
+      ],
+      "returnType": "void",
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Assign (or clear with null) the grid's MeshLibrary; the builder wires its runtime-built library at ready.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 203,
+      "className": "GridMap",
+      "methodName": "set_cell_item",
+      "hash": 3449088946,
+      "arguments": [
+        "Vector3i",
+        "int",
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3I_LONG_LONG_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Place or clear one grid cell (position, item, orientation) \u2014 the build/demolish core loop.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 204,
+      "className": "GridMap",
+      "methodName": "get_cell_item",
+      "hash": 3724960147,
+      "arguments": [
+        "Vector3i"
+      ],
+      "returnType": "int",
+      "shape": "VECTOR3I_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Read the item index at a cell (INVALID_CELL_ITEM = -1 round-trips through the integer query).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 205,
+      "className": "GridMap",
+      "methodName": "get_cell_item_orientation",
+      "hash": 3724960147,
+      "arguments": [
+        "Vector3i"
+      ],
+      "returnType": "int",
+      "shape": "VECTOR3I_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Read the orthogonal orientation index at a cell (map serialization).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 206,
+      "className": "GridMap",
+      "methodName": "get_orthogonal_index_from_basis",
+      "hash": 4210359952,
+      "arguments": [
+        "Basis"
+      ],
+      "returnType": "int",
+      "shape": "BASIS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Map a rotation basis to one of the 24 grid orientations (selector rotation applied on placement).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 207,
+      "className": "GridMap",
+      "methodName": "clear",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Remove every cell (map load resets the grid before repopulating).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 208,
+      "className": "GridMap",
+      "methodName": "get_used_cells",
+      "hash": 3995934104,
+      "arguments": [],
+      "returnType": "typedarray::Vector3i",
+      "shape": "NOARGS_RET_VECTOR3I_LIST",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "All occupied cells as packed integer triples (map save + smoke evidence).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 209,
+      "className": "MeshLibrary",
+      "methodName": "create_item",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "semantics": "Create an empty library item slot for a structure index.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 210,
+      "className": "MeshLibrary",
+      "methodName": "set_item_mesh",
+      "hash": 969122797,
+      "arguments": [
+        "int",
+        "Mesh"
+      ],
+      "returnType": "void",
+      "shape": "LONG_OBJECT_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Assign a mesh (extracted from the structure's PackedScene state) to a library item.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 211,
+      "className": "MeshLibrary",
+      "methodName": "set_item_mesh_transform",
+      "hash": 3616898986,
+      "arguments": [
+        "int",
+        "Transform3D"
+      ],
+      "returnType": "void",
+      "shape": "LONG_TRANSFORM3D_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Set a library item's mesh transform (the builder pins identity).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 212,
+      "className": "PackedScene",
+      "methodName": "get_state",
+      "hash": 3479783971,
+      "arguments": [],
+      "returnType": "SceneState",
+      "shape": "NOARGS_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "The scene's borrowed SceneState as a browser handle (mesh extraction without instantiating).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 213,
+      "className": "SceneState",
+      "methodName": "get_node_count",
+      "hash": 3905245786,
+      "arguments": [],
+      "returnType": "int",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Number of nodes recorded in the scene state.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 214,
+      "className": "SceneState",
+      "methodName": "get_node_type",
+      "hash": 659327637,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "StringName",
+      "shape": "LONG_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Recorded type name of a node by index (MeshInstance3D scan).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 215,
+      "className": "SceneState",
+      "methodName": "get_node_property_count",
+      "hash": 923996154,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "int",
+      "shape": "LONG_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Number of recorded properties for a node by index.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 216,
+      "className": "SceneState",
+      "methodName": "get_node_property_name",
+      "hash": 351665558,
+      "arguments": [
+        "int",
+        "int"
+      ],
+      "returnType": "StringName",
+      "shape": "LONG_LONG_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Recorded property name by node/property index (mesh property scan).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 217,
+      "className": "SceneState",
+      "methodName": "get_node_property_value",
+      "hash": 678354945,
+      "arguments": [
+        "int",
+        "int"
+      ],
+      "returnType": "Variant",
+      "shape": "LONG_LONG_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Recorded property value by node/property index; object values register as browser handles, non-objects resolve null.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 218,
+      "className": "Camera3D",
+      "methodName": "project_ray_origin",
+      "hash": 1718073306,
+      "arguments": [
+        "Vector2"
+      ],
+      "returnType": "Vector3",
+      "shape": "VECTOR2_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "World-space origin of the picking ray through a screen point (grid cursor).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 219,
+      "className": "Camera3D",
+      "methodName": "project_ray_normal",
+      "hash": 1718073306,
+      "arguments": [
+        "Vector2"
+      ],
+      "returnType": "Vector3",
+      "shape": "VECTOR2_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "World-space direction of the picking ray through a screen point (grid cursor).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 220,
+      "className": "Viewport",
+      "methodName": "get_mouse_position",
+      "hash": 3341600327,
+      "arguments": [],
+      "returnType": "Vector2",
+      "shape": "NOARGS_RET_VECTOR2",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Fresh viewport-space mouse position (per-frame grid cursor; no snapshot mirrors pointer state).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 221,
+      "className": "Input",
+      "methodName": "is_action_just_released",
+      "hash": 1558498928,
+      "arguments": [
+        "StringName",
+        "bool"
+      ],
+      "returnType": "bool",
+      "shape": "STRINGNAME_RET_BOOL_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Query whether an input action was just released this frame (camera zoom steps), via the active script proxy singleton.",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 222,
+      "className": "Resource",
+      "methodName": "duplicate",
+      "hash": 482882304,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "Resource",
+      "shape": "BOOL_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Duplicate a resource (the builder copies scene-state meshes so the library owns independent copies).",
+      "scope": "class",
+      "returnOwnership": "OWNED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 223,
+      "className": "ResourceSaver",
+      "methodName": "save",
+      "hash": 2983274697,
+      "arguments": [
+        "Resource",
+        "String",
+        "bitfield::ResourceSaver.SaverFlags"
+      ],
+      "returnType": "enum::Error",
+      "shape": "OBJECT_STRING_RET_LONG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Persist a resource to a path via the active script proxy singleton; scripted resources pull current Kotlin property values before serializing (map save).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 224,
+      "className": "Node",
+      "methodName": "find_children",
+      "hash": 2560337219,
+      "arguments": [
+        "String",
+        "String",
+        "bool",
+        "bool"
+      ],
+      "returnType": "typedarray::Node",
+      "shape": "STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "Find descendant nodes by pattern/type; scripted matches resolve to script handles, engine nodes get tracked browser handles (preview-model mesh pruning).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 225,
+      "className": "MeshInstance3D",
+      "methodName": "get_mesh",
+      "hash": 1808005922,
+      "arguments": [],
+      "returnType": "Mesh",
+      "shape": "NOARGS_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "semantics": "The instance's borrowed Mesh as a browser handle (null resolves to a null handle; the builder prunes empty preview MeshInstance3Ds).",
+      "scope": "class",
+      "returnOwnership": "BORROWED",
+      "introducedBy": "60h-citybuilder"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -32,9 +32,10 @@ import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
+import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -178,7 +178,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -1,0 +1,332 @@
+// demos/citybuilder.mjs -- Starter-Kit-City-Builder play + teardown assertions for
+// the Web smoke.
+//
+// The builder places structures on a GridMap at the cell under the mouse ray; headless
+// browsers never move the pointer, so every placement deterministically targets the cell
+// under the top-left screen ray. The driver injects actions at ENGINE level (ops 86/87),
+// observes the grid through the GridMap query family on the Builder's gridmap property
+// handle, and proves the full save round-trip: build -> save (user://map.res, scripted
+// DataMap/DataStructure resources) -> demolish -> load -> the placed cell comes back.
+// smoke_teardown (method#1) releases hydrated structure assets, frees the Audio autoload
+// and the scene root, draining every live handle to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[citybuilder ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        builderHandle: bridge.cbBuilderHandle,
+        smokeHandle: bridge.cbSmokeHandle,
+        builderReady: classCount(".Builder"),
+        viewReady: classCount(".View"),
+        audioReady: classCount(".Audio"),
+        smokeReady: classCount(".Smoke"),
+        processCalls: bridge.processCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+// Occupied grid cells through the GridMap string-query family (opcode 208) on the
+// Builder's gridmap property handle (property#5).
+async function usedCells(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const grid = Number(bridge.api.kanamaWebGetPackedProperty(bridge.cbBuilderHandle, 5));
+      if (!grid) return null;
+      const packed = bridge.immediateStringQuery(208, grid, "");
+      const cells = packed === "" ? [] : packed.split("\\u001f");
+      const items = cells.map((cell) => {
+        const item = bridge.immediateObjectQuery(204, grid, cell.replaceAll(",", "\\u001f"));
+        return { cell, item };
+      });
+      return { count: cells.length, items };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+// The selector's world position (opcode 138 on the Builder's selector property handle):
+// it lerps toward the mouse-ray cell every process tick.
+async function selectorPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const selector = Number(bridge.api.kanamaWebGetPackedProperty(bridge.cbBuilderHandle, 2));
+      if (!selector) return null;
+      const x = bridge.immediateNoArgsVector3X(138, selector);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.processCalls = Math.max(peak.processCalls, snap.processCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(`process=${snap.processCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} errs=${snap.callbackErrors}`);
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
+  // Engine-level action injection (ops 86/87) instead of browser key events: the first
+  // browser input gesture stalls the headless-Firefox main thread for the whole hold
+  // (audio-context resume), freezing gameplay under it.
+  const press = (action) =>
+    evaluate(
+      `globalThis.KanamaWebBridge.immediateObjectQuery(86, globalThis.KanamaWebBridge.cbSmokeHandle, "${action}"); true`,
+    );
+  const release = (action) =>
+    evaluate(
+      `globalThis.KanamaWebBridge.immediateObjectQuery(87, globalThis.KanamaWebBridge.cbSmokeHandle, "${action}"); true`,
+    );
+  const tap = async (action) => {
+    await press(action);
+    await delay(250);
+    await release(action);
+    await delay(250);
+  };
+
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?citybuilder=${Date.now()}`);
+
+  // Generous first-load window: startup itself exercises the new families (SceneState
+  // mesh extraction + duplication into the runtime MeshLibrary for all 13 structures).
+  const readyDeadline = Math.min(deadline, Date.now() + 120_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "citybuilder" &&
+      snap.protocol > 0 &&
+      snap.builderReady >= 1 &&
+      snap.viewReady >= 1 &&
+      snap.audioReady >= 1 &&
+      snap.smokeReady >= 1 &&
+      snap.builderHandle > 0 &&
+      snap.smokeHandle > 0
+    ) {
+      ready = snap;
+      break;
+    }
+    await delay(250);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm City-Builder did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`ready: builderHandle=${ready.builderHandle} protocol=${ready.protocol}`);
+
+  // Let process ticks flow before touching the grid (the selector needs a mouse-ray
+  // sample; the first ticks also settle the preview model instantiation).
+  const settledStart = await observe(
+    evaluate,
+    { ...seedFrom(ready), callbackErrors: 0 },
+    6_000,
+    deadline,
+    (snap) => snap.processCalls >= ready.processCalls + 30,
+  );
+  const baseline = settledStart.last ?? ready;
+  const baselineCells = await usedCells(evaluate);
+  if (!baselineCells) throw new Error("could not read the GridMap used cells");
+  const selectorStart = await selectorPosition(evaluate);
+  trace(`baseline: cells=${baselineCells.count} selector=${JSON.stringify(selectorStart)}`);
+
+  // Warm-up placement: the FIRST structure render compiles its materials on software GL,
+  // which can freeze the main thread for seconds. Place, wait for process to flow again,
+  // then demolish so the measured sequence starts from a clean grid.
+  await tap("build");
+  await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    12_000,
+    deadline,
+    (snap, p) => snap.processCalls >= p.processCalls && snap.processCalls > baseline.processCalls + 60,
+  );
+  const warmCells = await usedCells(evaluate);
+  trace(`warm-up build: cells=${warmCells?.count}`);
+  if (!warmCells || warmCells.count !== baselineCells.count + 1) {
+    throw new Error(`warm-up build did not place a cell (before=${baselineCells.count} after=${warmCells?.count})`);
+  }
+
+  // Toggle to the next structure and rotate the selector, then rebuild on the same cell:
+  // same cell count, different item index proves toggle + placement replacement.
+  await tap("structure_next");
+  await tap("rotate");
+  await tap("build");
+  const toggledCells = await usedCells(evaluate);
+  const warmItem = warmCells.items[0]?.item ?? -1;
+  const toggledItem = toggledCells?.items[0]?.item ?? -1;
+  trace(`toggled build: cells=${toggledCells?.count} item ${warmItem} -> ${toggledItem}`);
+
+  // Save the one-cell map: engine-side ResourceSaver.save on the scripted DataMap after
+  // pulling the current Kotlin property values (newScriptInstance -> DataStructure).
+  await tap("save");
+  const savedCells = await usedCells(evaluate);
+
+  // Demolish the cell, then load user://map.res back: the scripted resources hydrate
+  // and the placed cell returns.
+  await tap("demolish");
+  const demolishedCells = await usedCells(evaluate);
+  trace(`demolished: cells=${demolishedCells?.count}`);
+  await tap("load");
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    3_000,
+    deadline,
+    null,
+  );
+  const loadedCells = await usedCells(evaluate);
+  const selectorRun = await selectorPosition(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? baseline;
+  const selectorDisplacement =
+    selectorStart && selectorRun
+      ? Math.hypot(selectorRun.x - selectorStart.x, selectorRun.z - selectorStart.z)
+      : 0;
+  trace(`loaded: cells=${loadedCells?.count} selectorMoved=${selectorDisplacement.toFixed(2)}`);
+
+  // Full teardown: smoke_teardown (method#1) releases hydrated structure assets, frees
+  // the Audio autoload and the scene root; every node exits and releases its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.cbSmokeHandle, 1); true",
+  );
+  const teardown = await observe(evaluate, peak, 12_000, deadline, (snap) => snap.liveHandles === 0);
+  const settled = teardown.last ?? atPeak;
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} errs=${settled.callbackErrors}`);
+  if (DEBUG && settled.liveHandles !== 0) {
+    const liveKinds = await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const counts = {};
+      for (let index = 1; index < bridge.browserHandleSlots.length; index += 1) {
+        const slot = bridge.browserHandleSlots[index];
+        if (slot.live) counts[slot.kind] = (counts[slot.kind] ?? 0) + 1;
+      }
+      return counts;
+    })()`);
+    trace(`surviving handle kinds: ${JSON.stringify(liveKinds)}`);
+  }
+
+  const protocolVersion = ready.protocol;
+  const checks = {
+    modeCitybuilder: ready.mode === "citybuilder",
+    protocol14: protocolVersion === 14,
+    sceneScriptsReady:
+      ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
+    // Injected build placed a structure on the grid at the mouse-ray cell.
+    buildPlacedCell: warmCells.count === baselineCells.count + 1,
+    // structure_next + rebuild replaced the cell's item (same cell, new index).
+    toggleReplacedItem:
+      (toggledCells?.count ?? 0) === warmCells.count && toggledItem !== warmItem && toggledItem >= 0,
+    // demolish cleared the cell; loading user://map.res brought it back with its item —
+    // the scripted-resource save round-trip (newScriptInstance -> ResourceSaver.save ->
+    // ResourceLoader.load -> hydration) survived.
+    demolishClearedCell: (demolishedCells?.count ?? -1) === warmCells.count - 1,
+    saveLoadRoundTrip:
+      (savedCells?.count ?? 0) === (toggledCells?.count ?? -1) &&
+      (loadedCells?.count ?? 0) === (savedCells?.count ?? -1) &&
+      (loadedCells?.items[0]?.item ?? -2) === toggledItem,
+    processFramesAdvanced: peak.processCalls >= baseline.processCalls + 40,
+    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands,
+    crossingsAdvanced: peak.crossings > baseline.crossings,
+    fullTeardownToZero: settled.liveHandles === 0,
+    noCallbackFaults:
+      peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      loaded: ready.mode === "citybuilder",
+      outcome: ready.mode === "citybuilder" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      processCalls: peak.processCalls,
+      appliedCommands: peak.appliedCommands,
+      selectorDisplacement: Number(selectorDisplacement.toFixed(3)),
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+    },
+    boundaryErrors,
+  };
+}
+
+function seedFrom(snap) {
+  return {
+    processCalls: snap.processCalls,
+    appliedCommands: snap.appliedCommands,
+    maxLiveHandles: snap.liveHandles,
+    crossings: snap.crossings,
+  };
+}

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -153,7 +153,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -137,7 +137,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -227,7 +227,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol13: firstRun.settled.protocol === 13 && secondRun.settled.protocol === 13,
+    protocol14: firstRun.settled.protocol === 14 && secondRun.settled.protocol === 14,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -192,7 +192,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -183,7 +183,7 @@ export async function runThirdperson({ url, evaluate, navigate, keys, deadline }
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -121,7 +121,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol13: protocolVersion === 13,
+    protocol14: protocolVersion === 14,
     sceneReady: ready.mainReady >= 1,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -25,9 +25,10 @@ import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
+import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -24,9 +24,10 @@ import { runFps } from "./demos/fps.mjs";
 import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
+import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -30,6 +30,7 @@ val extraWebScriptSourceRoot: File? =
                     "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
                     "thirdperson" -> "kanamaWebThirdpersonProjectDir"
                     "racing" -> "kanamaWebRacingProjectDir"
+                    "citybuilder" -> "kanamaWebCitybuilderProjectDir"
                     else -> null
                 }
             projectDirProperty
@@ -140,6 +141,9 @@ val webThirdpersonStaging = layout.buildDirectory.dir("web-thirdperson/godot-pro
 val webRacingSourceProject =
     providers.gradleProperty("kanamaWebRacingProjectDir").orNull?.let(rootProject::file)
 val webRacingStaging = layout.buildDirectory.dir("web-racing/godot-project")
+val webCitybuilderSourceProject =
+    providers.gradleProperty("kanamaWebCitybuilderProjectDir").orNull?.let(rootProject::file)
+val webCitybuilderStaging = layout.buildDirectory.dir("web-citybuilder/godot-project")
 val webMatch3ImportLog = layout.buildDirectory.file("reports/web-match3-import.log")
 val webMatch3ImportOutput = ByteArrayOutputStream()
 val webGameplayCoverage = layout.buildDirectory.file("reports/web-gameplay-coverage.json")
@@ -1916,6 +1920,144 @@ tasks.register("stageWebRacingProject") {
     }
 }
 
+tasks.register("stageWebCitybuilderProject") {
+    group = "verification"
+    description = "Stages Starter-Kit-City-Builder with generated Web proxies (Task 60h)."
+    dependsOn("kspKotlinWasmJs", "generateWebGameplayCoverage")
+    webCitybuilderSourceProject?.let(inputs::dir)
+    inputs.dir(webSpikeAssets)
+    inputs.dir(webProxyResources)
+    inputs.file(webGameplayCoverage)
+    outputs.dir(webCitybuilderStaging)
+
+    doLast {
+        val sourceProject =
+            webCitybuilderSourceProject
+                ?: error(
+                    "Pass -PkanamaWebCitybuilderProjectDir=" +
+                        "/absolute/path/to/kanama-demos/Starter-Kit-City-Builder"
+                )
+        check(sourceProject.resolve("scenes/main.tscn").isFile) {
+            "City-Builder project not found: $sourceProject"
+        }
+
+        val stagingDir = webCitybuilderStaging.get().asFile
+        delete(stagingDir)
+        copy {
+            from(sourceProject) {
+                exclude(".git/**")
+                exclude(".godot/**")
+                exclude(".gradle/**")
+                exclude(".kotlin/**")
+                exclude("build/**")
+                exclude("web/**")
+                exclude("kotlin-src/**")
+                exclude("android/**")
+                exclude("addons/kanama_tools/**")
+                exclude("addons/kanama/**")
+                exclude("export_presets.cfg")
+            }
+            into(stagingDir)
+        }
+        copy {
+            from(webSpikeSourceProject.file("export_presets.cfg"))
+            into(stagingDir)
+        }
+        copy {
+            from(webProxyResources)
+            include("*.gd")
+            into(stagingDir.resolve("kanama-web/generated"))
+        }
+        copy {
+            from(webProxyResources)
+            include("KanamaWebProxyManifest.generated.tsv")
+            include("KanamaWebProtocol.generated.json")
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webSpikeAssets)
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webGameplayCoverage)
+            into(stagingDir.resolve("kanama-web"))
+        }
+
+        val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
+        val expectedSources =
+            setOf("Audio", "Builder", "DataMap", "DataStructure", "Smoke", "Structure", "View")
+                .map { "res://kotlin-src/$it.kt" }
+                .toSet()
+        val mappings =
+            manifest
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") }
+                .map { it.split('\t').let { c -> c[0] to c[1] } }
+                .filter { (sourcePath, _) -> sourcePath in expectedSources }
+                .toMap()
+        check(mappings.keys == expectedSources) {
+            "City-Builder Web proxy mappings incomplete: missing=${expectedSources - mappings.keys}"
+        }
+
+        fileTree(stagingDir) {
+                include("project.godot")
+                include("**/*.tscn")
+                include("**/*.tres")
+            }
+            .files
+            .forEach { stagedFile ->
+                val original = stagedFile.readText()
+                var rewritten =
+                    mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
+                        text.replace(sourcePath, proxyPath)
+                    }
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
+                if (rewritten != original) stagedFile.writeText(rewritten)
+                check(!rewritten.contains("res://kotlin-src/")) {
+                    "Unmapped Kotlin attachment remains in staged file: $stagedFile"
+                }
+            }
+
+        // Forward+ project with no mobile override: pin the Compatibility renderer the Web
+        // template actually runs.
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val forwardFeature = "config/features=PackedStringArray(\"4.7\", \"Forward Plus\")"
+        val renderingSection = "[rendering]"
+        check(stagedProjectText.contains(forwardFeature)) {
+            "City-Builder renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(renderingSection)) {
+            "City-Builder rendering section changed; update the Web staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    forwardFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    renderingSection,
+                    "$renderingSection\n\nrenderer/rendering_method=\"gl_compatibility\"",
+                )
+        )
+
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        shell.writeText(
+            shell.readText()
+                .replace(pageStart, "$pageStart\n      globalThis.KanamaWebMode = \"citybuilder\";")
+        )
+    }
+}
+
 tasks.register("stageWebThirdpersonProject") {
     group = "verification"
     description = "Stages the third-person controller with generated Web proxies (Task 60f)."
@@ -2185,9 +2327,10 @@ fun stageTaskFor(demo: String): String =
         "charactercontroller" -> "stageWebCharactercontrollerProject"
         "thirdperson" -> "stageWebThirdpersonProject"
         "racing" -> "stageWebRacingProject"
+        "citybuilder" -> "stageWebCitybuilderProject"
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder)"
             )
     }
 
@@ -2203,9 +2346,10 @@ fun stagingDirFor(demo: String): File =
         "charactercontroller" -> webCharacterStaging.get().asFile
         "thirdperson" -> webThirdpersonStaging.get().asFile
         "racing" -> webRacingStaging.get().asFile
+        "citybuilder" -> webCitybuilderStaging.get().asFile
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder)"
             )
     }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCityBuilderApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCityBuilderApi.kt
@@ -1,0 +1,332 @@
+@file:OptIn(net.multigesture.kanama.backend.InternalKanamaBackendApi::class)
+
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.backend.ClassDBBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
+import net.multigesture.kanama.backend.GodotBasis
+import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
+import net.multigesture.kanama.backend.GodotTransform3D
+import net.multigesture.kanama.backend.GodotVector2
+import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.GodotVector3i
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors
+import net.multigesture.kanama.types.Basis
+import net.multigesture.kanama.types.Transform3D
+import net.multigesture.kanama.types.Vector2
+import net.multigesture.kanama.types.Vector3
+import net.multigesture.kanama.types.Vector3i
+import net.multigesture.kanama.web.KanamaWebScript
+import net.multigesture.kanama.web.WebObjectId
+import net.multigesture.kanama.web.webScriptInstance
+
+private fun Vector3i.toBackend(): GodotVector3i = GodotVector3i(x, y, z)
+
+private fun Basis.toBackend(): GodotBasis =
+  GodotBasis(x.toBackend(), y.toBackend(), z.toBackend())
+
+private fun Vector3.toBackend(): GodotVector3 =
+  GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
+
+private fun GodotVector3.toApi(): Vector3 = Vector3(x.toDouble(), y.toDouble(), z.toDouble())
+
+/** City-Builder surface: the runtime-built structure grid. */
+class GridMap(godotObject: GodotHandle) : Node3D(godotObject) {
+  fun setMeshLibrary(meshLibrary: MeshLibrary?) {
+    GodotBackendCalls.invokeObjectArg(
+      InitialGodotCallDescriptors.GRIDMAP_SET_MESH_LIBRARY,
+      backendHandle,
+      meshLibrary?.backendHandle,
+    )
+  }
+
+  fun setCellItem(position: Vector3i, item: Int, orientation: Int = 0) {
+    GodotBackendCalls.invokeVector3iLongLongArg(
+      InitialGodotCallDescriptors.GRIDMAP_SET_CELL_ITEM,
+      backendHandle,
+      position.toBackend(),
+      item.toLong(),
+      orientation.toLong(),
+    )
+  }
+
+  fun getCellItem(position: Vector3i): Int =
+    GodotBackendCalls.invokeVector3iRetLong(
+        InitialGodotCallDescriptors.GRIDMAP_GET_CELL_ITEM,
+        backendHandle,
+        position.toBackend(),
+      )
+      .toInt()
+
+  fun getCellItemOrientation(position: Vector3i): Int =
+    GodotBackendCalls.invokeVector3iRetLong(
+        InitialGodotCallDescriptors.GRIDMAP_GET_CELL_ITEM_ORIENTATION,
+        backendHandle,
+        position.toBackend(),
+      )
+      .toInt()
+
+  fun getOrthogonalIndexFromBasis(basis: Basis): Int =
+    GodotBackendCalls.invokeBasisRetLong(
+        InitialGodotCallDescriptors.GRIDMAP_GET_ORTHOGONAL_INDEX_FROM_BASIS,
+        backendHandle,
+        basis.toBackend(),
+      )
+      .toInt()
+
+  fun clear() {
+    GodotBackendCalls.invokeNoArgsVoid(InitialGodotCallDescriptors.GRIDMAP_CLEAR, backendHandle)
+  }
+
+  fun getUsedCells(): List<Vector3i> =
+    GodotBackendCalls.invokeNoArgsRetVector3iList(
+        InitialGodotCallDescriptors.GRIDMAP_GET_USED_CELLS,
+        backendHandle,
+      )
+      .map { Vector3i(it.x, it.y, it.z) }
+
+  companion object {
+    const val INVALID_CELL_ITEM: Long = -1L
+  }
+}
+
+/** Runtime-built mesh library; `create()` hands back an owning wrapper — close what you create. */
+class MeshLibrary(godotObject: GodotHandle) : Resource(godotObject.toBackendHandle()) {
+  fun createItem(id: Int) {
+    GodotBackendCalls.invokeLongArg(
+      InitialGodotCallDescriptors.MESHLIBRARY_CREATE_ITEM,
+      backendHandle,
+      id.toLong(),
+    )
+  }
+
+  fun setItemMesh(id: Int, mesh: Mesh?) {
+    val target = requireNotNull(mesh) { "Kanama Web MeshLibrary.setItemMesh requires a mesh" }
+    GodotBackendCalls.invokeLongObjectArg(
+      InitialGodotCallDescriptors.MESHLIBRARY_SET_ITEM_MESH,
+      backendHandle,
+      id.toLong(),
+      target.backendHandle,
+    )
+  }
+
+  fun setItemMeshTransform(id: Int, meshTransform: Transform3D) {
+    GodotBackendCalls.invokeLongTransform3dArg(
+      InitialGodotCallDescriptors.MESHLIBRARY_SET_ITEM_MESH_TRANSFORM,
+      backendHandle,
+      id.toLong(),
+      GodotTransform3D(meshTransform.basis.toBackend(), meshTransform.origin.toBackend()),
+    )
+  }
+
+  /** Releases this constructed library's reference ("close what you create"). */
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  companion object {
+    fun create(): MeshLibrary {
+      val created =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("MeshLibrary")) {
+          "Godot could not instantiate MeshLibrary"
+        }
+      return MeshLibrary(WebObjectId(created.backendToken().toInt()))
+    }
+  }
+}
+
+/** Read-only recorded scene contents (mesh extraction without instantiating). */
+class SceneState internal constructor(godotObject: GodotHandle) : GodotObject(godotObject) {
+  fun getNodeCount(): Int =
+    GodotBackendCalls.invokeNoArgsRetLong(
+        InitialGodotCallDescriptors.SCENESTATE_GET_NODE_COUNT,
+        backendHandle,
+      )
+      .toInt()
+
+  fun getNodeType(idx: Int): String =
+    GodotBackendCalls.invokeLongRetString(
+      InitialGodotCallDescriptors.SCENESTATE_GET_NODE_TYPE,
+      backendHandle,
+      idx.toLong(),
+    )
+
+  fun getNodePropertyCount(idx: Int): Int =
+    GodotBackendCalls.invokeLongRetLong(
+        InitialGodotCallDescriptors.SCENESTATE_GET_NODE_PROPERTY_COUNT,
+        backendHandle,
+        idx.toLong(),
+      )
+      .toInt()
+
+  fun getNodePropertyName(idx: Int, propIdx: Int): String =
+    GodotBackendCalls.invokeLongLongRetString(
+      InitialGodotCallDescriptors.SCENESTATE_GET_NODE_PROPERTY_NAME,
+      backendHandle,
+      idx.toLong(),
+      propIdx.toLong(),
+    )
+
+  /** Object-valued recorded properties resolve to a tracked handle; other values are null. */
+  fun getNodePropertyValue(idx: Int, propIdx: Int): Any? =
+    GodotBackendCalls.invokeLongLongRetHandle(
+        InitialGodotCallDescriptors.SCENESTATE_GET_NODE_PROPERTY_VALUE,
+        backendHandle,
+        idx.toLong(),
+        propIdx.toLong(),
+      )
+      ?.let { GodotObject(WebObjectId(it.backendToken().toInt())) }
+}
+
+/** Mesh resource wrapper (extracted from scene state and duplicated for the library). */
+class Mesh internal constructor(godotObject: GodotHandle) : Resource(godotObject.toBackendHandle()) {
+  fun duplicate(subresources: Boolean = false): Resource? =
+    GodotBackendCalls.invokeBoolRetHandle(
+        InitialGodotCallDescriptors.RESOURCE_DUPLICATE,
+        backendHandle,
+        subresources,
+      )
+      ?.let { Resource(WebObjectId(it.backendToken().toInt())) }
+
+  companion object {
+    fun fromObject(value: GodotObject?): Mesh? =
+      value
+        ?.takeIf { GodotObjectBackendContractProbe(it.backendHandle).isClass("Mesh") }
+        ?.let { Mesh(it.handle) }
+  }
+}
+
+fun PackedScene.getState(): SceneState? =
+  GodotBackendCalls.invokeNoArgsRetHandle(
+      InitialGodotCallDescriptors.PACKEDSCENE_GET_STATE,
+      backendHandle,
+    )
+    ?.let { SceneState(WebObjectId(it.backendToken().toInt())) }
+
+fun MeshInstance3D.getMesh(): Mesh? =
+  GodotBackendCalls.invokeNoArgsRetHandle(
+      InitialGodotCallDescriptors.MESHINSTANCE3D_GET_MESH,
+      backendHandle,
+    )
+    ?.let { Mesh(WebObjectId(it.backendToken().toInt())) }
+
+fun Camera3D.projectRayOrigin(screenPoint: Vector2): Vector3 =
+  GodotBackendCalls.invokeVector2RetVector3(
+      InitialGodotCallDescriptors.CAMERA3D_PROJECT_RAY_ORIGIN,
+      backendHandle,
+      GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
+    )
+    .toApi()
+
+fun Camera3D.projectRayNormal(screenPoint: Vector2): Vector3 =
+  GodotBackendCalls.invokeVector2RetVector3(
+      InitialGodotCallDescriptors.CAMERA3D_PROJECT_RAY_NORMAL,
+      backendHandle,
+      GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
+    )
+    .toApi()
+
+/** Fresh viewport-space pointer position (no snapshot mirrors pointer state). */
+fun Viewport.getMousePosition(): Vector2 =
+  GodotBackendCalls.invokeNoArgsRetVector2(
+      InitialGodotCallDescriptors.VIEWPORT_GET_MOUSE_POSITION,
+      backendHandle,
+    )
+    .let { Vector2(it.x.toDouble(), it.y.toDouble()) }
+
+fun Node.findChildren(
+  pattern: String,
+  type: String = "",
+  recursive: Boolean = true,
+  owned: Boolean = true,
+): List<Node> =
+  GodotBackendCalls.invokeStringStringBoolBoolRetHandleList(
+      InitialGodotCallDescriptors.NODE_FIND_CHILDREN,
+      backendHandle,
+      pattern,
+      type,
+      recursive,
+      owned,
+    )
+    .map { Node(it) }
+
+fun GodotObject.isClass(name: String): Boolean =
+  GodotObjectBackendContractProbe(backendHandle).isClass(name)
+
+fun GodotObject.asObject(): GodotObject = this
+
+fun Input.isActionJustReleased(action: String): Boolean =
+  GodotBackendCalls.invokeStringNameRetBoolSingleton(
+    InitialGodotCallDescriptors.INPUT_IS_ACTION_JUST_RELEASED,
+    action,
+  )
+
+object ResourceSaver {
+  /** Persists [resource]; scripted resources pull current Kotlin values before serializing. */
+  fun save(resource: Resource, path: String, flags: Long = 0L): Long =
+    GodotBackendCalls.invokeObjectStringRetLongSingleton(
+      InitialGodotCallDescriptors.RESOURCESAVER_SAVE,
+      resource.backendHandle,
+      path,
+      flags,
+    )
+}
+
+/** Generic resource load (scripted resources resolve to their hydrated script handle). */
+fun ResourceLoader.load(
+  path: String,
+  typeHint: String = "",
+  cacheMode: Long = ResourceLoader.CACHE_MODE_REUSE,
+): Resource? =
+  net.multigesture.kanama.backend.ResourceLoaderBackendContractProbe.load(path, typeHint, cacheMode)
+    ?.let { Resource(WebObjectId(it.backendToken().toInt())) }
+
+/** An owned scripted resource created from Kotlin; release via [close] when handed off. */
+class OwnedScriptResource<out T>
+@PublishedApi
+internal constructor(
+  /** The live Kotlin script instance — your `@ScriptClass(attachTo = "Resource")` type. */
+  val instance: T,
+  /** The owning resource wrapper. Save it, assign it into a slot, or [close] to release. */
+  val resource: ScriptResource,
+) : AutoCloseable {
+  override fun close() = resource.close()
+}
+
+/** Resource wrapper over a live script handle whose creation reference we own. */
+class ScriptResource internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle()) {
+  private var closed = false
+
+  fun close() {
+    if (closed) return
+    closed = true
+    releaseWebScriptResource(handle.value)
+  }
+}
+
+/**
+ * Creates a brand-new, engine-backed script resource of type [T] purely from Kotlin — the Web
+ * counterpart of the desktop `newScriptInstance` ("close what you create" applies).
+ */
+inline fun <reified T : KanamaWebScript> newScriptInstance(): OwnedScriptResource<T> {
+  val className =
+    checkNotNull(T::class.simpleName) { "Kanama Web script resource type must be named" }
+  val handle = newWebScriptResourceHandle(className)
+  val instance =
+    checkNotNull(webScriptInstance(handle) as? T) {
+      "Godot did not hydrate a $className script instance"
+    }
+  return OwnedScriptResource(instance, newWebScriptResourceWrapper(handle))
+}
+
+@PublishedApi
+internal fun newWebScriptResourceHandle(className: String): Int {
+  val handle = instantiateWebScript(className)
+  check(handle != 0) { "Godot could not instantiate script resource $className" }
+  return handle
+}
+
+@PublishedApi
+internal fun newWebScriptResourceWrapper(handle: Int): ScriptResource =
+  ScriptResource(WebObjectId(handle))

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -269,7 +269,14 @@ abstract class KanamaScript<T : GodotObject>(
 }
 
 open class Resource internal constructor(backendHandle: BackendGodotHandle) :
-  GodotObject(backendHandle)
+  GodotObject(backendHandle) {
+  constructor(godotObject: GodotHandle) : this(godotObject.toBackendHandle())
+
+  companion object {
+    /** Re-types any Godot object as a Resource (the Web bridge carries no class metadata). */
+    fun fromObject(value: GodotObject?): Resource? = value?.let { Resource(it.backendHandle) }
+  }
+}
 
 @ManualGodotLifetimeApi
 class Texture2D internal constructor(private var resourceHandle: BackendGodotHandle?) :
@@ -345,11 +352,22 @@ object GD {
     Mathf.lerpAngle(from, to, weight)
 
   fun degToRad(degrees: Double): Double = degrees * kotlin.math.PI / 180.0
+
+  /** Web adaptation: Godot's print lands on the browser console via Wasm stdout. */
+  fun print(message: Any?) {
+    println(message)
+  }
 }
 
 internal fun GodotHandle.toBackendHandle(): BackendGodotHandle =
   BackendGodotHandle.fromBackendToken(value.toLong())
 
 internal expect fun releaseWebResource(resourceHandle: Int)
+
+internal expect fun instantiateWebScript(className: String): Int
+
+internal expect fun releaseWebScriptResource(handle: Int)
+
+internal expect fun releaseWebConstructedObject(handle: Int)
 
 internal expect fun isWebBrowserHandleLive(handle: Int): Boolean

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -155,6 +155,16 @@ object Mathf {
 
   fun max(a: Double, b: Double): Double = kotlin.math.max(a, b)
 
+  /** Godot's roundi: round half away from zero to the nearest integer. */
+  fun roundToInt(value: Double): Long = kotlin.math.round(value).toLong()
+
+  /** Godot's wrapi: wrap [value] into the half-open range [min, max). */
+  fun wrap(value: Long, min: Long, max: Long): Long {
+    val range = max - min
+    if (range == 0L) return min
+    return min + ((value - min) % range + range) % range
+  }
+
   fun isEqualApprox(a: Double, b: Double): Boolean = kotlin.math.abs(a - b) < 1e-6
 
   /** Godot's angle_lerp / lerp_angle: interpolate the shortest arc between two angles (radians). */

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -150,6 +150,29 @@ data class Rect2(val position: Vector2, val size: Vector2)
 
 data class Color(val r: Float, val g: Float, val b: Float, val a: Float = 1.0f)
 
+data class Vector3i(val x: Int, val y: Int, val z: Int) {
+  companion object {
+    val ZERO = Vector3i(0, 0, 0)
+  }
+}
+
+/** Godot's Plane in Hessian normal form: [normal] and signed distance [d] from the origin. */
+class Plane(val normal: Vector3, val d: Double) {
+  constructor(normal: Vector3, d: Number) : this(normal, d.toDouble())
+
+  /**
+   * Godot's intersects_ray: the intersection of the ray [from] + t * [dir] with this plane, or null
+   * when the ray is parallel to or points away from it.
+   */
+  fun intersectsRay(from: Vector3, dir: Vector3): Vector3? {
+    val den = normal.dot(dir)
+    if (kotlin.math.abs(den) < 1e-8) return null
+    val dist = (normal.dot(from) - d) / den
+    if (dist > 1e-5) return null
+    return from + dir * -dist
+  }
+}
+
 data class Vector2i(val x: Int, val y: Int) {
   companion object {
     val ZERO = Vector2i(0, 0)

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
@@ -26,3 +26,26 @@ internal actual fun releaseWebCollision(collisionHandle: Int) {
 
 private fun releaseWebCollisionInterop(collisionHandle: Int): Int =
   js("globalThis.KanamaWebBridge.releaseCollision(collisionHandle)")
+
+internal actual fun instantiateWebScript(className: String): Int =
+  instantiateWebScriptInterop(className)
+
+private fun instantiateWebScriptInterop(className: String): Int =
+  js("globalThis.KanamaWebBridge.instantiateScript(className)")
+
+internal actual fun releaseWebScriptResource(handle: Int) {
+  val released = releaseWebScriptResourceInterop(handle)
+  check(released == 1) { "Unknown or already released Kanama Web script resource handle=$handle" }
+}
+
+private fun releaseWebScriptResourceInterop(handle: Int): Int =
+  js("globalThis.KanamaWebBridge.releaseScriptResource(handle)")
+
+internal actual fun releaseWebConstructedObject(handle: Int) {
+  val released = releaseWebConstructedObjectInterop(handle)
+  check(released == 1) { "Unknown or already released Kanama Web constructed handle=$handle" }
+  unregisterWebBrowserHandle(handle, WebBrowserHandleKind.NODE)
+}
+
+private fun releaseWebConstructedObjectInterop(handle: Int): Int =
+  js("globalThis.KanamaWebBridge.releaseConstructedObject(handle)")

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -261,6 +261,21 @@ fun kanamaWebSetVector2Property(objectId: Int, propertyId: Int, x: Double, y: Do
 }
 
 @JsExport
+fun kanamaWebSetVector2iProperty(objectId: Int, propertyId: Int, x: Int, y: Int): Int {
+  return webCallbackBoundary(objectId, "property_set", "property", propertyId) { record ->
+    KanamaWebProjectRegistry.setVector2iProperty(record.scriptId, propertyId, record.script, x, y)
+    1
+  }
+}
+
+@JsExport
+fun kanamaWebGetPackedProperty(objectId: Int, propertyId: Int): String {
+  return webCallbackBoundary(objectId, "property_get", "property", propertyId) { record ->
+    KanamaWebProjectRegistry.getPackedProperty(record.scriptId, propertyId, record.script)
+  }
+}
+
+@JsExport
 fun kanamaWebSetVector3Property(
   objectId: Int,
   propertyId: Int,

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -153,7 +153,12 @@ internal fun registerReturnedNode(token: Int): GodotHandle? =
   token
     .takeIf { it > 0 }
     ?.let {
-      if (!instances.isLive(it)) registerWebBrowserHandle(it, WebBrowserHandleKind.NODE)
+      // A handle already tracked under another kind keeps it: a node that was first
+      // property-pushed (RESOURCE by convention) may later return from a node lookup
+      // (City-Builder's view camera is both an exported property and a requireAs child).
+      if (!instances.isLive(it) && !containsWebBrowserHandle(it)) {
+        registerWebBrowserHandle(it, WebBrowserHandleKind.NODE)
+      }
       GodotHandle.fromBackendToken(it.toLong())
     }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -187,6 +187,13 @@ internal fun immediateWebTweenCallback(
   method: String,
 ): Int = js("globalThis.KanamaWebBridge.immediateTweenCallback(opcode, tweenId, targetId, method)")
 
+internal fun immediateWebVector2ArgVector3X(
+  opcode: Int,
+  objectId: Int,
+  x: Double,
+  y: Double,
+): Double = js("globalThis.KanamaWebBridge.immediateVector2ArgVector3X(opcode, objectId, x, y)")
+
 internal fun immediateWebNoArgsVector3X(opcode: Int, objectId: Int): Double =
   js("globalThis.KanamaWebBridge.immediateNoArgsVector3X(opcode, objectId)")
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -6,15 +6,18 @@ package net.multigesture.kanama.web
 import kotlin.js.ExperimentalWasmJsInterop
 import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotBackendSpi
+import net.multigesture.kanama.backend.GodotBasis
 import net.multigesture.kanama.backend.GodotCallDescriptor
 import net.multigesture.kanama.backend.GodotCallSite
 import net.multigesture.kanama.backend.GodotColor
 import net.multigesture.kanama.backend.GodotExecutionMode
 import net.multigesture.kanama.backend.GodotHandle
 import net.multigesture.kanama.backend.GodotRect2
+import net.multigesture.kanama.backend.GodotTransform3D
 import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector2i
 import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.GodotVector3i
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
 /**
@@ -58,10 +61,24 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
     commands.flush()
-    return existingReturnedObject(
-      receiver,
-      immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
-    )
+    return when (descriptor.opcode) {
+      38 ->
+        existingReturnedObject(
+          receiver,
+          immediateWebTweenBoolRetObject(descriptor.opcode, receiver.webId(), value),
+        )
+      222 ->
+        // The Boolean rides the property-object-query string; the bridge appends the
+        // proposed handle and the applier registers the duplicate under it.
+        registerReturnedBrowserObject(
+          immediateWebPropertyObjectQuery(
+            descriptor.opcode,
+            receiver.webId(),
+            if (value) "1" else "0",
+          )
+        )
+      else -> error("Unsupported Web Boolean-return-handle opcode=${descriptor.opcode}")
+    }
   }
 
   override fun invokeBoolArg(
@@ -124,7 +141,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189))
+    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
     }
@@ -210,6 +227,10 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
             }
           120 ->
             check(immediateWebObjectQuery(120, objectId, "") == 1) {
+              "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+            }
+          207 ->
+            check(immediateWebObjectQuery(207, objectId, "") == 1) {
               "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
             }
           else -> error("Unsupported Web immediate void opcode=${descriptor.opcode}")
@@ -374,6 +395,12 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       171 -> {
         require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
         checkNotNull(value)
+      }
+      202 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        // The MeshLibrary was constructed via ClassDB.instantiate, so it is
+        // registered under the NODE kind like every constructed handle.
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }
       }
       else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
     }
@@ -646,6 +673,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
           114 -> registerReturnedNode(token)
           122 -> registerReturnedNode(token)
           194 -> registerReturnedNode(token)
+          212 -> registerReturnedBrowserObject(token)
+          225 -> registerReturnedBrowserObject(token)
           else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
         }
       }
@@ -1204,6 +1233,296 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       receiver.webId(),
       name + "" + value.webId().toString(),
     )
+  }
+
+  override fun invokeVector3iLongLongArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+    first: Long,
+    second: Long,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 203)
+    require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Cell position plus item/orientation packed as five integers (unit separator).
+    val packed =
+      listOf(value.x, value.y, value.z, first.toInt(), second.toInt()).joinToString("\u001f")
+    check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
+  }
+
+  override fun invokeVector3iRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector3i,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(204, 205))
+    commands.flush()
+    // Cell position packed as three integers; the result (INVALID_CELL_ITEM = -1
+    // included) rides the shared integer object-query transport.
+    return immediateWebObjectQuery(
+        descriptor.opcode,
+        receiver.webId(),
+        listOf(value.x, value.y, value.z).joinToString(""),
+      )
+      .toLong()
+  }
+
+  override fun invokeBasisRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotBasis,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 206)
+    commands.flush()
+    // Nine Float32 components packed column-major (x, y, z axes; unit separator).
+    val packed =
+      listOf(
+          value.x.x,
+          value.x.y,
+          value.x.z,
+          value.y.x,
+          value.y.y,
+          value.y.z,
+          value.z.x,
+          value.z.y,
+          value.z.z,
+        )
+        .joinToString("")
+    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed).toLong()
+  }
+
+  override fun invokeNoArgsRetVector3iList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): List<GodotVector3i> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 208)
+    commands.flush()
+    // The applier packs one comma-joined integer triple per cell (unit separator).
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
+      .split('')
+      .filter { it.isNotEmpty() }
+      .map { triple ->
+        val parts = triple.split(',')
+        GodotVector3i(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
+      }
+  }
+
+  override fun invokeLongObjectArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    longValue: Long,
+    objectValue: GodotHandle,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 210)
+    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    requireWebBrowserHandle(objectValue.webId(), WebBrowserHandleKind.OBJECT)
+    commands.flush()
+    // Item index and object handle packed into one query string (unit separator).
+    check(
+      immediateWebObjectQuery(
+        descriptor.opcode,
+        receiver.webId(),
+        longValue.toString() + "" + objectValue.webId().toString(),
+      ) == 1
+    ) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
+  }
+
+  override fun invokeLongTransform3dArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    longValue: Long,
+    value: GodotTransform3D,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 211)
+    require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Item index plus twelve Float32 transform components (basis columns then origin).
+    val packed =
+      listOf(
+          longValue.toInt().toFloat(),
+          value.basis.x.x,
+          value.basis.x.y,
+          value.basis.x.z,
+          value.basis.y.x,
+          value.basis.y.y,
+          value.basis.y.z,
+          value.basis.z.x,
+          value.basis.z.y,
+          value.basis.z.z,
+          value.origin.x,
+          value.origin.y,
+          value.origin.z,
+        )
+        .joinToString("")
+    check(immediateWebObjectQuery(descriptor.opcode, receiver.webId(), packed) == 1) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"
+    }
+  }
+
+  override fun invokeLongRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 214)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), value.toString())
+  }
+
+  override fun invokeLongRetLong(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Long,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 215)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    return immediateWebObjectQuery(descriptor.opcode, receiver.webId(), value.toString()).toLong()
+  }
+
+  override fun invokeLongLongRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 216)
+    require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Both indices packed into one query string (unit separator).
+    return immediateWebStringQuery(
+      descriptor.opcode,
+      receiver.webId(),
+      first.toString() + "" + second.toString(),
+    )
+  }
+
+  override fun invokeLongLongRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    first: Long,
+    second: Long,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 217)
+    require(first in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(second in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Both indices ride the property-object-query string; the bridge appends the
+    // proposed handle and non-object values resolve to a null handle.
+    return registerReturnedBrowserObject(
+      immediateWebPropertyObjectQuery(
+        descriptor.opcode,
+        receiver.webId(),
+        first.toString() + "" + second.toString(),
+      )
+    )
+  }
+
+  override fun invokeVector2RetVector3(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotVector2,
+  ): GodotVector3 {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(218, 219))
+    commands.flush()
+    return GodotVector3(
+      immediateWebVector2ArgVector3X(
+          descriptor.opcode,
+          receiver.webId(),
+          value.x.toDouble(),
+          value.y.toDouble(),
+        )
+        .toFloat(),
+      immediateWebNoArgsVector3Y().toFloat(),
+      immediateWebNoArgsVector3Z().toFloat(),
+    )
+  }
+
+  override fun invokeObjectStringRetLongSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    resource: GodotHandle,
+    path: String,
+    flags: Long,
+  ): Long {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 223)
+    require(flags in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Resource handle, destination path, and flags packed into one query string; the
+    // applier pulls current Kotlin property values into scripted resources first.
+    return immediateWebObjectQuery(
+        descriptor.opcode,
+        requireActiveWebScriptHandle(),
+        resource.webId().toString() + "" + path + "" + flags.toString(),
+      )
+      .toLong()
+  }
+
+  override fun invokeStringStringBoolBoolRetHandleList(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    pattern: String,
+    type: String,
+    recursive: Boolean,
+    owned: Boolean,
+  ): List<GodotHandle> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 224)
+    commands.flush()
+    // Pattern, type, and both flags packed into one query string; the applier packs the
+    // matches back as handles (scripted matches resolve to script handles, engine nodes
+    // get tracked browser handles).
+    val packed =
+      listOf(pattern, type, if (recursive) "1" else "0", if (owned) "1" else "0").joinToString("")
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), packed)
+      .split('')
+      .filter { it.isNotEmpty() }
+      .map { GodotHandle.fromBackendToken(it.toLong()) }
   }
 
   private fun requireOpcode(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -40,6 +40,8 @@
       opcode === 171 ||
       opcode === 185 ||
       opcode === 189 ||
+      opcode === 202 ||
+      opcode === 209 ||
       opcode === 66
     ) return 3;
     if (
@@ -156,6 +158,7 @@
     browserNodeHandlesByScript: new Map(),
     tweenChildren: new Map(),
     sceneTreeHandlesByOwner: new Map(),
+    viewportHandlesByOwner: new Map(),
     commandStringNamesByValue: new Map(),
     commandStringNamesById: new Map(),
     nextCommandStringNameId: 1,
@@ -264,6 +267,8 @@
     racingSmokeHandle: 0,
     racingVehicleHandle: 0,
     racingViewHandle: 0,
+    cbSmokeHandle: 0,
+    cbBuilderHandle: 0,
     // _physics_process/_process ordering evidence (Task 60d): Godot's iteration runs all
     // physics ticks BEFORE the idle/_process pass inside one requestAnimationFrame callback,
     // so a physics dispatch AFTER a process dispatch within the same rAF tick would be an
@@ -413,6 +418,11 @@
       }
       if (this.mode === "fps") {
         // FPS scripts own no coroutines; every script runs its plain dispatch.
+        return this.process(handle, delta);
+      }
+      if (this.mode === "citybuilder") {
+        // City-Builder scripts (Builder cursor/actions, View camera, Audio pool) own no
+        // coroutines; every script runs its plain _process dispatch.
         return this.process(handle, delta);
       }
       if (this.mode === "platformer") {
@@ -1301,7 +1311,10 @@
       // Object-valued property/animation read: the proxy resolves the named object,
       // registers the result under the proposed slot (or an existing/script handle), and
       // publishes the winning handle through the object-query integer channel.
-      const owner = this.ownerForHandle(handle);
+      // The result belongs to the SCRIPT that asked (always inside an invoke boundary),
+      // not to the receiver's owner: a scene-state property read off a cache-persistent
+      // Structure resource must release with the Builder that read it.
+      const owner = this.activeOwnerHandle || this.ownerForHandle(handle);
       const callback = this.callbackFor(this.objectQueryCallbacks, handle, "Godot object query");
       const resultHandle = this.allocateBrowserHandle("Object", owner);
       this.immediateLongResult = null;
@@ -1389,7 +1402,11 @@
       return result;
     },
     immediateNoArgsObject(opcode, handle) {
-      const owner = this.ownerForHandle(handle);
+      // Returned objects belong to the SCRIPT that asked (always inside an invoke
+      // boundary), not to the receiver's owner — a SceneState/Mesh read off a
+      // cache-persistent resource must release with the reading script (the
+      // packed-scene-instantiate ownership rule).
+      const owner = this.activeOwnerHandle || this.ownerForHandle(handle);
       const isSceneTree = opcode === 51;
       if (isSceneTree) {
         const existing = this.sceneTreeHandlesByOwner.get(owner);
@@ -1398,6 +1415,16 @@
           return existing;
         }
         this.sceneTreeHandlesByOwner.delete(owner);
+      }
+      // Per-frame get_viewport (City-Builder's mouse-ray cursor) must not mint a handle
+      // per call: reuse the owner's viewport handle like the SceneTree above.
+      const isViewport = opcode === 19;
+      if (isViewport) {
+        const existing = this.viewportHandlesByOwner.get(owner);
+        if (existing !== undefined && this.browserHandleSlot(existing)?.kind === "Node") {
+          return existing;
+        }
+        this.viewportHandlesByOwner.delete(owner);
       }
       const callback = this.callbackFor(
         this.noArgsObjectCallbacks,
@@ -1463,6 +1490,8 @@
       } else if (isSceneTree) {
         this.sceneTreeHandlesByOwner.set(owner, resultHandle);
         this.match3SceneTreeHandlesCreated += 1;
+      } else if (isViewport && result === resultHandle) {
+        this.viewportHandlesByOwner.set(owner, resultHandle);
       }
       return result;
     },
@@ -2175,6 +2204,16 @@
         // The camera rig lerps toward the vehicle every tick: its root position is the
         // driver's movement evidence (the Vehicle ROOT node intentionally never moves).
         this.racingViewHandle = handle;
+      }
+      if (this.mode === "citybuilder" && scriptName.endsWith(".Smoke")) {
+        // smoke_teardown (method#1) frees the Audio autoload, releases hydrated structure
+        // assets, and frees the scene root for the teardown assertion.
+        this.cbSmokeHandle = handle;
+      }
+      if (this.mode === "citybuilder" && scriptName.endsWith(".Builder")) {
+        // The driver reads the gridmap/selector property handles off the Builder to
+        // observe placements and selector movement.
+        this.cbBuilderHandle = handle;
       }
       if (this.mode === "match3") {
         this.match3ScriptNamesByHandle.set(handle, scriptName);

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 13;
+  const KANAMA_WEB_PROTOCOL_VERSION = 14;
 
   function commandWordCount(opcode) {
     if (
@@ -596,6 +596,24 @@
         0,
       );
     },
+    setVector2iProperty(handle, propertyId, x, y) {
+      return this.invoke(
+        handle,
+        "property_set",
+        `property#${propertyId}`,
+        () => this.api.kanamaWebSetVector2iProperty(handle, propertyId, x, y),
+        0,
+      );
+    },
+    getPackedProperty(handle, propertyId) {
+      return this.invoke(
+        handle,
+        "property_get",
+        `property#${propertyId}`,
+        () => this.api.kanamaWebGetPackedProperty(handle, propertyId),
+        "",
+      );
+    },
     setLongProperty(handle, propertyId, value) {
       this.recordMatch3Property(handle, propertyId, value);
       return this.invoke(
@@ -1069,7 +1087,14 @@
         this.immediateResourceHandleResult !== 0 &&
         this.immediateResourceHandleResult !== resourceHandle
       ) {
-        throw new Error("Godot resource callback published an invalid handle");
+        // A Kanama-scripted resource resolves to its live script handle instead of the
+        // proposed browser handle (node-lookup rule for loads).
+        if (this.api.kanamaWebIsLive(this.immediateResourceHandleResult) !== 1) {
+          throw new Error("Godot resource callback published an invalid handle");
+        }
+        this.releaseBrowserHandle(resourceHandle, "Resource");
+        this.resourceLoads += 1;
+        return this.immediateResourceHandleResult;
       }
       if (this.immediateResourceHandleResult === 0) {
         if (owner === this.match3AudioHandle) this.match3AudioResourceLoadFailures += 1;
@@ -1084,6 +1109,71 @@
       }
       this.resourceLoads += 1;
       return this.immediateResourceHandleResult;
+    },
+    instantiateScript(className) {
+      // Runtime factory crossing (reserved opcode 0 on the object-query channel): the
+      // active proxy instantiates the named Kanama scripted resource and returns the
+      // hydrated script handle (0 on failure).
+      const owner = this.activeOwnerHandle;
+      const callback = this.callbackFor(this.objectQueryCallbacks, owner, "Godot script instantiate");
+      this.immediateLongResult = null;
+      callback(0, owner, className);
+      const result = this.immediateLongResult;
+      if (!Number.isInteger(result)) {
+        throw new Error("Godot script instantiate callback did not publish a result");
+      }
+      if (result !== 0 && this.api.kanamaWebIsLive(result) !== 1) {
+        throw new Error("Godot script instantiate did not return a live script handle");
+      }
+      return result;
+    },
+    releaseScriptResource(handle) {
+      // Drop the proxies' dictionary reference to an owned scripted resource ("close what
+      // you create"): the target is a script handle, so no browser slot is retired.
+      if (this.api.kanamaWebIsLive(handle) !== 1) {
+        throw new Error(`Cannot release non-live Kanama script resource handle=${handle}`);
+      }
+      const callback = this.callbackFor(
+        this.resourceReleaseCallbacks,
+        handle,
+        "Godot script resource release",
+      );
+      this.immediateResourceReleaseResult = null;
+      callback(handle);
+      if (!Number.isInteger(this.immediateResourceReleaseResult)) {
+        throw new Error("Godot script resource release callback did not publish a result");
+      }
+      return this.immediateResourceReleaseResult;
+    },
+    releaseConstructedObject(handle) {
+      // Release a ClassDB-constructed handle whose bridge kind is its class name (e.g. a
+      // constructed MeshLibrary Resource): the applier erases the dictionary reference and
+      // the slot retires under its recorded kind.
+      const slot = this.browserHandleSlot(handle);
+      if (!slot) {
+        throw new Error(`Stale Kanama Web constructed handle=${handle}`);
+      }
+      const callback = this.callbackFor(
+        this.resourceReleaseCallbacks,
+        handle,
+        "Godot constructed release",
+      );
+      this.immediateResourceReleaseResult = null;
+      callback(handle);
+      if (!Number.isInteger(this.immediateResourceReleaseResult)) {
+        throw new Error("Godot constructed release callback did not publish a result");
+      }
+      if (this.immediateResourceReleaseResult === 1) {
+        this.releaseBrowserHandle(handle, slot.kind);
+      }
+      return this.immediateResourceReleaseResult;
+    },
+    allocateFoundNodeHandle(ownerHandle) {
+      // Node.find_children match without a script or existing handle: mint and adopt a
+      // tracked browser Node handle for the applier to register.
+      const handle = this.allocateBrowserHandle("Node", ownerHandle);
+      this.api.kanamaWebAdoptNodeHandle(handle);
+      return handle;
     },
     immediateConstructObject(className) {
       const owner = this.activeOwnerHandle;
@@ -1329,7 +1419,13 @@
       // lookup instead of requiring the proposed one. opcode 114 = Node.duplicate adopts a
       // genuinely new node through the proposed handle.
       const isCollider = opcode === 112 || opcode === 122;
-      const isObjectResult = isTween || isSceneTree || isSpriteFrames || isEnvironment;
+      // opcode 212 = PackedScene.get_state returns a SceneState, opcode 225 =
+      // MeshInstance3D.get_mesh returns a Mesh Resource — neither is a Node, so both
+      // follow the SpriteFrames/Environment handle-kind rule.
+      const isSceneState = opcode === 212;
+      const isMesh = opcode === 225;
+      const isObjectResult =
+        isTween || isSceneTree || isSpriteFrames || isEnvironment || isSceneState || isMesh;
       const kind = isTween
         ? "Tween"
         : isSceneTree
@@ -1338,7 +1434,11 @@
             ? "SpriteFrames"
             : isEnvironment
               ? "Environment"
-              : "Node";
+              : isSceneState
+                ? "SceneState"
+                : isMesh
+                  ? "Mesh"
+                  : "Node";
       const resultHandle = this.allocateBrowserHandle(kind, owner);
       if (isObjectResult) this.api.kanamaWebAdoptObjectHandle(resultHandle);
       else this.api.kanamaWebAdoptNodeHandle(resultHandle);
@@ -1423,6 +1523,24 @@
     },
     recordImmediateStringResult(value) {
       this.immediateStringResult = String(value);
+    },
+    immediateVector2ArgVector3X(opcode, handle, x, y) {
+      // Vector2-argument Vector3 query (camera ray projection): rides the no-args
+      // Vector3 channel with the screen point in the extra argument slots.
+      const callback = this.callbackFor(
+        this.noArgsVector3Callbacks,
+        handle,
+        "Godot Vector2-arg Vector3",
+      );
+      this.immediateVector3Result = null;
+      callback(opcode, handle, x, y);
+      if (
+        this.immediateVector3Result === null ||
+        !Number.isFinite(this.immediateVector3Result.x)
+      ) {
+        throw new Error("Godot Vector2-arg Vector3 callback did not publish a finite result");
+      }
+      return this.immediateVector3Result.x;
     },
     immediateIndexedVector3X(opcode, handle, index) {
       const callback = this.callbackFor(


### PR DESCRIPTION
Eleventh corpus demo on the Web backend (only tps-demo remains). City-Builder's surface needed the largest single-family batch since 60c: the GridMap cell family, runtime MeshLibrary building, PackedScene/SceneState mesh extraction, camera ray projection, viewport mouse position, `Resource.duplicate`, `ResourceSaver.save`, `Node.find_children`, `MeshInstance3D.get_mesh`, and `Input.is_action_just_released` — 25 contract opcodes (202–225), 13 new call shapes (default-error SPI bodies; pointer backends untouched), protocol 13 → 14.

**Scripted-resource runtime support** (the demo's save/load loop):
- `newScriptInstance<T>()` on Web: a reserved opcode-0 crossing instantiates the class's generated proxy engine-side and hydrates the Kotlin instance ("close what you create" via the script-resource release path).
- Save-time property pull-back: property flow is engine→Kotlin at hydration; `ResourceSaver.save` now calls the generated `_kanama_pull_properties()` on the scripted resource graph (recursive, cycle-guarded) so the engine serializes current Kotlin values through new packed property getters.
- `ResourceLoader.load` resolves Kanama-scripted resources to their hydrated script handles (the node-lookup rule for loads).

**Ownership/bookkeeping fixes the bring-up exposed** (all fail-loud catches):
- Queued opcodes 202/209 added to the command word-count table.
- A handle that is both a property push (RESOURCE) and a node-lookup result keeps its first kind.
- Per-owner viewport-handle reuse (per-frame `get_viewport` cursor).
- No-args-object / property-object query results now belong to the **active script**, not the receiver's owner — reads off cache-persistent resources drain with the reader (the packed-scene-instantiate rule). Chrome spot-regressions on thirdperson, charactercontroller, match3, and dodge all PASS on the new routing.

**Validation**
- citybuilder.mjs: engine-level action injection; grid evidence via GridMap queries on the Builder's gridmap property handle; warm-up first placement; toggle-and-replace on one cell; full save round-trip (build → save `user://map.res` → demolish → load → the cell returns with its item).
- Chrome 12.2s / Firefox 27.2s units: **12/12 checks, teardown-to-zero, zero console errors on both**. Safari deliberately skipped (standing instruction).
- `local_ci.sh` PASS (emitter golden tests re-pinned to protocol 14); dispatch drift check PASS; coverage blocking=0.

Companion: kanama-demos PR (task/60h-web-citybuilder) with the seven task-64-style web ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
