### PR TITLE
Docs: Safari joins the gated Web matrix; declare validated browser versions

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -31,15 +31,19 @@ crossings, mirrors state in snapshots, and tracks handles by generation.
 
 ## What Works
 
-Two production Godot 4.7 Web exports pass an automated, assertion-driven play
-sequence (not a page-load check) in headless **Chrome 150**, **Firefox 153**,
-and **Safari 26.5**:
+A twelve-demo corpus of production Godot 4.7 Web exports passes an automated,
+assertion-driven play sequence (not a page-load check) in headless
+**Chrome 150**, headless **Firefox 153**, and **Safari 26.5** (WebKit 605.1.15;
+Safari has no headless mode, so it runs windowed on a GUI session). Two
+representative members:
 
 - **Bunnymark** — 256 sprites, one bounded position batch, and deterministic
   257-to-zero handle teardown.
 - **Match3** (`Starter-Kit-Match3`) — original board, a runtime-selected legal
   swap, match/collapse/refill, particles, audio, restart, and two full
   zero-state teardowns.
+
+The full list is in [Exporting → Web](../exporting/web.md).
 
 Each run asserts gameplay deltas, crossing budgets, and handle/callback/scheduler
 teardown to baseline, and fails on stale-handle use.
@@ -192,9 +196,12 @@ error checks, and protocol-version match.
 
 Browser-specific notes:
 
-- **Safari** WebDriver input needs device-pixel-ratio-aware conversion from
-  Godot's logical canvas to trusted pointer coordinates, or the Retina backing
-  store targets the wrong tile. SafariDriver does not expose the legacy browser
+- **Safari** exposes Retina coordinate bugs the other engines hide. Godot's
+  coordinate space and W3C pointer coordinates are both **CSS pixels**, so a
+  driver must derive on-screen geometry from `getBoundingClientRect()`. Deriving
+  it from `canvas.width` — the `devicePixelRatio`-scaled backing store — happens
+  to agree at DPR 1, so it passes headless Chrome/Firefox and targets the wrong
+  tile on a Retina Safari. SafariDriver also does not expose the legacy browser
   log endpoint, so the Safari gate asserts bridge callback/failure telemetry
   plus every gameplay and teardown invariant.
 - **Firefox** collects console errors through BiDi `log.entryAdded`.

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -12,15 +12,18 @@ still being hardened, and there is no packaged install path yet.
 **Evidence.** The full twelve-demo corpus — Bunnymark, Starter-Kit-Match3, dodge,
 web3d, 3D-Platformer, squash, FPS, character-controller, third-person, Racing,
 City-Builder and tps-demo — passes the automated production export smoke in
