### PR TITLE
Task 60g: fresh-checkout Web export gate (W3, first half)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ example_project/addons/kanama/kanama_bootstrap.*
 example_project/addons/kanama/kanama.jar
 example_project/addons/kanama/kanama-scripts.jar
 example_project/hs_err_pid*.log
+# A JVM crash (seen once: a C2 JIT SIGSEGV during a Gradle build) drops these
+# in whatever directory it ran from; they must never reach a commit.
+hs_err_pid*.log
+replay_pid*.log
 
 # --- Android spike outputs ---
 android/godot-plugin/plugin/.cxx/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,5 +295,10 @@ Before a release tag, prefer an isolated clone gate:
 ./scripts/fresh_clone_smoke.sh /absolute/path/to/godot-4.7-stable
 ```
 
+The Web analog is `scripts/web_fresh_checkout_smoke.sh`: it exports from a clean
+clone in an isolated workspace, proves no build-machine path reaches a served
+file and that the demo source tree is untouched, then drives the artifact in a
+browser with the harness from that clone. See `docs/exporting/web.md`.
+
 Use demo-repo smoke tasks when a change affects real gameplay ports, wrappers
 used by demos, package onboarding, or Android exports.

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,21 +5,26 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 6). It is **not a Supported target**: two demos are
-validated (Starter-Kit-Match3 and Bunnymark) as production Web exports, the
-renderer is single-thread Compatibility only, and the corpus/browser matrix is
-still growing.
+JavaScript bridge (protocol 15). It is **not a Supported target**: the renderer is
+single-thread Compatibility only, the browser matrix and performance budgets are
+still being hardened, and there is no packaged install path yet.
 
-**Evidence.** Both demos pass the automated production export smoke in **Chrome**
-(the CI gate) and **Firefox**. In **Safari**, Bunnymark passes the automated gate
-and Match3 is verified running by hand (its runtime-selected swipe works and
-matches/collapses/refills); the automated SafariDriver gate cannot synthesize
-Match3's drag reliably, so that one cell is a manual local check — see Known
-Limitations.
+**Evidence.** The full twelve-demo corpus — Bunnymark, Starter-Kit-Match3, dodge,
+web3d, 3D-Platformer, squash, FPS, character-controller, third-person, Racing,
+City-Builder and tps-demo — passes the automated production export smoke in
+**Chrome** (the CI gate) and **Firefox**, each with a play-and-teardown driver
+run, zero console errors, and live handles draining to zero. Every corpus export
+is also proven to embed no build-machine paths in any served file, and to be
+reproducible from a clean clone (see [Fresh-Checkout Gate](#fresh-checkout-gate)).
 
-This page is the reproducible export workflow for those two validated demos. For
-the architecture — batching, snapshots, handle generations, the bridge protocol
-— see [Web Internals](../contributing/web-internals.md).
+**Safari** is not part of the gated matrix: as of the 57f validation Bunnymark
+passed the automated Safari gate and Match3 was verified by hand, but
+SafariDriver cannot reliably synthesize Match3's drag, so the wider corpus is not
+Safari-gated — see Known Limitations.
+
+This page is the reproducible export workflow. For the architecture — batching,
+snapshots, handle generations, the bridge protocol — see
+[Web Internals](../contributing/web-internals.md).
 
 ## How Web Differs
 
@@ -79,6 +84,18 @@ installs the Kotlin/Wasm runtime and bridge, cache-busts the entry scripts, and
 writes a self-contained served directory plus a release payload report. Point it
 at a **clean checkout** of the demo (never a shared working tree); the Web script
 root is auto-derived from `<project>/web`.
+
+Each demo is selected with `-PkanamaWebDemo=<key>` and given its checkout with
+the matching `-PkanamaWeb<Key>ProjectDir`:
+
+| Key | Demo project | Key | Demo project |
+|---|---|---|---|
+| `match3` | Starter-Kit-Match3 | `thirdperson` | godot-4-3d-third-person-controller |
+| `bunnymark` | Bunnymark | `charactercontroller` | godot-4-3d-character-controller-tutorial |
+| `dodge` | godot-demo-2d-dodge-the-creeps | `racing` | Starter-Kit-Racing |
+| `platformer` | Starter-Kit-3D-Platformer | `citybuilder` | Starter-Kit-City-Builder |
+| `squash` | godot-demo-3d-squash-the-creeps | `tpsdemo` | tps-demo-kanama |
+| `fps` | Starter-Kit-FPS | `web3d` | in-repo fixture (no checkout needed) |
 
 Match3:
 
@@ -140,6 +157,36 @@ release gates** run before a promotion. Each gate asserts gameplay deltas,
 crossing budgets, handle/callback/scheduler teardown to baseline, stale-handle
 rejection, console-error checks, and a protocol-version match.
 
+## Fresh-Checkout Gate
+
+`web_fresh_checkout_smoke.sh` answers a different question from the export smoke:
+not "does this export run?" but "can anyone reproduce it?". It clones Kanama (and
+kanama-demos, when the selected demo lives there) into a throwaway workspace with
+its own `HOME`, Gradle home and Maven-local, exports from that clone, and then
+asserts what a promotion review needs to see:
+
+1. **no build-machine path in any served file** — the whole export tree is
+   scanned byte-for-byte, not just `index.html`;
+2. **the demo source tree is untouched** — checksummed before and after, plus a
+   `git status` check on the demo checkout; and
+3. **the artifact really runs** — the export smoke drives it in a real browser
+   using the harness *from the fresh clone*, so the tooling is proven to ship.
+
+```sh
+scripts/web_fresh_checkout_smoke.sh \
+  --template "$HOME/Library/Application Support/Godot/export_templates/4.7.stable/web_nothreads_release.zip" \
+  --demo web3d --demo match3 \
+  --evidence /tmp/web-fresh-checkout.json \
+  /absolute/path/to/godot
+```
+
+The default demo set is `web3d` (an in-repo fixture, so the Kanama clone alone is
+enough) plus `match3` (an external demo, exercising the demos checkout);
+`--demo all` runs the whole corpus. `--kanama-source` / `--demos-source` accept a
+local path for validating an unmerged branch, and `--skip-browser` reduces the
+run to the export and artifact checks. The `--evidence` JSON records the clone
+commits, per-demo checksums, payload sizes, protocol version and driver results.
+
 ## Browser Debugging
 
 - **Chrome** — the driver self-launches headless Chrome and drives it over the
@@ -175,8 +222,8 @@ rejection, console-error checks, and a protocol-version match.
 
 ## Known Limitations
 
-- Only **Starter-Kit-Match3** and **Bunnymark** are validated; the wider demo
-  corpus and 3D are not yet on Web.
+- **Safari is not in the gated matrix.** Chrome and Firefox gate every corpus
+  demo; Safari coverage stops at the 57f Bunnymark/Match3 validation below.
 - **Safari automated Match3 drag.** The Match3 export runs correctly in Safari by
   hand, but SafariDriver's synthesized pointer drag does not reliably trigger the
   swipe in the automated gate (coordinates and Godot picking are correct; the

--- a/scripts/web/check_no_local_paths.py
+++ b/scripts/web/check_no_local_paths.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Fail if a built Web export embeds workstation-absolute paths.
+
+`exportWeb` already asserts that the exported `index.html` leaks neither the
+staging directory nor `$HOME`. That covers the shell Godot writes, but a served
+export is more than its HTML: the Godot engine JS, the pck, the Kotlin/Wasm
+payload and the export report are all shipped, and any of them embedding a build
+machine's paths would make the artifact non-portable evidence (task 60g, W3).
+
+This scans every served byte for the forbidden prefixes the caller names — the
+build workspace, the build user's home — and reports each hit with its file and
+a short context window. Binary files are scanned too: the point is exactly to
+catch a path baked into a compiled payload.
+
+Usage:
+    python3 check_no_local_paths.py <export-dir> --forbid <absolute-path>...
+                                    [--allow-file <relative-path>]...
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_CONTEXT = 60
+
+
+def _hits(data: bytes, needle: bytes) -> list[int]:
+    found: list[int] = []
+    start = 0
+    while True:
+        index = data.find(needle, start)
+        if index < 0:
+            return found
+        found.append(index)
+        start = index + 1
+        if len(found) >= 5:
+            return found
+
+
+def scan(export_dir: str, forbidden: list[str], allowed: set[str]) -> list[str]:
+    problems: list[str] = []
+    needles = [(text, text.encode("utf-8")) for text in forbidden if text]
+    for dirpath, dirnames, filenames in os.walk(export_dir):
+        dirnames.sort()
+        for name in sorted(filenames):
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, export_dir)
+            if rel in allowed:
+                continue
+            with open(path, "rb") as handle:
+                data = handle.read()
+            for text, needle in needles:
+                for offset in _hits(data, needle):
+                    window = data[max(0, offset - 10) : offset + _CONTEXT]
+                    context = window.decode("utf-8", errors="replace").replace("\n", " ")
+                    problems.append(f"{rel}: embeds {text!r} at byte {offset} ({context!r})")
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(
+            "usage: check_no_local_paths.py <export-dir> --forbid <path>... "
+            "[--allow-file <relative-path>]...",
+            file=sys.stderr,
+        )
+        return 2
+    export_dir = argv[0]
+    forbidden: list[str] = []
+    allowed: set[str] = set()
+    rest = argv[1:]
+    while rest:
+        flag = rest[0]
+        if flag in ("--forbid", "--allow-file") and len(rest) >= 2:
+            if flag == "--forbid":
+                forbidden.append(os.path.normpath(rest[1]))
+            else:
+                allowed.add(rest[1])
+            rest = rest[2:]
+            continue
+        print(f"unexpected argument: {flag}", file=sys.stderr)
+        return 2
+
+    if not os.path.isdir(export_dir):
+        print(f"not a directory: {export_dir}", file=sys.stderr)
+        return 2
+    if not forbidden:
+        print("at least one --forbid path is required", file=sys.stderr)
+        return 2
+
+    problems = scan(export_dir, forbidden, allowed)
+    if problems:
+        print(f"check_no_local_paths: {len(problems)} leak(s) in {export_dir}", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print(f"check_no_local_paths: OK ({export_dir}: no local paths in any served file)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -97,6 +97,13 @@ async function main() {
       "--no-first-run",
       "--no-default-browser-check",
       "--disable-extensions",
+      // Never touch the OS credential store. Without these, a Chrome launched
+      // under an unfamiliar HOME (the fresh-checkout gate's isolated workspace)
+      // pops a MODAL "Keychain Not Found" dialog on macOS, which blocks
+      // navigation until a human dismisses it — the driver just sees
+      // Page.navigate hang until its timeout.
+      "--use-mock-keychain",
+      "--password-store=basic",
       "--hide-scrollbars",
       "--force-device-scale-factor=1",
       `--user-data-dir=${profileDir}`,

--- a/scripts/web/tree_checksum.py
+++ b/scripts/web/tree_checksum.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Deterministic checksum over a directory tree.
+
+Used as immutability evidence by the Web gates: `web_export_smoke.sh` proves the
+served export was not mutated by serving/driving it, and
+`web_fresh_checkout_smoke.sh` proves exporting never writes into the demo source
+tree. Both must agree byte-for-byte, so the algorithm lives in one file.
+
+The digest covers sorted (relative-path, contents) pairs, so it is stable across
+filesystems and platforms (macOS `shasum` vs Linux `sha256sum` never enter into
+it). Symlinks are hashed as their target string rather than followed, so a
+dangling or re-pointed link is a difference.
+
+Usage:
+    python3 tree_checksum.py <dir> [--exclude NAME]...
+
+`--exclude` drops a directory *name* anywhere in the tree (e.g. `.git`), which
+is what callers need for source trees carrying VCS or engine caches.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+
+
+def tree_checksum(root: str, exclude: frozenset[str] = frozenset()) -> str:
+    digest = hashlib.sha256()
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(name for name in dirnames if name not in exclude)
+        for name in sorted(filenames):
+            if name in exclude:
+                continue
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, root)
+            digest.update(rel.encode("utf-8"))
+            digest.update(b"\0")
+            if os.path.islink(path):
+                digest.update(b"symlink:")
+                digest.update(os.readlink(path).encode("utf-8"))
+            else:
+                with open(path, "rb") as handle:
+                    for chunk in iter(lambda: handle.read(65536), b""):
+                        digest.update(chunk)
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: tree_checksum.py <dir> [--exclude NAME]...", file=sys.stderr)
+        return 2
+    root = argv[0]
+    exclude: set[str] = set()
+    rest = argv[1:]
+    while rest:
+        if rest[0] != "--exclude" or len(rest) < 2:
+            print(f"unexpected argument: {rest[0]}", file=sys.stderr)
+            return 2
+        exclude.add(rest[1])
+        rest = rest[2:]
+    if not os.path.isdir(root):
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 2
+    print(tree_checksum(root, frozenset(exclude)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -103,25 +103,9 @@ fi
 
 # --- source-tree immutability: checksum the served tree before the run. -------
 tree_checksum() {
-  # Deterministic checksum over sorted (relative-path, sha256) pairs. Portable
-  # across macOS (shasum) and Linux CI (sha256sum) via python3.
-  python3 - "$1" <<'PY'
-import hashlib, os, sys
-root = sys.argv[1]
-digest = hashlib.sha256()
-for dirpath, dirnames, filenames in os.walk(root):
-    dirnames.sort()
-    for name in sorted(filenames):
-        path = os.path.join(dirpath, name)
-        rel = os.path.relpath(path, root)
-        digest.update(rel.encode("utf-8"))
-        digest.update(b"\0")
-        with open(path, "rb") as handle:
-            for chunk in iter(lambda: handle.read(65536), b""):
-                digest.update(chunk)
-        digest.update(b"\0")
-print(digest.hexdigest())
-PY
+  # Deterministic checksum over sorted (relative-path, contents) pairs, shared
+  # with the fresh-checkout gate so the two agree byte-for-byte (task 60g).
+  python3 "$WEB_DIR/tree_checksum.py" "$1"
 }
 
 CHECKSUM_BEFORE="$(tree_checksum "$EXPORT_DIR")"

--- a/scripts/web_fresh_checkout_smoke.sh
+++ b/scripts/web_fresh_checkout_smoke.sh
@@ -268,15 +268,23 @@ print(json.load(open(sys.argv[1])).get("protocolVersion", ""))
 ' "$export_dir/kanama-web/export-report.json")"
 
   # (3) The artifact runs: drive it with the harness from the fresh clone.
+  #
+  # The BUILD is what must be free of workstation state, not the browser: run the
+  # driver under the caller's real HOME so the browser behaves like a normal user
+  # session (its profile is a throwaway dir either way). Under the isolated HOME
+  # macOS pops a modal keychain dialog that silently blocks navigation.
   result_path=""
   driver_pass="null"
   if [[ "$SKIP_BROWSER" -eq 0 ]]; then
     result_path="$RESULT_DIR/$demo-$ENGINE.json"
-    if run "$KANAMA_DIR/scripts/web_export_smoke.sh" \
-      --engine "$ENGINE" \
-      --export-dir "$export_dir" \
-      --demo "$demo" \
-      --result "$result_path"; then
+    if (
+      export HOME="$CALLER_HOME"
+      run "$KANAMA_DIR/scripts/web_export_smoke.sh" \
+        --engine "$ENGINE" \
+        --export-dir "$export_dir" \
+        --demo "$demo" \
+        --result "$result_path"
+    ); then
       driver_pass="true"
     else
       echo "[web_fresh_checkout] $demo: export smoke FAILED on $ENGINE" >&2

--- a/scripts/web_fresh_checkout_smoke.sh
+++ b/scripts/web_fresh_checkout_smoke.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+#
+# web_fresh_checkout_smoke.sh -- fresh-source-checkout Web export gate (Task 60g, W3).
+#
+# Proves a Web export is reproducible from a CLEAN CLONE with nothing but a Godot
+# binary and the matching web_nothreads_release template: it clones Kanama (and
+# kanama-demos when an external demo is selected) into a throwaway workspace with
+# its own HOME, Gradle home and Maven-local, exports each requested demo from
+# that clone, and then asserts the three things W3 asks for:
+#
+#   1. the export succeeds with no workstation-absolute path in ANY served file
+#      (not just index.html, which exportWeb already checks),
+#   2. exporting never mutates the demo source tree (checksum + git status), and
+#   3. the exported artifact really runs -- the shipped export smoke drives it in
+#      a real browser out of the fresh clone, so the harness is proven to ship.
+#
+# It writes a machine-readable evidence file recording commits, checksums,
+# payload sizes and per-demo driver results, which is what a promotion review
+# reads. It never touches the caller's checkout, Gradle home or demo trees.
+#
+# Usage:
+#   scripts/web_fresh_checkout_smoke.sh \
+#       --template /path/to/web_nothreads_release.zip \
+#       [--demo web3d] [--demo match3] ... | [--demo all] \
+#       [--kanama-source URL_OR_PATH] [--demos-source URL_OR_PATH] \
+#       [--engine chrome|firefox|safari] [--skip-browser] \
+#       [--work-dir DIR] [--keep-work-dir] [--evidence FILE] \
+#       /path/to/godot
+#
+# Default demo set: web3d (in-repo fixture: proves the Kanama clone alone can
+# export) and match3 (external demo: proves the demos-checkout path).
+
+set -euo pipefail
+
+KANAMA_SOURCE="https://github.com/falcon4ever/kanama.git"
+DEMOS_SOURCE="https://github.com/falcon4ever/kanama-demos.git"
+TEMPLATE=""
+ENGINE="chrome"
+SKIP_BROWSER=0
+WORK_DIR="${KANAMA_WEB_FRESH_WORK_DIR:-}"
+KEEP_WORK_DIR="${KANAMA_WEB_FRESH_KEEP:-0}"
+EVIDENCE=""
+GODOT_BIN=""
+DEMOS=()
+CREATED_WORK_DIR=0
+
+ALL_DEMOS=(match3 bunnymark dodge web3d platformer squash fps charactercontroller thirdperson racing citybuilder tpsdemo)
+
+# demo key -> kanama-demos project directory. `web3d` is an in-repo fixture and
+# needs no demos checkout; its project dir is resolved by the build itself.
+demo_project_dir() {
+  case "$1" in
+    match3) echo "Starter-Kit-Match3" ;;
+    bunnymark) echo "Bunnymark" ;;
+    dodge) echo "godot-demo-2d-dodge-the-creeps" ;;
+    web3d) echo "" ;;
+    platformer) echo "Starter-Kit-3D-Platformer" ;;
+    squash) echo "godot-demo-3d-squash-the-creeps" ;;
+    fps) echo "Starter-Kit-FPS" ;;
+    charactercontroller) echo "godot-4-3d-character-controller-tutorial" ;;
+    thirdperson) echo "godot-4-3d-third-person-controller" ;;
+    racing) echo "Starter-Kit-Racing" ;;
+    citybuilder) echo "Starter-Kit-City-Builder" ;;
+    tpsdemo) echo "tps-demo-kanama" ;;
+    *) return 1 ;;
+  esac
+}
+
+# demo key -> the -PkanamaWeb<Key>ProjectDir gradle property the build reads.
+demo_project_property() {
+  case "$1" in
+    match3) echo "kanamaWebMatch3ProjectDir" ;;
+    bunnymark) echo "kanamaWebBunnymarkProjectDir" ;;
+    dodge) echo "kanamaWebDodgeProjectDir" ;;
+    web3d) echo "" ;;
+    platformer) echo "kanamaWebPlatformerProjectDir" ;;
+    squash) echo "kanamaWebSquashProjectDir" ;;
+    fps) echo "kanamaWebFpsProjectDir" ;;
+    charactercontroller) echo "kanamaWebCharactercontrollerProjectDir" ;;
+    thirdperson) echo "kanamaWebThirdpersonProjectDir" ;;
+    racing) echo "kanamaWebRacingProjectDir" ;;
+    citybuilder) echo "kanamaWebCitybuilderProjectDir" ;;
+    tpsdemo) echo "kanamaWebTpsdemoProjectDir" ;;
+    *) return 1 ;;
+  esac
+}
+
+die() {
+  echo "[web_fresh_checkout] $*" >&2
+  exit 2
+}
+
+usage() {
+  sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kanama-source) KANAMA_SOURCE="${2:?}"; shift 2 ;;
+    --demos-source) DEMOS_SOURCE="${2:?}"; shift 2 ;;
+    --template) TEMPLATE="${2:?}"; shift 2 ;;
+    --demo) DEMOS+=("${2:?}"); shift 2 ;;
+    --engine) ENGINE="${2:?}"; shift 2 ;;
+    --skip-browser) SKIP_BROWSER=1; shift ;;
+    --work-dir) WORK_DIR="${2:?}"; shift 2 ;;
+    --keep-work-dir) KEEP_WORK_DIR=1; shift ;;
+    --evidence) EVIDENCE="${2:?}"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    --*) die "unknown option: $1" ;;
+    *)
+      [[ -z "$GODOT_BIN" ]] || die "unexpected extra argument: $1"
+      GODOT_BIN="$1"; shift ;;
+  esac
+done
+
+[[ -n "$GODOT_BIN" ]] || die "missing Godot binary (positional argument)"
+[[ -x "$GODOT_BIN" ]] || die "Godot binary is not executable: $GODOT_BIN"
+[[ -n "$TEMPLATE" ]] || die "--template /path/to/web_nothreads_release.zip is required"
+[[ -f "$TEMPLATE" ]] || die "export template not found: $TEMPLATE"
+GODOT_BIN="$(cd "$(dirname "$GODOT_BIN")" && pwd)/$(basename "$GODOT_BIN")"
+TEMPLATE="$(cd "$(dirname "$TEMPLATE")" && pwd)/$(basename "$TEMPLATE")"
+
+if [[ "${#DEMOS[@]}" -eq 0 ]]; then
+  DEMOS=(web3d match3)
+elif [[ "${#DEMOS[@]}" -eq 1 && "${DEMOS[0]}" == "all" ]]; then
+  DEMOS=("${ALL_DEMOS[@]}")
+fi
+for demo in "${DEMOS[@]}"; do
+  demo_project_dir "$demo" >/dev/null || die "unknown --demo: $demo (expected one of: ${ALL_DEMOS[*]} | all)"
+done
+
+# Only clone kanama-demos when a selected demo actually lives there.
+NEED_DEMOS=0
+for demo in "${DEMOS[@]}"; do
+  if [[ -n "$(demo_project_dir "$demo")" ]]; then
+    NEED_DEMOS=1
+  fi
+done
+
+if [[ -z "$WORK_DIR" ]]; then
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kanama_web_fresh.XXXXXX")"
+  CREATED_WORK_DIR=1
+else
+  mkdir -p "$WORK_DIR"
+fi
+WORK_DIR="$(cd "$WORK_DIR" && pwd)"
+
+cleanup() {
+  if [[ "$CREATED_WORK_DIR" -eq 1 && "$KEEP_WORK_DIR" != "1" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+FRESH_HOME="$WORK_DIR/home"
+GRADLE_HOME="$WORK_DIR/gradle-home"
+MAVEN_REPO="$WORK_DIR/m2-repository"
+KANAMA_DIR="$WORK_DIR/kanama"
+DEMOS_DIR="$WORK_DIR/kanama-demos"
+RESULT_DIR="$WORK_DIR/results"
+RUNS_DIR="$WORK_DIR/runs"
+mkdir -p "$FRESH_HOME" "$GRADLE_HOME" "$MAVEN_REPO" "$RESULT_DIR" "$RUNS_DIR"
+
+if [[ -z "$EVIDENCE" ]]; then
+  EVIDENCE="$WORK_DIR/web-fresh-checkout-evidence.json"
+else
+  mkdir -p "$(dirname "$EVIDENCE")"
+  EVIDENCE="$(cd "$(dirname "$EVIDENCE")" && pwd)/$(basename "$EVIDENCE")"
+fi
+
+run() {
+  echo "[web_fresh_checkout] $*"
+  "$@"
+}
+
+checksum() {
+  python3 "$KANAMA_DIR/scripts/web/tree_checksum.py" "$@"
+}
+
+echo "[web_fresh_checkout] workspace: $WORK_DIR"
+echo "[web_fresh_checkout] demos: ${DEMOS[*]}"
+run git clone --quiet "$KANAMA_SOURCE" "$KANAMA_DIR"
+KANAMA_COMMIT="$(git -C "$KANAMA_DIR" rev-parse HEAD)"
+DEMOS_COMMIT=""
+if [[ "$NEED_DEMOS" -eq 1 ]]; then
+  run git clone --quiet "$DEMOS_SOURCE" "$DEMOS_DIR"
+  DEMOS_COMMIT="$(git -C "$DEMOS_DIR" rev-parse HEAD)"
+fi
+
+# Isolated build environment: nothing may reach the caller's HOME, Gradle caches
+# or Maven-local, or the run is not evidence of a fresh checkout.
+CALLER_HOME="$HOME"
+export HOME="$FRESH_HOME"
+export GRADLE_USER_HOME="$GRADLE_HOME"
+export KANAMA_MAVEN_LOCAL_REPO="$MAVEN_REPO"
+export GRADLE_OPTS="-Dmaven.repo.local=$MAVEN_REPO ${GRADLE_OPTS:-}"
+
+FAILED=0
+RUN_INDEX=0
+
+for demo in "${DEMOS[@]}"; do
+  RUN_INDEX=$((RUN_INDEX + 1))
+  echo "[web_fresh_checkout] === $demo ==="
+  project_subdir="$(demo_project_dir "$demo")"
+  project_property="$(demo_project_property "$demo")"
+
+  gradle_args=(
+    --no-daemon
+    -Pkotlin.compiler.execution.strategy=in-process
+    :web-runtime:exportWeb
+    "-PkanamaWebDemo=$demo"
+    "-PkanamaGodotExecutable=$GODOT_BIN"
+    "-PkanamaWebTemplateRelease=$TEMPLATE"
+  )
+
+  project_dir=""
+  source_before=""
+  if [[ -n "$project_subdir" ]]; then
+    project_dir="$DEMOS_DIR/$project_subdir"
+    [[ -d "$project_dir" ]] || die "$demo: demo project not found in the fresh clone: $project_dir"
+    gradle_args+=("-P$project_property=$project_dir")
+    source_before="$(checksum "$project_dir" --exclude .git --exclude .godot)"
+  fi
+  # Bunnymark's validated Web configuration is the 256-sprite V1Sprites variant.
+  if [[ "$demo" == "bunnymark" ]]; then
+    gradle_args+=("-PkanamaWebBunnymarkVariant=BunnymarkV1Sprites")
+  fi
+
+  run "$KANAMA_DIR/gradlew" -p "$KANAMA_DIR" "${gradle_args[@]}"
+
+  export_dir="$KANAMA_DIR/web-runtime/build/web-export/$demo"
+  [[ -f "$export_dir/index.html" ]] || die "$demo: export produced no index.html at $export_dir"
+
+  # (1) No workstation-absolute path in ANY served file. The workspace covers the
+  # clone and the fresh home; the caller's real home catches anything the build
+  # picked up from the machine it ran on.
+  if ! run python3 "$KANAMA_DIR/scripts/web/check_no_local_paths.py" "$export_dir" \
+    --forbid "$WORK_DIR" --forbid "$CALLER_HOME"; then
+    echo "[web_fresh_checkout] $demo: served export embeds local paths" >&2
+    FAILED=1
+  fi
+
+  # (2) Exporting must not have written into the demo source tree.
+  source_after=""
+  if [[ -n "$project_dir" ]]; then
+    source_after="$(checksum "$project_dir" --exclude .git --exclude .godot)"
+    if [[ "$source_before" != "$source_after" ]]; then
+      echo "[web_fresh_checkout] $demo: export MUTATED the demo source tree" >&2
+      git -C "$DEMOS_DIR" status --short >&2 || true
+      FAILED=1
+    fi
+    if [[ -n "$(git -C "$DEMOS_DIR" status --porcelain -- "$project_subdir")" ]]; then
+      echo "[web_fresh_checkout] $demo: demo checkout is dirty after export" >&2
+      git -C "$DEMOS_DIR" status --short -- "$project_subdir" >&2
+      FAILED=1
+    fi
+  fi
+
+  payload_bytes="$(python3 -c '
+import json, sys
+report = json.load(open(sys.argv[1]))
+print(report.get("totalBytes") or sum(f["bytes"] for f in report["files"]))
+' "$export_dir/kanama-web/export-report.json")"
+  protocol="$(python3 -c '
+import json, sys
+print(json.load(open(sys.argv[1])).get("protocolVersion", ""))
+' "$export_dir/kanama-web/export-report.json")"
+
+  # (3) The artifact runs: drive it with the harness from the fresh clone.
+  result_path=""
+  driver_pass="null"
+  if [[ "$SKIP_BROWSER" -eq 0 ]]; then
+    result_path="$RESULT_DIR/$demo-$ENGINE.json"
+    if run "$KANAMA_DIR/scripts/web_export_smoke.sh" \
+      --engine "$ENGINE" \
+      --export-dir "$export_dir" \
+      --demo "$demo" \
+      --result "$result_path"; then
+      driver_pass="true"
+    else
+      echo "[web_fresh_checkout] $demo: export smoke FAILED on $ENGINE" >&2
+      driver_pass="false"
+      FAILED=1
+    fi
+  fi
+
+  python3 -c '
+import json, sys
+out, demo, project, before, after, export_dir, payload, protocol, engine, result, passed = sys.argv[1:]
+run = {
+    "demo": demo,
+    "projectDir": project or "(in-repo fixture)",
+    "exportDir": export_dir,
+    "sourceChecksumBefore": before or None,
+    "sourceChecksumAfter": after or None,
+    "sourceImmutable": (before == after) if before else None,
+    "exportPayloadBytes": int(payload),
+    "protocolVersion": int(protocol) if protocol else None,
+    "engine": engine if result else None,
+    "resultPath": result or None,
+    "driverPass": {"true": True, "false": False, "null": None}[passed],
+}
+with open(out, "w") as handle:
+    json.dump(run, handle, indent=2)
+' "$RUNS_DIR/$(printf '%02d' "$RUN_INDEX")-$demo.json" \
+  "$demo" "${project_subdir:-}" "$source_before" "$source_after" "$export_dir" \
+  "$payload_bytes" "$protocol" "$ENGINE" "$result_path" "$driver_pass"
+done
+
+python3 - "$EVIDENCE" "$KANAMA_SOURCE" "$KANAMA_COMMIT" "$DEMOS_SOURCE" "$DEMOS_COMMIT" \
+  "$GODOT_BIN" "$TEMPLATE" "$FAILED" "$RUNS_DIR" <<'PY'
+import glob, json, os, subprocess, sys, datetime
+(path, kanama_source, kanama_commit, demos_source, demos_commit, godot, template, failed,
+ runs_dir) = sys.argv[1:]
+runs = [json.load(open(name)) for name in sorted(glob.glob(os.path.join(runs_dir, "*.json")))]
+godot_version = subprocess.run(
+    [godot, "--headless", "--version"], capture_output=True, text=True
+).stdout.strip().splitlines()[-1:]
+evidence = {
+    "schemaVersion": 1,
+    "gate": "web-fresh-checkout",
+    "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+    "kanama": {"source": kanama_source, "commit": kanama_commit},
+    "demos": {"source": demos_source, "commit": demos_commit or None},
+    "godot": {"binary": godot, "version": godot_version[0] if godot_version else None},
+    "template": template,
+    "runs": runs,
+    "pass": failed == "0",
+}
+with open(path, "w") as handle:
+    json.dump(evidence, handle, indent=2)
+    handle.write("\n")
+print(f"[web_fresh_checkout] evidence: {path}")
+PY
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "[web_fresh_checkout] FAIL" >&2
+  if [[ "$CREATED_WORK_DIR" -eq 1 && "$KEEP_WORK_DIR" != "1" ]]; then
+    echo "[web_fresh_checkout] re-run with --keep-work-dir to preserve $WORK_DIR" >&2
+  fi
+  exit 1
+fi
+
+echo "[web_fresh_checkout] PASS -- ${#DEMOS[@]} demo(s) exported from a fresh clone"


### PR DESCRIPTION
Half of promotion criterion **W3**: prove a Web export is reproducible by someone who is not this workstation. The packaged/addon path — the other half — is untouched and still listed as a limitation; see the note at the end.

## The gate

`scripts/web_fresh_checkout_smoke.sh` clones Kanama (and kanama-demos, when the selected demo lives there) into a throwaway workspace with its own `HOME`, Gradle home and Maven-local, exports each requested demo from that clone, and asserts:

1. **no workstation-absolute path in ANY served file** — `exportWeb` only checked `index.html`; this scans every served byte, engine JS and pck and Wasm payload included;
2. **the demo source tree is untouched** — checksummed before and after, plus `git status` on the demo checkout;
3. **the artifact actually runs** — the export smoke drives it in a real browser *using the harness from the fresh clone*, so the tooling is proven to ship, not just the payload.

It writes an evidence JSON (clone commits, per-demo checksums, payload sizes, protocol version, driver results) — the thing a promotion review reads.

Two helpers back it. `scripts/web/tree_checksum.py` is the directory digest, lifted out of `web_export_smoke.sh` so both gates' immutability evidence is the same algorithm by construction. `scripts/web/check_no_local_paths.py` does the byte scan and reports file + offset; all twelve existing corpus exports already pass it.

## Evidence

2026-07-27, Godot `4.7.stable.official.5b4e0cb0f`, clean clone into an isolated workspace — **web3d, match3 and dodge all PASS**, zero local paths, `sourceImmutable: true`, payloads 40.4 / 41.2 / 42.2 MB at protocol 15. `scripts/local_ci.sh` green (the smoke scaffold self-test, 10/10, covers the refactored checksum path).

## A real bug it flushed out

Under an unfamiliar `HOME` the driver's Chrome pops a **modal macOS "Keychain Not Found" dialog**, which blocks navigation until a human dismisses it — the driver only sees `Page.navigate` hang to its timeout, which reads like a flaky export. It cost two false failures on exports that pass. Fixed at the source: the driver now launches with `--use-mock-keychain --password-store=basic`, so no gate run can reach the credential store, and the fresh-checkout gate runs the browser step under the caller's real `HOME` (the isolation that matters is the *build's*; the browser profile is a throwaway dir either way).

## Docs

The Web export page still claimed protocol 6 and two validated demos. It now states the twelve-demo Chrome+Firefox evidence, carries the demo-key table, documents this gate, and scopes the Safari claim to what 57f actually validated. **No support claim moves — Web stays Experimental.**

## Still open for W3

For Web there is no runtime-only packaged shape: gameplay is AOT-compiled *into* the Wasm payload, so a packaged Web artifact must carry the compiling toolchain (Gradle-consumable runtime artifacts + the KSP processor + a project template), not an `addons/` drop-in like the desktop store add-on. There is also no generic "export any project" path yet — `exportWeb` is demo-keyed. Both need a decision; recorded in the task spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)