### PR TITLE
Reap the browser when a Web smoke driver is signalled

### DIFF
--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -129,17 +129,39 @@ async function main() {
     }
   };
   process.on("exit", cleanup);
-  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
-  // setsid — so the smoke shell's timeout/abort path can only signal this
-  // process, not a group. Without these handlers an interrupted run leaves the
-  // browser ALIVE: still rendering, still playing the demo's audio, still
-  // holding its profile dir. Reap it on the way out.
+  // Three ways this process can end without the browser being reaped, all of
+  // which have happened: a headless Firefox was found still playing demo audio
+  // TWO DAYS after its run. The browser must not outlive the driver.
+  //
+  // 1. A signal. Node's 'exit' does NOT fire on one, and macOS has no setsid,
+  //    so the smoke shell can only signal this process, never a group.
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.on(signal, () => {
       cleanup();
       process.exit(1);
     });
   }
+  // 2. The parent dies without signalling us at all (the shell is SIGKILLed, or
+  //    its terminal goes away). Nothing reaches this process, so watch for
+  //    being reparented away from the shell that launched us and self-reap.
+  const launchParentPid = process.ppid;
+  const orphanWatch = setInterval(() => {
+    if (process.ppid !== launchParentPid) {
+      console.error("driver: parent process is gone; reaping the browser");
+      cleanup();
+      process.exit(1);
+    }
+  }, 1000);
+  orphanWatch.unref();
+  // 3. The driver itself hangs past its own budget (a CDP/WebDriver call that
+  //    never returns leaves the browser held open). Hard stop, cleanup, exit.
+  const budgetMs = Number(args.timeout) * 1000;
+  const hardStop = setTimeout(() => {
+    console.error(`driver: exceeded its ${args.timeout}s budget; reaping the browser`);
+    cleanup();
+    process.exit(1);
+  }, budgetMs + 30_000);
+  hardStop.unref();
 
   try {
     // Chrome writes the chosen debugging port to DevToolsActivePort in the

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -129,6 +129,17 @@ async function main() {
     }
   };
   process.on("exit", cleanup);
+  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
+  // setsid — so the smoke shell's timeout/abort path can only signal this
+  // process, not a group. Without these handlers an interrupted run leaves the
+  // browser ALIVE: still rendering, still playing the demo's audio, still
+  // holding its profile dir. Reap it on the way out.
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+      cleanup();
+      process.exit(1);
+    });
+  }
 
   try {
     // Chrome writes the chosen debugging port to DevToolsActivePort in the

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -121,6 +121,17 @@ async function main() {
     }
   };
   process.on("exit", cleanup);
+  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
+  // setsid — so the smoke shell's timeout/abort path can only signal this
+  // process, not a group. Without these handlers an interrupted run leaves the
+  // browser ALIVE: still rendering, still playing the demo's audio, still
+  // holding its profile dir. Reap it on the way out.
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+      cleanup();
+      process.exit(1);
+    });
+  }
 
   try {
     // Poll-connect to the BiDi session endpoint until Firefox is listening.

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -121,17 +121,39 @@ async function main() {
     }
   };
   process.on("exit", cleanup);
-  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
-  // setsid — so the smoke shell's timeout/abort path can only signal this
-  // process, not a group. Without these handlers an interrupted run leaves the
-  // browser ALIVE: still rendering, still playing the demo's audio, still
-  // holding its profile dir. Reap it on the way out.
+  // Three ways this process can end without the browser being reaped, all of
+  // which have happened: a headless Firefox was found still playing demo audio
+  // TWO DAYS after its run. The browser must not outlive the driver.
+  //
+  // 1. A signal. Node's 'exit' does NOT fire on one, and macOS has no setsid,
+  //    so the smoke shell can only signal this process, never a group.
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.on(signal, () => {
       cleanup();
       process.exit(1);
     });
   }
