### PR TITLE
Task 60i: tps-demo runs on Web — families 226-286, protocol 15 (the corpus is complete)

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -899,7 +899,9 @@ interface GodotBackendSpi {
 @InternalKanamaBackendApi
 @OptIn(InternalKanamaBackendApi::class)
 object GodotBackendCalls {
-  private const val MAX_INITIAL_OPCODE = 255
+  // Derived from the shared contract so the cache cannot silently fall behind the
+  // opcode table (task 60i grew it past the previous hardcoded bound).
+  private val MAX_INITIAL_OPCODE = InitialGodotCallDescriptors.MAX_OPCODE
   private val resolved = arrayOfNulls<GodotCallSite>(MAX_INITIAL_OPCODE + 1)
   private var backend: GodotBackendSpi? = null
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -91,6 +91,14 @@ enum class GodotCallShape {
   VECTOR2_RET_VECTOR3,
   OBJECT_STRING_RET_LONG_SINGLETON,
   STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST,
+  STRINGNAME_LONG_ARG,
+  STRINGNAME_VECTOR2_ARG,
+  STRINGNAME_OBJECT_ARG,
+  STRINGNAME_RET_VECTOR2,
+  NOARGS_RET_STRING,
+  STRINGNAME_RET_STRING,
+  DOUBLE_RET_DOUBLE,
+  VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING,
 }
 
 @InternalKanamaBackendApi
@@ -789,6 +797,94 @@ interface GodotBackendSpi {
     recursive: Boolean,
     owned: Boolean,
   ): List<GodotHandle> {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Named int-valued property write (AnimationTree one-shot requests). */
+  fun invokeStringNameLongArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: Long,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Named Vector2-valued property write (AnimationTree blend positions). */
+  fun invokeStringNameVector2Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotVector2,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Named object-valued call (one-object deferred dispatch). */
+  fun invokeStringNameObjectArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Named Vector2-valued property read (AnimationTree blend positions). */
+  fun invokeStringNameRetVector2(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+  ): GodotVector2 {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** No-argument String read (Node.get_name, LineEdit.get_text). */
+  fun invokeNoArgsRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): String {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Named String read (ConfigFile.get_value's tagged transport). */
+  fun invokeStringNameRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+  ): String {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /** Double-argument Double query (Noise.get_noise_1d). */
+  fun invokeDoubleRetDouble(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Double,
+  ): Double {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /**
+   * Space-state ray query. The receiver is a node in the target world: the backend derives the
+   * space state and builds the query parameters on its own side, so RIDs never cross the seam.
+   */
+  fun invokeVector3Vector3LongObjectRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    from: GodotVector3,
+    to: GodotVector3,
+    collisionMask: Long,
+    exclude: GodotHandle?,
+  ): String {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
 }
@@ -1726,6 +1822,137 @@ object GodotBackendCalls {
       type,
       recursive,
       owned,
+    )
+  }
+
+  fun invokeStringNameLongArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    value: Long,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_LONG_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeStringNameLongArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      value,
+    )
+  }
+
+  fun invokeStringNameVector2Arg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotVector2,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_VECTOR2_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeStringNameVector2Arg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      value,
+    )
+  }
+
+  fun invokeStringNameObjectArg(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_OBJECT_ARG)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    selected.invokeStringNameObjectArg(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+      value,
+    )
+  }
+
+  fun invokeStringNameRetVector2(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+  ): GodotVector2 {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_RET_VECTOR2)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeStringNameRetVector2(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+    )
+  }
+
+  fun invokeNoArgsRetString(descriptor: GodotCallDescriptor, receiver: GodotHandle): String {
+    requireShape(descriptor, GodotCallShape.NOARGS_RET_STRING)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeNoArgsRetString(descriptor, resolve(selected, descriptor), receiver)
+  }
+
+  fun invokeStringNameRetString(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    name: String,
+  ): String {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_RET_STRING)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeStringNameRetString(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      name,
+    )
+  }
+
+  fun invokeDoubleRetDouble(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: Double,
+  ): Double {
+    requireShape(descriptor, GodotCallShape.DOUBLE_RET_DOUBLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeDoubleRetDouble(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+    )
+  }
+
+  fun invokeVector3Vector3LongObjectRetString(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    from: GodotVector3,
+    to: GodotVector3,
+    collisionMask: Long,
+    exclude: GodotHandle?,
+  ): String {
+    requireShape(descriptor, GodotCallShape.VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeVector3Vector3LongObjectRetString(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      from,
+      to,
+      collisionMask,
+      exclude,
     )
   }
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3149,4 +3149,7 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.QUEUED_MUTATION,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
+  const val MAX_OPCODE = 286
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -2478,4 +2478,653 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val CHARACTERBODY3D_SET_UP_DIRECTION =
+    GodotCallDescriptor(
+      opcode = 226,
+      className = "CharacterBody3D",
+      methodName = "set_up_direction",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PHYSICSBODY3D_GET_GRAVITY =
+    GodotCallDescriptor(
+      opcode = 227,
+      className = "PhysicsBody3D",
+      methodName = "get_gravity",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RIGIDBODY3D_SET_LINEAR_VELOCITY =
+    GodotCallDescriptor(
+      opcode = 228,
+      className = "RigidBody3D",
+      methodName = "set_linear_velocity",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val PHYSICSDIRECTSPACESTATE3D_INTERSECT_RAY =
+    GodotCallDescriptor(
+      opcode = 229,
+      className = "PhysicsDirectSpaceState3D",
+      methodName = "intersect_ray",
+      hash = 3957970750L,
+      shape = GodotCallShape.VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_SET_INDEXED_STRING =
+    GodotCallDescriptor(
+      opcode = 230,
+      className = "Object",
+      methodName = "set_indexed",
+      hash = 3500910842L,
+      shape = GodotCallShape.STRINGNAME_STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_SET_INDEXED_LONG =
+    GodotCallDescriptor(
+      opcode = 231,
+      className = "Object",
+      methodName = "set_indexed",
+      hash = 3500910842L,
+      shape = GodotCallShape.STRINGNAME_LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_SET_INDEXED_VECTOR2 =
+    GodotCallDescriptor(
+      opcode = 232,
+      className = "Object",
+      methodName = "set_indexed",
+      hash = 3500910842L,
+      shape = GodotCallShape.STRINGNAME_VECTOR2_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_GET_PROPERTY_VECTOR2 =
+    GodotCallDescriptor(
+      opcode = 233,
+      className = "Object",
+      methodName = "get",
+      hash = 2760726917L,
+      shape = GodotCallShape.STRINGNAME_RET_VECTOR2,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONMIXER_GET_ROOT_MOTION_POSITION =
+    GodotCallDescriptor(
+      opcode = 234,
+      className = "AnimationMixer",
+      methodName = "get_root_motion_position",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ANIMATIONMIXER_GET_ROOT_MOTION_ROTATION =
+    GodotCallDescriptor(
+      opcode = 235,
+      className = "AnimationMixer",
+      methodName = "get_root_motion_rotation",
+      hash = 1222331677L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CPUPARTICLES3D_SET_EMITTING =
+    GodotCallDescriptor(
+      opcode = 236,
+      className = "CPUParticles3D",
+      methodName = "set_emitting",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CPUPARTICLES3D_RESTART =
+    GodotCallDescriptor(
+      opcode = 237,
+      className = "CPUParticles3D",
+      methodName = "restart",
+      hash = 107499316L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CPUPARTICLES3D_SET_EMISSION_BOX_EXTENTS =
+    GodotCallDescriptor(
+      opcode = 238,
+      className = "CPUParticles3D",
+      methodName = "set_emission_box_extents",
+      hash = 3460891852L,
+      shape = GodotCallShape.VECTOR3_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CPUPARTICLES3D_GET_EMISSION_BOX_EXTENTS =
+    GodotCallDescriptor(
+      opcode = 239,
+      className = "CPUParticles3D",
+      methodName = "get_emission_box_extents",
+      hash = 3360562783L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR3,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CPUPARTICLES3D_GET_LIFETIME =
+    GodotCallDescriptor(
+      opcode = 240,
+      className = "CPUParticles3D",
+      methodName = "get_lifetime",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LIGHT3D_SET_SHADOW =
+    GodotCallDescriptor(
+      opcode = 241,
+      className = "Light3D",
+      methodName = "set_shadow",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENVIRONMENT_SET_GLOW_ENABLED =
+    GodotCallDescriptor(
+      opcode = 242,
+      className = "Environment",
+      methodName = "set_glow_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESHINSTANCE3D_GET_SURFACE_OVERRIDE_MATERIAL =
+    GodotCallDescriptor(
+      opcode = 243,
+      className = "MeshInstance3D",
+      methodName = "get_surface_override_material",
+      hash = 2897466400L,
+      shape = GodotCallShape.LONG_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESH_SURFACE_GET_MATERIAL =
+    GodotCallDescriptor(
+      opcode = 244,
+      className = "Mesh",
+      methodName = "surface_get_material",
+      hash = 2897466400L,
+      shape = GodotCallShape.LONG_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MESH_SURFACE_SET_MATERIAL =
+    GodotCallDescriptor(
+      opcode = 245,
+      className = "Mesh",
+      methodName = "surface_set_material",
+      hash = 3671737478L,
+      shape = GodotCallShape.LONG_OBJECT_ARG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MATERIAL_GET_NEXT_PASS =
+    GodotCallDescriptor(
+      opcode = 246,
+      className = "Material",
+      methodName = "get_next_pass",
+      hash = 5934680L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val MATERIAL_SET_NEXT_PASS =
+    GodotCallDescriptor(
+      opcode = 247,
+      className = "Material",
+      methodName = "set_next_pass",
+      hash = 2757459619L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SHADERMATERIAL_SET_SHADER_PARAMETER =
+    GodotCallDescriptor(
+      opcode = 248,
+      className = "ShaderMaterial",
+      methodName = "set_shader_parameter",
+      hash = 3776071444L,
+      shape = GodotCallShape.STRINGNAME_DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val TIMER_GET_TIME_LEFT =
+    GodotCallDescriptor(
+      opcode = 249,
+      className = "Timer",
+      methodName = "get_time_left",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENETREE_GET_ROOT =
+    GodotCallDescriptor(
+      opcode = 250,
+      className = "SceneTree",
+      methodName = "get_root",
+      hash = 1757182445L,
+      shape = GodotCallShape.NOARGS_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_GRAB_FOCUS =
+    GodotCallDescriptor(
+      opcode = 251,
+      className = "Control",
+      methodName = "grab_focus",
+      hash = 107499316L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_GET_POSITION =
+    GodotCallDescriptor(
+      opcode = 252,
+      className = "Control",
+      methodName = "get_position",
+      hash = 3341600327L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR2,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_GET_SIZE =
+    GodotCallDescriptor(
+      opcode = 253,
+      className = "Control",
+      methodName = "get_size",
+      hash = 3341600327L,
+      shape = GodotCallShape.NOARGS_RET_VECTOR2,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val BASEBUTTON_SET_PRESSED =
+    GodotCallDescriptor(
+      opcode = 254,
+      className = "BaseButton",
+      methodName = "set_pressed",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val BASEBUTTON_IS_PRESSED =
+    GodotCallDescriptor(
+      opcode = 255,
+      className = "BaseButton",
+      methodName = "is_pressed",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val BASEBUTTON_SET_DISABLED =
+    GodotCallDescriptor(
+      opcode = 256,
+      className = "BaseButton",
+      methodName = "set_disabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val BASEBUTTON_SET_BUTTON_GROUP =
+    GodotCallDescriptor(
+      opcode = 257,
+      className = "BaseButton",
+      methodName = "set_button_group",
+      hash = 1794463739L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val BUTTON_SET_TEXT =
+    GodotCallDescriptor(
+      opcode = 258,
+      className = "Button",
+      methodName = "set_text",
+      hash = 83702148L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LINEEDIT_GET_TEXT =
+    GodotCallDescriptor(
+      opcode = 259,
+      className = "LineEdit",
+      methodName = "get_text",
+      hash = 201670096L,
+      shape = GodotCallShape.NOARGS_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LINEEDIT_SET_TEXT =
+    GodotCallDescriptor(
+      opcode = 260,
+      className = "LineEdit",
+      methodName = "set_text",
+      hash = 83702148L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LINEEDIT_SET_EDITABLE =
+    GodotCallDescriptor(
+      opcode = 261,
+      className = "LineEdit",
+      methodName = "set_editable",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RANGE_SET_VALUE =
+    GodotCallDescriptor(
+      opcode = 262,
+      className = "Range",
+      methodName = "set_value",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RANGE_GET_VALUE =
+    GodotCallDescriptor(
+      opcode = 263,
+      className = "Range",
+      methodName = "get_value",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONFIGFILE_LOAD =
+    GodotCallDescriptor(
+      opcode = 264,
+      className = "ConfigFile",
+      methodName = "load",
+      hash = 166001499L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONFIGFILE_SAVE =
+    GodotCallDescriptor(
+      opcode = 265,
+      className = "ConfigFile",
+      methodName = "save",
+      hash = 166001499L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONFIGFILE_HAS_SECTION_KEY =
+    GodotCallDescriptor(
+      opcode = 266,
+      className = "ConfigFile",
+      methodName = "has_section_key",
+      hash = 820780508L,
+      shape = GodotCallShape.STRINGNAME_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONFIGFILE_SET_VALUE =
+    GodotCallDescriptor(
+      opcode = 267,
+      className = "ConfigFile",
+      methodName = "set_value",
+      hash = 2504492430L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONFIGFILE_GET_VALUE =
+    GodotCallDescriptor(
+      opcode = 268,
+      className = "ConfigFile",
+      methodName = "get_value",
+      hash = 89809366L,
+      shape = GodotCallShape.STRINGNAME_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENGINE_SET_MAX_FPS =
+    GodotCallDescriptor(
+      opcode = 269,
+      className = "Engine",
+      methodName = "set_max_fps",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENGINE_GET_FRAMES_PER_SECOND =
+    GodotCallDescriptor(
+      opcode = 270,
+      className = "Engine",
+      methodName = "get_frames_per_second",
+      hash = 1740695150L,
+      shape = GodotCallShape.NOARGS_RET_LONG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OS_GET_STATIC_MEMORY_USAGE =
+    GodotCallDescriptor(
+      opcode = 271,
+      className = "OS",
+      methodName = "get_static_memory_usage",
+      hash = 3905245786L,
+      shape = GodotCallShape.NOARGS_RET_LONG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_GET_ACTION_STRENGTH =
+    GodotCallDescriptor(
+      opcode = 272,
+      className = "Input",
+      methodName = "get_action_strength",
+      hash = 801543509L,
+      shape = GodotCallShape.STRINGNAME_RET_DOUBLE_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val FASTNOISELITE_SET_SEED =
+    GodotCallDescriptor(
+      opcode = 273,
+      className = "FastNoiseLite",
+      methodName = "set_seed",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val FASTNOISELITE_SET_FRACTAL_OCTAVES =
+    GodotCallDescriptor(
+      opcode = 274,
+      className = "FastNoiseLite",
+      methodName = "set_fractal_octaves",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val FASTNOISELITE_SET_FRACTAL_LACUNARITY =
+    GodotCallDescriptor(
+      opcode = 275,
+      className = "FastNoiseLite",
+      methodName = "set_fractal_lacunarity",
+      hash = 373806689L,
+      shape = GodotCallShape.DOUBLE_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NOISE_GET_NOISE_1D =
+    GodotCallDescriptor(
+      opcode = 276,
+      className = "Noise",
+      methodName = "get_noise_1d",
+      hash = 3919130443L,
+      shape = GodotCallShape.DOUBLE_RET_DOUBLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_SET_NAME =
+    GodotCallDescriptor(
+      opcode = 277,
+      className = "Node",
+      methodName = "set_name",
+      hash = 3304788590L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_GET_NAME =
+    GodotCallDescriptor(
+      opcode = 278,
+      className = "Node",
+      methodName = "get_name",
+      hash = 2002593661L,
+      shape = GodotCallShape.NOARGS_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_PROPAGATE_SET_BOOL =
+    GodotCallDescriptor(
+      opcode = 279,
+      className = "Node",
+      methodName = "propagate_call",
+      hash = 1871007965L,
+      shape = GodotCallShape.STRINGNAME_BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_CALL_DEFERRED_NOARGS =
+    GodotCallDescriptor(
+      opcode = 280,
+      className = "Object",
+      methodName = "call_deferred",
+      hash = 3400424181L,
+      shape = GodotCallShape.STRINGNAME_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_CALL_DEFERRED_OBJECT =
+    GodotCallDescriptor(
+      opcode = 281,
+      className = "Object",
+      methodName = "call_deferred",
+      hash = 3400424181L,
+      shape = GodotCallShape.STRINGNAME_OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OBJECT_HAS_SIGNAL =
+    GodotCallDescriptor(
+      opcode = 282,
+      className = "Object",
+      methodName = "has_signal",
+      hash = 2619796661L,
+      shape = GodotCallShape.STRINGNAME_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CAMERA3D_MAKE_CURRENT =
+    GodotCallDescriptor(
+      opcode = 283,
+      className = "Camera3D",
+      methodName = "make_current",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LIGHTMAPGI_SET_LIGHT_DATA =
+    GodotCallDescriptor(
+      opcode = 284,
+      className = "LightmapGI",
+      methodName = "set_light_data",
+      hash = 1790597277L,
+      shape = GodotCallShape.OBJECT_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3127,4 +3127,26 @@ object InitialGodotCallDescriptors {
       executionMode = GodotExecutionMode.QUEUED_MUTATION,
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
+
+  val COLLISIONOBJECT3D_SET_COLLISION_LAYER =
+    GodotCallDescriptor(
+      opcode = 285,
+      className = "CollisionObject3D",
+      methodName = "set_collision_layer",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val COLLISIONOBJECT3D_SET_COLLISION_MASK =
+    GodotCallDescriptor(
+      opcode = 286,
+      className = "CollisionObject3D",
+      methodName = "set_collision_mask",
+      hash = 1286410249L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -8,7 +8,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 14
+    const val PROTOCOL_VERSION = 15
     const val PROTOCOL_SCHEMA_VERSION = 1
   }
 
@@ -1860,6 +1860,227 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 20")
+    appendLine("\\t\\telif opcode == 226 and target_object is CharacterBody3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as CharacterBody3D).up_direction = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 20")
+    appendLine("\\t\\telif opcode == 228 and target_object is RigidBody3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as RigidBody3D).linear_velocity = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 20")
+    appendLine("\\t\\telif opcode == 230 and target_object != null:")
+    appendLine(
+      "\\t\\t\\tvar indexed_string_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\\t\\t\\tvar indexed_string_value := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 12)))"
+    )
+    appendLine(
+      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_string_path), indexed_string_value)"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 231 and target_object != null:")
+    appendLine(
+      "\\t\\t\\tvar indexed_long_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_long_path), bytes.decode_s32(offset + 12))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 232 and target_object != null:")
+    appendLine(
+      "\\t\\t\\tvar indexed_vec2_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_vec2_path), Vector2(bytes.decode_float(offset + 12), bytes.decode_float(offset + 16)))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 20")
+    appendLine("\\t\\telif opcode == 236 and target_object is CPUParticles3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as CPUParticles3D).emitting = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 237 and target_object is CPUParticles3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as CPUParticles3D).restart(bytes.decode_s32(offset + 8) != 0)"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 238 and target_object is CPUParticles3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as CPUParticles3D).emission_box_extents = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 20")
+    appendLine("\\t\\telif opcode == 241 and target_object is Light3D:")
+    appendLine(
+      "\\t\\t\\t(target_object as Light3D).shadow_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 242 and target_object is Environment:")
+    appendLine(
+      "\\t\\t\\t(target_object as Environment).glow_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 247 and target_object is Material:")
+    appendLine("\\t\\t\\tvar next_pass_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\\t\\t\\t(target_object as Material).next_pass = null if next_pass_handle == 0 else _kanama_object_handles.get(next_pass_handle) as Material"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 248 and target_object is ShaderMaterial:")
+    appendLine(
+      "\\t\\t\\tvar shader_param_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\\t\\t\\t(target_object as ShaderMaterial).set_shader_parameter(StringName(shader_param_name), bytes.decode_double(offset + 12))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 20")
+    appendLine("\\t\\telif opcode == 251 and target_object is Control:")
+    appendLine("\\t\\t\\t(target_object as Control).grab_focus()")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 8")
+    appendLine("\\t\\telif opcode == 254 and target_object is BaseButton:")
+    appendLine(
+      "\\t\\t\\t(target_object as BaseButton).button_pressed = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 256 and target_object is BaseButton:")
+    appendLine(
+      "\\t\\t\\t(target_object as BaseButton).disabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 257 and target_object is BaseButton:")
+    appendLine("\\t\\t\\tvar button_group_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\\t\\t\\t(target_object as BaseButton).button_group = null if button_group_handle == 0 else _kanama_object_handles.get(button_group_handle) as ButtonGroup"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 258 and target_object is Button:")
+    appendLine(
+      "\\t\\t\\t(target_object as Button).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 260 and target_object is LineEdit:")
+    appendLine(
+      "\\t\\t\\t(target_object as LineEdit).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 261 and target_object is LineEdit:")
+    appendLine("\\t\\t\\t(target_object as LineEdit).editable = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 262 and target_object is Range:")
+    appendLine("\\t\\t\\t(target_object as Range).value = bytes.decode_double(offset + 8)")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 264 and target_object is ConfigFile:")
+    appendLine(
+      "\\t\\t\\t(target_object as ConfigFile).load(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 265 and target_object is ConfigFile:")
+    appendLine(
+      "\\t\\t\\t(target_object as ConfigFile).save(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 267 and target_object is ConfigFile:")
+    appendLine(
+      "\\t\\t\\tvar config_parts := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))).split(\"\\u001f\")"
+    )
+    appendLine("\\t\\t\\tvar config_tagged: String = config_parts[2]")
+    appendLine("\\t\\t\\tvar config_value: Variant = null")
+    appendLine("\\t\\t\\tif config_tagged.begins_with(\"i:\"):")
+    appendLine("\\t\\t\\t\\tconfig_value = int(config_tagged.substr(2))")
+    appendLine("\\t\\t\\telif config_tagged.begins_with(\"f:\"):")
+    appendLine("\\t\\t\\t\\tconfig_value = float(config_tagged.substr(2))")
+    appendLine("\\t\\t\\telif config_tagged.begins_with(\"b:\"):")
+    appendLine("\\t\\t\\t\\tconfig_value = config_tagged.substr(2) == \"true\"")
+    appendLine("\\t\\t\\telse:")
+    appendLine("\\t\\t\\t\\tconfig_value = config_tagged.substr(2)")
+    appendLine(
+      "\\t\\t\\t(target_object as ConfigFile).set_value(config_parts[0], config_parts[1], config_value)"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 273 and target_object is FastNoiseLite:")
+    appendLine("\\t\\t\\t(target_object as FastNoiseLite).seed = bytes.decode_s32(offset + 8)")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 274 and target_object is FastNoiseLite:")
+    appendLine(
+      "\\t\\t\\t(target_object as FastNoiseLite).fractal_octaves = bytes.decode_s32(offset + 8)"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 275 and target_object is FastNoiseLite:")
+    appendLine(
+      "\\t\\t\\t(target_object as FastNoiseLite).fractal_lacunarity = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 277 and target_object is Node:")
+    appendLine(
+      "\\t\\t\\t(target_object as Node).name = StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 279 and target_object is Node:")
+    appendLine(
+      "\\t\\t\\tvar propagate_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\\t\\t\\t(target_object as Node).propagate_call(\"set\", [propagate_name, bytes.decode_s32(offset + 12) != 0])"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 280 and target_object != null:")
+    appendLine(
+      "\\t\\t\\ttarget_object.call_deferred(StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))))"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\\t\\telif opcode == 281 and target_object != null:")
+    appendLine(
+      "\\t\\t\\tvar deferred_method := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\\t\\t\\tvar deferred_arg_handle := bytes.decode_s32(offset + 12)")
+    appendLine(
+      "\\t\\t\\tvar deferred_arg: Object = null if deferred_arg_handle == 0 else _kanama_object_handles.get(deferred_arg_handle)"
+    )
+    appendLine("\\t\\t\\ttarget_object.call_deferred(StringName(deferred_method), deferred_arg)")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 16")
+    appendLine("\\t\\telif opcode == 283 and target_object is Camera3D:")
+    appendLine("\\t\\t\\t(target_object as Camera3D).make_current()")
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 8")
+    appendLine("\\t\\telif opcode == 284 and target_object is LightmapGI:")
+    appendLine("\\t\\t\\tvar light_data_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\\t\\t\\t(target_object as LightmapGI).light_data = null if light_data_handle == 0 else _kanama_object_handles.get(light_data_handle) as LightmapGIData"
+    )
+    appendLine("\\t\\t\\tapplied += 1")
+    appendLine("\\t\\t\\toffset += 12")
     appendLine("\t\telse:")
     appendLine(
       "\t\t\tpush_error(\"Invalid Kanama Web command opcode/object: %d/%d\" % [opcode, object_handle])"
@@ -2036,6 +2257,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvalue = (receiver as Node).duplicate()")
     appendLine("\telif opcode == 122 and receiver is RayCast3D:")
     appendLine("\t\tvalue = (receiver as RayCast3D).get_collider()")
+    appendLine("\\telif opcode == 246 and receiver is Material:")
+    appendLine("\\t\\tvalue = (receiver as Material).next_pass")
+    appendLine("\\telif opcode == 250 and receiver is SceneTree:")
+    appendLine("\\t\\tvalue = (receiver as SceneTree).root")
     appendLine("\tif value == null:")
     appendLine("\t\t_kanama_bridge.recordImmediateObjectHandle(0)")
     appendLine("\t\treturn 0")
@@ -2721,6 +2946,148 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tfound_handles.append(str(found_handle))")
     appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(found_handles))")
     appendLine("\t\t\tresult = 1")
+    appendLine("\\t\\telif opcode == 229 and value is Node3D:")
+    appendLine("\\t\\t\\tvar ray_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\\t\\t\\tvar ray_from := Vector3(float(ray_parts[0]), float(ray_parts[1]), float(ray_parts[2]))"
+    )
+    appendLine(
+      "\\t\\t\\tvar ray_to := Vector3(float(ray_parts[3]), float(ray_parts[4]), float(ray_parts[5]))"
+    )
+    appendLine("\\t\\t\\tvar ray_exclude_handle := int(ray_parts[7])")
+    appendLine(
+      "\\t\\t\\tvar ray_query := PhysicsRayQueryParameters3D.create(ray_from, ray_to, int(ray_parts[6]))"
+    )
+    appendLine("\\t\\t\\tif ray_exclude_handle != 0:")
+    appendLine(
+      "\\t\\t\\t\\tvar ray_excluded: Object = self if ray_exclude_handle == _kanama_handle else _kanama_object_handles.get(ray_exclude_handle)"
+    )
+    appendLine("\\t\\t\\t\\tif ray_excluded is CollisionObject3D:")
+    appendLine("\\t\\t\\t\\t\\tray_query.exclude = [(ray_excluded as CollisionObject3D).get_rid()]")
+    appendLine("\\t\\t\\tvar ray_space := (value as Node3D).get_world_3d().direct_space_state")
+    appendLine("\\t\\t\\tvar ray_hit: Dictionary = ray_space.intersect_ray(ray_query)")
+    appendLine("\\t\\t\\tvar ray_result := PackedStringArray()")
+    appendLine("\\t\\t\\tif ray_hit.is_empty():")
+    appendLine("\\t\\t\\t\\tray_result.append(\"0\")")
+    appendLine("\\t\\t\\t\\tray_result.append_array([\"0\", \"0\", \"0\", \"0\"])")
+    appendLine("\\t\\t\\telse:")
+    appendLine("\\t\\t\\t\\tvar ray_point: Vector3 = ray_hit[\"position\"]")
+    appendLine(
+      "\\t\\t\\t\\t# The collider only ever gets compared against an already-tracked handle, so an"
+    )
+    appendLine(
+      "\\t\\t\\t\\t# untracked engine body (level geometry) reports 0 rather than minting a handle."
+    )
+    appendLine("\\t\\t\\t\\tvar ray_collider_handle := 0")
+    appendLine("\\t\\t\\t\\tvar ray_collider: Object = ray_hit.get(\"collider\")")
+    appendLine("\\t\\t\\t\\tif ray_collider != null:")
+    appendLine("\\t\\t\\t\\t\\tif ray_collider.has_method(\"_kanama_ensure_created\"):")
+    appendLine(
+      "\\t\\t\\t\\t\\t\\tray_collider_handle = int(ray_collider.call(\"_kanama_ensure_created\"))"
+    )
+    appendLine("\\t\\t\\t\\t\\tif ray_collider_handle == 0:")
+    appendLine("\\t\\t\\t\\t\\t\\tfor ray_existing in _kanama_object_handles:")
+    appendLine(
+      "\\t\\t\\t\\t\\t\\t\\tif is_same(_kanama_object_handles[ray_existing], ray_collider):"
+    )
+    appendLine("\\t\\t\\t\\t\\t\\t\\t\\tray_collider_handle = int(ray_existing)")
+    appendLine("\\t\\t\\t\\t\\t\\t\\t\\tbreak")
+    appendLine("\\t\\t\\t\\tray_result.append(\"1\")")
+    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.x))")
+    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.y))")
+    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.z))")
+    appendLine("\\t\\t\\t\\tray_result.append(str(ray_collider_handle))")
+    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(ray_result))")
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 233:")
+    appendLine("\\t\\t\\tvar property_variant: Variant = value.get(StringName(String(args[2])))")
+    appendLine(
+      "\\t\\t\\tvar property_vector := property_variant if property_variant is Vector2 else Vector2.ZERO"
+    )
+    appendLine(
+      "\\t\\t\\t_kanama_bridge.recordImmediateStringResult(\"%s\\u001f%s\" % [property_vector.x, property_vector.y])"
+    )
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 240 and value is CPUParticles3D:")
+    appendLine("\\t\\t\\tresult = int(round((value as CPUParticles3D).lifetime * 1000.0))")
+    appendLine("\\t\\telif opcode == 249 and value is Timer:")
+    appendLine("\\t\\t\\tresult = int(round((value as Timer).time_left * 1000.0))")
+    appendLine("\\t\\telif opcode == 263 and value is Range:")
+    appendLine("\\t\\t\\tresult = int(round((value as Range).value * 1000.0))")
+    appendLine("\\t\\telif opcode == 243 and value is MeshInstance3D:")
+    appendLine("\\t\\t\\tvar override_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\\t\\t\\tvar override_material := (value as MeshInstance3D).get_surface_override_material(int(override_parts[0]))"
+    )
+    appendLine("\\t\\t\\tif override_material != null:")
+    appendLine("\\t\\t\\t\\tresult = int(override_parts[1])")
+    appendLine("\\t\\t\\t\\t_kanama_object_handles[result] = override_material")
+    appendLine("\\t\\telif opcode == 244 and value is Mesh:")
+    appendLine("\\t\\t\\tvar surface_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\\t\\t\\tvar surface_material := (value as Mesh).surface_get_material(int(surface_parts[0]))"
+    )
+    appendLine("\\t\\t\\tif surface_material != null:")
+    appendLine("\\t\\t\\t\\tresult = int(surface_parts[1])")
+    appendLine("\\t\\t\\t\\t_kanama_object_handles[result] = surface_material")
+    appendLine("\\t\\telif opcode == 245 and value is Mesh:")
+    appendLine("\\t\\t\\tvar set_surface_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\\t\\t\\tvar set_surface_handle := int(set_surface_parts[1])")
+    appendLine(
+      "\\t\\t\\tvar set_surface_material: Material = null if set_surface_handle == 0 else _kanama_object_handles.get(set_surface_handle) as Material"
+    )
+    appendLine(
+      "\\t\\t\\t(value as Mesh).surface_set_material(int(set_surface_parts[0]), set_surface_material)"
+    )
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 255 and value is BaseButton:")
+    appendLine("\\t\\t\\tresult = int((value as BaseButton).button_pressed)")
+    appendLine("\\t\\telif opcode == 259 and value is LineEdit:")
+    appendLine(
+      "\\t\\t\\t_kanama_bridge.recordImmediateStringResult(String((value as LineEdit).text))"
+    )
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 266 and value is ConfigFile:")
+    appendLine("\\t\\t\\tvar has_key_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\\t\\t\\tresult = int((value as ConfigFile).has_section_key(has_key_parts[0], has_key_parts[1]))"
+    )
+    appendLine("\\t\\telif opcode == 268 and value is ConfigFile:")
+    appendLine("\\t\\t\\tvar get_value_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\\t\\t\\tvar config_read: Variant = (value as ConfigFile).get_value(get_value_parts[0], get_value_parts[1])"
+    )
+    appendLine("\\t\\t\\tvar config_read_tagged := \"n:\"")
+    appendLine("\\t\\t\\tif config_read is bool:")
+    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"b:true\" if config_read else \"b:false\"")
+    appendLine("\\t\\t\\telif config_read is int:")
+    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"i:%d\" % config_read")
+    appendLine("\\t\\t\\telif config_read is float:")
+    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"f:%s\" % config_read")
+    appendLine("\\t\\t\\telif config_read != null:")
+    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"s:%s\" % config_read")
+    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(config_read_tagged)")
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 269:")
+    appendLine("\\t\\t\\tEngine.max_fps = int(String(args[2]))")
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 270:")
+    appendLine("\\t\\t\\tresult = int(Engine.get_frames_per_second())")
+    appendLine("\\t\\telif opcode == 271:")
+    appendLine("\\t\\t\\tresult = int(OS.get_static_memory_usage())")
+    appendLine("\\t\\telif opcode == 272:")
+    appendLine(
+      "\\t\\t\\tresult = int(round(Input.get_action_strength(StringName(String(args[2]))) * 1000.0))"
+    )
+    appendLine("\\t\\telif opcode == 276 and value is Noise:")
+    appendLine(
+      "\\t\\t\\tresult = int(round((value as Noise).get_noise_1d(float(args[2])) * 1000.0))"
+    )
+    appendLine("\\t\\telif opcode == 278 and value is Node:")
+    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(String((value as Node).name))")
+    appendLine("\\t\\t\\tresult = 1")
+    appendLine("\\t\\telif opcode == 282:")
+    appendLine("\\t\\t\\tresult = int(value.has_signal(StringName(String(args[2]))))")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2737,6 +3104,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as InputEventMouseMotion).relative")
     appendLine("\telif opcode == 220 and value is Viewport:")
     appendLine("\t\tresult = (value as Viewport).get_mouse_position()")
+    appendLine("\\telif opcode == 252 and value is Control:")
+    appendLine("\\t\\tresult = (value as Control).position")
+    appendLine("\\telif opcode == 253 and value is Control:")
+    appendLine("\\t\\tresult = (value as Control).size")
     appendLine("\t_kanama_bridge.recordImmediateVector2(result.x, result.y)")
     appendLine("\treturn 1")
     appendLine()
@@ -2775,6 +3146,17 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\telif opcode == 197 and value is RigidBody3D:")
     appendLine("\t\tresult = (value as RigidBody3D).angular_velocity")
+    appendLine("\\telif opcode == 227 and value is PhysicsBody3D:")
+    appendLine("\\t\\tresult = (value as PhysicsBody3D).get_gravity()")
+    appendLine("\\telif opcode == 234 and value is AnimationMixer:")
+    appendLine("\\t\\tresult = (value as AnimationMixer).get_root_motion_position()")
+    appendLine("\\telif opcode == 235 and value is AnimationMixer:")
+    appendLine(
+      "\\t\\t# Web adaptation: the Quaternion crosses as euler angles and the wrapper recomposes it."
+    )
+    appendLine("\\t\\tresult = (value as AnimationMixer).get_root_motion_rotation().get_euler()")
+    appendLine("\\telif opcode == 239 and value is CPUParticles3D:")
+    appendLine("\\t\\tresult = (value as CPUParticles3D).emission_box_extents")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -2081,6 +2081,18 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\\t\\t\\tapplied += 1")
     appendLine("\\t\\t\\toffset += 12")
+    appendLine("\t\telif opcode == 285 and target_object is CollisionObject3D:")
+    appendLine(
+      "\t\t\t(target_object as CollisionObject3D).collision_layer = bytes.decode_s32(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 286 and target_object is CollisionObject3D:")
+    appendLine(
+      "\t\t\t(target_object as CollisionObject3D).collision_mask = bytes.decode_s32(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
     appendLine("\t\telse:")
     appendLine(
       "\t\t\tpush_error(\"Invalid Kanama Web command opcode/object: %d/%d\" % [opcode, object_handle])"

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1860,227 +1860,223 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 20")
-    appendLine("\\t\\telif opcode == 226 and target_object is CharacterBody3D:")
+    appendLine("\t\telif opcode == 226 and target_object is CharacterBody3D:")
     appendLine(
-      "\\t\\t\\t(target_object as CharacterBody3D).up_direction = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
+      "\t\t\t(target_object as CharacterBody3D).up_direction = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 20")
-    appendLine("\\t\\telif opcode == 228 and target_object is RigidBody3D:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 228 and target_object is RigidBody3D:")
     appendLine(
-      "\\t\\t\\t(target_object as RigidBody3D).linear_velocity = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
+      "\t\t\t(target_object as RigidBody3D).linear_velocity = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 20")
-    appendLine("\\t\\telif opcode == 230 and target_object != null:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 230 and target_object != null:")
     appendLine(
-      "\\t\\t\\tvar indexed_string_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
-    )
-    appendLine(
-      "\\t\\t\\tvar indexed_string_value := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 12)))"
+      "\t\t\tvar indexed_string_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
     )
     appendLine(
-      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_string_path), indexed_string_value)"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 231 and target_object != null:")
-    appendLine(
-      "\\t\\t\\tvar indexed_long_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+      "\t\t\tvar indexed_string_value := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 12)))"
     )
     appendLine(
-      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_long_path), bytes.decode_s32(offset + 12))"
+      "\t\t\ttarget_object.set_indexed(NodePath(indexed_string_path), indexed_string_value)"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 232 and target_object != null:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 231 and target_object != null:")
     appendLine(
-      "\\t\\t\\tvar indexed_vec2_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
-    )
-    appendLine(
-      "\\t\\t\\ttarget_object.set_indexed(NodePath(indexed_vec2_path), Vector2(bytes.decode_float(offset + 12), bytes.decode_float(offset + 16)))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 20")
-    appendLine("\\t\\telif opcode == 236 and target_object is CPUParticles3D:")
-    appendLine(
-      "\\t\\t\\t(target_object as CPUParticles3D).emitting = bytes.decode_s32(offset + 8) != 0"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 237 and target_object is CPUParticles3D:")
-    appendLine(
-      "\\t\\t\\t(target_object as CPUParticles3D).restart(bytes.decode_s32(offset + 8) != 0)"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 238 and target_object is CPUParticles3D:")
-    appendLine(
-      "\\t\\t\\t(target_object as CPUParticles3D).emission_box_extents = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 20")
-    appendLine("\\t\\telif opcode == 241 and target_object is Light3D:")
-    appendLine(
-      "\\t\\t\\t(target_object as Light3D).shadow_enabled = bytes.decode_s32(offset + 8) != 0"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 242 and target_object is Environment:")
-    appendLine(
-      "\\t\\t\\t(target_object as Environment).glow_enabled = bytes.decode_s32(offset + 8) != 0"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 247 and target_object is Material:")
-    appendLine("\\t\\t\\tvar next_pass_handle := bytes.decode_s32(offset + 8)")
-    appendLine(
-      "\\t\\t\\t(target_object as Material).next_pass = null if next_pass_handle == 0 else _kanama_object_handles.get(next_pass_handle) as Material"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 248 and target_object is ShaderMaterial:")
-    appendLine(
-      "\\t\\t\\tvar shader_param_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+      "\t\t\tvar indexed_long_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
     )
     appendLine(
-      "\\t\\t\\t(target_object as ShaderMaterial).set_shader_parameter(StringName(shader_param_name), bytes.decode_double(offset + 12))"
+      "\t\t\ttarget_object.set_indexed(NodePath(indexed_long_path), bytes.decode_s32(offset + 12))"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 20")
-    appendLine("\\t\\telif opcode == 251 and target_object is Control:")
-    appendLine("\\t\\t\\t(target_object as Control).grab_focus()")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 8")
-    appendLine("\\t\\telif opcode == 254 and target_object is BaseButton:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 232 and target_object != null:")
     appendLine(
-      "\\t\\t\\t(target_object as BaseButton).button_pressed = bytes.decode_s32(offset + 8) != 0"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 256 and target_object is BaseButton:")
-    appendLine(
-      "\\t\\t\\t(target_object as BaseButton).disabled = bytes.decode_s32(offset + 8) != 0"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 257 and target_object is BaseButton:")
-    appendLine("\\t\\t\\tvar button_group_handle := bytes.decode_s32(offset + 8)")
-    appendLine(
-      "\\t\\t\\t(target_object as BaseButton).button_group = null if button_group_handle == 0 else _kanama_object_handles.get(button_group_handle) as ButtonGroup"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 258 and target_object is Button:")
-    appendLine(
-      "\\t\\t\\t(target_object as Button).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 260 and target_object is LineEdit:")
-    appendLine(
-      "\\t\\t\\t(target_object as LineEdit).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 261 and target_object is LineEdit:")
-    appendLine("\\t\\t\\t(target_object as LineEdit).editable = bytes.decode_s32(offset + 8) != 0")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 262 and target_object is Range:")
-    appendLine("\\t\\t\\t(target_object as Range).value = bytes.decode_double(offset + 8)")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 264 and target_object is ConfigFile:")
-    appendLine(
-      "\\t\\t\\t(target_object as ConfigFile).load(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 265 and target_object is ConfigFile:")
-    appendLine(
-      "\\t\\t\\t(target_object as ConfigFile).save(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 267 and target_object is ConfigFile:")
-    appendLine(
-      "\\t\\t\\tvar config_parts := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))).split(\"\\u001f\")"
-    )
-    appendLine("\\t\\t\\tvar config_tagged: String = config_parts[2]")
-    appendLine("\\t\\t\\tvar config_value: Variant = null")
-    appendLine("\\t\\t\\tif config_tagged.begins_with(\"i:\"):")
-    appendLine("\\t\\t\\t\\tconfig_value = int(config_tagged.substr(2))")
-    appendLine("\\t\\t\\telif config_tagged.begins_with(\"f:\"):")
-    appendLine("\\t\\t\\t\\tconfig_value = float(config_tagged.substr(2))")
-    appendLine("\\t\\t\\telif config_tagged.begins_with(\"b:\"):")
-    appendLine("\\t\\t\\t\\tconfig_value = config_tagged.substr(2) == \"true\"")
-    appendLine("\\t\\t\\telse:")
-    appendLine("\\t\\t\\t\\tconfig_value = config_tagged.substr(2)")
-    appendLine(
-      "\\t\\t\\t(target_object as ConfigFile).set_value(config_parts[0], config_parts[1], config_value)"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 273 and target_object is FastNoiseLite:")
-    appendLine("\\t\\t\\t(target_object as FastNoiseLite).seed = bytes.decode_s32(offset + 8)")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 274 and target_object is FastNoiseLite:")
-    appendLine(
-      "\\t\\t\\t(target_object as FastNoiseLite).fractal_octaves = bytes.decode_s32(offset + 8)"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 275 and target_object is FastNoiseLite:")
-    appendLine(
-      "\\t\\t\\t(target_object as FastNoiseLite).fractal_lacunarity = bytes.decode_double(offset + 8)"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 277 and target_object is Node:")
-    appendLine(
-      "\\t\\t\\t(target_object as Node).name = StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
-    )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 279 and target_object is Node:")
-    appendLine(
-      "\\t\\t\\tvar propagate_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+      "\t\t\tvar indexed_vec2_path := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
     )
     appendLine(
-      "\\t\\t\\t(target_object as Node).propagate_call(\"set\", [propagate_name, bytes.decode_s32(offset + 12) != 0])"
+      "\t\t\ttarget_object.set_indexed(NodePath(indexed_vec2_path), Vector2(bytes.decode_float(offset + 12), bytes.decode_float(offset + 16)))"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 280 and target_object != null:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 236 and target_object is CPUParticles3D:")
     appendLine(
-      "\\t\\t\\ttarget_object.call_deferred(StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))))"
+      "\t\t\t(target_object as CPUParticles3D).emitting = bytes.decode_s32(offset + 8) != 0"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
-    appendLine("\\t\\telif opcode == 281 and target_object != null:")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 237 and target_object is CPUParticles3D:")
+    appendLine("\t\t\t(target_object as CPUParticles3D).restart(bytes.decode_s32(offset + 8) != 0)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 238 and target_object is CPUParticles3D:")
     appendLine(
-      "\\t\\t\\tvar deferred_method := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+      "\t\t\t(target_object as CPUParticles3D).emission_box_extents = Vector3(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12), bytes.decode_float(offset + 16))"
     )
-    appendLine("\\t\\t\\tvar deferred_arg_handle := bytes.decode_s32(offset + 12)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 241 and target_object is Light3D:")
     appendLine(
-      "\\t\\t\\tvar deferred_arg: Object = null if deferred_arg_handle == 0 else _kanama_object_handles.get(deferred_arg_handle)"
+      "\t\t\t(target_object as Light3D).shadow_enabled = bytes.decode_s32(offset + 8) != 0"
     )
-    appendLine("\\t\\t\\ttarget_object.call_deferred(StringName(deferred_method), deferred_arg)")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 16")
-    appendLine("\\t\\telif opcode == 283 and target_object is Camera3D:")
-    appendLine("\\t\\t\\t(target_object as Camera3D).make_current()")
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 8")
-    appendLine("\\t\\telif opcode == 284 and target_object is LightmapGI:")
-    appendLine("\\t\\t\\tvar light_data_handle := bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 242 and target_object is Environment:")
     appendLine(
-      "\\t\\t\\t(target_object as LightmapGI).light_data = null if light_data_handle == 0 else _kanama_object_handles.get(light_data_handle) as LightmapGIData"
+      "\t\t\t(target_object as Environment).glow_enabled = bytes.decode_s32(offset + 8) != 0"
     )
-    appendLine("\\t\\t\\tapplied += 1")
-    appendLine("\\t\\t\\toffset += 12")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 247 and target_object is Material:")
+    appendLine("\t\t\tvar next_pass_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\t(target_object as Material).next_pass = null if next_pass_handle == 0 else _kanama_object_handles.get(next_pass_handle) as Material"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 248 and target_object is ShaderMaterial:")
+    appendLine(
+      "\t\t\tvar shader_param_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\t\t\t(target_object as ShaderMaterial).set_shader_parameter(StringName(shader_param_name), bytes.decode_double(offset + 12))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 20")
+    appendLine("\t\telif opcode == 251 and target_object is Control:")
+    appendLine("\t\t\t(target_object as Control).grab_focus()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 254 and target_object is BaseButton:")
+    appendLine(
+      "\t\t\t(target_object as BaseButton).button_pressed = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 256 and target_object is BaseButton:")
+    appendLine("\t\t\t(target_object as BaseButton).disabled = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 257 and target_object is BaseButton:")
+    appendLine("\t\t\tvar button_group_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\t(target_object as BaseButton).button_group = null if button_group_handle == 0 else _kanama_object_handles.get(button_group_handle) as ButtonGroup"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 258 and target_object is Button:")
+    appendLine(
+      "\t\t\t(target_object as Button).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 260 and target_object is LineEdit:")
+    appendLine(
+      "\t\t\t(target_object as LineEdit).text = String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 261 and target_object is LineEdit:")
+    appendLine("\t\t\t(target_object as LineEdit).editable = bytes.decode_s32(offset + 8) != 0")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 262 and target_object is Range:")
+    appendLine("\t\t\t(target_object as Range).value = bytes.decode_double(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 264 and target_object is ConfigFile:")
+    appendLine(
+      "\t\t\t(target_object as ConfigFile).load(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 265 and target_object is ConfigFile:")
+    appendLine(
+      "\t\t\t(target_object as ConfigFile).save(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 267 and target_object is ConfigFile:")
+    appendLine(
+      "\t\t\tvar config_parts := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))).split(\"\\u001f\")"
+    )
+    appendLine("\t\t\tvar config_tagged: String = config_parts[2]")
+    appendLine("\t\t\tvar config_value: Variant = null")
+    appendLine("\t\t\tif config_tagged.begins_with(\"i:\"):")
+    appendLine("\t\t\t\tconfig_value = int(config_tagged.substr(2))")
+    appendLine("\t\t\telif config_tagged.begins_with(\"f:\"):")
+    appendLine("\t\t\t\tconfig_value = float(config_tagged.substr(2))")
+    appendLine("\t\t\telif config_tagged.begins_with(\"b:\"):")
+    appendLine("\t\t\t\tconfig_value = config_tagged.substr(2) == \"true\"")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\tconfig_value = config_tagged.substr(2)")
+    appendLine(
+      "\t\t\t(target_object as ConfigFile).set_value(config_parts[0], config_parts[1], config_value)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 273 and target_object is FastNoiseLite:")
+    appendLine("\t\t\t(target_object as FastNoiseLite).seed = bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 274 and target_object is FastNoiseLite:")
+    appendLine(
+      "\t\t\t(target_object as FastNoiseLite).fractal_octaves = bytes.decode_s32(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 275 and target_object is FastNoiseLite:")
+    appendLine(
+      "\t\t\t(target_object as FastNoiseLite).fractal_lacunarity = bytes.decode_double(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 277 and target_object is Node:")
+    appendLine(
+      "\t\t\t(target_object as Node).name = StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8))))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 279 and target_object is Node:")
+    appendLine(
+      "\t\t\tvar propagate_name := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine(
+      "\t\t\t(target_object as Node).propagate_call(\"set\", [propagate_name, bytes.decode_s32(offset + 12) != 0])"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 280 and target_object != null:")
+    appendLine(
+      "\t\t\ttarget_object.call_deferred(StringName(String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 281 and target_object != null:")
+    appendLine(
+      "\t\t\tvar deferred_method := String(_kanama_bridge.resolveCommandStringName(bytes.decode_s32(offset + 8)))"
+    )
+    appendLine("\t\t\tvar deferred_arg_handle := bytes.decode_s32(offset + 12)")
+    appendLine(
+      "\t\t\tvar deferred_arg: Object = null if deferred_arg_handle == 0 else _kanama_object_handles.get(deferred_arg_handle)"
+    )
+    appendLine("\t\t\ttarget_object.call_deferred(StringName(deferred_method), deferred_arg)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 283 and target_object is Camera3D:")
+    appendLine("\t\t\t(target_object as Camera3D).make_current()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 284 and target_object is LightmapGI:")
+    appendLine("\t\t\tvar light_data_handle := bytes.decode_s32(offset + 8)")
+    appendLine(
+      "\t\t\t(target_object as LightmapGI).light_data = null if light_data_handle == 0 else _kanama_object_handles.get(light_data_handle) as LightmapGIData"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
     appendLine("\t\telif opcode == 285 and target_object is CollisionObject3D:")
     appendLine(
       "\t\t\t(target_object as CollisionObject3D).collision_layer = bytes.decode_s32(offset + 8)"
@@ -2104,9 +2100,13 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("func _kanama_immediate_call(args: Array) -> int:")
     appendLine("\tvar object_handle := int(args[0])")
     appendLine("\tvar result := -1")
-    appendLine("\tvar self_object: Object = self")
-    appendLine("\tif object_handle == _kanama_handle and self_object is Node:")
-    appendLine("\t\tresult = (self_object as Node).get_child_count(bool(args[1]))")
+    appendLine("\t# Any tracked node can be counted, not just this proxy's own: a script may walk")
+    appendLine("\t# the children of a node it looked up (the tps level counts spawn points).")
+    appendLine(
+      "\tvar count_target: Object = self if object_handle == _kanama_handle else _kanama_object_handles.get(object_handle)"
+    )
+    appendLine("\tif count_target is Node:")
+    appendLine("\t\tresult = (count_target as Node).get_child_count(bool(args[1]))")
     appendLine("\t_kanama_bridge.recordImmediateChildCount(result)")
     appendLine("\treturn result")
     appendLine()
@@ -2200,6 +2200,13 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine(
       "\t\t_kanama_bridge.refreshNode3DSnapshot(result_handle, node_3d.position.x, node_3d.position.y, node_3d.position.z, node_3d.rotation.x, node_3d.rotation.y, node_3d.rotation.z, node_3d.scale.x, node_3d.scale.y, node_3d.scale.z)"
     )
+    appendLine("\tif value is Control:")
+    appendLine("\t\t# Controls are CanvasItems but not Node2Ds: seed the mirrored canvas snapshot")
+    appendLine("\t\t# so modulate reads (HUD fades) resolve without a prior write.")
+    appendLine("\t\tvar control := value as Control")
+    appendLine(
+      "\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, control.position.x, control.position.y, control.scale.x, control.scale.y, control.modulate.r, control.modulate.g, control.modulate.b, control.modulate.a, control.rotation)"
+    )
     appendLine("\tif value is RayCast3D:")
     appendLine("\t\tvar ray := value as RayCast3D")
     appendLine(
@@ -2269,10 +2276,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tvalue = (receiver as Node).duplicate()")
     appendLine("\telif opcode == 122 and receiver is RayCast3D:")
     appendLine("\t\tvalue = (receiver as RayCast3D).get_collider()")
-    appendLine("\\telif opcode == 246 and receiver is Material:")
-    appendLine("\\t\\tvalue = (receiver as Material).next_pass")
-    appendLine("\\telif opcode == 250 and receiver is SceneTree:")
-    appendLine("\\t\\tvalue = (receiver as SceneTree).root")
+    appendLine("\telif opcode == 246 and receiver is Material:")
+    appendLine("\t\tvalue = (receiver as Material).next_pass")
+    appendLine("\telif opcode == 250 and receiver is SceneTree:")
+    appendLine("\t\tvalue = (receiver as SceneTree).root")
     appendLine("\tif value == null:")
     appendLine("\t\t_kanama_bridge.recordImmediateObjectHandle(0)")
     appendLine("\t\treturn 0")
@@ -2407,6 +2414,18 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tif result_handle == 0:")
     appendLine("\t\t\t\t\t_kanama_object_handles[proposed_child] = child_node")
     appendLine("\t\t\t\t\tresult_handle = proposed_child")
+    appendLine("\t\t\t\t# Seed the mirrored transform snapshots like a node lookup does: the")
+    appendLine("\t\t\t\t# caller may read the child's transform straight away (spawn points).")
+    appendLine("\t\t\t\tif child_node is Node2D:")
+    appendLine("\t\t\t\t\tvar child_2d := child_node as Node2D")
+    appendLine(
+      "\t\t\t\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, child_2d.position.x, child_2d.position.y, child_2d.scale.x, child_2d.scale.y, child_2d.modulate.r, child_2d.modulate.g, child_2d.modulate.b, child_2d.modulate.a, child_2d.rotation)"
+    )
+    appendLine("\t\t\t\tif child_node is Node3D:")
+    appendLine("\t\t\t\t\tvar child_3d := child_node as Node3D")
+    appendLine(
+      "\t\t\t\t\t_kanama_bridge.refreshNode3DSnapshot(result_handle, child_3d.position.x, child_3d.position.y, child_3d.position.z, child_3d.rotation.x, child_3d.rotation.y, child_3d.rotation.z, child_3d.scale.x, child_3d.scale.y, child_3d.scale.z)"
+    )
     appendLine("\telif opcode == 166:")
     appendLine(
       "\t\tvar sweep_body: Object = self if receiver_handle == _kanama_handle else _kanama_object_handles.get(receiver_handle)"
@@ -2958,148 +2977,142 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\tfound_handles.append(str(found_handle))")
     appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(found_handles))")
     appendLine("\t\t\tresult = 1")
-    appendLine("\\t\\telif opcode == 229 and value is Node3D:")
-    appendLine("\\t\\t\\tvar ray_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\telif opcode == 229 and value is Node3D:")
+    appendLine("\t\t\tvar ray_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(
-      "\\t\\t\\tvar ray_from := Vector3(float(ray_parts[0]), float(ray_parts[1]), float(ray_parts[2]))"
+      "\t\t\tvar ray_from := Vector3(float(ray_parts[0]), float(ray_parts[1]), float(ray_parts[2]))"
     )
     appendLine(
-      "\\t\\t\\tvar ray_to := Vector3(float(ray_parts[3]), float(ray_parts[4]), float(ray_parts[5]))"
+      "\t\t\tvar ray_to := Vector3(float(ray_parts[3]), float(ray_parts[4]), float(ray_parts[5]))"
     )
-    appendLine("\\t\\t\\tvar ray_exclude_handle := int(ray_parts[7])")
+    appendLine("\t\t\tvar ray_exclude_handle := int(ray_parts[7])")
     appendLine(
-      "\\t\\t\\tvar ray_query := PhysicsRayQueryParameters3D.create(ray_from, ray_to, int(ray_parts[6]))"
+      "\t\t\tvar ray_query := PhysicsRayQueryParameters3D.create(ray_from, ray_to, int(ray_parts[6]))"
     )
-    appendLine("\\t\\t\\tif ray_exclude_handle != 0:")
+    appendLine("\t\t\tif ray_exclude_handle != 0:")
     appendLine(
-      "\\t\\t\\t\\tvar ray_excluded: Object = self if ray_exclude_handle == _kanama_handle else _kanama_object_handles.get(ray_exclude_handle)"
+      "\t\t\t\tvar ray_excluded: Object = self if ray_exclude_handle == _kanama_handle else _kanama_object_handles.get(ray_exclude_handle)"
     )
-    appendLine("\\t\\t\\t\\tif ray_excluded is CollisionObject3D:")
-    appendLine("\\t\\t\\t\\t\\tray_query.exclude = [(ray_excluded as CollisionObject3D).get_rid()]")
-    appendLine("\\t\\t\\tvar ray_space := (value as Node3D).get_world_3d().direct_space_state")
-    appendLine("\\t\\t\\tvar ray_hit: Dictionary = ray_space.intersect_ray(ray_query)")
-    appendLine("\\t\\t\\tvar ray_result := PackedStringArray()")
-    appendLine("\\t\\t\\tif ray_hit.is_empty():")
-    appendLine("\\t\\t\\t\\tray_result.append(\"0\")")
-    appendLine("\\t\\t\\t\\tray_result.append_array([\"0\", \"0\", \"0\", \"0\"])")
-    appendLine("\\t\\t\\telse:")
-    appendLine("\\t\\t\\t\\tvar ray_point: Vector3 = ray_hit[\"position\"]")
+    appendLine("\t\t\t\tif ray_excluded is CollisionObject3D:")
+    appendLine("\t\t\t\t\tray_query.exclude = [(ray_excluded as CollisionObject3D).get_rid()]")
+    appendLine("\t\t\tvar ray_space := (value as Node3D).get_world_3d().direct_space_state")
+    appendLine("\t\t\tvar ray_hit: Dictionary = ray_space.intersect_ray(ray_query)")
+    appendLine("\t\t\tvar ray_result := PackedStringArray()")
+    appendLine("\t\t\tif ray_hit.is_empty():")
+    appendLine("\t\t\t\tray_result.append(\"0\")")
+    appendLine("\t\t\t\tray_result.append_array([\"0\", \"0\", \"0\", \"0\"])")
+    appendLine("\t\t\telse:")
+    appendLine("\t\t\t\tvar ray_point: Vector3 = ray_hit[\"position\"]")
     appendLine(
-      "\\t\\t\\t\\t# The collider only ever gets compared against an already-tracked handle, so an"
-    )
-    appendLine(
-      "\\t\\t\\t\\t# untracked engine body (level geometry) reports 0 rather than minting a handle."
-    )
-    appendLine("\\t\\t\\t\\tvar ray_collider_handle := 0")
-    appendLine("\\t\\t\\t\\tvar ray_collider: Object = ray_hit.get(\"collider\")")
-    appendLine("\\t\\t\\t\\tif ray_collider != null:")
-    appendLine("\\t\\t\\t\\t\\tif ray_collider.has_method(\"_kanama_ensure_created\"):")
-    appendLine(
-      "\\t\\t\\t\\t\\t\\tray_collider_handle = int(ray_collider.call(\"_kanama_ensure_created\"))"
-    )
-    appendLine("\\t\\t\\t\\t\\tif ray_collider_handle == 0:")
-    appendLine("\\t\\t\\t\\t\\t\\tfor ray_existing in _kanama_object_handles:")
-    appendLine(
-      "\\t\\t\\t\\t\\t\\t\\tif is_same(_kanama_object_handles[ray_existing], ray_collider):"
-    )
-    appendLine("\\t\\t\\t\\t\\t\\t\\t\\tray_collider_handle = int(ray_existing)")
-    appendLine("\\t\\t\\t\\t\\t\\t\\t\\tbreak")
-    appendLine("\\t\\t\\t\\tray_result.append(\"1\")")
-    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.x))")
-    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.y))")
-    appendLine("\\t\\t\\t\\tray_result.append(str(ray_point.z))")
-    appendLine("\\t\\t\\t\\tray_result.append(str(ray_collider_handle))")
-    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(ray_result))")
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 233:")
-    appendLine("\\t\\t\\tvar property_variant: Variant = value.get(StringName(String(args[2])))")
-    appendLine(
-      "\\t\\t\\tvar property_vector := property_variant if property_variant is Vector2 else Vector2.ZERO"
+      "\t\t\t\t# The collider only ever gets compared against an already-tracked handle, so an"
     )
     appendLine(
-      "\\t\\t\\t_kanama_bridge.recordImmediateStringResult(\"%s\\u001f%s\" % [property_vector.x, property_vector.y])"
+      "\t\t\t\t# untracked engine body (level geometry) reports 0 rather than minting a handle."
     )
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 240 and value is CPUParticles3D:")
-    appendLine("\\t\\t\\tresult = int(round((value as CPUParticles3D).lifetime * 1000.0))")
-    appendLine("\\t\\telif opcode == 249 and value is Timer:")
-    appendLine("\\t\\t\\tresult = int(round((value as Timer).time_left * 1000.0))")
-    appendLine("\\t\\telif opcode == 263 and value is Range:")
-    appendLine("\\t\\t\\tresult = int(round((value as Range).value * 1000.0))")
-    appendLine("\\t\\telif opcode == 243 and value is MeshInstance3D:")
-    appendLine("\\t\\t\\tvar override_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\t\tvar ray_collider_handle := 0")
+    appendLine("\t\t\t\tvar ray_collider: Object = ray_hit.get(\"collider\")")
+    appendLine("\t\t\t\tif ray_collider != null:")
+    appendLine("\t\t\t\t\tif ray_collider.has_method(\"_kanama_ensure_created\"):")
     appendLine(
-      "\\t\\t\\tvar override_material := (value as MeshInstance3D).get_surface_override_material(int(override_parts[0]))"
+      "\t\t\t\t\t\tray_collider_handle = int(ray_collider.call(\"_kanama_ensure_created\"))"
     )
-    appendLine("\\t\\t\\tif override_material != null:")
-    appendLine("\\t\\t\\t\\tresult = int(override_parts[1])")
-    appendLine("\\t\\t\\t\\t_kanama_object_handles[result] = override_material")
-    appendLine("\\t\\telif opcode == 244 and value is Mesh:")
-    appendLine("\\t\\t\\tvar surface_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\t\t\tif ray_collider_handle == 0:")
+    appendLine("\t\t\t\t\t\tfor ray_existing in _kanama_object_handles:")
+    appendLine("\t\t\t\t\t\t\tif is_same(_kanama_object_handles[ray_existing], ray_collider):")
+    appendLine("\t\t\t\t\t\t\t\tray_collider_handle = int(ray_existing)")
+    appendLine("\t\t\t\t\t\t\t\tbreak")
+    appendLine("\t\t\t\tray_result.append(\"1\")")
+    appendLine("\t\t\t\tray_result.append(str(ray_point.x))")
+    appendLine("\t\t\t\tray_result.append(str(ray_point.y))")
+    appendLine("\t\t\t\tray_result.append(str(ray_point.z))")
+    appendLine("\t\t\t\tray_result.append(str(ray_collider_handle))")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\"\\u001f\".join(ray_result))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 233:")
+    appendLine("\t\t\tvar property_variant: Variant = value.get(StringName(String(args[2])))")
     appendLine(
-      "\\t\\t\\tvar surface_material := (value as Mesh).surface_get_material(int(surface_parts[0]))"
-    )
-    appendLine("\\t\\t\\tif surface_material != null:")
-    appendLine("\\t\\t\\t\\tresult = int(surface_parts[1])")
-    appendLine("\\t\\t\\t\\t_kanama_object_handles[result] = surface_material")
-    appendLine("\\t\\telif opcode == 245 and value is Mesh:")
-    appendLine("\\t\\t\\tvar set_surface_parts := String(args[2]).split(\"\\u001f\")")
-    appendLine("\\t\\t\\tvar set_surface_handle := int(set_surface_parts[1])")
-    appendLine(
-      "\\t\\t\\tvar set_surface_material: Material = null if set_surface_handle == 0 else _kanama_object_handles.get(set_surface_handle) as Material"
+      "\t\t\tvar property_vector: Vector2 = property_variant if property_variant is Vector2 else Vector2.ZERO"
     )
     appendLine(
-      "\\t\\t\\t(value as Mesh).surface_set_material(int(set_surface_parts[0]), set_surface_material)"
+      "\t\t\t_kanama_bridge.recordImmediateStringResult(\"%s\\u001f%s\" % [property_vector.x, property_vector.y])"
     )
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 255 and value is BaseButton:")
-    appendLine("\\t\\t\\tresult = int((value as BaseButton).button_pressed)")
-    appendLine("\\t\\telif opcode == 259 and value is LineEdit:")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 240 and value is CPUParticles3D:")
+    appendLine("\t\t\tresult = int(round((value as CPUParticles3D).lifetime * 1000.0))")
+    appendLine("\t\telif opcode == 249 and value is Timer:")
+    appendLine("\t\t\tresult = int(round((value as Timer).time_left * 1000.0))")
+    appendLine("\t\telif opcode == 263 and value is Range:")
+    appendLine("\t\t\tresult = int(round((value as Range).value * 1000.0))")
+    appendLine("\t\telif opcode == 243 and value is MeshInstance3D:")
+    appendLine("\t\t\tvar override_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(
-      "\\t\\t\\t_kanama_bridge.recordImmediateStringResult(String((value as LineEdit).text))"
+      "\t\t\tvar override_material := (value as MeshInstance3D).get_surface_override_material(int(override_parts[0]))"
     )
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 266 and value is ConfigFile:")
-    appendLine("\\t\\t\\tvar has_key_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tif override_material != null:")
+    appendLine("\t\t\t\tresult = int(override_parts[1])")
+    appendLine("\t\t\t\t_kanama_object_handles[result] = override_material")
+    appendLine("\t\telif opcode == 244 and value is Mesh:")
+    appendLine("\t\t\tvar surface_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(
-      "\\t\\t\\tresult = int((value as ConfigFile).has_section_key(has_key_parts[0], has_key_parts[1]))"
+      "\t\t\tvar surface_material := (value as Mesh).surface_get_material(int(surface_parts[0]))"
     )
-    appendLine("\\t\\telif opcode == 268 and value is ConfigFile:")
-    appendLine("\\t\\t\\tvar get_value_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tif surface_material != null:")
+    appendLine("\t\t\t\tresult = int(surface_parts[1])")
+    appendLine("\t\t\t\t_kanama_object_handles[result] = surface_material")
+    appendLine("\t\telif opcode == 245 and value is Mesh:")
+    appendLine("\t\t\tvar set_surface_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar set_surface_handle := int(set_surface_parts[1])")
     appendLine(
-      "\\t\\t\\tvar config_read: Variant = (value as ConfigFile).get_value(get_value_parts[0], get_value_parts[1])"
+      "\t\t\tvar set_surface_material: Material = null if set_surface_handle == 0 else _kanama_object_handles.get(set_surface_handle) as Material"
     )
-    appendLine("\\t\\t\\tvar config_read_tagged := \"n:\"")
-    appendLine("\\t\\t\\tif config_read is bool:")
-    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"b:true\" if config_read else \"b:false\"")
-    appendLine("\\t\\t\\telif config_read is int:")
-    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"i:%d\" % config_read")
-    appendLine("\\t\\t\\telif config_read is float:")
-    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"f:%s\" % config_read")
-    appendLine("\\t\\t\\telif config_read != null:")
-    appendLine("\\t\\t\\t\\tconfig_read_tagged = \"s:%s\" % config_read")
-    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(config_read_tagged)")
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 269:")
-    appendLine("\\t\\t\\tEngine.max_fps = int(String(args[2]))")
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 270:")
-    appendLine("\\t\\t\\tresult = int(Engine.get_frames_per_second())")
-    appendLine("\\t\\telif opcode == 271:")
-    appendLine("\\t\\t\\tresult = int(OS.get_static_memory_usage())")
-    appendLine("\\t\\telif opcode == 272:")
     appendLine(
-      "\\t\\t\\tresult = int(round(Input.get_action_strength(StringName(String(args[2]))) * 1000.0))"
+      "\t\t\t(value as Mesh).surface_set_material(int(set_surface_parts[0]), set_surface_material)"
     )
-    appendLine("\\t\\telif opcode == 276 and value is Noise:")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 255 and value is BaseButton:")
+    appendLine("\t\t\tresult = int((value as BaseButton).button_pressed)")
+    appendLine("\t\telif opcode == 259 and value is LineEdit:")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(String((value as LineEdit).text))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 266 and value is ConfigFile:")
+    appendLine("\t\t\tvar has_key_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(
-      "\\t\\t\\tresult = int(round((value as Noise).get_noise_1d(float(args[2])) * 1000.0))"
+      "\t\t\tresult = int((value as ConfigFile).has_section_key(has_key_parts[0], has_key_parts[1]))"
     )
-    appendLine("\\t\\telif opcode == 278 and value is Node:")
-    appendLine("\\t\\t\\t_kanama_bridge.recordImmediateStringResult(String((value as Node).name))")
-    appendLine("\\t\\t\\tresult = 1")
-    appendLine("\\t\\telif opcode == 282:")
-    appendLine("\\t\\t\\tresult = int(value.has_signal(StringName(String(args[2]))))")
+    appendLine("\t\telif opcode == 268 and value is ConfigFile:")
+    appendLine("\t\t\tvar get_value_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine(
+      "\t\t\tvar config_read: Variant = (value as ConfigFile).get_value(get_value_parts[0], get_value_parts[1])"
+    )
+    appendLine("\t\t\tvar config_read_tagged := \"n:\"")
+    appendLine("\t\t\tif config_read is bool:")
+    appendLine("\t\t\t\tconfig_read_tagged = \"b:true\" if config_read else \"b:false\"")
+    appendLine("\t\t\telif config_read is int:")
+    appendLine("\t\t\t\tconfig_read_tagged = \"i:%d\" % config_read")
+    appendLine("\t\t\telif config_read is float:")
+    appendLine("\t\t\t\tconfig_read_tagged = \"f:%s\" % config_read")
+    appendLine("\t\t\telif config_read != null:")
+    appendLine("\t\t\t\tconfig_read_tagged = \"s:%s\" % config_read")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(config_read_tagged)")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 269:")
+    appendLine("\t\t\tEngine.max_fps = int(String(args[2]))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 270:")
+    appendLine("\t\t\tresult = int(Engine.get_frames_per_second())")
+    appendLine("\t\telif opcode == 271:")
+    appendLine("\t\t\tresult = int(OS.get_static_memory_usage())")
+    appendLine("\t\telif opcode == 272:")
+    appendLine(
+      "\t\t\tresult = int(round(Input.get_action_strength(StringName(String(args[2]))) * 1000.0))"
+    )
+    appendLine("\t\telif opcode == 276 and value is Noise:")
+    appendLine("\t\t\tresult = int(round((value as Noise).get_noise_1d(float(args[2])) * 1000.0))")
+    appendLine("\t\telif opcode == 278 and value is Node:")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(String((value as Node).name))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 282:")
+    appendLine("\t\t\tresult = int(value.has_signal(StringName(String(args[2]))))")
     appendLine("\t_kanama_bridge.recordImmediateLongResult(result)")
     appendLine("\treturn result")
     appendLine()
@@ -3116,10 +3129,10 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult = (value as InputEventMouseMotion).relative")
     appendLine("\telif opcode == 220 and value is Viewport:")
     appendLine("\t\tresult = (value as Viewport).get_mouse_position()")
-    appendLine("\\telif opcode == 252 and value is Control:")
-    appendLine("\\t\\tresult = (value as Control).position")
-    appendLine("\\telif opcode == 253 and value is Control:")
-    appendLine("\\t\\tresult = (value as Control).size")
+    appendLine("\telif opcode == 252 and value is Control:")
+    appendLine("\t\tresult = (value as Control).position")
+    appendLine("\telif opcode == 253 and value is Control:")
+    appendLine("\t\tresult = (value as Control).size")
     appendLine("\t_kanama_bridge.recordImmediateVector2(result.x, result.y)")
     appendLine("\treturn 1")
     appendLine()
@@ -3158,17 +3171,17 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\telif opcode == 197 and value is RigidBody3D:")
     appendLine("\t\tresult = (value as RigidBody3D).angular_velocity")
-    appendLine("\\telif opcode == 227 and value is PhysicsBody3D:")
-    appendLine("\\t\\tresult = (value as PhysicsBody3D).get_gravity()")
-    appendLine("\\telif opcode == 234 and value is AnimationMixer:")
-    appendLine("\\t\\tresult = (value as AnimationMixer).get_root_motion_position()")
-    appendLine("\\telif opcode == 235 and value is AnimationMixer:")
+    appendLine("\telif opcode == 227 and value is PhysicsBody3D:")
+    appendLine("\t\tresult = (value as PhysicsBody3D).get_gravity()")
+    appendLine("\telif opcode == 234 and value is AnimationMixer:")
+    appendLine("\t\tresult = (value as AnimationMixer).get_root_motion_position()")
+    appendLine("\telif opcode == 235 and value is AnimationMixer:")
     appendLine(
-      "\\t\\t# Web adaptation: the Quaternion crosses as euler angles and the wrapper recomposes it."
+      "\t\t# Web adaptation: the Quaternion crosses as euler angles and the wrapper recomposes it."
     )
-    appendLine("\\t\\tresult = (value as AnimationMixer).get_root_motion_rotation().get_euler()")
-    appendLine("\\telif opcode == 239 and value is CPUParticles3D:")
-    appendLine("\\t\\tresult = (value as CPUParticles3D).emission_box_extents")
+    appendLine("\t\tresult = (value as AnimationMixer).get_root_motion_rotation().get_euler()")
+    appendLine("\telif opcode == 239 and value is CPUParticles3D:")
+    appendLine("\t\tresult = (value as CPUParticles3D).emission_box_extents")
     appendLine("\t_kanama_bridge.recordImmediateVector3(result.x, result.y, result.z)")
     appendLine("\treturn 1")
     appendLine()

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -72,7 +72,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 14"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 15"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -410,7 +410,7 @@ class WebScriptCodeEmitterTest {
     )
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 14"))
+    assertTrue(protocol.contains("\"protocolVersion\": 15"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -421,7 +421,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=14\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=15\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))

--- a/scripts/generate_platform_backend_contract.py
+++ b/scripts/generate_platform_backend_contract.py
@@ -77,6 +77,13 @@ def render() -> str:
         )
     if lines[-1] == "":
         lines.pop()
+    lines.extend(
+        [
+            "",
+            "  /** Highest opcode in the shared contract; sizes the call-site resolution cache. */",
+            f"  const val MAX_OPCODE = {max(policy.opcode for policy in INITIAL_BACKEND_CALLS)}",
+        ]
+    )
     lines.append("}")
     lines.append("")
     return "\n".join(lines)

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -268,6 +268,65 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     223: {},
     224: {},
     225: {"ret": "browser"},
+    226: {},
+    227: {},
+    228: {},
+    229: {},
+    230: {},
+    231: {},
+    232: {},
+    233: {},
+    234: {},
+    235: {},
+    236: {},
+    237: {},
+    238: {},
+    239: {},
+    240: {},
+    241: {},
+    242: {},
+    243: {"ret": "indexed_browser"},
+    244: {"ret": "indexed_browser"},
+    245: {},
+    246: {"ret": "browser"},
+    247: {},
+    248: {},
+    249: {},
+    250: {"ret": "node"},
+    251: {},
+    252: {},
+    253: {},
+    254: {},
+    255: {},
+    256: {},
+    257: {},
+    258: {},
+    259: {},
+    260: {},
+    261: {},
+    262: {},
+    263: {},
+    264: {},
+    265: {},
+    266: {},
+    267: {},
+    268: {},
+    269: {},
+    270: {},
+    271: {},
+    272: {},
+    273: {},
+    274: {},
+    275: {},
+    276: {},
+    277: {},
+    278: {},
+    279: {},
+    280: {},
+    281: {},
+    282: {},
+    283: {},
+    284: {},
 }
 
 
@@ -736,7 +795,14 @@ def body_VECTOR3_ARG(calls):
         "when (descriptor.opcode) {",
     ]
     for c in queued:
-        lines.append(f"{c.opcode} -> webWriteVector3Snapshot(objectId, {_slot3(c.opcode)}, value)")
+        # Opcodes without a mirrored slot are write-only on the Kotlin side: their reads (where
+        # the corpus has any) go through a synchronous immediate rather than a snapshot.
+        if WEB_POLICY[c.opcode].get("vec3_slot") is None:
+            lines.append(f"{c.opcode} -> {{}}")
+        else:
+            lines.append(
+                f"{c.opcode} -> webWriteVector3Snapshot(objectId, {_slot3(c.opcode)}, value)"
+            )
     lines.append('else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")')
     lines.append("}")
     lines.append("}")
@@ -935,6 +1001,30 @@ def body_OBJECT_ARG(calls):
                 "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }",
                 "}",
             ]
+        elif op == 247:
+            lines += [
+                "247 -> {",
+                f"require(descriptor.executionMode == {_QUEUED})",
+                "// Duplicated materials return through the browser-object channel.",
+                "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.OBJECT) }",
+                "}",
+            ]
+        elif op == 257:
+            lines += [
+                "257 -> {",
+                f"require(descriptor.executionMode == {_QUEUED})",
+                "// The ButtonGroup was constructed via ClassDB.instantiate (NODE kind).",
+                "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }",
+                "}",
+            ]
+        elif op == 284:
+            lines += [
+                "284 -> {",
+                f"require(descriptor.executionMode == {_QUEUED})",
+                "// Baked lightmap data arrives through ResourceLoader.load (RESOURCE kind).",
+                "value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }",
+                "}",
+            ]
         else:
             raise GenerationError(f"OBJECT_ARG opcode {op} has no emitter arm")
     lines += [
@@ -987,6 +1077,18 @@ def body_LONG_RET_HANDLE(calls):
     indexed_node_ops = [
         c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "indexed_node"
     ]
+    indexed_browser_ops = [
+        c.opcode for c in calls if WEB_POLICY[c.opcode].get("ret") == "indexed_browser"
+    ]
+    for op in indexed_browser_ops:
+        # Resource-valued indexed reads ride the property-object channel (which allocates an
+        # OBJECT-kind slot), not the node-shaped indexed lookup: a Material is never a Node.
+        lines.append(f"{op} ->")
+        lines.append(
+            "registerReturnedBrowserObject("
+            "immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), value.toString())"
+            ")"
+        )
     for op in indexed_node_ops:
         lines.append(f"{op} ->")
         lines.append(
@@ -1604,6 +1706,117 @@ def body_STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST(calls):
     ]
 
 
+def body_STRINGNAME_LONG_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_QUEUED})",
+        f"require({_opcode_guard(calls)})",
+        "require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit '
+        "Godot's int32 ABI\"",
+        "}",
+        "commands.appendStringNameLongMutation(descriptor.opcode, receiver.webId(), name, value)",
+    ]
+
+
+def body_STRINGNAME_VECTOR2_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_QUEUED})",
+        f"require({_opcode_guard(calls)})",
+        "commands.appendStringNameVector2Mutation(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "name,",
+        "value.x,",
+        "value.y,",
+        ")",
+    ]
+
+
+def body_STRINGNAME_OBJECT_ARG(calls):
+    return [
+        f"require(descriptor.executionMode == {_QUEUED})",
+        f"require({_opcode_guard(calls)})",
+        "commands.appendStringNameObjectMutation(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "name,",
+        "value.webId(),",
+        ")",
+    ]
+
+
+def body_STRINGNAME_RET_VECTOR2(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Both components ride the shared string channel (unit separator); non-Vector2",
+        "// properties resolve to the zero vector applier-side.",
+        "val packed = immediateWebStringQuery(descriptor.opcode, receiver.webId(), name)",
+        "val parts = packed.split('\u001f')",
+        "require(parts.size == 2) {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} returned $packed"',
+        "}",
+        "return GodotVector2(parts[0].toFloat(), parts[1].toFloat())",
+    ]
+
+
+def body_NOARGS_RET_STRING(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        'return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")',
+    ]
+
+
+def body_STRINGNAME_RET_STRING(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "return immediateWebStringQuery(descriptor.opcode, receiver.webId(), name)",
+    ]
+
+
+def body_DOUBLE_RET_DOUBLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(value.isFinite()) {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"',
+        "}",
+        "commands.flush()",
+        "// Scaled by 1000 through the shared integer double-query transport.",
+        "return immediateWebDoubleQuery(descriptor.opcode, receiver.webId(), value) / 1000.0",
+    ]
+
+
+def body_VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(collisionMask in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "commands.flush()",
+        "// Ray endpoints, mask, and the optional exclusion handle ride one query string",
+        "// (unit separator). The applier resolves the receiver's world, builds the query",
+        "// parameters, and turns the exclusion handle into an RID on its own side.",
+        "val packed =",
+        "listOf(",
+        "from.x.toString(),",
+        "from.y.toString(),",
+        "from.z.toString(),",
+        "to.x.toString(),",
+        "to.y.toString(),",
+        "to.z.toString(),",
+        "collisionMask.toString(),",
+        "(exclude?.webId() ?: 0).toString(),",
+        ")",
+        '.joinToString("\u001f")',
+        "return immediateWebStringQuery(descriptor.opcode, receiver.webId(), packed)",
+    ]
+
+
 # Signature: (params-after-descriptor/callSite, return-type). `receiver` present unless noted.
 SIGNATURES: dict[str, tuple[list[str], str]] = {
     "BOOL_RET_INT": (["receiver: GodotHandle", "value: Boolean"], "Int"),
@@ -1822,6 +2035,29 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ["resource: GodotHandle", "path: String", "flags: Long"],
         "Long",
     ),
+    "STRINGNAME_LONG_ARG": (["receiver: GodotHandle", "name: String", "value: Long"], ""),
+    "STRINGNAME_VECTOR2_ARG": (
+        ["receiver: GodotHandle", "name: String", "value: GodotVector2"],
+        "",
+    ),
+    "STRINGNAME_OBJECT_ARG": (
+        ["receiver: GodotHandle", "name: String", "value: GodotHandle"],
+        "",
+    ),
+    "STRINGNAME_RET_VECTOR2": (["receiver: GodotHandle", "name: String"], "GodotVector2"),
+    "NOARGS_RET_STRING": (["receiver: GodotHandle"], "String"),
+    "STRINGNAME_RET_STRING": (["receiver: GodotHandle", "name: String"], "String"),
+    "DOUBLE_RET_DOUBLE": (["receiver: GodotHandle", "value: Double"], "Double"),
+    "VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING": (
+        [
+            "receiver: GodotHandle",
+            "from: GodotVector3",
+            "to: GodotVector3",
+            "collisionMask: Long",
+            "exclude: GodotHandle?",
+        ],
+        "String",
+    ),
     "STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST": (
         [
             "receiver: GodotHandle",
@@ -1950,6 +2186,14 @@ EMIT_ORDER = [
     "VECTOR2_RET_VECTOR3",
     "OBJECT_STRING_RET_LONG_SINGLETON",
     "STRING_STRING_BOOL_BOOL_RET_HANDLE_LIST",
+    "STRINGNAME_LONG_ARG",
+    "STRINGNAME_VECTOR2_ARG",
+    "STRINGNAME_OBJECT_ARG",
+    "STRINGNAME_RET_VECTOR2",
+    "NOARGS_RET_STRING",
+    "STRINGNAME_RET_STRING",
+    "DOUBLE_RET_DOUBLE",
+    "VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING",
 ]
 
 

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -327,6 +327,8 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     282: {},
     283: {},
     284: {},
+    285: {},
+    286: {},
 }
 
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -3536,6 +3536,942 @@
       "scope": "class",
       "returnOwnership": "BORROWED",
       "introducedBy": "60h-citybuilder"
+    },
+    {
+      "opcode": 226,
+      "scope": "class",
+      "className": "CharacterBody3D",
+      "methodName": "set_up_direction",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the floor-detection up vector before move_and_slide (tps player/robot).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 227,
+      "scope": "class",
+      "className": "PhysicsBody3D",
+      "methodName": "get_gravity",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Current gravity vector for the body (tps applies gravity manually each physics tick).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 228,
+      "scope": "class",
+      "className": "RigidBody3D",
+      "methodName": "set_linear_velocity",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a linear velocity write (tps robot death parts launch).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 229,
+      "scope": "class",
+      "className": "PhysicsDirectSpaceState3D",
+      "methodName": "intersect_ray",
+      "hash": 3957970750,
+      "arguments": [
+        "PhysicsRayQueryParameters3D"
+      ],
+      "returnType": "Dictionary",
+      "shape": "VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Space-state ray query adapted to the Web seam: receiver is a node in the target world, the applier builds the ray parameters engine-side (handles resolve to RIDs there), and the packed result carries hit/position/tracked-collider.",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 230,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "set_indexed",
+      "hash": 3500910842,
+      "arguments": [
+        "NodePath",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a String-valued property-path write (AnimationTree state transition requests).",
+      "introducedBy": "60i-tpsdemo",
+      "descriptorName": "OBJECT_SET_INDEXED_STRING"
+    },
+    {
+      "opcode": 231,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "set_indexed",
+      "hash": 3500910842,
+      "arguments": [
+        "NodePath",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue an int-valued property-path write (AnimationTree one-shot hit requests; typed proxy int properties like player_id).",
+      "introducedBy": "60i-tpsdemo",
+      "descriptorName": "OBJECT_SET_INDEXED_LONG"
+    },
+    {
+      "opcode": 232,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "set_indexed",
+      "hash": 3500910842,
+      "arguments": [
+        "NodePath",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_VECTOR2_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a Vector2-valued property-path write (AnimationTree blend positions).",
+      "introducedBy": "60i-tpsdemo",
+      "descriptorName": "OBJECT_SET_INDEXED_VECTOR2"
+    },
+    {
+      "opcode": 233,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "get",
+      "hash": 2760726917,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_RET_VECTOR2",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Vector2-valued property read by name (AnimationTree aim blend position).",
+      "introducedBy": "60i-tpsdemo",
+      "descriptorName": "OBJECT_GET_PROPERTY_VECTOR2"
+    },
+    {
+      "opcode": 234,
+      "scope": "class",
+      "className": "AnimationMixer",
+      "methodName": "get_root_motion_position",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Root motion translation delta for the current frame (tps locomotion).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 235,
+      "scope": "class",
+      "className": "AnimationMixer",
+      "methodName": "get_root_motion_rotation",
+      "hash": 1222331677,
+      "arguments": [],
+      "returnType": "Quaternion",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Root motion rotation delta adapted to the Web seam as euler angles (the applier converts the Quaternion; the wrapper recomposes it).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 236,
+      "scope": "class",
+      "className": "CPUParticles3D",
+      "methodName": "set_emitting",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the CPU-particles emitting toggle (muzzle flash, death sparks, part disappearance).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 237,
+      "scope": "class",
+      "className": "CPUParticles3D",
+      "methodName": "restart",
+      "hash": 107499316,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a CPU-particles restart (keep_seed baked false; shoot particle retrigger).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 238,
+      "scope": "class",
+      "className": "CPUParticles3D",
+      "methodName": "set_emission_box_extents",
+      "hash": 3460891852,
+      "arguments": [
+        "Vector3"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR3_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the emission box extents write (laser ember length follows the clipped beam).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 239,
+      "scope": "class",
+      "className": "CPUParticles3D",
+      "methodName": "get_emission_box_extents",
+      "hash": 3360562783,
+      "arguments": [],
+      "returnType": "Vector3",
+      "shape": "NOARGS_RET_VECTOR3",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Emission box extents read (laser ember length update composes on the current value).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 240,
+      "scope": "class",
+      "className": "CPUParticles3D",
+      "methodName": "get_lifetime",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_DOUBLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Particle lifetime read (part-disappear effect schedules its own free).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 241,
+      "scope": "class",
+      "className": "Light3D",
+      "methodName": "set_shadow",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a per-light shadow toggle (bullet omni light, forklift spotlight).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 242,
+      "scope": "class",
+      "className": "Environment",
+      "methodName": "set_glow_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the environment glow toggle (the only tps environment setting the compatibility renderer honors).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 243,
+      "scope": "class",
+      "className": "MeshInstance3D",
+      "methodName": "get_surface_override_material",
+      "hash": 2897466400,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "Material",
+      "shape": "LONG_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Surface override material as a tracked browser handle (robot laser beam clip shader).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 244,
+      "scope": "class",
+      "className": "Mesh",
+      "methodName": "surface_get_material",
+      "hash": 2897466400,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "Material",
+      "shape": "LONG_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Mesh surface material as a tracked browser handle (death-part fade material chain).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 245,
+      "scope": "class",
+      "className": "Mesh",
+      "methodName": "surface_set_material",
+      "hash": 3671737478,
+      "arguments": [
+        "int",
+        "Material"
+      ],
+      "returnType": "void",
+      "shape": "LONG_OBJECT_ARG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Replace one mesh surface material (death parts swap in the duplicated fade chain).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 246,
+      "scope": "class",
+      "className": "Material",
+      "methodName": "get_next_pass",
+      "hash": 5934680,
+      "arguments": [],
+      "returnType": "Material",
+      "shape": "NOARGS_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Next-pass material as a tracked browser handle (death-part fade shader lives on the second pass).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 247,
+      "scope": "class",
+      "className": "Material",
+      "methodName": "set_next_pass",
+      "hash": 2757459619,
+      "arguments": [
+        "Material"
+      ],
+      "returnType": "void",
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a next-pass material assignment (duplicated fade chain wiring).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 248,
+      "scope": "class",
+      "className": "ShaderMaterial",
+      "methodName": "set_shader_parameter",
+      "hash": 3776071444,
+      "arguments": [
+        "StringName",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a double-valued shader parameter write (laser clip length, part fade cutout).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 249,
+      "scope": "class",
+      "className": "Timer",
+      "methodName": "get_time_left",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_DOUBLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Remaining time on a Timer node (fire cooldown gate).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 250,
+      "scope": "class",
+      "className": "SceneTree",
+      "methodName": "get_root",
+      "hash": 1757182445,
+      "arguments": [],
+      "returnType": "Window",
+      "shape": "NOARGS_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Root window as a tracked node handle (blast camera lookup, robot blast parenting).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 251,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "grab_focus",
+      "hash": 107499316,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue keyboard focus onto a control (menu navigation).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 252,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "get_position",
+      "hash": 3341600327,
+      "arguments": [],
+      "returnType": "Vector2",
+      "shape": "NOARGS_RET_VECTOR2",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Control rect position read (crosshair center for the shoot ray).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 253,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "get_size",
+      "hash": 3341600327,
+      "arguments": [],
+      "returnType": "Vector2",
+      "shape": "NOARGS_RET_VECTOR2",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Control rect size read (crosshair center for the shoot ray).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 254,
+      "scope": "class",
+      "className": "BaseButton",
+      "methodName": "set_pressed",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a toggle-button pressed state write (settings menu reflects the config).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 255,
+      "scope": "class",
+      "className": "BaseButton",
+      "methodName": "is_pressed",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle-button pressed state read (settings apply collects the selection).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 256,
+      "scope": "class",
+      "className": "BaseButton",
+      "methodName": "set_disabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a button disabled toggle (lobby buttons while connecting).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 257,
+      "scope": "class",
+      "className": "BaseButton",
+      "methodName": "set_button_group",
+      "hash": 1794463739,
+      "arguments": [
+        "ButtonGroup"
+      ],
+      "returnType": "void",
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a radio-group assignment (settings option rows share a ButtonGroup).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 258,
+      "scope": "class",
+      "className": "Button",
+      "methodName": "set_text",
+      "hash": 83702148,
+      "arguments": [
+        "String"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a button label write (host button toggles HOST GAME / START GAME).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 259,
+      "scope": "class",
+      "className": "LineEdit",
+      "methodName": "get_text",
+      "hash": 201670096,
+      "arguments": [],
+      "returnType": "String",
+      "shape": "NOARGS_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Line-edit text read (lobby address field).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 260,
+      "scope": "class",
+      "className": "LineEdit",
+      "methodName": "set_text",
+      "hash": 83702148,
+      "arguments": [
+        "String"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a line-edit text write (lobby address field reset).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 261,
+      "scope": "class",
+      "className": "LineEdit",
+      "methodName": "set_editable",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a line-edit editable toggle (lobby busy state).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 262,
+      "scope": "class",
+      "className": "Range",
+      "methodName": "set_value",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a Range value write (loading progress bar, lobby port spin box).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 263,
+      "scope": "class",
+      "className": "Range",
+      "methodName": "get_value",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_DOUBLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Range value read (lobby port spin box).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 264,
+      "scope": "class",
+      "className": "ConfigFile",
+      "methodName": "load",
+      "hash": 166001499,
+      "arguments": [
+        "String"
+      ],
+      "returnType": "enum::Error",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a config load from user:// (result intentionally unchecked; missing files leave the defaults).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 265,
+      "scope": "class",
+      "className": "ConfigFile",
+      "methodName": "save",
+      "hash": 166001499,
+      "arguments": [
+        "String"
+      ],
+      "returnType": "enum::Error",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a config save to user:// (result intentionally unchecked).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 266,
+      "scope": "class",
+      "className": "ConfigFile",
+      "methodName": "has_section_key",
+      "hash": 820780508,
+      "arguments": [
+        "String",
+        "String"
+      ],
+      "returnType": "bool",
+      "shape": "STRINGNAME_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Section/key existence check; both names ride one query string (unit separator).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 267,
+      "scope": "class",
+      "className": "ConfigFile",
+      "methodName": "set_value",
+      "hash": 2504492430,
+      "arguments": [
+        "String",
+        "String",
+        "Variant"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a typed config write; section, key, and tagged value ride one interned string (unit separator, i:/f:/b: tags).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 268,
+      "scope": "class",
+      "className": "ConfigFile",
+      "methodName": "get_value",
+      "hash": 89809366,
+      "arguments": [
+        "String",
+        "String",
+        "Variant"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Typed config read; section and key ride one query string and the value returns tagged (i:/f:/b:).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 269,
+      "scope": "singleton",
+      "className": "Engine",
+      "methodName": "set_max_fps",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Frame-rate cap write (tps caps 60 in headless-style runs and via settings).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 270,
+      "scope": "singleton",
+      "className": "Engine",
+      "methodName": "get_frames_per_second",
+      "hash": 1740695150,
+      "arguments": [],
+      "returnType": "float",
+      "shape": "NOARGS_RET_LONG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Whole-frames-per-second read (debug overlay).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 271,
+      "scope": "singleton",
+      "className": "OS",
+      "methodName": "get_static_memory_usage",
+      "hash": 3905245786,
+      "arguments": [],
+      "returnType": "int",
+      "shape": "NOARGS_RET_LONG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Static memory usage read (debug overlay).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 272,
+      "scope": "singleton",
+      "className": "Input",
+      "methodName": "get_action_strength",
+      "hash": 801543509,
+      "arguments": [
+        "StringName",
+        "bool"
+      ],
+      "returnType": "float",
+      "shape": "STRINGNAME_RET_DOUBLE_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Analog action strength read (tps movement and camera axes).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 273,
+      "scope": "class",
+      "className": "FastNoiseLite",
+      "methodName": "set_seed",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the noise seed write (camera shake channels re-seed per axis).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 274,
+      "scope": "class",
+      "className": "FastNoiseLite",
+      "methodName": "set_fractal_octaves",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the fractal octave count write (camera shake noise setup).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 275,
+      "scope": "class",
+      "className": "FastNoiseLite",
+      "methodName": "set_fractal_lacunarity",
+      "hash": 373806689,
+      "arguments": [
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "DOUBLE_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the fractal lacunarity write (camera shake noise setup).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 276,
+      "scope": "class",
+      "className": "Noise",
+      "methodName": "get_noise_1d",
+      "hash": 3919130443,
+      "arguments": [
+        "float"
+      ],
+      "returnType": "float",
+      "shape": "DOUBLE_RET_DOUBLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "1D noise sample (camera shake; x1000 integer transport, millis precision).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 277,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "set_name",
+      "hash": 3304788590,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a node rename (players are named by peer id before entering the tree).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 278,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "get_name",
+      "hash": 2002593661,
+      "arguments": [],
+      "returnType": "StringName",
+      "shape": "NOARGS_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Node name read (target checks and logging).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 279,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "propagate_call",
+      "hash": 1871007965,
+      "arguments": [
+        "StringName",
+        "Array",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a propagated bool property write: propagate_call(\"set\", [name, value]) (shadow_enabled sweep).",
+      "introducedBy": "60i-tpsdemo",
+      "descriptorName": "NODE_PROPAGATE_SET_BOOL"
+    },
+    {
+      "opcode": 280,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "call_deferred",
+      "hash": 3400424181,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a no-argument deferred call (lobby host/connect re-entry).",
+      "introducedBy": "60i-tpsdemo",
+      "isVararg": true,
+      "typedVarargTail": [],
+      "descriptorName": "OBJECT_CALL_DEFERRED_NOARGS"
+    },
+    {
+      "opcode": 281,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "call_deferred",
+      "hash": 3400424181,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "Variant",
+      "shape": "STRINGNAME_OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a one-object deferred call (scene handoff into replace_main_scene).",
+      "introducedBy": "60i-tpsdemo",
+      "isVararg": true,
+      "typedVarargTail": [
+        "Object"
+      ],
+      "descriptorName": "OBJECT_CALL_DEFERRED_OBJECT"
+    },
+    {
+      "opcode": 282,
+      "scope": "class",
+      "className": "Object",
+      "methodName": "has_signal",
+      "hash": 2619796661,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "bool",
+      "shape": "STRINGNAME_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Signal existence check (main wires quit/replace_main_scene only when declared).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 283,
+      "scope": "class",
+      "className": "Camera3D",
+      "methodName": "make_current",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue making this camera current (player camera on spawn).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 284,
+      "scope": "class",
+      "className": "LightmapGI",
+      "methodName": "set_light_data",
+      "hash": 1790597277,
+      "arguments": [
+        "LightmapGIData"
+      ],
+      "returnType": "void",
+      "shape": "OBJECT_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the baked lightmap data assignment (LightmapGI GI mode).",
+      "introducedBy": "60i-tpsdemo"
     }
   ],
   "compositions": [

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4472,6 +4472,38 @@
       "returnOwnership": "BORROWED",
       "semantics": "Queue the baked lightmap data assignment (LightmapGI GI mode).",
       "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 285,
+      "scope": "class",
+      "className": "CollisionObject3D",
+      "methodName": "set_collision_layer",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a whole collision-layer mask write (robot/part death clears every layer at once).",
+      "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 286,
+      "scope": "class",
+      "className": "CollisionObject3D",
+      "methodName": "set_collision_mask",
+      "hash": 1286410249,
+      "arguments": [
+        "int"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a whole collision-mask write (robot/part death clears every mask bit at once).",
+      "introducedBy": "60i-tpsdemo"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -33,9 +33,10 @@ import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
+import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -178,7 +178,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -254,7 +254,7 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeCitybuilder: ready.mode === "citybuilder",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
     // Injected build placed a structure on the grid at the mouse-ray cell.

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -153,7 +153,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -137,7 +137,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -227,7 +227,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol14: firstRun.settled.protocol === 14 && secondRun.settled.protocol === 14,
+    protocol15: firstRun.settled.protocol === 15 && secondRun.settled.protocol === 15,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -192,7 +192,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -183,7 +183,7 @@ export async function runThirdperson({ url, evaluate, navigate, keys, deadline }
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -1,0 +1,275 @@
+// demos/tpsdemo.mjs -- tps-demo-kanama play + teardown assertions for the Web smoke.
+//
+// The demo boots into its menu; the driver presses Play through Main.smoke_start_game
+// (method#1) and waits for the level to finish streaming in (four red robots, the player,
+// its input synchronizer and camera-shake camera). It then holds move_forward at ENGINE
+// level (ops 86/87 — browser key synthesis stalls headless Firefox) and PROVES movement by
+// reading the player's global position through the immediate Vector3 channel (opcode 138).
+// The robots' AI, the AnimationTree-driven locomotion, and the level's coroutine timers all
+// run under that window. Main.smoke_teardown (method#2) releases the cached scenes and the
+// settings ConfigFile, then frees the scene root, draining every live handle to zero.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[tpsdemo ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      const classCount = (suffix) => {
+        const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
+        mainHandle: bridge.tpsMainHandle,
+        menuHandle: bridge.tpsMenuHandle,
+        levelHandle: bridge.tpsLevelHandle,
+        playerHandle: bridge.tpsPlayerHandle,
+        readyCount: bridge.readyCount,
+        mainReady: classCount(".Main"),
+        menuReady: classCount(".Menu"),
+        levelReady: classCount(".Level"),
+        playerReady: classCount(".Player"),
+        inputReady: classCount(".PlayerInputSynchronizer"),
+        robotReady: classCount(".RedRobot"),
+        partReady: classCount(".Part"),
+        shakeReady: classCount(".CameraNoiseShakeEffect"),
+        processCalls: bridge.processCalls ?? 0,
+        physicsCalls: bridge.physicsProcessCalls ?? 0,
+        appliedCommands: bridge.appliedCommands,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        physicsAfterProcess: bridge.physicsAfterProcessSameTick ?? 0,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+// The player's world position through the immediate no-args Vector3 channel
+// (opcode 138 = Node3D.get_global_position on the player's script handle).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.tpsPlayerHandle;
+      if (!handle) return null;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+function seedFrom(snap) {
+  return {
+    processCalls: snap.processCalls,
+    physicsCalls: snap.physicsCalls,
+    appliedCommands: snap.appliedCommands,
+    maxLiveHandles: snap.maxLiveHandles,
+    crossings: snap.crossings,
+    callbackErrors: snap.callbackErrors,
+  };
+}
+
+async function observe(evaluate, seed, windowMs, deadline, predicate) {
+  const peak = { ...seed };
+  let last = null;
+  const until = Math.min(deadline, Date.now() + windowMs);
+  while (Date.now() < until) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      peak.processCalls = Math.max(peak.processCalls, snap.processCalls);
+      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+      peak.crossings = Math.max(peak.crossings, snap.crossings);
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      last = snap;
+      trace(
+        `process=${snap.processCalls} physics=${snap.physicsCalls} applied=${snap.appliedCommands} live=${snap.liveHandles} errs=${snap.callbackErrors}`,
+      );
+      if (predicate && predicate(snap, peak)) break;
+    }
+    await delay(150);
+  }
+  return { last, peak };
+}
+
+export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
+  // Engine-level action injection (ops 86/87) on the player's own handle: browser key
+  // synthesis stalls the headless-Firefox main thread for the whole hold.
+  const action = (opcode, name) =>
+    evaluate(
+      `globalThis.KanamaWebBridge.immediateObjectQuery(${opcode}, globalThis.KanamaWebBridge.tpsPlayerHandle, "${name}"); true`,
+    );
+
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?tpsdemo=${Date.now()}`);
+
+  // Generous first-load window: this is the largest export in the corpus.
+  const menuDeadline = Math.min(deadline, Date.now() + 180_000);
+  let menu = null;
+  while (Date.now() < menuDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.mode === "tpsdemo" &&
+      snap.protocol > 0 &&
+      snap.mainReady >= 1 &&
+      snap.menuReady >= 1 &&
+      snap.mainHandle > 0
+    ) {
+      menu = snap;
+      break;
+    }
+    await delay(250);
+  }
+  if (!menu) throw new Error("Kotlin/Wasm tps-demo menu did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace(`menu ready: readyCount=${menu.readyCount} mainHandle=${menu.mainHandle}`);
+
+  // Press Play: Main.smoke_start_game (method#1) drives the menu's own play path, which
+  // loads the level and hands it to Main through the demo's replace_main_scene signal.
+  trace("smoke_start_game");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpsMainHandle, 1); true",
+  );
+
+  const levelDeadline = Math.min(deadline, Date.now() + 180_000);
+  let level = null;
+  while (Date.now() < levelDeadline) {
+    const snap = await snapshot(evaluate);
+    if (
+      snap &&
+      snap.levelReady >= 1 &&
+      snap.playerReady >= 1 &&
+      snap.inputReady >= 1 &&
+      snap.robotReady >= 1 &&
+      snap.playerHandle > 0
+    ) {
+      level = snap;
+      break;
+    }
+    if (snap?.failure) throw new Error(`tps-demo failed while loading the level: ${snap.failure}`);
+    await delay(250);
+  }
+  if (!level) throw new Error("tps-demo level did not come up after pressing Play");
+  trace(
+    `level ready: robots=${level.robotReady} parts=${level.partReady} player=${level.playerHandle}`,
+  );
+
+  // Let the level settle before measuring: the first frames compile the robot laser and
+  // particle shaders, which freezes the software-GL main thread for seconds.
+  const settled = await observe(
+    evaluate,
+    { ...seedFrom(level), callbackErrors: 0 },
+    20_000,
+    deadline,
+    (snap) => snap.physicsCalls >= level.physicsCalls + 120,
+  );
+  const baseline = settled.last ?? level;
+  const startPosition = await playerPosition(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  trace(`settled: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
+
+  // Hold move_forward for a FIXED wall-time: the tick rate races past any physics-count
+  // predicate before the first observe sample, which would cut the hold short.
+  await action(86, "move_forward");
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(baseline), callbackErrors: 0 },
+    4_000,
+    deadline,
+    null,
+  );
+  await action(87, "move_forward");
+  const runPosition = await playerPosition(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? baseline;
+  const displacement = runPosition
+    ? Math.hypot(runPosition.x - startPosition.x, runPosition.z - startPosition.z)
+    : 0;
+  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls}`);
+
+  // Full teardown: smoke_teardown (method#2) releases the cached scenes and the settings
+  // ConfigFile, then frees the scene root; every node exits the tree and drops its handles.
+  trace("smoke_teardown");
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpsMainHandle, 2); true",
+  );
+  const teardown = await observe(evaluate, peak, 20_000, deadline, (snap) => snap.liveHandles === 0);
+  const torndown = teardown.last ?? atPeak;
+  trace(`teardown: live=${torndown.liveHandles} callbacks=${torndown.callbacks} errs=${torndown.callbackErrors}`);
+
+  const protocolVersion = menu.protocol;
+  const checks = {
+    modeTpsdemo: menu.mode === "tpsdemo",
+    protocol15: protocolVersion === 15,
+    // The menu boots, and pressing Play streams the whole level in: the AnimationTree-driven
+    // player, its input synchronizer, the shake camera, and the four red robots with their
+    // detachable death parts.
+    menuScriptsReady: menu.mainReady >= 1 && menu.menuReady >= 1,
+    levelScriptsReady:
+      level.levelReady >= 1 &&
+      level.playerReady >= 1 &&
+      level.inputReady >= 1 &&
+      level.shakeReady >= 1,
+    enemiesSpawned: level.robotReady >= 4 && level.partReady >= 12,
+    playerMovedOnInput: displacement > 0.5,
+    physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    processFramesAdvanced: peak.processCalls > baseline.processCalls,
+    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
+    crossingsAdvanced: peak.crossings > baseline.crossings,
+    fullTeardownToZero: torndown.liveHandles === 0,
+    physicsOrderingDeterministic: (torndown.physicsAfterProcess ?? 0) === 0,
+    noCallbackFaults:
+      peak.callbackErrors === 0 && torndown.callbackErrors === 0 && torndown.failure === null,
+  };
+
+  const boundaryErrors = [];
+  if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
+  if (torndown.failure !== null) boundaryErrors.push(`failure: ${torndown.failure}`);
+
+  return {
+    protocolVersion,
+    startup: {
+      startupDurationMs,
+      readyCount: level.readyCount,
+      loaded: menu.mode === "tpsdemo",
+    },
+    checks,
+    boundaryErrors,
+    metrics: {
+      startupDurationMs,
+      displacement,
+      processCalls: peak.processCalls,
+      physicsCalls: peak.physicsCalls,
+      appliedCommands: peak.appliedCommands,
+      maxLiveHandles: peak.maxLiveHandles,
+      crossings: peak.crossings,
+      liveAfterTeardown: torndown.liveHandles,
+      pendingCallbacks: torndown.callbacks,
+      pendingCoroutines: torndown.pending,
+      registeredJobs: torndown.jobs,
+      robotsSpawned: level.robotReady,
+      deathPartsSpawned: level.partReady,
+    },
+  };
+}

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -121,7 +121,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol14: protocolVersion === 14,
+    protocol15: protocolVersion === 15,
     sceneReady: ready.mainReady >= 1,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -26,9 +26,10 @@ import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
+import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
 const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -25,9 +25,10 @@ import { runCharactercontroller } from "./demos/charactercontroller.mjs";
 import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
+import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder|tpsdemo> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -2206,6 +2206,20 @@ tasks.register("stageWebTpsdemoProject") {
                 )
         )
 
+        // The menu's FogVolume needs the volumetric-fog shader, which the Compatibility
+        // renderer this export runs has no implementation for (it logs "shader type fog not
+        // supported"). Drop the node from the staged scene rather than ship a broken effect.
+        val stagedMenu = stagingDir.resolve("menu/menu.tscn")
+        val menuText = stagedMenu.readText()
+        val fogHeader = "[node name=\"FogVolume\" type=\"FogVolume\" parent=\"WorldEnvironment\"]"
+        check(menuText.contains(fogHeader)) {
+            "tps-demo menu FogVolume changed; update the Web staging transform"
+        }
+        val fogStart = menuText.indexOf(fogHeader)
+        val fogEnd = menuText.indexOf("\n[", fogStart + fogHeader.length)
+        check(fogEnd > fogStart) { "tps-demo menu FogVolume block is not delimited as expected" }
+        stagedMenu.writeText(menuText.removeRange(fogStart, fogEnd + 1))
+
         val shell = stagingDir.resolve("kanama-web/shell.html")
         val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
         shell.writeText(

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -31,6 +31,7 @@ val extraWebScriptSourceRoot: File? =
                     "thirdperson" -> "kanamaWebThirdpersonProjectDir"
                     "racing" -> "kanamaWebRacingProjectDir"
                     "citybuilder" -> "kanamaWebCitybuilderProjectDir"
+                    "tpsdemo" -> "kanamaWebTpsdemoProjectDir"
                     else -> null
                 }
             projectDirProperty
@@ -144,6 +145,9 @@ val webRacingStaging = layout.buildDirectory.dir("web-racing/godot-project")
 val webCitybuilderSourceProject =
     providers.gradleProperty("kanamaWebCitybuilderProjectDir").orNull?.let(rootProject::file)
 val webCitybuilderStaging = layout.buildDirectory.dir("web-citybuilder/godot-project")
+val webTpsdemoSourceProject =
+    providers.gradleProperty("kanamaWebTpsdemoProjectDir").orNull?.let(rootProject::file)
+val webTpsdemoStaging = layout.buildDirectory.dir("web-tpsdemo/godot-project")
 val webMatch3ImportLog = layout.buildDirectory.file("reports/web-match3-import.log")
 val webMatch3ImportOutput = ByteArrayOutputStream()
 val webGameplayCoverage = layout.buildDirectory.file("reports/web-gameplay-coverage.json")
@@ -2058,6 +2062,159 @@ tasks.register("stageWebCitybuilderProject") {
     }
 }
 
+tasks.register("stageWebTpsdemoProject") {
+    group = "verification"
+    description = "Stages tps-demo-kanama with generated Web proxies (Task 60i)."
+    dependsOn("kspKotlinWasmJs", "generateWebGameplayCoverage")
+    webTpsdemoSourceProject?.let(inputs::dir)
+    inputs.dir(webSpikeAssets)
+    inputs.dir(webProxyResources)
+    inputs.file(webGameplayCoverage)
+    outputs.dir(webTpsdemoStaging)
+
+    doLast {
+        val sourceProject =
+            webTpsdemoSourceProject
+                ?: error(
+                    "Pass -PkanamaWebTpsdemoProjectDir=" +
+                        "/absolute/path/to/kanama-demos/tps-demo-kanama"
+                )
+        check(sourceProject.resolve("main/main.tscn").isFile) {
+            "tps-demo project not found: $sourceProject"
+        }
+
+        val stagingDir = webTpsdemoStaging.get().asFile
+        delete(stagingDir)
+        copy {
+            from(sourceProject) {
+                exclude(".git/**")
+                exclude(".godot/**")
+                exclude(".gradle/**")
+                exclude(".kotlin/**")
+                exclude("build/**")
+                exclude("web/**")
+                exclude("kotlin-src/**")
+                exclude("android/**")
+                exclude("addons/kanama_tools/**")
+                exclude("addons/kanama/**")
+                exclude("export_presets.cfg")
+            }
+            into(stagingDir)
+        }
+        copy {
+            from(webSpikeSourceProject.file("export_presets.cfg"))
+            into(stagingDir)
+        }
+        copy {
+            from(webProxyResources)
+            include("*.gd")
+            into(stagingDir.resolve("kanama-web/generated"))
+        }
+        copy {
+            from(webProxyResources)
+            include("KanamaWebProxyManifest.generated.tsv")
+            include("KanamaWebProtocol.generated.json")
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webSpikeAssets)
+            into(stagingDir.resolve("kanama-web"))
+        }
+        copy {
+            from(webGameplayCoverage)
+            into(stagingDir.resolve("kanama-web"))
+        }
+
+        val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
+        val expectedSources =
+            setOf(
+                    "Blast",
+                    "Bullet",
+                    "CameraNoiseShakeEffect",
+                    "DebugLabel",
+                    "Door",
+                    "FlyingForklift",
+                    "Level",
+                    "Main",
+                    "Menu",
+                    "Part",
+                    "PartDisappear",
+                    "Player",
+                    "PlayerInputSynchronizer",
+                    "RedRobot",
+                    "Settings",
+                )
+                .map { "res://kotlin-src/$it.kt" }
+                .toSet()
+        val mappings =
+            manifest
+                .readLines()
+                .filter { it.isNotBlank() && !it.startsWith("#") }
+                .map { it.split('\t').let { c -> c[0] to c[1] } }
+                .filter { (sourcePath, _) -> sourcePath in expectedSources }
+                .toMap()
+        check(mappings.keys == expectedSources) {
+            "tps-demo Web proxy mappings incomplete: missing=${expectedSources - mappings.keys}"
+        }
+
+        fileTree(stagingDir) {
+                include("project.godot")
+                include("**/*.tscn")
+                include("**/*.tres")
+            }
+            .files
+            .forEach { stagedFile ->
+                val original = stagedFile.readText()
+                var rewritten =
+                    mappings.entries.fold(original) { text, (sourcePath, proxyPath) ->
+                        text.replace(sourcePath, proxyPath)
+                    }
+                rewritten =
+                    rewritten.replace(
+                        Regex(
+                            "(\\[ext_resource type=\"Script\") uid=\"uid://[^\"]*\" " +
+                                "(path=\"res://kanama-web/generated/)"
+                        ),
+                        "$1 $2",
+                    )
+                if (rewritten != original) stagedFile.writeText(rewritten)
+                check(!rewritten.contains("res://kotlin-src/")) {
+                    "Unmapped Kotlin attachment remains in staged file: $stagedFile"
+                }
+            }
+
+        // Default (Forward+) project: pin the Compatibility renderer the Web template runs.
+        val stagedProject = stagingDir.resolve("project.godot")
+        val stagedProjectText = stagedProject.readText()
+        val forwardFeature = "config/features=PackedStringArray(\"4.7\")"
+        val renderingSection = "[rendering]"
+        check(stagedProjectText.contains(forwardFeature)) {
+            "tps-demo renderer feature changed; update the Web staging transform"
+        }
+        check(stagedProjectText.contains(renderingSection)) {
+            "tps-demo rendering section changed; update the Web staging transform"
+        }
+        stagedProject.writeText(
+            stagedProjectText
+                .replace(
+                    forwardFeature,
+                    "config/features=PackedStringArray(\"4.7\", \"GL Compatibility\")",
+                )
+                .replace(
+                    renderingSection,
+                    "$renderingSection\n\nrenderer/rendering_method=\"gl_compatibility\"",
+                )
+        )
+
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        shell.writeText(
+            shell.readText()
+                .replace(pageStart, "$pageStart\n      globalThis.KanamaWebMode = \"tpsdemo\";")
+        )
+    }
+}
+
 tasks.register("stageWebThirdpersonProject") {
     group = "verification"
     description = "Stages the third-person controller with generated Web proxies (Task 60f)."
@@ -2328,9 +2485,10 @@ fun stageTaskFor(demo: String): String =
         "thirdperson" -> "stageWebThirdpersonProject"
         "racing" -> "stageWebRacingProject"
         "citybuilder" -> "stageWebCitybuilderProject"
+        "tpsdemo" -> "stageWebTpsdemoProject"
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder|tpsdemo)"
             )
     }
 
@@ -2347,9 +2505,10 @@ fun stagingDirFor(demo: String): File =
         "thirdperson" -> webThirdpersonStaging.get().asFile
         "racing" -> webRacingStaging.get().asFile
         "citybuilder" -> webCitybuilderStaging.get().asFile
+        "tpsdemo" -> webTpsdemoStaging.get().asFile
         else ->
             error(
-                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder)"
+                "Unsupported -PkanamaWebDemo=$demo (expected match3|bunnymark|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder|tpsdemo)"
             )
     }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -44,7 +44,7 @@ class AnimationNodeStateMachinePlayback internal constructor(godotObject: GodotH
 }
 
 /** AnimationPlayer/AnimationTree base: the tutorial drives an AnimationTree state machine. */
-class AnimationMixer(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
+open class AnimationMixer(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
   /** Resolve the playback object behind a `parameters/.../playback` property. */
   fun getStateMachinePlayback(path: String): AnimationNodeStateMachinePlayback =
     GodotObjectBackendContractProbe(backendHandle).getObjectProperty(path)?.let { handle ->

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebDodgeApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebDodgeApi.kt
@@ -119,4 +119,5 @@ class Label(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle()
     }
 }
 
-class Button(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())
+/** Push/toggle button; the settings menus drive its pressed, disabled, and group state. */
+class Button(godotObject: GodotHandle) : BaseButton(godotObject)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
@@ -104,7 +104,7 @@ open class BaseButton(godotObject: GodotHandle) : Control(godotObject) {
 class TextureButton(godotObject: GodotHandle) : BaseButton(godotObject)
 
 /** Crosshair rect (FPS HUD): texture is write-only on Web. */
-class TextureRect(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle()) {
+class TextureRect(godotObject: GodotHandle) : Control(godotObject) {
   var texture: Texture2D?
     get() = unsupportedWebGameplayFamily("TextureRect.get_texture")
     set(value) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -370,4 +370,7 @@ internal expect fun releaseWebScriptResource(handle: Int)
 
 internal expect fun releaseWebConstructedObject(handle: Int)
 
+/** Release a tracked OBJECT-kind handle (a duplicated resource the script owns). */
+internal expect fun releaseWebTrackedObject(handle: Int)
+
 internal expect fun isWebBrowserHandleLive(handle: Int): Boolean

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -3,6 +3,7 @@
 package net.multigesture.kanama.api
 
 import kotlin.math.ln
+import kotlin.math.pow
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -148,6 +149,10 @@ object Mathf {
     if (to == from) 0.0 else (value - from) / (to - from)
 
   fun sqrt(value: Double): Double = kotlin.math.sqrt(value)
+
+  fun pow(value: Double, exponent: Double): Double = value.pow(exponent)
+
+  fun atan2(y: Double, x: Double): Double = kotlin.math.atan2(y, x)
 
   fun min(a: Double, b: Double): Double = kotlin.math.min(a, b)
 
@@ -299,6 +304,24 @@ class Viewport(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
         Vector2(rect.size.x.toDouble(), rect.size.y.toDouble()),
       )
     }
+
+  /**
+   * Scaling/anti-aliasing enum values (tps's graphics menu records them in its config file). The
+   * Web canvas fixes its own scaling, so writing them back through the Window facade is inert.
+   */
+  companion object {
+    const val SCALING_3D_MODE_BILINEAR: Long = 0L
+    const val SCALING_3D_MODE_FSR: Long = 1L
+    const val SCALING_3D_MODE_FSR2: Long = 2L
+    const val SCALING_3D_MODE_METALFX_SPATIAL: Long = 3L
+    const val SCALING_3D_MODE_METALFX_TEMPORAL: Long = 4L
+    const val MSAA_DISABLED: Long = 0L
+    const val MSAA_2X: Long = 1L
+    const val MSAA_4X: Long = 2L
+    const val MSAA_8X: Long = 3L
+    const val SCREEN_SPACE_AA_DISABLED: Long = 0L
+    const val SCREEN_SPACE_AA_FXAA: Long = 1L
+  }
 }
 
 class GPUParticles2D(godotObject: GodotHandle) : Node2D(godotObject) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
@@ -1,0 +1,971 @@
+@file:OptIn(net.multigesture.kanama.backend.InternalKanamaBackendApi::class)
+
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.backend.ClassDBBackendContractProbe
+import net.multigesture.kanama.backend.GodotBackendCalls
+import net.multigesture.kanama.backend.GodotVector2
+import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
+import net.multigesture.kanama.types.Basis
+import net.multigesture.kanama.types.Quaternion
+import net.multigesture.kanama.types.Vector2
+import net.multigesture.kanama.types.Vector3
+import net.multigesture.kanama.web.WebObjectId
+
+/**
+ * Web API surface for tps-demo (Task 60i) — the last demo of the Web corpus.
+ *
+ * Three groups live here:
+ * 1. wrappers over the families admitted in the 60i contract pass (AnimationTree parameters and
+ *    root motion, the material chain, CPU particles, the settings UI, ConfigFile, noise);
+ * 2. the space-state ray query, whose parameters are built engine-side (RIDs never cross the
+ *    Web seam), so [PhysicsRayQueryParameters3D] is a plain Kotlin value here;
+ * 3. facades for families the browser cannot host. Web builds are single-player: ENet needs UDP
+ *    sockets, so the multiplayer surface reports a local authoritative session (peer 1, no
+ *    remote peers) and the lobby's connect paths fail the way the demo already handles. The
+ *    display/renderer settings that the compatibility renderer ignores are no-ops.
+ */
+private fun Vector3.toBackend(): GodotVector3 =
+  GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
+
+private fun GodotVector3.toApi(): Vector3 = Vector3(x.toDouble(), y.toDouble(), z.toDouble())
+
+private fun Vector2.toBackend(): GodotVector2 = GodotVector2(x.toFloat(), y.toFloat())
+
+private fun GodotVector2.toApi(): Vector2 = Vector2(x.toDouble(), y.toDouble())
+
+// ---------------------------------------------------------------------------
+// Liveness. Web adaptation: the tracked-handle registry is the source of truth,
+// so both desktop guards collapse onto GD.isInstanceValid (the corpus-wide rule).
+// ---------------------------------------------------------------------------
+
+fun GodotObject.isQueuedForDeletion(): Boolean = !GD.isInstanceValid(this)
+
+fun GodotObject.isInsideTree(): Boolean = GD.isInstanceValid(this)
+
+// ---------------------------------------------------------------------------
+// Node / Object surface.
+// ---------------------------------------------------------------------------
+
+fun Node.getName(): String = GodotBackendCalls.invokeNoArgsRetString(D.NODE_GET_NAME, backendHandle)
+
+fun Node.setName(name: String) {
+  GodotBackendCalls.invokeStringNameArg(D.NODE_SET_NAME, backendHandle, name)
+}
+
+fun Node.hasNode(path: String): Boolean = getNodeOrNull(path) != null
+
+fun Node.getNode(path: String): GodotObject? = getNodeOrNull(path)
+
+/** Godot's `propagate_call("set", [property, value])` (the shadow-mapping sweep). */
+fun Node.propagateSet(property: String, value: Boolean) {
+  GodotBackendCalls.invokeStringNameBoolArg(
+    D.NODE_PROPAGATE_SET_BOOL,
+    backendHandle,
+    property,
+    value,
+  )
+}
+
+fun GodotObject.callDeferred(method: String) {
+  GodotBackendCalls.invokeStringNameArg(D.OBJECT_CALL_DEFERRED_NOARGS, backendHandle, method)
+}
+
+fun GodotObject.callDeferred(method: String, argument: GodotObject) {
+  GodotBackendCalls.invokeStringNameObjectArg(
+    D.OBJECT_CALL_DEFERRED_OBJECT,
+    backendHandle,
+    method,
+    argument.backendHandle,
+  )
+}
+
+fun GodotObject.hasSignal(signal: String): Boolean =
+  GodotBackendCalls.invokeStringNameRetBool(D.OBJECT_HAS_SIGNAL, backendHandle, signal)
+
+/** Property-path write (AnimationTree parameters); the typed overloads pick the transport. */
+fun GodotObject.set(path: String, value: String) {
+  GodotBackendCalls.invokeStringNameStringNameArg(D.OBJECT_SET_INDEXED_STRING, backendHandle, path, value)
+}
+
+fun GodotObject.set(path: String, value: Long) {
+  GodotBackendCalls.invokeStringNameLongArg(D.OBJECT_SET_INDEXED_LONG, backendHandle, path, value)
+}
+
+fun GodotObject.set(path: String, value: Double) {
+  GodotBackendCalls.invokeStringNameDoubleArg(
+    D.OBJECT_SET_INDEXED_DOUBLE,
+    backendHandle,
+    path,
+    value,
+  )
+}
+
+fun GodotObject.set(path: String, value: Vector2) {
+  GodotBackendCalls.invokeStringNameVector2Arg(
+    D.OBJECT_SET_INDEXED_VECTOR2,
+    backendHandle,
+    path,
+    value.toBackend(),
+  )
+}
+
+/** Vector2-valued property read (the robot's aim blend position). */
+fun GodotObject.getVector2(path: String): Vector2 =
+  GodotBackendCalls.invokeStringNameRetVector2(D.OBJECT_GET_PROPERTY_VECTOR2, backendHandle, path)
+    .toApi()
+
+// ---------------------------------------------------------------------------
+// AnimationTree.
+// ---------------------------------------------------------------------------
+
+/** Blend-tree driver: parameters are property-path writes, root motion reads are synchronous. */
+class AnimationTree(godotObject: GodotHandle) : AnimationMixer(godotObject) {
+  fun getRootMotionPosition(): Vector3 =
+    GodotBackendCalls.invokeNoArgsRetVector3(D.ANIMATIONMIXER_GET_ROOT_MOTION_POSITION, backendHandle)
+      .toApi()
+
+  /**
+   * Web adaptation: the engine's Quaternion crosses as euler angles (the applier converts) and is
+   * recomposed here, so no new value-type channel is needed for one call.
+   */
+  fun getRootMotionRotation(): Quaternion =
+    Basis.fromEuler(
+        GodotBackendCalls.invokeNoArgsRetVector3(
+            D.ANIMATIONMIXER_GET_ROOT_MOTION_ROTATION,
+            backendHandle,
+          )
+          .toApi()
+      )
+      .getRotationQuaternion()
+}
+
+// ---------------------------------------------------------------------------
+// Particles, lights, and the material chain.
+// ---------------------------------------------------------------------------
+
+class CPUParticles3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject) {
+  var emitting: Boolean
+    get() = unsupportedWebGameplayFamily("CPUParticles3D.is_emitting")
+    set(value) {
+      GodotBackendCalls.invokeBoolArg(D.CPUPARTICLES3D_SET_EMITTING, backendHandle, value)
+    }
+
+  var emissionBoxExtents: Vector3
+    get() =
+      GodotBackendCalls.invokeNoArgsRetVector3(
+          D.CPUPARTICLES3D_GET_EMISSION_BOX_EXTENTS,
+          backendHandle,
+        )
+        .toApi()
+    set(value) {
+      GodotBackendCalls.invokeVector3Arg(
+        D.CPUPARTICLES3D_SET_EMISSION_BOX_EXTENTS,
+        backendHandle,
+        value.toBackend(),
+      )
+    }
+
+  val lifetime: Double
+    get() = GodotBackendCalls.invokeNoArgsRetDouble(D.CPUPARTICLES3D_GET_LIFETIME, backendHandle)
+
+  fun restart(keepSeed: Boolean = false) {
+    GodotBackendCalls.invokeBoolArg(D.CPUPARTICLES3D_RESTART, backendHandle, keepSeed)
+  }
+}
+
+class OmniLight3D(godotObject: GodotHandle) : Light3D(godotObject)
+
+class SpotLight3D(godotObject: GodotHandle) : Light3D(godotObject)
+
+var Light3D.shadowEnabled: Boolean
+  get() = unsupportedWebGameplayFamily("Light3D.get_shadow")
+  set(value) {
+    GodotBackendCalls.invokeBoolArg(D.LIGHT3D_SET_SHADOW, backendHandle, value)
+  }
+
+/** Baked lightmap payload; only ever loaded and assigned. */
+class LightmapGIData internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle())
+
+class LightmapGI(godotObject: GodotHandle) : VisualInstance3D(godotObject) {
+  var lightData: LightmapGIData?
+    get() = unsupportedWebGameplayFamily("LightmapGI.get_light_data")
+    set(value) {
+      GodotBackendCalls.invokeObjectArg(
+        D.LIGHTMAPGI_SET_LIGHT_DATA,
+        backendHandle,
+        value?.backendHandle,
+      )
+    }
+
+  companion object {
+    fun create(): LightmapGI {
+      val handle =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("LightmapGI")) {
+          "Godot could not instantiate LightmapGI"
+        }
+      return LightmapGI(WebObjectId(handle.backendToken().toInt()))
+    }
+  }
+}
+
+/** Surface material; `nextPass` is the fade-shader chain the death parts duplicate. */
+open class Material internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle()) {
+  var nextPass: Material?
+    get() =
+      GodotBackendCalls.invokeNoArgsRetHandle(D.MATERIAL_GET_NEXT_PASS, backendHandle)?.let {
+        Material(WebObjectId(it.backendToken().toInt()))
+      }
+    set(value) {
+      GodotBackendCalls.invokeObjectArg(
+        D.MATERIAL_SET_NEXT_PASS,
+        backendHandle,
+        value?.backendHandle,
+      )
+    }
+
+  /** Duplicate this material; the copy is owned (close it, or release it at teardown). */
+  fun duplicate(deep: Boolean = false): Material? =
+    GodotBackendCalls.invokeBoolRetHandle(D.RESOURCE_DUPLICATE, backendHandle, deep)?.let {
+      Material(WebObjectId(it.backendToken().toInt()))
+    }
+
+  /** Release this material's tracked browser handle (duplicates are Kotlin-owned). */
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  companion object {
+    fun fromResource(resource: Resource?): Material? =
+      resource?.let { Material(WebObjectId(it.backendHandle.backendToken().toInt())) }
+  }
+}
+
+class ShaderMaterial internal constructor(godotObject: GodotHandle) : Material(godotObject) {
+  fun setShaderParameter(name: String, value: Double) {
+    GodotBackendCalls.invokeStringNameDoubleArg(
+      D.SHADERMATERIAL_SET_SHADER_PARAMETER,
+      backendHandle,
+      name,
+      value,
+    )
+  }
+
+  companion object {
+    fun fromResource(resource: Resource?): ShaderMaterial? =
+      resource?.let { ShaderMaterial(WebObjectId(it.backendHandle.backendToken().toInt())) }
+  }
+}
+
+fun MeshInstance3D.getSurfaceOverrideMaterial(surface: Int): Material? =
+  GodotBackendCalls.invokeLongRetHandle(
+      D.MESHINSTANCE3D_GET_SURFACE_OVERRIDE_MATERIAL,
+      backendHandle,
+      surface.toLong(),
+    )
+    ?.let { Material(WebObjectId(it.backendToken().toInt())) }
+
+fun Mesh.surfaceGetMaterial(surface: Int): Material? =
+  GodotBackendCalls.invokeLongRetHandle(
+      D.MESH_SURFACE_GET_MATERIAL,
+      backendHandle,
+      surface.toLong(),
+    )
+    ?.let { Material(WebObjectId(it.backendToken().toInt())) }
+
+fun Mesh.surfaceSetMaterial(surface: Int, material: Material) {
+  GodotBackendCalls.invokeLongObjectArg(
+    D.MESH_SURFACE_SET_MATERIAL,
+    backendHandle,
+    surface.toLong(),
+    material.backendHandle,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Space-state ray query. The applier builds the query parameters engine-side.
+// ---------------------------------------------------------------------------
+
+/**
+ * Ray query inputs. Web adaptation: this never becomes an engine object — the applier constructs
+ * `PhysicsRayQueryParameters3D` on its side, so the RID exclusion list stays engine-side too and
+ * [exclude] carries the excluded body itself.
+ */
+class PhysicsRayQueryParameters3D
+private constructor(
+  internal val from: Vector3,
+  internal val to: Vector3,
+  internal val collisionMask: Long,
+  internal val exclude: GodotObject?,
+) {
+  companion object {
+    fun create(
+      from: Vector3,
+      to: Vector3,
+      collisionMask: Long = 0xffffffffL,
+      exclude: List<GodotObject> = emptyList(),
+    ): PhysicsRayQueryParameters3D? {
+      require(exclude.size <= 1) {
+        "Kanama Web ray queries carry at most one exclusion (the corpus excludes only self)"
+      }
+      return PhysicsRayQueryParameters3D(from, to, collisionMask, exclude.firstOrNull())
+    }
+  }
+}
+
+/** A ray hit: `position` and `collider` mirror the engine Dictionary the desktop demo reads. */
+class RayHit internal constructor(val position: Vector3, val collider: GodotObject?) {
+  val isEmpty: Boolean
+    get() = false
+}
+
+/**
+ * Direct space state bound to the querying node. Web adaptation: the receiver of the crossing is
+ * that node, and the engine resolves its world on the applier side.
+ */
+class PhysicsDirectSpaceState3D internal constructor(private val owner: Node3D) {
+  /**
+   * Returns null when the ray misses. The collider resolves to an already-tracked handle (script
+   * or browser); untracked engine geometry reports no collider, which is all the demo needs — it
+   * only ever compares the collider against a node it already holds.
+   */
+  fun intersectRay(query: PhysicsRayQueryParameters3D): RayHit? {
+    val packed =
+      GodotBackendCalls.invokeVector3Vector3LongObjectRetString(
+        D.PHYSICSDIRECTSPACESTATE3D_INTERSECT_RAY,
+        owner.backendHandle,
+        query.from.toBackend(),
+        query.to.toBackend(),
+        query.collisionMask,
+        query.exclude?.backendHandle,
+      )
+    val parts = packed.split('')
+    require(parts.size == 5) { "Kanama Web ray query returned $packed" }
+    if (parts[0] != "1") return null
+    val colliderToken = parts[4].toInt()
+    return RayHit(
+      Vector3(parts[1].toDouble(), parts[2].toDouble(), parts[3].toDouble()),
+      colliderToken.takeIf { it > 0 }?.let { GodotObject(WebObjectId(it)) },
+    )
+  }
+}
+
+class World3D internal constructor(private val owner: Node3D) {
+  val directSpaceState: PhysicsDirectSpaceState3D
+    get() = PhysicsDirectSpaceState3D(owner)
+}
+
+fun Node3D.getWorld3d(): World3D = World3D(this)
+
+// ---------------------------------------------------------------------------
+// Bodies.
+// ---------------------------------------------------------------------------
+
+/** Current gravity vector; tps integrates gravity itself each physics tick. */
+fun PhysicsBody3D.getGravity(): Vector3 =
+  GodotBackendCalls.invokeNoArgsRetVector3(D.PHYSICSBODY3D_GET_GRAVITY, backendHandle).toApi()
+
+fun CharacterBody3D.setUpDirection(direction: Vector3) {
+  GodotBackendCalls.invokeVector3Arg(
+    D.CHARACTERBODY3D_SET_UP_DIRECTION,
+    backendHandle,
+    direction.toBackend(),
+  )
+}
+
+/** Whole-mask collision writes (death clears every layer/mask bit at once). */
+var PhysicsBody3D.collisionLayer: Long
+  get() = unsupportedWebGameplayFamily("CollisionObject3D.get_collision_layer")
+  set(value) {
+    GodotBackendCalls.invokeLongArg(D.COLLISIONOBJECT3D_SET_COLLISION_LAYER, backendHandle, value)
+  }
+
+var PhysicsBody3D.collisionMask: Long
+  get() = unsupportedWebGameplayFamily("CollisionObject3D.get_collision_mask")
+  set(value) {
+    GodotBackendCalls.invokeLongArg(D.COLLISIONOBJECT3D_SET_COLLISION_MASK, backendHandle, value)
+  }
+
+var CollisionShape3D.disabled: Boolean
+  get() = unsupportedWebGameplayFamily("CollisionShape3D.is_disabled")
+  set(value) {
+    setDisabled(value)
+  }
+
+/** Indexed child as a tracked handle (the forklift and death-part models index their model child). */
+fun Node.getChild(index: Int): GodotObject? =
+  GodotBackendCalls.invokeLongRetHandle(D.NODE_GET_CHILD, backendHandle, index.toLong())?.let {
+    GodotObject(WebObjectId(it.backendToken().toInt()))
+  }
+
+fun Node3D.show() {
+  visible = true
+}
+
+/** Godot's Node3D.orthonormalize: re-orthonormalize the local basis in place. */
+fun Node3D.orthonormalize() {
+  basis = basis.orthonormalized()
+}
+
+var RigidBody3D.linearVelocity: Vector3
+  get() = unsupportedWebGameplayFamily("RigidBody3D.get_linear_velocity")
+  set(value) {
+    GodotBackendCalls.invokeVector3Arg(
+      D.RIGIDBODY3D_SET_LINEAR_VELOCITY,
+      backendHandle,
+      value.toBackend(),
+    )
+  }
+
+// ---------------------------------------------------------------------------
+// Timers, tree, camera.
+// ---------------------------------------------------------------------------
+
+fun Timer.getTimeLeft(): Double =
+  GodotBackendCalls.invokeNoArgsRetDouble(D.TIMER_GET_TIME_LEFT, backendHandle)
+
+val SceneTree.root: Viewport
+  get() =
+    Viewport(
+      checkNotNull(GodotBackendCalls.invokeNoArgsRetHandle(D.SCENETREE_GET_ROOT, backendHandle)) {
+          "SceneTree has no root window"
+        }
+        .let { WebObjectId(it.backendToken().toInt()) }
+    )
+
+fun Viewport.getCamera3d(): Camera3D? =
+  GodotBackendCalls.invokeNoArgsRetHandle(D.VIEWPORT_GET_CAMERA_3D, backendHandle)?.let {
+    Camera3D(WebObjectId(it.backendToken().toInt()))
+  }
+
+fun Camera3D.makeCurrent() {
+  GodotBackendCalls.invokeNoArgsVoid(D.CAMERA3D_MAKE_CURRENT, backendHandle)
+}
+
+// ---------------------------------------------------------------------------
+// Settings UI.
+// ---------------------------------------------------------------------------
+
+fun Control.grabFocus() {
+  GodotBackendCalls.invokeNoArgsVoid(D.CONTROL_GRAB_FOCUS, backendHandle)
+}
+
+val Control.position: Vector2
+  get() = GodotBackendCalls.invokeNoArgsRetVector2(D.CONTROL_GET_POSITION, backendHandle).toApi()
+
+val Control.size: Vector2
+  get() = GodotBackendCalls.invokeNoArgsRetVector2(D.CONTROL_GET_SIZE, backendHandle).toApi()
+
+var BaseButton.buttonPressed: Boolean
+  get() = GodotBackendCalls.invokeNoArgsRetBool(D.BASEBUTTON_IS_PRESSED, backendHandle)
+  set(value) {
+    GodotBackendCalls.invokeBoolArg(D.BASEBUTTON_SET_PRESSED, backendHandle, value)
+  }
+
+var BaseButton.disabled: Boolean
+  get() = unsupportedWebGameplayFamily("BaseButton.is_disabled")
+  set(value) {
+    GodotBackendCalls.invokeBoolArg(D.BASEBUTTON_SET_DISABLED, backendHandle, value)
+  }
+
+var BaseButton.buttonGroup: ButtonGroup?
+  get() = unsupportedWebGameplayFamily("BaseButton.get_button_group")
+  set(value) {
+    GodotBackendCalls.invokeObjectArg(
+      D.BASEBUTTON_SET_BUTTON_GROUP,
+      backendHandle,
+      value?.backendHandle,
+    )
+  }
+
+/** Radio-group resource; constructed and owned by the settings menu. */
+class ButtonGroup internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle()) {
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  companion object {
+    fun create(): ButtonGroup {
+      val handle =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("ButtonGroup")) {
+          "Godot could not instantiate ButtonGroup"
+        }
+      return ButtonGroup(WebObjectId(handle.backendToken().toInt()))
+    }
+  }
+}
+
+var Button.text: String
+  get() = unsupportedWebGameplayFamily("Button.get_text")
+  set(value) {
+    GodotBackendCalls.invokeStringNameArg(D.BUTTON_SET_TEXT, backendHandle, value)
+  }
+
+class LineEdit(godotObject: GodotHandle) : Control(godotObject) {
+  var text: String
+    get() = GodotBackendCalls.invokeNoArgsRetString(D.LINEEDIT_GET_TEXT, backendHandle)
+    set(value) {
+      GodotBackendCalls.invokeStringNameArg(D.LINEEDIT_SET_TEXT, backendHandle, value)
+    }
+
+  var editable: Boolean
+    get() = unsupportedWebGameplayFamily("LineEdit.is_editable")
+    set(value) {
+      GodotBackendCalls.invokeBoolArg(D.LINEEDIT_SET_EDITABLE, backendHandle, value)
+    }
+}
+
+/** Range base (SpinBox port value, ProgressBar loading value). */
+open class Range(godotObject: GodotHandle) : Control(godotObject) {
+  var value: Double
+    get() = GodotBackendCalls.invokeNoArgsRetDouble(D.RANGE_GET_VALUE, backendHandle)
+    set(newValue) {
+      GodotBackendCalls.invokeDoubleArg(D.RANGE_SET_VALUE, backendHandle, newValue)
+    }
+}
+
+class SpinBox(godotObject: GodotHandle) : Range(godotObject)
+
+class ProgressBar(godotObject: GodotHandle) : Range(godotObject)
+
+class ColorRect(godotObject: GodotHandle) : Control(godotObject)
+
+// ---------------------------------------------------------------------------
+// ConfigFile. Values ride a tagged string through the shared query channel.
+// ---------------------------------------------------------------------------
+
+private const val UNIT = ""
+
+class ConfigFile internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle()) {
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  fun load(path: String) {
+    GodotBackendCalls.invokeStringNameArg(D.CONFIGFILE_LOAD, backendHandle, path)
+  }
+
+  fun save(path: String) {
+    GodotBackendCalls.invokeStringNameArg(D.CONFIGFILE_SAVE, backendHandle, path)
+  }
+
+  fun hasSectionKey(section: String, key: String): Boolean =
+    GodotBackendCalls.invokeStringNameRetBool(
+      D.CONFIGFILE_HAS_SECTION_KEY,
+      backendHandle,
+      section + UNIT + key,
+    )
+
+  fun setValue(section: String, key: String, value: Any?) {
+    val tagged =
+      when (value) {
+        is Boolean -> "b:$value"
+        is Long -> "i:$value"
+        is Int -> "i:$value"
+        is Double -> "f:$value"
+        is String -> "s:$value"
+        else -> error("Kanama Web ConfigFile does not carry ${value?.let { it::class }} values")
+      }
+    GodotBackendCalls.invokeStringNameArg(
+      D.CONFIGFILE_SET_VALUE,
+      backendHandle,
+      section + UNIT + key + UNIT + tagged,
+    )
+  }
+
+  fun getValue(section: String, key: String): Any? {
+    val tagged =
+      GodotBackendCalls.invokeStringNameRetString(
+        D.CONFIGFILE_GET_VALUE,
+        backendHandle,
+        section + UNIT + key,
+      )
+    val body = tagged.drop(2)
+    return when {
+      tagged.startsWith("b:") -> body == "true"
+      tagged.startsWith("i:") -> body.toLong()
+      tagged.startsWith("f:") -> body.toDouble()
+      tagged.startsWith("s:") -> body
+      else -> null
+    }
+  }
+
+  companion object {
+    fun create(): ConfigFile {
+      val handle =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("ConfigFile")) {
+          "Godot could not instantiate ConfigFile"
+        }
+      return ConfigFile(WebObjectId(handle.backendToken().toInt()))
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Noise (camera shake).
+// ---------------------------------------------------------------------------
+
+class FastNoiseLite internal constructor(godotObject: GodotHandle) :
+  Resource(godotObject.toBackendHandle()) {
+  var seed: Int
+    get() = unsupportedWebGameplayFamily("FastNoiseLite.get_seed")
+    set(value) {
+      GodotBackendCalls.invokeLongArg(D.FASTNOISELITE_SET_SEED, backendHandle, value.toLong())
+    }
+
+  var fractalOctaves: Int
+    get() = unsupportedWebGameplayFamily("FastNoiseLite.get_fractal_octaves")
+    set(value) {
+      GodotBackendCalls.invokeLongArg(
+        D.FASTNOISELITE_SET_FRACTAL_OCTAVES,
+        backendHandle,
+        value.toLong(),
+      )
+    }
+
+  var fractalLacunarity: Double
+    get() = unsupportedWebGameplayFamily("FastNoiseLite.get_fractal_lacunarity")
+    set(value) {
+      GodotBackendCalls.invokeDoubleArg(
+        D.FASTNOISELITE_SET_FRACTAL_LACUNARITY,
+        backendHandle,
+        value,
+      )
+    }
+
+  fun getNoise1d(position: Double): Double =
+    GodotBackendCalls.invokeDoubleRetDouble(D.NOISE_GET_NOISE_1D, backendHandle, position)
+
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  companion object {
+    fun create(): FastNoiseLite {
+      val handle =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("FastNoiseLite")) {
+          "Godot could not instantiate FastNoiseLite"
+        }
+      return FastNoiseLite(WebObjectId(handle.backendToken().toInt()))
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton attachment (the robot's ray origin bone).
+// ---------------------------------------------------------------------------
+
+class BoneAttachment3D(godotObject: GodotHandle) : Node3D(godotObject)
+
+// ---------------------------------------------------------------------------
+// Engine / OS singletons.
+// ---------------------------------------------------------------------------
+
+object Engine {
+  var maxFps: Int
+    get() = unsupportedWebGameplayFamily("Engine.get_max_fps")
+    set(value) {
+      GodotBackendCalls.invokeLongArgSingleton(D.ENGINE_SET_MAX_FPS, value.toLong())
+    }
+
+  fun getFramesPerSecond(): Long =
+    GodotBackendCalls.invokeNoArgsRetLongSingleton(D.ENGINE_GET_FRAMES_PER_SECOND)
+}
+
+fun OS.getStaticMemoryUsage(): Long =
+  GodotBackendCalls.invokeNoArgsRetLongSingleton(D.OS_GET_STATIC_MEMORY_USAGE)
+
+fun Input.getActionStrength(action: String): Double =
+  GodotBackendCalls.invokeStringNameRetDoubleSingleton(D.INPUT_GET_ACTION_STRENGTH, action)
+
+// ---------------------------------------------------------------------------
+// Multiplayer facade. Web builds are single-player: the browser has no UDP
+// sockets for ENet, so this reports a local authoritative session and the
+// lobby's connect paths fail through the demo's own error handling.
+// ---------------------------------------------------------------------------
+
+open class MultiplayerPeer internal constructor() {
+  open fun closeConnection() = Unit
+
+  open fun close() = Unit
+}
+
+class OfflineMultiplayerPeer internal constructor() : MultiplayerPeer() {
+  companion object {
+    fun create(): OfflineMultiplayerPeer = OfflineMultiplayerPeer()
+  }
+}
+
+class ENetMultiplayerPeer internal constructor() : MultiplayerPeer() {
+  /** Always fails on Web (no UDP sockets); the lobby surfaces the error to the player. */
+  fun createServer(@Suppress("UNUSED_PARAMETER") port: Int): Long = ERR_UNAVAILABLE
+
+  fun createClient(
+    @Suppress("UNUSED_PARAMETER") address: String,
+    @Suppress("UNUSED_PARAMETER") port: Int,
+  ): Long = ERR_UNAVAILABLE
+
+  companion object {
+    private const val ERR_UNAVAILABLE = 35L
+
+    fun create(): ENetMultiplayerPeer = ENetMultiplayerPeer()
+  }
+}
+
+class MultiplayerAPI internal constructor() {
+  fun isServer(): Boolean = true
+
+  fun getUniqueId(): Int = 1
+
+  fun getPeers(): List<Int> = emptyList()
+
+  fun getRemoteSenderId(): Int = 0
+
+  fun getMultiplayerPeer(): MultiplayerPeer? = peer
+
+  var multiplayerPeer: MultiplayerPeer?
+    get() = peer
+    set(value) {
+      peer = value
+    }
+
+  /** No remote peers ever connect, so these signals never fire; connects are no-ops. */
+  fun signal(@Suppress("UNUSED_PARAMETER") name: String): InertSignal = InertSignal
+
+  object Signals {
+    const val peerConnected = "peer_connected"
+    const val peerDisconnected = "peer_disconnected"
+    const val connectedToServer = "connected_to_server"
+    const val connectionFailed = "connection_failed"
+    const val serverDisconnected = "server_disconnected"
+  }
+
+  private companion object {
+    var peer: MultiplayerPeer? = null
+  }
+}
+
+/** A signal that can never fire on Web; connecting to it is deliberately inert. */
+object InertSignal {
+  fun connect(
+    @Suppress("UNUSED_PARAMETER") target: GodotObject,
+    @Suppress("UNUSED_PARAMETER") argumentCount: Int = 0,
+    @Suppress("UNUSED_PARAMETER") handler: (List<Any?>) -> Unit,
+  ) = Unit
+}
+
+object SceneMultiplayer {
+  fun fromApi(api: MultiplayerAPI?): SceneMultiplayerHandle? = api?.let { SceneMultiplayerHandle }
+}
+
+object SceneMultiplayerHandle {
+  var serverRelay: Boolean = false
+}
+
+private val multiplayerApi = MultiplayerAPI()
+
+/** Nullable to match the desktop shape, so ported call sites keep their `?.` chains. */
+fun Node.getMultiplayer(): MultiplayerAPI? = multiplayerApi
+
+/** Mirrors the desktop owned-peer idiom ("close what you create", task 61). */
+inline fun <T : MultiplayerPeer, R> T.use(block: (T) -> R): R {
+  try {
+    return block(this)
+  } finally {
+    close()
+  }
+}
+
+/** Same owned-handle idiom for the settings menu's radio groups. */
+inline fun <R> ButtonGroup.use(block: (ButtonGroup) -> R): R {
+  try {
+    return block(this)
+  } finally {
+    close()
+  }
+}
+
+/** Replication node; with a single local peer there is nothing to synchronize. */
+class MultiplayerSynchronizer(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
+  var publicVisibility: Boolean = true
+
+  fun setMultiplayerAuthority(@Suppress("UNUSED_PARAMETER") id: Int) = Unit
+
+  fun getMultiplayerAuthority(): Int = 1
+}
+
+object IP {
+  /** No socket surface on Web; the lobby falls back to its "this device" copy. */
+  fun getLocalAddresses(): List<String> = emptyList()
+}
+
+// ---------------------------------------------------------------------------
+// Display / renderer settings. The compatibility renderer ignores most of the
+// tps graphics menu, so those writes are no-ops rather than fake successes.
+// ---------------------------------------------------------------------------
+
+/** Window settings facade: mode and 3D scaling are fixed by the browser canvas. */
+class Window internal constructor() {
+  var mode: Long = MODE_WINDOWED
+  var scaling3dScale: Double = 1.0
+  var scaling3dMode: Long = 0L
+  var useTaa: Boolean = false
+  var msaa3d: Long = 0L
+  var screenSpaceAa: Long = 0L
+
+  companion object {
+    const val MODE_WINDOWED = 0L
+    const val MODE_FULLSCREEN = 3L
+    const val MODE_EXCLUSIVE_FULLSCREEN = 4L
+    const val MODE_MAXIMIZED = 2L
+  }
+}
+
+private val browserWindow = Window()
+
+fun Node.getWindow(): Window = browserWindow
+
+object DisplayServer {
+  const val VSYNC_DISABLED = 0L
+  const val VSYNC_ENABLED = 1L
+  const val VSYNC_ADAPTIVE = 2L
+  const val VSYNC_MAILBOX = 3L
+
+  /** Web adaptation: the demo branches on "headless"; the browser is a real display. */
+  fun getName(): String = "Web"
+
+  fun windowSetVsyncMode(@Suppress("UNUSED_PARAMETER") mode: Long) = Unit
+
+  fun windowGetVsyncMode(): Long = VSYNC_ENABLED
+}
+
+/**
+ * Renderer settings the compatibility renderer has no equivalent for. They stay inert rather than
+ * pretending to apply; the settings menu still records the player's choice in the config file.
+ */
+object RenderingServerQuality {
+  const val ENV_SDFGI_RAY_COUNT_32 = 2L
+  const val ENV_SDFGI_RAY_COUNT_96 = 5L
+  const val VOXEL_GI_QUALITY_LOW = 0L
+  const val VOXEL_GI_QUALITY_HIGH = 1L
+  const val ENV_SSAO_QUALITY_MEDIUM = 1L
+  const val ENV_SSAO_QUALITY_HIGH = 2L
+  const val ENV_SSIL_QUALITY_MEDIUM = 1L
+  const val ENV_SSIL_QUALITY_HIGH = 2L
+}
+
+fun RenderingServer.getCurrentRenderingDriverName(): String = "opengl3"
+
+fun RenderingServer.environmentSetSdfgiRayCount(@Suppress("UNUSED_PARAMETER") count: Long) = Unit
+
+fun RenderingServer.voxelGiSetQuality(@Suppress("UNUSED_PARAMETER") quality: Long) = Unit
+
+fun RenderingServer.environmentSetSsaoQuality(
+  @Suppress("UNUSED_PARAMETER") quality: Long,
+  @Suppress("UNUSED_PARAMETER") halfSize: Boolean,
+  @Suppress("UNUSED_PARAMETER") adaptiveTarget: Double,
+  @Suppress("UNUSED_PARAMETER") blurPasses: Int,
+  @Suppress("UNUSED_PARAMETER") fadeOutFrom: Double,
+  @Suppress("UNUSED_PARAMETER") fadeOutTo: Double,
+) = Unit
+
+fun RenderingServer.environmentSetSsilQuality(
+  @Suppress("UNUSED_PARAMETER") quality: Long,
+  @Suppress("UNUSED_PARAMETER") halfSize: Boolean,
+  @Suppress("UNUSED_PARAMETER") adaptiveTarget: Double,
+  @Suppress("UNUSED_PARAMETER") blurPasses: Int,
+  @Suppress("UNUSED_PARAMETER") fadeOutFrom: Double,
+  @Suppress("UNUSED_PARAMETER") fadeOutTo: Double,
+) = Unit
+
+/** The browser canvas owns fullscreen; the demo's own toggle stays inert. */
+fun Viewport.setInputAsHandled() = Unit
+
+/** Baked lightmap data load (the LightmapGI settings path). */
+fun ResourceLoader.loadLightmapGIData(path: String): LightmapGIData? =
+  load(path, "LightmapGIData")?.let { LightmapGIData(it.handle) }
+
+/**
+ * Threaded-load facade. The Web export is a `nothreads` build, so a background load would never
+ * make progress: the request loads synchronously and then reports LOADED. The demo's loading
+ * screen still runs its normal status/progress path, it just completes on the first poll.
+ */
+object ThreadedLoad {
+  const val THREAD_LOAD_IN_PROGRESS = 0L
+  const val THREAD_LOAD_FAILED = 1L
+  const val THREAD_LOAD_INVALID_RESOURCE = 2L
+  const val THREAD_LOAD_LOADED = 3L
+
+  private val loaded = mutableMapOf<String, PackedScene?>()
+
+  fun request(path: String) {
+    loaded[path] = ResourceLoader.loadPackedScene(path)
+  }
+
+  fun status(path: String): Long =
+    when {
+      !loaded.containsKey(path) -> THREAD_LOAD_IN_PROGRESS
+      loaded[path] == null -> THREAD_LOAD_FAILED
+      else -> THREAD_LOAD_LOADED
+    }
+
+  fun take(path: String): PackedScene? = loaded[path]
+}
+
+class ThreadedLoadStatus internal constructor(val status: Long, val progress: Double?)
+
+fun ResourceLoader.loadThreadedRequest(
+  path: String,
+  @Suppress("UNUSED_PARAMETER") typeHint: String = "",
+  @Suppress("UNUSED_PARAMETER") useSubThreads: Boolean = false,
+) {
+  ThreadedLoad.request(path)
+}
+
+fun ResourceLoader.loadThreadedGetStatusWithProgress(path: String): ThreadedLoadStatus {
+  val status = ThreadedLoad.status(path)
+  return ThreadedLoadStatus(status, if (status == ThreadedLoad.THREAD_LOAD_LOADED) 1.0 else 0.0)
+}
+
+fun ResourceLoader.loadThreadedGetPackedScene(path: String): PackedScene? = ThreadedLoad.take(path)
+
+/** Frame-deferred work; the Web scheduler already runs posts on the next frame. */
+fun MainThread.postNextFrame(block: () -> Unit) = post(block)
+
+fun GD.radToDeg(radians: Double): Double = radians * 180.0 / kotlin.math.PI
+
+fun GD.pushError(message: Any?) {
+  println("ERROR: $message")
+}
+
+var Environment.glowEnabled: Boolean
+  get() = unsupportedWebGameplayFamily("Environment.is_glow_enabled")
+  set(value) {
+    GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_GLOW_ENABLED, backendHandle, value)
+  }
+
+/**
+ * Global-illumination and screen-space effect toggles. The Web export runs the compatibility
+ * renderer, which has no SDFGI, VoxelGI, SSAO, SSIL, or volumetric fog: these stay inert rather
+ * than pretending to apply.
+ */
+var Environment.sdfgiEnabled: Boolean
+  get() = false
+  set(@Suppress("UNUSED_PARAMETER") value) = Unit
+
+var Environment.ssaoEnabled: Boolean
+  get() = false
+  set(@Suppress("UNUSED_PARAMETER") value) = Unit
+
+var Environment.ssilEnabled: Boolean
+  get() = false
+  set(@Suppress("UNUSED_PARAMETER") value) = Unit
+
+var Environment.volumetricFogEnabled: Boolean
+  get() = false
+  set(@Suppress("UNUSED_PARAMETER") value) = Unit

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
@@ -235,7 +235,7 @@ open class Material internal constructor(godotObject: GodotHandle) :
 
   /** Release this material's tracked browser handle (duplicates are Kotlin-owned). */
   fun close() {
-    releaseWebConstructedObject(handle.value)
+    releaseWebTrackedObject(handle.value)
   }
 
   companion object {

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
@@ -49,3 +49,11 @@ internal actual fun releaseWebConstructedObject(handle: Int) {
 
 private fun releaseWebConstructedObjectInterop(handle: Int): Int =
   js("globalThis.KanamaWebBridge.releaseConstructedObject(handle)")
+
+internal actual fun releaseWebTrackedObject(handle: Int) {
+  // Same bridge release as a constructed handle (the slot retires under its recorded kind);
+  // returned resources such as a duplicated Material are tracked as OBJECT, not NODE.
+  val released = releaseWebConstructedObjectInterop(handle)
+  check(released == 1) { "Unknown or already released Kanama Web object handle=$handle" }
+  unregisterWebBrowserHandle(handle, WebBrowserHandleKind.OBJECT)
+}

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -154,6 +154,10 @@ internal fun immediateWebSetProgressRatio(objectId: Int, ratio: Double): Int =
 internal fun immediateWebSetProgressRatio3D(objectId: Int, ratio: Double): Int =
   js("globalThis.KanamaWebBridge.immediateDoubleQuery(107, objectId, ratio)")
 
+/** Generic Double-argument query channel (Noise.get_noise_1d; x1000 integer result). */
+internal fun immediateWebDoubleQuery(opcode: Int, objectId: Int, value: Double): Int =
+  js("globalThis.KanamaWebBridge.immediateDoubleQuery(opcode, objectId, value)")
+
 internal fun immediateWebRotateY(objectId: Int, angle: Double): Int =
   js("globalThis.KanamaWebBridge.immediateDoubleQuery(109, objectId, angle)")
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
@@ -143,6 +143,38 @@ internal class WebCommandBuffer(capacity: Int) {
     words[offset + 3] = if (value) 1 else 0
   }
 
+  fun appendStringNameLongMutation(opcode: Int, objectHandle: Int, name: String, value: Long) {
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    val offset = reserve(WORDS_SCALAR_OR_VECTOR)
+    words[offset] = opcode
+    words[offset + 1] = objectHandle
+    words[offset + 2] = internWebCommandStringName(name)
+    words[offset + 3] = value.toInt()
+  }
+
+  fun appendStringNameObjectMutation(opcode: Int, objectHandle: Int, name: String, value: Int) {
+    val offset = reserve(WORDS_SCALAR_OR_VECTOR)
+    words[offset] = opcode
+    words[offset + 1] = objectHandle
+    words[offset + 2] = internWebCommandStringName(name)
+    words[offset + 3] = value
+  }
+
+  fun appendStringNameVector2Mutation(
+    opcode: Int,
+    objectHandle: Int,
+    name: String,
+    x: Float,
+    y: Float,
+  ) {
+    val offset = reserve(WORDS_STRINGNAME_VECTOR2)
+    words[offset] = opcode
+    words[offset + 1] = objectHandle
+    words[offset + 2] = internWebCommandStringName(name)
+    words[offset + 3] = x.toBits()
+    words[offset + 4] = y.toBits()
+  }
+
   fun appendStringNameStringNameMutation(
     opcode: Int,
     objectHandle: Int,
@@ -245,6 +277,7 @@ internal class WebCommandBuffer(capacity: Int) {
     const val WORDS_VECTOR3 = 5
     const val WORDS_LONG_DOUBLE = 5
     const val WORDS_STRINGNAME_DOUBLE = 5
+    const val WORDS_STRINGNAME_VECTOR2 = 5
     const val WORDS_COLOR = 6
     const val WORDS_STRINGNAME_VECTOR3_VECTOR3 = 9
     const val WORDS_DRAW_TEXTURE = 9

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -168,7 +168,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209, 273, 274))
+    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209, 273, 274, 285, 286))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
     }

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -91,7 +91,33 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
     require(
       descriptor.opcode in
-        setOf(43, 54, 55, 56, 61, 80, 93, 94, 95, 96, 97, 144, 152, 153, 162, 168, 169, 180)
+        setOf(
+          43,
+          54,
+          55,
+          56,
+          61,
+          80,
+          93,
+          94,
+          95,
+          96,
+          97,
+          144,
+          152,
+          153,
+          162,
+          168,
+          169,
+          180,
+          236,
+          237,
+          241,
+          242,
+          254,
+          256,
+          261,
+        )
     )
     val objectId = receiver.webId()
     commands.appendBoolMutation(descriptor.opcode, objectId, value)
@@ -114,7 +140,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     when (descriptor.executionMode) {
       GodotExecutionMode.QUEUED_MUTATION -> {
         require(
-          descriptor.opcode in setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183, 200)
+          descriptor.opcode in
+            setOf(48, 49, 50, 53, 62, 82, 99, 146, 158, 161, 182, 183, 200, 262, 275)
         )
         commands.appendDoubleMutation(descriptor.opcode, receiver.webId(), value)
       }
@@ -141,7 +168,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209))
+    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209, 273, 274))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
     }
@@ -402,6 +429,21 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         // registered under the NODE kind like every constructed handle.
         value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }
       }
+      247 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        // Duplicated materials return through the browser-object channel.
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.OBJECT) }
+      }
+      257 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        // The ButtonGroup was constructed via ClassDB.instantiate (NODE kind).
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.NODE) }
+      }
+      284 -> {
+        require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+        // Baked lightmap data arrives through ResourceLoader.load (RESOURCE kind).
+        value?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.RESOURCE) }
+      }
       else -> error("Unsupported Web object-argument opcode=${descriptor.opcode}")
     }
     commands.appendObjectArg(descriptor.opcode, receiver.webId(), value?.webId() ?: 0)
@@ -416,7 +458,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(47, 57, 66, 128, 150))
+    require(descriptor.opcode in setOf(47, 57, 66, 128, 150, 258, 260, 264, 265, 267, 277, 280))
     commands.appendStringNameMutation(descriptor.opcode, receiver.webId(), value)
   }
 
@@ -429,7 +471,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode == 67)
+    require(descriptor.opcode in setOf(67, 279))
     commands.appendStringNameBoolMutation(descriptor.opcode, receiver.webId(), name, value)
   }
 
@@ -519,7 +561,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ): Double {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(186, 187))
+    require(descriptor.opcode in setOf(186, 187, 272))
     commands.flush()
     // Scaled by 1000 through the shared integer object-query transport.
     return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value) /
@@ -597,7 +639,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(68, 105))
+    require(descriptor.opcode in setOf(68, 105, 230))
     commands.appendStringNameStringNameMutation(descriptor.opcode, receiver.webId(), first, second)
   }
 
@@ -632,6 +674,14 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     commands.flush()
     return when (descriptor.opcode) {
+      243 ->
+        registerReturnedBrowserObject(
+          immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), value.toString())
+        )
+      244 ->
+        registerReturnedBrowserObject(
+          immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), value.toString())
+        )
       174 ->
         registerReturnedNode(
           immediateWebIndexedObjectLookup(descriptor.opcode, receiver.webId(), value.toInt())
@@ -675,6 +725,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
           194 -> registerReturnedNode(token)
           212 -> registerReturnedBrowserObject(token)
           225 -> registerReturnedBrowserObject(token)
+          246 -> registerReturnedBrowserObject(token)
+          250 -> registerReturnedNode(token)
           else -> error("Unsupported Web no-args-object opcode=${descriptor.opcode}")
         }
       }
@@ -832,7 +884,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(199, 201))
+        require(descriptor.opcode in setOf(199, 201, 240, 249, 263))
         commands.flush()
         // Scaled by 1000 through the shared integer object-query transport.
         immediateWebObjectQuery(descriptor.opcode, receiver.webId(), "") / 1000.0
@@ -987,7 +1039,10 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
               "object handle=${receiver.webId()}"
           )
       GodotExecutionMode.IMMEDIATE_RESULT -> {
-        require(descriptor.opcode in setOf(113, 123, 124, 138, 141, 156, 176, 178, 197))
+        require(
+          descriptor.opcode in
+            setOf(113, 123, 124, 138, 141, 156, 176, 178, 197, 227, 234, 235, 239)
+        )
         commands.flush()
         GodotVector3(
           immediateWebNoArgsVector3X(descriptor.opcode, receiver.webId()).toFloat(),
@@ -1018,6 +1073,9 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
           88 -> webWriteVector3Snapshot(objectId, WebVector3Slot.VELOCITY, value)
           101 -> webWriteVector3Snapshot(objectId, WebVector3Slot.ROTATION_DEGREES, value)
           118 -> webWriteVector3Snapshot(objectId, WebVector3Slot.TARGET_POSITION, value)
+          226 -> {}
+          228 -> {}
+          238 -> {}
           else -> error("Unsupported Web Vector3 mutation opcode=${descriptor.opcode}")
         }
       }
@@ -1088,7 +1146,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(103, 132, 151))
+    require(descriptor.opcode in setOf(103, 132, 151, 248))
     require(doubleValue.isFinite())
     commands.appendStringNameDoubleMutation(descriptor.opcode, receiver.webId(), value, doubleValue)
   }
@@ -1139,7 +1197,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(116, 126))
+    require(descriptor.opcode in setOf(116, 126, 269))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     commands.flush()
     immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
@@ -1210,7 +1268,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ): Long {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 145)
+    require(descriptor.opcode in setOf(145, 270, 271))
     commands.flush()
     return immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), "").toLong()
   }
@@ -1332,7 +1390,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode == 210)
+    require(descriptor.opcode in setOf(210, 245))
     require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     requireWebBrowserHandle(objectValue.webId(), WebBrowserHandleKind.OBJECT)
     commands.flush()
@@ -1523,6 +1581,153 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       .split('')
       .filter { it.isNotEmpty() }
       .map { GodotHandle.fromBackendToken(it.toLong()) }
+  }
+
+  override fun invokeStringNameLongArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: Long,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 231)
+    require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
+    }
+    commands.appendStringNameLongMutation(descriptor.opcode, receiver.webId(), name, value)
+  }
+
+  override fun invokeStringNameVector2Arg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotVector2,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 232)
+    commands.appendStringNameVector2Mutation(
+      descriptor.opcode,
+      receiver.webId(),
+      name,
+      value.x,
+      value.y,
+    )
+  }
+
+  override fun invokeStringNameObjectArg(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
+    require(descriptor.opcode == 281)
+    commands.appendStringNameObjectMutation(
+      descriptor.opcode,
+      receiver.webId(),
+      name,
+      value.webId(),
+    )
+  }
+
+  override fun invokeStringNameRetVector2(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+  ): GodotVector2 {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 233)
+    commands.flush()
+    // Both components ride the shared string channel (unit separator); non-Vector2
+    // properties resolve to the zero vector applier-side.
+    val packed = immediateWebStringQuery(descriptor.opcode, receiver.webId(), name)
+    val parts = packed.split('')
+    require(parts.size == 2) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} returned $packed"
+    }
+    return GodotVector2(parts[0].toFloat(), parts[1].toFloat())
+  }
+
+  override fun invokeNoArgsRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(259, 278))
+    commands.flush()
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
+  }
+
+  override fun invokeStringNameRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    name: String,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 268)
+    commands.flush()
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), name)
+  }
+
+  override fun invokeDoubleRetDouble(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Double,
+  ): Double {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 276)
+    require(value.isFinite()) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} requires a finite Double"
+    }
+    commands.flush()
+    // Scaled by 1000 through the shared integer double-query transport.
+    return immediateWebDoubleQuery(descriptor.opcode, receiver.webId(), value) / 1000.0
+  }
+
+  override fun invokeVector3Vector3LongObjectRetString(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    from: GodotVector3,
+    to: GodotVector3,
+    collisionMask: Long,
+    exclude: GodotHandle?,
+  ): String {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 229)
+    require(collisionMask in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    commands.flush()
+    // Ray endpoints, mask, and the optional exclusion handle ride one query string
+    // (unit separator). The applier resolves the receiver's world, builds the query
+    // parameters, and turns the exclusion handle into an RID on its own side.
+    val packed =
+      listOf(
+          from.x.toString(),
+          from.y.toString(),
+          from.z.toString(),
+          to.x.toString(),
+          to.y.toString(),
+          to.z.toString(),
+          collisionMask.toString(),
+          (exclude?.webId() ?: 0).toString(),
+        )
+        .joinToString("")
+    return immediateWebStringQuery(descriptor.opcode, receiver.webId(), packed)
   }
 
   private fun requireOpcode(descriptor: GodotCallDescriptor, callSite: GodotCallSite) {

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -56,6 +56,8 @@
       opcode === 277 ||
       opcode === 280 ||
       opcode === 284 ||
+      opcode === 285 ||
+      opcode === 286 ||
       opcode === 66
     ) return 3;
     if (
@@ -297,6 +299,10 @@
     tpSmokeQuitHandle: 0,
     tpPlayerHandle: 0,
     tpDemoPageHandle: 0,
+    tpsMainHandle: 0,
+    tpsMenuHandle: 0,
+    tpsLevelHandle: 0,
+    tpsPlayerHandle: 0,
     racingSmokeHandle: 0,
     racingVehicleHandle: 0,
     racingViewHandle: 0,
@@ -451,6 +457,24 @@
       }
       if (this.mode === "fps") {
         // FPS scripts own no coroutines; every script runs its plain dispatch.
+        return this.process(handle, delta);
+      }
+      if (this.mode === "tpsdemo") {
+        // Main is the persistent scene root (it survives the menu/level swap), so it pumps the
+        // shared coroutine frame scheduler for every coroutine owner in the demo (Level robot
+        // respawns, Part fade timers, Blast/PartDisappear lifetimes). Every other script runs
+        // its plain _process dispatch; nothing here takes the spike benchmark transport.
+        if (handle === this.tpsMainHandle) {
+          const executed = this.invoke(
+            handle,
+            "frame_scheduler",
+            "frame scheduler",
+            () => this.api.kanamaWebFrame(handle, delta),
+            0,
+          );
+          this.processCalls += 1;
+          return executed;
+        }
         return this.process(handle, delta);
       }
       if (this.mode === "citybuilder") {
@@ -2260,6 +2284,22 @@
         // The camera rig lerps toward the vehicle every tick: its root position is the
         // driver's movement evidence (the Vehicle ROOT node intentionally never moves).
         this.racingViewHandle = handle;
+      }
+      if (this.mode === "tpsdemo" && scriptName.endsWith(".Main")) {
+        // The scene root pumps the frame scheduler and hosts the harness entry points:
+        // smoke_start_game (method#1) presses Play, smoke_teardown (method#2) releases the
+        // cached scenes plus the settings ConfigFile and frees the root.
+        this.tpsMainHandle = handle;
+      }
+      if (this.mode === "tpsdemo" && scriptName.endsWith(".Menu")) {
+        this.tpsMenuHandle = handle;
+      }
+      if (this.mode === "tpsdemo" && scriptName.endsWith(".Level")) {
+        this.tpsLevelHandle = handle;
+      }
+      if (this.mode === "tpsdemo" && scriptName.endsWith(".Player")) {
+        // The player body is the driver's movement evidence (opcode 138 on this handle).
+        this.tpsPlayerHandle = handle;
       }
       if (this.mode === "citybuilder" && scriptName.endsWith(".Smoke")) {
         // smoke_teardown (method#1) frees the Audio autoload, releases hydrated structure

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 14;
+  const KANAMA_WEB_PROTOCOL_VERSION = 15;
 
   function commandWordCount(opcode) {
     if (
@@ -20,6 +20,8 @@
       opcode === 63 ||
       opcode === 64 ||
       opcode === 147 ||
+      opcode === 251 ||
+      opcode === 283 ||
       opcode === 181
     ) return 2;
     if (
@@ -42,6 +44,18 @@
       opcode === 189 ||
       opcode === 202 ||
       opcode === 209 ||
+      opcode === 247 ||
+      opcode === 257 ||
+      opcode === 258 ||
+      opcode === 260 ||
+      opcode === 264 ||
+      opcode === 265 ||
+      opcode === 267 ||
+      opcode === 273 ||
+      opcode === 274 ||
+      opcode === 277 ||
+      opcode === 280 ||
+      opcode === 284 ||
       opcode === 66
     ) return 3;
     if (
@@ -83,6 +97,19 @@
       opcode === 182 ||
       opcode === 183 ||
       opcode === 200 ||
+      opcode === 230 ||
+      opcode === 231 ||
+      opcode === 236 ||
+      opcode === 237 ||
+      opcode === 241 ||
+      opcode === 242 ||
+      opcode === 254 ||
+      opcode === 256 ||
+      opcode === 261 ||
+      opcode === 262 ||
+      opcode === 275 ||
+      opcode === 279 ||
+      opcode === 281 ||
       opcode === 1000
     ) return 4;
     if (
@@ -96,6 +123,11 @@
       opcode === 101 ||
       opcode === 103 ||
       opcode === 132 ||
+      opcode === 226 ||
+      opcode === 228 ||
+      opcode === 232 ||
+      opcode === 238 ||
+      opcode === 248 ||
       opcode === 151
     ) return 5;
     if (opcode === 32) return 6;
@@ -159,6 +191,7 @@
     tweenChildren: new Map(),
     sceneTreeHandlesByOwner: new Map(),
     viewportHandlesByOwner: new Map(),
+    rootHandlesByOwner: new Map(),
     commandStringNamesByValue: new Map(),
     commandStringNamesById: new Map(),
     nextCommandStringNameId: 1,
@@ -1426,6 +1459,16 @@
         }
         this.viewportHandlesByOwner.delete(owner);
       }
+      // Per-shot SceneTree.get_root (the robot laser parents its blast under the root)
+      // follows the same per-owner reuse rule as get_viewport.
+      const isRoot = opcode === 250;
+      if (isRoot) {
+        const existing = this.rootHandlesByOwner.get(owner);
+        if (existing !== undefined && this.browserHandleSlot(existing)?.kind === "Node") {
+          return existing;
+        }
+        this.rootHandlesByOwner.delete(owner);
+      }
       const callback = this.callbackFor(
         this.noArgsObjectCallbacks,
         handle,
@@ -1451,8 +1494,17 @@
       // follow the SpriteFrames/Environment handle-kind rule.
       const isSceneState = opcode === 212;
       const isMesh = opcode === 225;
+      // opcode 246 = Material.get_next_pass returns a Material Resource — same handle-kind
+      // rule as SpriteFrames/Environment/Mesh (adopt as Object, never as a Node).
+      const isMaterial = opcode === 246;
       const isObjectResult =
-        isTween || isSceneTree || isSpriteFrames || isEnvironment || isSceneState || isMesh;
+        isTween ||
+        isSceneTree ||
+        isSpriteFrames ||
+        isEnvironment ||
+        isSceneState ||
+        isMesh ||
+        isMaterial;
       const kind = isTween
         ? "Tween"
         : isSceneTree
@@ -1465,7 +1517,9 @@
                 ? "SceneState"
                 : isMesh
                   ? "Mesh"
-                  : "Node";
+                  : isMaterial
+                    ? "Material"
+                    : "Node";
       const resultHandle = this.allocateBrowserHandle(kind, owner);
       if (isObjectResult) this.api.kanamaWebAdoptObjectHandle(resultHandle);
       else this.api.kanamaWebAdoptNodeHandle(resultHandle);
@@ -1492,6 +1546,8 @@
         this.match3SceneTreeHandlesCreated += 1;
       } else if (isViewport && result === resultHandle) {
         this.viewportHandlesByOwner.set(owner, resultHandle);
+      } else if (isRoot && result === resultHandle) {
+        this.rootHandlesByOwner.set(owner, resultHandle);
       }
       return result;
     },


### PR DESCRIPTION
Admits the call families tps-demo needs and brings it up on the Web backend. With this,
**all 12 corpus demos run on Web**. Companion port: falcon4ever/kanama-demos#22.

Chrome 13/13 checks in ~67s, Firefox 13/13 in ~158s, both with zero console errors and
teardown to zero.

## Contract (225 -> 286 opcodes, protocol 14 -> 15)

Hashes are validated against `extension_api.json` by the generator. New families: movement
and space-state ray queries, AnimationTree parameters and root motion, CPU particles, the
material duplicate/next-pass chain, per-light shadows, the settings UI (Control focus and
rect, BaseButton state and groups, Button/LineEdit text, Range value), ConfigFile,
FastNoiseLite, Engine/OS/Input singletons, and the Node/Object surface tps needs.

Eight new call shapes reach the platform seam with default error bodies, so desktop,
Android, and iOS are unaffected. Only **one** new transport extern (a generic
Double-argument query) — everything else rides the existing object/string/property-object
channels, including `intersect_ray`, whose parameters are built engine-side so RIDs never
cross the seam.

## Backend fixes the bring-up found

All general rather than tps-specific:

- the call-site cache was sized by a hardcoded 255-opcode bound and silently rejected
  anything past it; it now derives from the contract (`MAX_OPCODE`)
- `get_child_count` resolved only the proxy's own node, so walking any other node's
  children returned an empty list
- nodes reached through `get_child` never got their mirrored transform seeded, so reading a
  looked-up child's transform failed
- node lookups now seed a canvas snapshot for Controls, which are CanvasItems but not
  Node2Ds and so were skipped
- releasing a tracked OBJECT-kind handle (a duplicated Material) went through the
  constructed-handle path and tripped its NODE kind check
- the emitter's new GDScript arms were emitting literal `\t` instead of tabs (double-escaped
  at the Kotlin string layer), which the parser rejected

## Web adaptations

Documented where they are defined: the multiplayer surface is a single-player facade (no
UDP sockets in the browser); threaded resource loading is synchronous on this `nothreads`
build; renderer settings the Compatibility renderer has no implementation for stay inert
rather than pretending to apply. Staging drops the menu's `FogVolume` for the same reason.

## Validation

- tpsdemo driver: Chrome + Firefox wrapper-PASS, 13/13, `liveAfterTeardown == 0`
- spot-regressions re-exported at protocol 15 and re-run on Chrome: dodge 10/10, fps 10/10,
  citybuilder 12/12, thirdperson 11/11, match3 11/11, all with zero console errors
- `scripts/local_ci.sh` PASS (including both generator drift gates and ktfmtCheck)
