### PR TITLE
Hold thirdperson's movement at engine level instead of browser keys (unblocks Safari)

### DIFF
--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -93,9 +93,20 @@ async function observe(evaluate, seed, windowMs, deadline, predicate) {
   return { last, peak };
 }
 
-export async function runThirdperson({ url, evaluate, navigate, keys, deadline }) {
-  const keyDown = keys ? () => keys("down", "w") : () => { throw new Error("thirdperson needs the keys transport"); };
-  const keyUp = keys ? () => keys("up", "w") : () => {};
+export async function runThirdperson({ url, evaluate, navigate, deadline }) {
+  // Engine-level action injection (ops 86/87) on the player's own handle, the
+  // same path racing and tpsdemo already use. Player.kt reads movement through
+  // Input.get_vector("move_left", "move_right", "move_up", "move_down"), and
+  // action_press bakes strength 1.0, so pressing move_up is what holding W
+  // expresses. This was the last driver still requiring a browser `keys`
+  // transport, which SafariDriver does not provide -- and browser key synthesis
+  // stalls headless Firefox anyway, so one injected path serves all engines.
+  const action = (opcode) =>
+    evaluate(
+      `globalThis.KanamaWebBridge.immediateObjectQuery(${opcode}, globalThis.KanamaWebBridge.tpPlayerHandle, "move_up"); true`,
+    );
+  const keyDown = () => action(86);
+  const keyUp = () => action(87);
 
   const startupStart = Date.now();
   trace("navigate");


### PR DESCRIPTION
Part of [task 69](../kanama-tasks/69-web-safari-gate.md) (**W2**). thirdperson was the last driver still requiring a browser `keys` transport, and it hard-failed without one:

```
safari_webdriver: Error: thirdperson needs the keys transport
```

SafariDriver provides no key transport, so this demo could never run on Safari at all.

## The change

Switch to the `action_press` / `action_release` path (ops 86/87) that `racing.mjs` and `tpsdemo.mjs` already use, on the player's own handle. `Player.kt` reads movement through `Input.get_vector("move_left", "move_right", "move_up", "move_down")`, and `action_press` bakes strength 1.0, so pressing `move_up` is exactly what holding W expressed.

This is the direction `WEB-NEXT-KICKOFF.md` already recommends — browser key synthesis stalls the headless-Firefox main thread — and it collapses three per-engine input paths into one. No protocol change: opcodes 86/87 have existed since 60c.

## Evidence (2026-07-27, protocol 15)

| engine | result |
|---|---|
| chrome | PASS — 11/11, `liveAfterTeardown` 0, teardown clean, 22.9s |
| firefox | PASS — 11/11, `liveAfterTeardown` 0, teardown clean, 90.7s |
| safari | PASS — 11/11, `liveAfterTeardown` 0, teardown clean, 9.0s — **first Safari run of this demo** |

## Corpus status on Safari

With this and kanama#117 (Match3 geometry) and kanama#118 (tpsdemo envelope), **all 12 corpus demos now pass `web_export_smoke.sh --engine safari`** at protocol 15. Version floors and the docs changes that W2 needs are still to come; no support claim is touched here.

`charactercontroller` still uses browser keys with a DOM-event fallback and passes on all three engines, so it is deliberately left alone — converging it onto the injected path is a consistency follow-up, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)