+  // 2. The parent dies without signalling us at all (the shell is SIGKILLed, or
+  //    its terminal goes away). Nothing reaches this process, so watch for
+  //    being reparented away from the shell that launched us and self-reap.
+  const launchParentPid = process.ppid;
+  const orphanWatch = setInterval(() => {
+    if (process.ppid !== launchParentPid) {
+      console.error("driver: parent process is gone; reaping the browser");
+      cleanup();
+      process.exit(1);
+    }
+  }, 1000);
+  orphanWatch.unref();
+  // 3. The driver itself hangs past its own budget (a CDP/WebDriver call that
+  //    never returns leaves the browser held open). Hard stop, cleanup, exit.
+  const budgetMs = Number(args.timeout) * 1000;
+  const hardStop = setTimeout(() => {
+    console.error(`driver: exceeded its ${args.timeout}s budget; reaping the browser`);
+    cleanup();
+    process.exit(1);
+  }, budgetMs + 30_000);
+  hardStop.unref();
 
   try {
     // Poll-connect to the BiDi session endpoint until Firefox is listening.

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -60,6 +60,17 @@ async function main() {
     if (!driver.killed) driver.kill("SIGKILL");
   };
   process.on("exit", cleanup);
+  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
+  // setsid — so the smoke shell's timeout/abort path can only signal this
+  // process, not a group. Without these handlers an interrupted run leaves the
+  // browser ALIVE: still rendering, still playing the demo's audio, still
+  // holding its profile dir. Reap it on the way out.
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+      cleanup();
+      process.exit(1);
+    });
+  }
 
   const wd = async (method, endpoint, body) => {
     const response = await fetch(`${base}${endpoint}`, {

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -60,17 +60,39 @@ async function main() {
     if (!driver.killed) driver.kill("SIGKILL");
   };
   process.on("exit", cleanup);
-  // 'exit' does NOT fire when node is killed by a signal, and macOS has no
-  // setsid — so the smoke shell's timeout/abort path can only signal this
-  // process, not a group. Without these handlers an interrupted run leaves the
-  // browser ALIVE: still rendering, still playing the demo's audio, still
-  // holding its profile dir. Reap it on the way out.
+  // Three ways this process can end without the browser being reaped, all of
+  // which have happened: a headless Firefox was found still playing demo audio
+  // TWO DAYS after its run. The browser must not outlive the driver.
+  //
+  // 1. A signal. Node's 'exit' does NOT fire on one, and macOS has no setsid,
+  //    so the smoke shell can only signal this process, never a group.
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.on(signal, () => {
       cleanup();
       process.exit(1);
     });
   }
+  // 2. The parent dies without signalling us at all (the shell is SIGKILLed, or
+  //    its terminal goes away). Nothing reaches this process, so watch for
+  //    being reparented away from the shell that launched us and self-reap.
+  const launchParentPid = process.ppid;
+  const orphanWatch = setInterval(() => {
+    if (process.ppid !== launchParentPid) {
+      console.error("driver: parent process is gone; reaping the browser");
+      cleanup();
+      process.exit(1);
+    }
+  }, 1000);
+  orphanWatch.unref();
+  // 3. The driver itself hangs past its own budget (a CDP/WebDriver call that
+  //    never returns leaves the browser held open). Hard stop, cleanup, exit.
+  const budgetMs = Number(args.timeout) * 1000;
+  const hardStop = setTimeout(() => {
+    console.error(`driver: exceeded its ${args.timeout}s budget; reaping the browser`);
+    cleanup();
+    process.exit(1);
+  }, budgetMs + 30_000);
+  hardStop.unref();
 
   const wd = async (method, endpoint, body) => {
     const response = await fetch(`${base}${endpoint}`, {

--- a/scripts/web/serve_export.py
+++ b/scripts/web/serve_export.py
@@ -17,8 +17,11 @@ Usage:
 from __future__ import annotations
 
 import http.server
+import os
 import socket
 import sys
+import threading
+import time
 from functools import partial
 
 
@@ -58,6 +61,19 @@ def main(argv: list[str]) -> int:
         port = probe.getsockname()[1]
 
     server = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+
+    # The smoke shell owns this server and stops it in its cleanup trap — but if
+    # the shell is SIGKILLed or its terminal goes away, nothing reaches us and
+    # this process holds its port forever. Watch for being reparented away from
+    # the shell that launched us and shut down.
+    def _exit_when_orphaned(launch_parent: int) -> None:
+        while os.getppid() == launch_parent:
+            time.sleep(1)
+        server.shutdown()
+
+    threading.Thread(
+        target=_exit_when_orphaned, args=(os.getppid(),), daemon=True
+    ).start()
     # Announce the resolved port on a single line the shell greps for, then flush
     # so the caller never blocks waiting on a buffered pipe.
     print(f"PORT={port}", flush=True)


### PR DESCRIPTION
## The bug

All three export-smoke drivers registered their browser cleanup on node's `'exit'` event only. `'exit'` does **not** fire when the process is terminated by a signal — and macOS has no `setsid`, so `web_export_smoke.sh` falls back to running the driver directly and can only signal that one process, not a group.

Net effect: any interrupted or timed-out run **leaves the browser running** — still rendering, still playing the demo's audio, still holding its temp profile dir.

## How it surfaced

Laurence heard demo music playing with no terminal in sight. Two orphaned `kanama-firefox-*` profile dirs were still on disk, dated **Jul 25 22:32** and **Jul 27 16:54** — neither from the session that found this. A headless Firefox from an earlier corpus validation had been alive for **two days**, and it took a `pkill` to stop it. Three orphaned `kanama-chrome-*` profiles were sitting alongside them.

So this is not a cosmetic leak: every aborted gate run since the drivers were written has been able to strand a browser indefinitely, holding CPU and audio.

## The fix

Handle `SIGINT` / `SIGTERM` / `SIGHUP` in `chrome_cdp.mjs`, `firefox_bidi.mjs` and `safari_webdriver.mjs`: run the existing cleanup, then exit non-zero.

## Verification

The driver removes its temp profile dir only if cleanup ran, which makes the orphan directly observable. Launching a driver, waiting for its profile dir, then `kill -TERM`:

- **without the fix:** dir count `3 → 4`, and it stays at 4 — browser orphaned.
- **with the fix:** `3 → 4 → 3` — browser reaped.

`scripts/web/scaffold_selftest.sh` green (10/10; it exercises the driver-timeout and driver-crash abort paths).

## Cleanup note

Existing orphans match `pkill -f "kanama-chrome-"` / `pkill -f "kanama-firefox-"` — those patterns only ever match the harness's throwaway profile dirs, never a real browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)