### PR TITLE
Task 66a: reject Web-undispatched script virtuals at build time

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -182,6 +182,11 @@ rejection, console-error checks, and a protocol-version match.
   swipe in the automated gate (coordinates and Godot picking are correct; the
   drag-to-swipe is a WebDriver synthesis limitation). The automated Safari gate
   covers Bunnymark; Safari Match3 is a manual local check.
+- **Lifecycle virtuals are limited to what the proxy dispatches**: `_ready`,
+  `_process`, `_physics_process`, `_draw`, `_exit_tree`, `_input`, and
+  `_unhandled_input`. Anything else — `@OnEnterTree` in particular — is rejected
+  at build time with a KSP error naming the script and the function, rather than
+  compiling and then never running. Move the body into an `@OnReady` function.
 - Single-thread Compatibility renderer only; no threads, no cross-origin
   isolation.
 - No Web editor, no compiler, no hot reload, no Web GDExtension, and no TeaVM or

--- a/docs/game-dev/scripts.md
+++ b/docs/game-dev/scripts.md
@@ -99,6 +99,10 @@ GDScript uses overridable virtual methods. Kanama uses annotations:
 The function name is up to you — the annotation is what wires it up. Drop the
 leading underscore; `fun ready()` is the convention.
 
+`@OnEnterTree` is not dispatched by the experimental Web backend; a Web build
+rejects it at build time and asks you to move the body into `@OnReady`. See
+`docs/exporting/web.md`.
+
 ## Overriding Engine Virtuals
 
 Beyond the lifecycle annotations, any engine virtual method (the `_*` override

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -66,7 +66,7 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
   private val emitJvmCode: Boolean =
     env.platforms.isEmpty() ||
       env.platforms.any { it.platformName.equals("JVM", ignoreCase = true) }
-  private val emitWebCode: Boolean = env.options["kanamaRuntimeTarget"] == "web"
+  private val emitWebCode: Boolean = WebScriptCodeEmitter.isWebTarget(env.options)
   private val emitIosCode: Boolean = !emitJvmCode && !emitWebCode
 
   override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -115,6 +115,9 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
           env.logger.error("[kanama:ksp] ${e.message}", symbol)
           continue
         }
