### PR TITLE
Report tpsdemo's smoke result in the envelope schema's shape (it never passed the wrapper gate)

### DIFF
--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -249,27 +249,54 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
 
   return {
     protocolVersion,
+    // The envelope schema (scripts/web/result_schema.py) requires startup
+    // {loaded, outcome, durationMs} plus the handles/crossings/callbacks/
+    // connections/scheduler/teardown sections. tpsdemo shipped a flat `metrics`
+    // bag instead, so web_export_smoke.sh rejected its result on EVERY engine
+    // and the demo never passed the wrapper gate -- only its own 13 driver
+    // checks, which is exactly the distinction the kickoff warns about. Same
+    // facts, reported in the shape the other eleven modules use.
     startup: {
-      startupDurationMs,
-      readyCount: level.readyCount,
       loaded: menu.mode === "tpsdemo",
+      outcome: menu.mode === "tpsdemo" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+      readyCount: level.readyCount,
     },
     checks,
-    boundaryErrors,
-    metrics: {
-      startupDurationMs,
-      displacement,
-      processCalls: peak.processCalls,
-      physicsCalls: peak.physicsCalls,
-      appliedCommands: peak.appliedCommands,
-      maxLiveHandles: peak.maxLiveHandles,
-      crossings: peak.crossings,
+    handles: {
+      liveAfterGameplay: peak.maxLiveHandles,
       liveAfterTeardown: torndown.liveHandles,
-      pendingCallbacks: torndown.callbacks,
-      pendingCoroutines: torndown.pending,
-      registeredJobs: torndown.jobs,
+      // tpsdemo has no stale-handle probe; teardown-to-zero is its invariant.
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: peak.crossings,
+      physicsProcessCalls: peak.physicsCalls,
+      processCalls: peak.processCalls,
+      appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(displacement.toFixed(3)),
       robotsSpawned: level.robotReady,
       deathPartsSpawned: level.partReady,
     },
+    callbacks: {
+      pendingSignalCallbacks: torndown.callbacks,
+    },
+    connections: {
+      afterTeardownLiveHandles: torndown.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: torndown.pending,
+      registeredJobs: torndown.jobs,
+    },
+    teardown: {
+      outcome:
+        checks.fullTeardownToZero && torndown.callbackErrors === 0 && torndown.failure === null
+          ? "clean"
+          : "incomplete",
+      ownerRegistriesToBaseline:
+        torndown.liveHandles === 0 && torndown.callbacks === 0 &&
+        torndown.pending === 0 && torndown.jobs === 0,
+    },
+    boundaryErrors,
   };
 }


### PR DESCRIPTION
Found while running the corpus on Safari for task 69. **It is not a Safari problem** — `web_export_smoke.sh` has never accepted a tpsdemo result on *any* engine, Chrome and Firefox included.

## What was wrong

`demos/tpsdemo.mjs` returned `startup: {startupDurationMs, readyCount, loaded}` and a flat `metrics` bag. `scripts/web/result_schema.py` requires `startup: {loaded, outcome, durationMs}` plus the `handles` / `crossings` / `callbacks` / `connections` / `scheduler` / `teardown` sections. Validation therefore rejected the envelope before it could be judged — first on `startup.outcome is required`, then on the missing sections. The other eleven modules all emit the required shape; tpsdemo is the only one that diverged.

## Why it matters

The demo itself was fine — 13/13 of its own driver checks pass, and always did. What was missing is exactly the distinction `WEB-NEXT-KICKOFF.md` warns about:

> Check the smoke wrapper's PASS line (schema enforces `liveAfterTeardown===0`), not just driver checks.

tpsdemo entered the corpus on driver evidence alone. And since the schema is what enforces `liveAfterTeardown === 0`, the single invariant the wrapper exists to guarantee was never actually checked for this demo. It does hold — `liveAfterTeardown` is 0 on all three engines — but that is now verified rather than assumed.

**This puts a hole in W1's evidence.** W1 was recorded MET on "all 12 demos, Chrome+Firefox"; the twelfth was passing its driver, not the gate. After this PR that claim is true as stated. No support claim is touched here.

## The change

No behavioural change — the same facts, reported under the section names the other eleven modules use. `staleRejected` is 0 (tpsdemo has no stale-handle probe; teardown-to-zero is its invariant), matching `racing.mjs`.

## Evidence (2026-07-27, protocol 15)

| engine | result |
|---|---|
| chrome | PASS — 13/13, `liveAfterGameplay` 352, `liveAfterTeardown` 0, teardown clean, 62.0s |
| firefox | PASS — 13/13, `liveAfterGameplay` 388, `liveAfterTeardown` 0, teardown clean, 151.8s |
| safari | PASS — 13/13, `liveAfterGameplay` 352, `liveAfterTeardown` 0, teardown clean, 13.0s |

First time tpsdemo has produced a wrapper PASS on any engine.

## Follow-up worth considering in 60h

Nothing stops this recurring: a demo module can diverge from the envelope contract and still look green to whoever runs its driver directly. A CI matrix that runs every demo through `web_export_smoke.sh` would have caught it on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)