-**Chrome** (the CI gate) and **Firefox**, each with a play-and-teardown driver
-run, zero console errors, and live handles draining to zero. Every corpus export
-is also proven to embed no build-machine paths in any served file, and to be
-reproducible from a clean clone (see [Fresh-Checkout Gate](#fresh-checkout-gate)).
+**Chrome** (the CI gate), **Firefox**, and **Safari**, each with a
+play-and-teardown driver run, zero console errors, and live handles draining to
+zero. Every corpus export is also proven to embed no build-machine paths in any
+served file, and to be reproducible from a clean clone (see
+[Fresh-Checkout Gate](#fresh-checkout-gate)).
 
-**Safari** is not part of the gated matrix: as of the 57f validation Bunnymark
-passed the automated Safari gate and Match3 was verified by hand, but
-SafariDriver cannot reliably synthesize Match3's drag, so the wider corpus is not
-Safari-gated — see Known Limitations.
+**Validated browser versions** (2026-07-27, protocol 15): Chrome 150 (headless),
+Firefox 153 (headless), and **Safari 26.5 / WebKit 605.1.15 on macOS 26.5.1**.
+These are the versions the corpus has actually been driven on, not a tested
+lower bound — no older release has been validated. **iOS and iPadOS have not
+been validated at all**; `safaridriver` drives desktop Safari only, so no
+mobile-WebKit claim is made here.
 
 This page is the reproducible export workflow. For the architecture — batching,
 snapshots, handle generations, the bridge protocol — see
@@ -196,10 +199,24 @@ commits, per-demo checksums, payload sizes, protocol version and driver results.
   `--disable-gpu`, which disables it. It collects console/exception events.
 - **Firefox** — driven over WebDriver BiDi; console errors via
   `log.entryAdded`.
-- **Safari** — driven over WebDriver. SafariDriver exposes no browser-log
-  endpoint, so the Safari gate asserts bridge callback/telemetry plus every
-  gameplay and teardown invariant, and needs device-pixel-ratio-aware pointer
-  coordinates.
+- **Safari** — driven over classic W3C WebDriver; needs a one-time
+  `safaridriver --enable` and "Allow Remote Automation" in the Develop menu.
+  SafariDriver exposes no browser-log endpoint, so the Safari gate asserts bridge
+  callback/telemetry plus every gameplay and teardown invariant. Three traps,
+  all of which have cost real debugging time:
+    - **Retina coordinates.** Pointer coordinates are CSS client pixels (W3C),
+      and Godot's own coordinate space is CSS pixels too. A driver that derives
+      screen geometry from `canvas.width` — the `devicePixelRatio`-scaled
+      backing store — is correct only at DPR 1, so it passes headless
+      Chrome/Firefox and silently misses on a Retina Safari. Use
+      `getBoundingClientRect()`.
+    - **One `POST /actions` per gesture.** SafariDriver dispatches a pointer
+      sequence on the trailing `DELETE /actions`, and does not carry pointer
+      position across requests — a press sent in its own request lands at
+      `0,0`. Put the whole press/move/release in a single request.
+    - **The browser outlives its driver.** The automation Safari is not a child
+      of `safaridriver`, so killing the driver leaks it; the driver reaps it by
+      PID instead.
 
 ## Renderer And Thread Constraints
 
@@ -222,13 +239,13 @@ commits, per-demo checksums, payload sizes, protocol version and driver results.
 
 ## Known Limitations
 
-- **Safari is not in the gated matrix.** Chrome and Firefox gate every corpus
-  demo; Safari coverage stops at the 57f Bunnymark/Match3 validation below.
-- **Safari automated Match3 drag.** The Match3 export runs correctly in Safari by
-  hand, but SafariDriver's synthesized pointer drag does not reliably trigger the
-  swipe in the automated gate (coordinates and Godot picking are correct; the
-  drag-to-swipe is a WebDriver synthesis limitation). The automated Safari gate
-  covers Bunnymark; Safari Match3 is a manual local check.
+- **Safari cannot run headless.** Chrome and Firefox gate the corpus headless, so
+  they run unattended; `safaridriver` drives a real Safari window on a logged-in
+  GUI session. The Safari gate is therefore a **local** gate, not a CI cell, and
+  two Safari runs must not be started concurrently on one machine.
+- **Safari on iOS/iPadOS is unvalidated.** Every iOS browser is WebKit, but
+  `safaridriver` covers desktop Safari only. No mobile-WebKit version floor is
+  claimed.
 - **Lifecycle virtuals are limited to what the proxy dispatches**: `_ready`,
   `_process`, `_physics_process`, `_draw`, `_exit_tree`, `_input`, and
   `_unhandled_input`. Anything else — `@OnEnterTree` in particular — is rejected

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -13,7 +13,7 @@ page records the platforms and engine versions validated for it.
 | Linux x86_64 | Supported (4.7 stable) | Full local CI, native bootstrap preflight, strict docs, all 11 demo builds, the nine-demo desktop smoke matrix, TPS checked smoke, distribution packaging, and desktop-kit/store-addon install smokes passed on Ubuntu 25.04 with Godot `4.7.stable.official.5b4e0cb0f` and OpenJDK 25.0.2 (2026-07-13/14). The resource-loader/saver teardown fix is required. Packaged desktop exports remain a separate release-readiness track. |
 | Windows x86_64 | Supported (4.7 stable) | Full local revalidation on the 4.7 stable console binary (2026-07-13): demo audits, script builds, imports, the nine-demo desktop runtime smoke, the TPS smoke, and the packaged desktop-kit + store-addon install smokes all passed. Gradle commands that build the native bootstrap run from a VS 2022 developer environment (VsDevCmd); Git Bash runs the smoke scripts. |
 | iOS (Kotlin/Native backend) | Supported (4.7 stable) | Promoted from Experimental 2026-07-14 (§7 mobile promotion bar B1–B4 MET). The iOS backend runs full Kanama project scripts via a C shim + Kotlin/Native static `.xcframework`, using the same wrapper generator as desktop/Android (no JVM on device). Full device gate (9-demo matrix + fresh-project install path) passed on two models: **iPhone 12** (iOS 26.5, 2026-06-25; 0 guardrail failures) + **iPhone 15 Pro** (iOS 26.5, 2026-07-10, full-breadth wrapper runtime), both on 4.7 stable iOS templates. Packaged `.xcframework` addon is runtime-only (compiling project scripts needs the Kanama checkout; ~199.5 MB debug / ~87.6 MB release static `.a`). No mobile hot reload. One FPS Audio autoload follow-up + task-26 multiplayer UI polish tracked as non-blocking — see [exporting/ios.md](../exporting/ios.md). |
-| Web | Experimental (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs the Bunnymark and Match3 production exports in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge, with a reproducible source-checkout export workflow ([guide](../exporting/web.md)). **Not a Supported target: source-checkout export only (no packaged addon), single-thread Compatibility renderer, 2-demo corpus.** See §Web below. |
+| Web | Experimental (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs a twelve-demo production-export corpus in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge, with a reproducible source-checkout export workflow ([guide](../exporting/web.md)). **Not a Supported target: source-checkout export only (no packaged addon), single-thread Compatibility renderer, desktop browsers only (iOS/iPadOS WebKit unvalidated).** See §Web below. |
 
 Validated support is only claimed after the matching smoke path passes.
 Use the
@@ -104,20 +104,19 @@ stays in sync with desktop/Android).
 ## Web
 
 Web is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable baseline. It
-is **not a Supported target**: it is a source-checkout export of the two validated
-demos (no packaged addon), single-thread Compatibility renderer only, and makes no
-support claim. A user-facing export guide is at
-[Exporting → Web](../exporting/web.md). The two demos pass the automated production
-export smoke in Chrome and Firefox; in Safari, Bunnymark passes automatically and
-Match3 is verified by hand (a SafariDriver drag-synthesis limitation, not a runtime
-defect). This supersedes the earlier note that ruled Web out entirely.
+is **not a Supported target**: it is a source-checkout export (no packaged addon),
+single-thread Compatibility renderer only, and makes no support claim. A
+user-facing export guide is at [Exporting → Web](../exporting/web.md). The
+twelve-demo corpus passes the automated production export smoke in Chrome,
+Firefox, and Safari. This supersedes the earlier note that ruled Web out
+entirely.
 
 Unlike desktop/Android/iOS, the Web backend does **not** use a JVM or an
 FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles
 to WebAssembly and talks to the Godot 4.7 Web export (Emscripten/Wasm) through a
 generated per-call proxy and a versioned JavaScript bridge
 (`web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js`, protocol version
-6). The typed backend seam is shared with the other platforms through
+15). The typed backend seam is shared with the other platforms through
 `scripts/platform_backend_calls.json`, and
 `scripts/generate_web_gameplay_coverage.py` fails loudly if a call the demo
 executes has no admitted backend family. See
@@ -125,26 +124,37 @@ executes has no admitted backend family. See
 
 ### Validated evidence
 
-Two production Godot Web exports pass an automated, assertion-driven play
-sequence — not a page-load check — in three browsers:
+Twelve production Godot Web exports — Bunnymark, Starter-Kit-Match3, dodge,
+web3d, 3D-Platformer, squash, FPS, character-controller, third-person, Racing,
+City-Builder and tps-demo — each pass an automated, assertion-driven play
+sequence, not a page-load check. Every run asserts gameplay deltas, crossing
+budgets, and handle/callback/scheduler teardown to baseline, and rejects stale
+handles. Gameplay coverage reports zero blocking calls;
+`GodotObject.emit_signal_typed` remains visible as one explicit nonblocking
+unsupported family rather than being pattern-hidden.
 
-- **Match3** (`Starter-Kit-Match3`): original board, a runtime-selected legal
-  swap, match/collapse/refill, particles, audio, restart, and two full
-  zero-state teardowns.
-- **Bunnymark**: 256 sprites, one bounded position batch, and deterministic
-  257-to-zero handle teardown.
+Browser versions validated, all at protocol 15 on 2026-07-27:
 
-Browsers (headless): **Chrome 150**, **Firefox 153**, and **Safari 26.5**. Each
-run asserts gameplay deltas, crossing budgets, and handle/callback/scheduler
-teardown to baseline, and rejects stale handles. Gameplay coverage reports zero
-blocking calls; `GodotObject.emit_signal_typed` remains visible as one explicit
-nonblocking unsupported family rather than being pattern-hidden.
+| Browser | Version | Notes |
+|---|---|---|
+| Chrome | 150 (headless) | the CI gate |
+| Firefox | 153 (headless) | local gate |
+| Safari | 26.5 / WebKit 605.1.15, macOS 26.5.1 | local gate; **no headless mode**, so it needs a logged-in GUI session |
+
+These are the versions actually driven, **not tested lower bounds** — no older
+release has been validated, so treat each as "validated at", not "supported
+from". **iOS and iPadOS are unvalidated**: `safaridriver` drives desktop Safari
+only, and no mobile-WebKit floor is claimed.
 
 ### Explicit non-support limitations
 
-- No packaged/user export workflow and no `exporting/web.md` guide yet.
+- No packaged/user export workflow: export requires a Kanama source checkout,
+  and there is no runtime-only addon (gameplay is AOT-compiled into the Wasm
+  payload). The guide is at [Exporting → Web](../exporting/web.md).
 - Godot **Compatibility renderer, single-thread** only.
 - No Web editor, no hot reload, no threads, no Kotlin/JS path.
+- Safari has **no headless mode**, so the Safari gate is a local GUI gate rather
+  than a CI cell; iOS/iPadOS WebKit is unvalidated.
 - Reproducible export builds currently require
   `--no-daemon -Pkotlin.compiler.execution.strategy=in-process` (Kotlin daemon
   builds exhausted memory).


### PR DESCRIPTION
Documentation half of [task 69](../kanama-tasks/69-web-safari-gate.md) (**W2**), on top of kanama#117, #118 and #119.

## What changed

The corpus now passes on Safari, so the two Safari limitations are removed. The second of them was simply **wrong**: SafariDriver always delivered the drag correctly — captured DOM events land at the right coordinates and every Godot crossing fires — and the fault was the driver's own Retina geometry (kanama#117). Leaving that claim in the docs would have kept sending the next reader down the wrong path.

**Validated versions, not invented floors.** Chrome 150, Firefox 153, Safari 26.5 / WebKit 605.1.15 on macOS 26.5.1 — all at protocol 15 on 2026-07-27. The docs state explicitly that these are the versions *actually driven*, **not tested lower bounds**: "validated at", not "supported from". No older release has been tried, so no floor is claimed below them.

**iOS/iPadOS is called out as unvalidated.** `safaridriver` drives desktop Safari only. Since every iOS browser is WebKit, this is a real gap rather than a footnote, and task 69's exit gate asks for an iOS floor that this work cannot supply.

Two structural facts are now recorded where they'll be read:

- **Safari has no headless mode**, so its gate is a local GUI gate, not a CI cell. This directly constrains the browser matrix 60h is meant to build — it can't be three equivalent cells.
- **The three SafariDriver traps** found while fixing the gate: CSS-pixel coordinates (not the DPR-scaled backing store), one `POST /actions` per gesture (pointer position does not survive across requests — a press in its own request lands at `0,0`), and the automation Safari outliving its driver.

## Incidental corrections

These edits sat directly on top of stale claims, so they are fixed rather than left to contradict the text around them: the corpus is **twelve** demos, not two (`version-support.md` and `web-internals.md` both still said two), the bridge protocol is **15**, not 6, and `exporting/web.md` exists (it was listed as a missing deliverable).

## Not in this PR

**No support claim moves — Web stays Experimental.** The Experimental → Supported wording only moves in `60i-web-supported-release-decision.md` once W1–W4 are each MET with dated evidence.

`mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)