+      for (message in WebScriptCodeEmitter.undispatchedVirtualErrors(model, env.options)) {
+        env.logger.error("[kanama:ksp] $message", symbol)
+      }
       symbol.containingFile?.let {
         aggregatorSources += it
         scriptAggregatorSources += it

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -10,6 +10,51 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   companion object {
     const val PROTOCOL_VERSION = 15
     const val PROTOCOL_SCHEMA_VERSION = 1
+
+    /**
+     * Godot virtuals the emitted proxy actually crosses into Kotlin. Keep in sync with the
+     * `append*Dispatcher()` functions below — a virtual outside this set is emitted into the script
+     * model, compiles cleanly, and is then never dispatched.
+     */
+    val DISPATCHED_VIRTUALS =
+      linkedSetOf(
+        "_ready",
+        "_process",
+        "_physics_process",
+        "_draw",
+        "_exit_tree",
+        "_input",
+        "_unhandled_input",
+      )
+
+    /** True when KSP is running for the Web (Kotlin/Wasm) target. */
+    fun isWebTarget(options: Map<String, String>): Boolean = options["kanamaRuntimeTarget"] == "web"
+
+    /**
+     * Errors for virtuals a Web build would silently drop (task 66).
+     *
+     * `@OnEnterTree` and friends compile for a Web target and are then never called, so the body
+     * just disappears — in the tps-demo port that cost a long debugging detour for what should have
+     * been a build failure. Fail the build instead, naming the script and the function. Empty on
+     * every non-Web target, where the same virtuals are dispatched normally.
+     */
+    fun undispatchedVirtualErrors(model: ScriptModel, options: Map<String, String>): List<String> {
+      if (!isWebTarget(options)) return emptyList()
+      return model.virtuals
+        .filter { it.virtualName !in DISPATCHED_VIRTUALS }
+        .map { virtual ->
+          val where = "${model.simpleName}.${virtual.kotlinMethodName}"
+          val advice =
+            if (virtual.virtualName == "_enter_tree")
+              "move its body into an @OnReady function — the Web backend dispatches script " +
+                "lifecycle from _ready"
+            else
+              "move the work into a dispatched virtual " +
+                "(${DISPATCHED_VIRTUALS.joinToString(", ")})"
+          "$where: ${virtual.virtualName} is not dispatched by the Kanama Web backend, so this " +
+            "function would never run in a Web build; $advice."
+        }
+    }
   }
 
   data class ProxySource(

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -431,4 +431,110 @@ class WebScriptCodeEmitterTest {
     assertTrue(registry.contains("(script as Main).onTilePressed(Vector2i(x, y))"))
     assertTrue(registry.contains("(script as Tile).inputEvent("))
   }
+
+  // ---------- Task 66a: virtuals the Web backend does not dispatch ----------
+
+  private fun scriptWith(vararg virtuals: VirtualModel) =
+    ScriptModel(
+      simpleName = "Player",
+      fqName = "net.multigesture.kanama.web.Player",
+      attachTo = "CharacterBody3D",
+      isTool = false,
+      isGlobalClass = false,
+      properties = emptyList(),
+      toolButtons = emptyList(),
+      virtuals = virtuals.toList(),
+      methods = emptyList(),
+      signals = emptyList(),
+    )
+
+  private val webOptions = mapOf("kanamaRuntimeTarget" to "web")
+
+  @Test
+  fun rejectsEnterTreeOnAWebTargetNamingTheScriptAndTheFix() {
+    val model = scriptWith(VirtualModel("_enter_tree", "enterTree", "enterTree"))
+
+    val errors = WebScriptCodeEmitter.undispatchedVirtualErrors(model, webOptions)
+
+    assertEquals(1, errors.size, "expected exactly one error, got $errors")
+    val error = errors.single()
+    assertTrue(error.contains("Player.enterTree"), error)
+    assertTrue(error.contains("_enter_tree"), error)
+    assertTrue(error.contains("@OnReady"), error)
+  }
+
+  @Test
+  fun acceptsEnterTreeOnJvmAndIosTargets() {
+    val model = scriptWith(VirtualModel("_enter_tree", "callEnterTree", "enterTree"))
+
+    // JVM and iOS leave `kanamaRuntimeTarget` unset (only web-runtime sets it); an explicit
+    // non-web value must not trip the gate either.
+    assertTrue(WebScriptCodeEmitter.undispatchedVirtualErrors(model, emptyMap()).isEmpty())
+    assertTrue(
+      WebScriptCodeEmitter.undispatchedVirtualErrors(model, mapOf("kanamaRuntimeTarget" to "ios"))
+        .isEmpty()
+    )
+    assertFalse(WebScriptCodeEmitter.isWebTarget(emptyMap()))
+    assertFalse(WebScriptCodeEmitter.isWebTarget(mapOf("kanamaRuntimeTarget" to "ios")))
+    assertTrue(WebScriptCodeEmitter.isWebTarget(webOptions))
+  }
+
+  @Test
+  fun rejectsEveryOtherUndispatchedVirtualOnAWebTarget() {
+    val model =
+      scriptWith(
+        VirtualModel("_ready", "ready", "ready"),
+        VirtualModel(
+          "_shortcut_input",
+          "shortcutInput",
+          "shortcutInput",
+          args =
+            listOf(ArgModel("event", TypeMapping.OBJECT, "net.multigesture.kanama.api.GodotObject")),
+        ),
+      )
+
+    val errors = WebScriptCodeEmitter.undispatchedVirtualErrors(model, webOptions)
+
+    assertEquals(1, errors.size, "only the undispatched virtual may be rejected, got $errors")
+    assertTrue(errors.single().contains("Player.shortcutInput"), errors.single())
+    assertTrue(errors.single().contains("_shortcut_input"), errors.single())
+  }
+
+  @Test
+  fun everyDispatchedVirtualReachesTheGeneratedRegistry() {
+    val eventArg =
+      listOf(ArgModel("event", TypeMapping.OBJECT, "net.multigesture.kanama.api.GodotObject"))
+    val deltaArg = listOf(ArgModel("delta", TypeMapping.FLOAT))
+    val model =
+      scriptWith(
+        VirtualModel("_ready", "ready", "onReady"),
+        VirtualModel("_process", "process", "onProcess", args = deltaArg),
+        VirtualModel("_physics_process", "physicsProcess", "onPhysicsProcess", args = deltaArg),
+        VirtualModel("_draw", "draw", "onDraw"),
+        VirtualModel("_exit_tree", "exitTree", "onExitTree"),
+        VirtualModel("_input", "input", "onInput", args = eventArg),
+        VirtualModel("_unhandled_input", "unhandledInput", "onUnhandledInput", args = eventArg),
+      )
+
+    // The claim behind the gate: everything in DISPATCHED_VIRTUALS really is crossed into
+    // Kotlin, so a virtual outside the set is the only silent drop.
+    assertTrue(
+      WebScriptCodeEmitter.undispatchedVirtualErrors(model, webOptions).isEmpty(),
+      "DISPATCHED_VIRTUALS must cover this fixture",
+    )
+    assertEquals(
+      WebScriptCodeEmitter.DISPATCHED_VIRTUALS,
+      model.virtuals.map { it.virtualName }.toSet(),
+      "fixture must exercise exactly the dispatched set",
+    )
+
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(model, "res://Player.kt"))).registrySource()
+    for (virtual in model.virtuals) {
+      assertTrue(
+        registry.contains("(script as Player).${virtual.kotlinMethodName}("),
+        "${virtual.virtualName} is listed as dispatched but never reaches the script",
+      )
+    }
+  }
 }


