### PR TITLE
Task 69: Match3 green on Safari (DPR board geometry) + reap automation Safari

### DIFF
--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -119,16 +119,23 @@ function findLegalSwap(tileGrid) {
 
 async function drag(pointer, evaluate, { x, y, dx, dy }) {
   // Board -> CSS client-pixel geometry is browser-agnostic; each driver's
-  // pointer() handles the protocol (and any device-pixel-ratio adjustment).
+  // pointer() handles the protocol.
+  //
+  // Godot's coordinate space here is CSS pixels, NOT the canvas backing store.
+  // Main.center_grid_on_screen() centres the board on get_viewport().
+  // get_visible_rect(), whose size is the canvas's CSS size, and the engine
+  // reports mouse positions in those same units (verified against
+  // CanvasItem.get_local_mouse_position: a click at CSS 538,186 reads back as
+  // 538,186 at devicePixelRatio 2). Deriving the board origin from
+  // canvas.width instead only agrees at devicePixelRatio 1 -- which is why this
+  // worked in headless Chrome/Firefox and put Safari's press two tiles off the
+  // intended cell with half the intended drag distance (task 69).
   const geometry = await evaluate(`(() => {
     const canvas = document.querySelector("canvas");
     const rect = canvas.getBoundingClientRect();
-    const boardX = canvas.width / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
-    const boardY = canvas.height / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
-    const toClient = (gx, gy) => ({
-      x: rect.left + gx * rect.width / canvas.width,
-      y: rect.top + gy * rect.height / canvas.height,
-    });
+    const boardX = rect.width / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
+    const boardY = rect.height / 2 - ((${BOARD} - 1) * ${OFFSET}) / 2;
+    const toClient = (gx, gy) => ({ x: rect.left + gx, y: rect.top + gy });
     return {
       press: toClient(boardX + ${x} * ${OFFSET}, boardY + ${y} * ${OFFSET}),
       release: toClient(boardX + (${x} + ${dx}) * ${OFFSET}, boardY + (${y} + ${dy}) * ${OFFSET}),

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -11,7 +11,7 @@
 // Args match the other drivers: --url --result --demo --timeout --source-checksum
 // --export-dir [--browser-binary(unused)].
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 
 import { runMatch3 } from "./demos/match3.mjs";
@@ -51,6 +51,28 @@ async function main() {
   const runDemo = DEMOS[args.demo];
   if (!runDemo) throw new Error(`safari_webdriver: unknown demo '${args.demo}'`);
 
+  // Killing safaridriver does NOT reap the Safari it drives: the automation
+  // Safari is not its child, so it survives and keeps its window, its port and
+  // its share of the GPU. Leftovers measurably degrade later runs (a Match3
+  // board that settles in 1s against a clean machine took over 400s with
+  // orphans present), which reads exactly like a flaky gate. Safari also has no
+  // headless mode, so there is no run without a window to leak.
+  //
+  // Attribute by difference: whatever automation Safari appears after we spawn
+  // safaridriver is ours. A concurrent Safari gate starting inside this window
+  // could be misattributed, so the drivers are not safe to run two-at-a-time on
+  // one machine -- which is already true of a gate that needs an unoccluded
+  // window.
+  const automationSafariPids = () => {
+    try {
+      return execFileSync("pgrep", ["-f", "Safari.*--automation"], { encoding: "utf8" })
+        .trim().split("\n").filter(Boolean);
+    } catch {
+      return []; // pgrep exits non-zero when nothing matches
+    }
+  };
+  const preexistingSafari = new Set(automationSafariPids());
+
   const port = 9500 + Math.floor(Math.random() * 400);
   const driver = spawn("safaridriver", ["-p", String(port)], { stdio: ["ignore", "pipe", "pipe"] });
   const base = `http://127.0.0.1:${port}`;
@@ -58,6 +80,14 @@ async function main() {
 
   const cleanup = () => {
     if (!driver.killed) driver.kill("SIGKILL");
+    for (const pid of automationSafariPids()) {
+      if (preexistingSafari.has(pid)) continue;
+      try {
+        process.kill(Number(pid), "SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
   };
   process.on("exit", cleanup);
   // Three ways this process can end without the browser being reaped, all of


### PR DESCRIPTION
Restores Safari to the automated Web matrix for Match3 — the single concrete failure that has kept Safari skipped by standing instruction since 57f, and the blocker on promotion criterion **W2**.

## The failure was the driver's geometry, not pointer synthesis

SafariDriver delivers the drag correctly. Captured DOM events show `pointerdown` at the press cell, interpolated moves, and `pointerup` at the target cell; on the engine side every crossing fires (`_input_event` on the tile, `_input` on `Main`, both `setCursor` calls). Hover picking lands on the intended tile.

`Main.center_grid_on_screen()` centres the board on the engine viewport, whose size is the canvas's **CSS** size, and Godot reports mouse positions in those same units. Verified directly by querying `CanvasItem.get_local_mouse_position` (opcode 27) after a synthesized move: a click at CSS `538,186` reads back as `538,186` at `devicePixelRatio` 2.

The driver instead derived the board origin from `canvas.width` — the DPR-scaled backing store. At DPR 1 the two agree, which is why headless Chrome and Firefox have always passed. On a Retina Safari the press landed **two tiles off** the intended cell and dragged **half** the intended distance, so `calculateSwipe` fell under its 32px threshold and silently did nothing — no error, no match, just a board that never changed.

## Reaping the automation Safari

Killing `safaridriver` does not stop the browser it drives; the automation Safari is not its child, so every run leaked one. Safari has no headless mode, so there is no run without a window to leak.

Leftovers are not cosmetic: a Match3 board that settles in ~1s on a clean machine took **over 400 seconds** with orphans present. That reads exactly like a flaky gate, and is most likely what the 57f-era investigation was actually seeing. This is the Safari half of the gap kanama#116 closed for Chrome and Firefox.

Attribution is by difference — any automation Safari appearing after we spawn `safaridriver` is ours — so two Safari gates must not run concurrently on one machine. That was already true of a gate needing an unoccluded window.

## Evidence (2026-07-27, protocol 15)

| demo | engine | result |
|---|---|---|
| match3 | **safari** (26.5 / WebKit 605.1.15, macOS 26.5.1) | **PASS** — 11/11 checks, `liveAfterTeardown` 0, `staleRejected` 2, 7.6s |
| match3 | chrome | PASS (regression — no-op at DPR 1) |
| match3 | firefox | PASS (regression — no-op at DPR 1) |

`scripts/web/scaffold_selftest.sh`: 10 passed, 0 failed. Reaping verified on both the normal-exit and signalled-abort paths.

## Scope

This is the Match3 blocker only. Still open on [task 69](../kanama-tasks/69-web-safari-gate.md) before W2 can be called MET: the remaining 11 demos have never been run on Safari, the Safari driver has no `keys` transport (`thirdperson` needs it outright, `charactercontroller` falls back to synthetic DOM events), and the Safari/WebKit version floors for macOS and iOS are not yet declared. No support claim is touched here.

One finding worth carrying into **60h**: Safari cannot be a headless CI matrix cell alongside Chrome and Firefox. It needs a logged-in GUI session with an unoccluded window, so it is structurally a local gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)