### PR DESCRIPTION
## Problem

`@OnEnterTree` compiles for a Web target and is then **never dispatched** — the Web script emitter has no `_enter_tree` path at all, so the annotated function silently disappears from the build. Found the hard way in the 60i tps-demo port: the `Player` resolved its `InputSynchronizer` child in `@OnEnterTree`, that body never ran on Web, and `_ready` died with `lateinit property inputSynchronizer has not been initialized` on every physics tick. That should have been a build failure.

## Change

The Web proxy dispatches exactly seven virtuals — `_ready`, `_process`, `_physics_process`, `_draw`, `_exit_tree`, `_input`, `_unhandled_input`. Anything else reaching a Web build is the same silent drop (`@OnEnterTree`, `@OnShortcutInput`, `@OnUnhandledKeyInput`, an `@OverrideVirtual` outside the set), so the gate is the whole set rather than `_enter_tree` alone.

`KanamaProcessor` now emits a KSP **error** naming the script and the function; `@OnEnterTree` gets the specific advice (move the body into `@OnReady`). The check is keyed on the `kanamaRuntimeTarget=web` KSP option — which only `web-runtime` sets — so JVM and iOS are untouched, and the processor reads the target through the same helper so the two cannot drift.

Real Web build, temporary `@OnEnterTree` on `WebSpikeScript`:

```
e: [ksp] .../WebSpikeScript.kt:21: [kanama:ksp] WebSpikeScript.tempEnterTreeProbe: _enter_tree is not
dispatched by the Kanama Web backend, so this function would never run in a Web build; move its body
into an @OnReady function — the Web backend dispatches script lifecycle from _ready.
```

No protocol change, no re-export, no driver churn. No script in the corpus (12 demo web ports + the in-repo web sources) uses an undispatched virtual today, so nothing existing starts failing.

## Tests

`WebScriptCodeEmitterTest` gains four cases: the error fires for a Web target and names the script, the function and `@OnReady`; it does not fire for JVM (option unset) or a non-web option value; a non-`_enter_tree` undispatched virtual is rejected while a dispatched one beside it is not; and — the claim the gate rests on — every name in `DISPATCHED_VIRTUALS` really does reach the script in the generated registry, so the list cannot silently drift from the emitter.

## Validation

- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot` — PASS (includes the web Wasm compile + coverage gate and all four runtime smokes).
- `:processor:test` — 11/11 in `WebScriptCodeEmitterTest`.

Docs: the Web export page gains the dispatched-virtual limitation, and `docs/game-dev/scripts.md` notes it beside the lifecycle annotation table.

Task 66b (actually dispatching `_enter_tree`; a protocol bump with full corpus re-validation) stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)