### PR TITLE
Gate the Web corpus in CI: Chrome + Firefox browser matrix (Task 60h)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -181,11 +181,96 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: web-matrix-evidence
+          name: web-matrix-evidence-${{ github.run_attempt }}
           # Result envelopes, driver logs and server logs -- everything needed to
           # triage a red cell without re-running it.
           path: |
             ${{ runner.temp }}/web-matrix/*.json
             ${{ runner.temp }}/web-matrix/*.log
             ${{ runner.temp }}/web-matrix/runs/*.json
+          if-no-files-found: warn
+
+  # The long-run leak gate. Nightly only: it costs ten minutes of wall clock and
+  # answers a question a per-PR run cannot ask -- does the handle registry still
+  # sit at a fixed working set after hundreds of node create/free cycles?
+  soak:
+    name: soak (leak gate, chrome)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Kanama
+        uses: actions/checkout@v6
+
+      - name: Checkout kanama-demos (pinned)
+        uses: actions/checkout@v6
+        with:
+          repository: falcon4ever/kanama-demos
+          ref: ${{ env.DEMOS_REF }}
+          path: kanama-demos
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Cache Godot binary and Web export template
+        id: godot-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/godot
+          key: godot-web-${{ env.GODOT_VERSION }}-linux-x86_64
+
+      - name: Download Godot and the Web export template
+        if: steps.godot-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/godot"
+          godot_zip="$(mktemp)"
+          curl -fL -o "$godot_zip" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q "$godot_zip" -d "$HOME/godot"
+          rm -f "$godot_zip"
+          tpz="$(mktemp)"
+          curl -fL -o "$tpz" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_export_templates.tpz"
+          unzip -q -j "$tpz" "templates/web_nothreads_release.zip" -d "$HOME/godot"
+          rm -f "$tpz"
+
+      - name: Run the soak gate
+        shell: bash
+        env:
+          KANAMA_WEB_SOAK_SECONDS: "600"
+        run: |
+          godot_bin="$HOME/godot/Godot_v${GODOT_VERSION}_linux.x86_64"
+          chmod +x "$godot_bin"
+          scripts/web_ci_matrix.sh \
+            --godot "$godot_bin" \
+            --template "$HOME/godot/web_nothreads_release.zip" \
+            --demos-dir "$GITHUB_WORKSPACE/kanama-demos" \
+            --demo soak \
+            --engine chrome \
+            --result-dir "$RUNNER_TEMP/web-soak" \
+            --evidence "$RUNNER_TEMP/web-soak/evidence.json" \
+            --summary-md "$RUNNER_TEMP/web-soak/summary.md"
+
+      - name: Publish soak summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/web-soak/summary.md" ]; then
+            cat "$RUNNER_TEMP/web-soak/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload soak evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-soak-evidence-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/web-soak/*.json
+            ${{ runner.temp }}/web-soak/*.log
+            ${{ runner.temp }}/web-soak/runs/*.json
           if-no-files-found: warn

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -151,6 +151,9 @@ jobs:
         shell: bash
         env:
           DEMO_SET: ${{ github.event.inputs.demo_set || (github.event_name == 'pull_request' && 'pr' || 'full') }}
+          # Per-sample driver tracing into the uploaded driver logs. A red cell on a
+          # host nobody can log into is only as debuggable as what it recorded.
+          KANAMA_WEB_SMOKE_DEBUG: "1"
         run: |
           godot_bin="$HOME/godot/Godot_v${GODOT_VERSION}_linux.x86_64"
           chmod +x "$godot_bin"
@@ -243,6 +246,7 @@ jobs:
         shell: bash
         env:
           KANAMA_WEB_SOAK_SECONDS: "600"
+          KANAMA_WEB_SMOKE_DEBUG: "1"
         run: |
           godot_bin="$HOME/godot/Godot_v${GODOT_VERSION}_linux.x86_64"
           chmod +x "$godot_bin"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,191 @@
+name: web
+
+# Web browser matrix (Task 60h, promotion criterion W4).
+#
+# Exports demos to Web and drives each one in a real browser through
+# `scripts/web_ci_matrix.sh`, which routes every cell through
+# `web_export_smoke.sh` so the versioned result envelope -- not a driver's own
+# check count -- decides green.
+#
+# Cadence:
+#   - pull_request  -> the PR subset (match3, web3d, dodge) x Chrome + Firefox.
+#   - push to main  -> the full 12-demo corpus x Chrome + Firefox.
+#   - nightly       -> the full corpus, to catch browser-side regressions on a
+#                      tree that has not changed.
+#
+# Safari is NOT a cell here and cannot become one: it has no headless mode, needs
+# a logged-in GUI session with an unoccluded window, and two concurrent Safari
+# gates defeat the driver's PID-diff browser reaping. It is a documented local
+# pre-promotion gate -- see docs/exporting/web.md.
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  schedule:
+    # 04:20 UTC daily; off the hour to avoid the scheduler's peak queue.
+    - cron: "20 4 * * *"
+  workflow_dispatch:
+    inputs:
+      demo_set:
+        description: "Which corpus slice to run"
+        type: choice
+        default: full
+        options: [pr, full]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Dash form of kanamaGodotVersion in gradle.properties (the single-source pin).
+  GODOT_VERSION: 4.7-stable
+  # The kanama-demos commit the matrix runs against. Pinned on purpose: an
+  # unpinned demos checkout means an unrelated demo-repo commit can redden every
+  # Kanama PR. Bump it deliberately when a demo port lands (see
+  # docs/exporting/web.md, "Bumping the demos pin").
+  DEMOS_REF: 535082f3a7b806ab9def598207ee1bd21498f415
+
+jobs:
+  # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job
+  # reports "skipped", which satisfies a required status check.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Web-relevant changes
+        id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "non-PR event -> running the Web matrix"
+            exit 0
+          fi
+          changed="$(git diff --name-only '${{ github.event.pull_request.base.sha }}'...HEAD)"
+          echo "changed files:"; echo "$changed"
+          # web-runtime and the shared contract are obvious; processor/ emits the
+          # per-proxy GDScript, kanama-common-api carries the opcode table, and
+          # scripts/web + the two smoke shells are the harness itself.
+          if printf '%s\n' "$changed" | grep -qE '^(web-runtime/|kanama-common-api/|processor/|annotations/|scripts/web/|scripts/web_.*\.sh|scripts/generate_web_backend\.py|scripts/platform_backend_calls\.json|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/web\.yml)'; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "web=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  matrix:
+    name: web matrix (chrome + firefox)
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-24.04
+    # The full corpus is 12 Kotlin/Wasm exports plus 24 driven browser sessions
+    # on a software GL; the PR subset is a small fraction of that.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 90 || 300 }}
+    steps:
+      - name: Checkout Kanama
+        uses: actions/checkout@v6
+
+      - name: Checkout kanama-demos (pinned)
+        uses: actions/checkout@v6
+        with:
+          repository: falcon4ever/kanama-demos
+          ref: ${{ env.DEMOS_REF }}
+          path: kanama-demos
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Install CLI dependencies
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
+
+      - name: Report browser versions
+        shell: bash
+        run: |
+          google-chrome --version
+          firefox --version
+
+      - name: Cache Godot binary and Web export template
+        id: godot-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/godot
+          key: godot-web-${{ env.GODOT_VERSION }}-linux-x86_64
+
+      - name: Download Godot and the Web export template
+        if: steps.godot-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/godot"
+          godot_zip="$(mktemp)"
+          curl -fL -o "$godot_zip" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q "$godot_zip" -d "$HOME/godot"
+          rm -f "$godot_zip"
+          # The export templates ship as one archive; the Web export needs only
+          # the nothreads release template, which is the configuration Kanama
+          # exports (single-thread Compatibility).
+          tpz="$(mktemp)"
+          curl -fL -o "$tpz" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_export_templates.tpz"
+          unzip -q -j "$tpz" "templates/web_nothreads_release.zip" -d "$HOME/godot"
+          rm -f "$tpz"
+
+      - name: Run the Web matrix
+        shell: bash
+        env:
+          DEMO_SET: ${{ github.event.inputs.demo_set || (github.event_name == 'pull_request' && 'pr' || 'full') }}
+        run: |
+          godot_bin="$HOME/godot/Godot_v${GODOT_VERSION}_linux.x86_64"
+          chmod +x "$godot_bin"
+          # A GitHub-hosted runner is slower than the workstation these budgets
+          # were measured on, and its GL is software-only: scale, do not edit the
+          # per-demo budgets, so local and CI numbers stay comparable.
+          scripts/web_ci_matrix.sh \
+            --godot "$godot_bin" \
+            --template "$HOME/godot/web_nothreads_release.zip" \
+            --demos-dir "$GITHUB_WORKSPACE/kanama-demos" \
+            --demo-set "$DEMO_SET" \
+            --engine chrome \
+            --engine firefox \
+            --timeout-scale 2 \
+            --result-dir "$RUNNER_TEMP/web-matrix" \
+            --evidence "$RUNNER_TEMP/web-matrix/evidence.json" \
+            --summary-md "$RUNNER_TEMP/web-matrix/summary.md"
+
+      - name: Publish matrix summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/web-matrix/summary.md" ]; then
+            cat "$RUNNER_TEMP/web-matrix/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload matrix evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-matrix-evidence
+          # Result envelopes, driver logs and server logs -- everything needed to
+          # triage a red cell without re-running it.
+          path: |
+            ${{ runner.temp }}/web-matrix/*.json
+            ${{ runner.temp }}/web-matrix/*.log
+            ${{ runner.temp }}/web-matrix/runs/*.json
+          if-no-files-found: warn

--- a/docs/contributing/godot-upgrade.md
+++ b/docs/contributing/godot-upgrade.md
@@ -128,6 +128,14 @@ mkdocs build --strict
 ./scripts/local_ci.sh /absolute/path/to/new_godot_binary
 ```
 
+A Godot bump also **invalidates the Web evidence**: the export template, the
+generated proxy and the bridge protocol all move with it, and CI's Web matrix
+only covers Chrome and Firefox. Re-run the full corpus on all three browsers,
+including the Safari local gate, and re-run the fresh-checkout gate against a
+clone built on the new pin — see
+[Regression cadence](../exporting/web.md#regression-cadence) for exactly which
+gate runs when.
+
 ## Dry Run
 
 The pipeline can be exercised against the **current** pin as a no-op bump:

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -12,7 +12,8 @@ still being hardened, and there is no packaged install path yet.
 **Evidence.** The full twelve-demo corpus — Bunnymark, Starter-Kit-Match3, dodge,
 web3d, 3D-Platformer, squash, FPS, character-controller, third-person, Racing,
 City-Builder and tps-demo — passes the automated production export smoke in
-**Chrome** (the CI gate), **Firefox**, and **Safari**, each with a
+**Chrome** and **Firefox** (both CI cells) and **Safari** (a local gate — it has
+no headless mode), each with a
 play-and-teardown driver run, zero console errors, and live handles draining to
 zero. Every corpus export is also proven to embed no build-machine paths in any
 served file, and to be reproducible from a clean clone (see
@@ -155,10 +156,51 @@ scripts/web_export_smoke.sh \
   --result /tmp/match3-chrome.json
 ```
 
-**Chrome is the intended CI gate.** Firefox and Safari are explicit **local
-release gates** run before a promotion. Each gate asserts gameplay deltas,
-crossing budgets, handle/callback/scheduler teardown to baseline, stale-handle
-rejection, console-error checks, and a protocol-version match.
+Each gate asserts gameplay deltas, crossing budgets, handle/callback/scheduler
+teardown to baseline, stale-handle rejection, console-error checks, and a
+protocol-version match.
+
+Read the harness's own `web_export_smoke: PASS` line, not a driver's check count.
+The driver's checks and the envelope schema are two different gates: a demo can
+pass 13/13 of its own checks and still be rejected by the schema (which is what
+enforces `liveAfterTeardown === 0`), and that is exactly how one demo stayed
+un-gated on every engine for weeks.
+
+## Browser Matrix
+
+`web_ci_matrix.sh` is the corpus-wide gate: it exports each demo and drives it in
+each requested browser through `web_export_smoke.sh`, then aggregates every cell
+into one evidence JSON plus a Markdown summary.
+
+```sh
+scripts/web_ci_matrix.sh \
+  --godot /absolute/path/to/godot \
+  --template "$HOME/Library/Application Support/Godot/export_templates/4.7.stable/web_nothreads_release.zip" \
+  --demos-dir /absolute/path/to/kanama-demos \
+  --demo-set full \
+  --engine chrome --engine firefox \
+  --evidence /tmp/web-matrix.json
+```
+
+Every cell runs even after an earlier one fails, so a red run reports the whole
+picture. `--demo-set pr` is the per-PR subset (`match3`, `web3d`, `dodge` — a
+pointer-drag demo, a 3D demo needing no demos checkout, and a full-lifecycle
+demo); `--demo-set full` is the 12-demo corpus. Per-demo budgets live in
+`scripts/web/demos.sh`; scale them for a slower host with `--timeout-scale`
+rather than editing them, so local and CI numbers stay comparable.
+
+**Chrome and Firefox are the CI cells** (`.github/workflows/web.yml`): the PR
+subset on every Web-relevant pull request, the full corpus on push to `main` and
+nightly. **Safari is a local pre-promotion gate, not a CI cell** — see Known
+Limitations. Run it with the same script, `--engine safari`, one run at a time.
+
+### Bumping The Demos Pin
+
+The workflow checks out `kanama-demos` at the `DEMOS_REF` commit pinned in
+`.github/workflows/web.yml`. This is deliberate: an unpinned checkout lets an
+unrelated demo-repo commit redden every Kanama pull request. When a demo port
+lands in `kanama-demos`, bump `DEMOS_REF` in the same pass — a Kanama change that
+needs new demo code is not green until both sides are pinned together.
 
 ## Fresh-Checkout Gate
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -210,6 +210,47 @@ subset on every Web-relevant pull request, the full corpus on push to `main` and
 nightly. **Safari is a local pre-promotion gate, not a CI cell** — see Known
 Limitations. Run it with the same script, `--engine safari`, one run at a time.
 
+### Regression Cadence
+
+Which gate runs when, and where. A gate that is not on this list runs nowhere.
+
+| Gate | Cadence | Where |
+|---|---|---|
+| PR subset × Chrome + Firefox | every Web-relevant pull request | CI (`web` workflow) |
+| Full 12-demo corpus × Chrome + Firefox | push to `main`, and nightly | CI |
+| Soak (10 min, `--demo soak`) | nightly | CI |
+| Full corpus on **Safari** | before a release tag, and before any promotion decision | local (no headless mode) |
+| Fresh-checkout gate | before a release tag | local |
+| Browser floor re-bisect | when a floor is claimed to move, or a browser major ships that breaks a cell | local |
+| Everything above | **on a Godot baseline bump** — the export template, generated proxy and bridge protocol all move together | local + CI |
+
+The nightly run matters because two of the inputs change without anyone touching
+the repository: the browsers on the runner image, and the runner itself. A red
+nightly on an unchanged tree is a browser-side regression, which is exactly the
+class of failure a per-PR gate can never see.
+
+### Soak Gate
+
+```sh
+KANAMA_WEB_SOAK_SECONDS=600 scripts/web_ci_matrix.sh \
+  --godot /absolute/path/to/godot --template <web_nothreads_release.zip> \
+  --demos-dir /absolute/path/to/kanama-demos --demo soak --engine chrome
+```
+
+The soak driver runs against the **dodge** export for ten minutes, restarting the
+round every sixty seconds. Dodge is the choice on purpose: leak detection wants
+churn, not polygons — a mob is instantiated every half second and frees itself on
+leaving the screen, so a ten-minute run is hundreds of full node create/free
+cycles through the handle registry, the signal-connection table and the
+deferred-free path.
+
+It splits its samples in half and compares high-water marks, so it fails on a
+*trend* rather than on a threshold: live handles, pending signal callbacks and
+registered coroutine jobs must not be higher in the second half than the first
+(plus a few handles of sampling slack), gameplay must still be running at the
+end, and teardown must still drain to zero after a long run rather than only
+after a short one.
+
 ### Bumping The Demos Pin
 
 The workflow checks out `kanama-demos` at the `DEMOS_REF` commit pinned in

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -251,6 +251,21 @@ registered coroutine jobs must not be higher in the second half than the first
 end, and teardown must still drain to zero after a long run rather than only
 after a short one.
 
+### Quarantined Cells
+
+A known-failing `demo:engine` pair can be **quarantined** in
+`scripts/web/demos.sh` with a reason that names a task. A quarantined cell still
+exports, still runs and still reports — it just does not fail the build. Deleting
+the demo from the matrix instead would be the trap this gate exists to close: the
+corpus would look green because nobody was looking.
+
+A quarantined cell that **passes** is reported just as loudly, with an explicit
+"lift the quarantine" line, because a stale quarantine is worse than none.
+Lifting one is a one-line deletion.
+
+Currently quarantined: `dodge:firefox` (task 71 — mobs never free on a Linux
+host; it passes on macOS Chrome and Firefox, and on CI Chrome).
+
 ### Bumping The Demos Pin
 
 The workflow checks out `kanama-demos` at the `DEMOS_REF` commit pinned in

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -19,12 +19,28 @@ zero. Every corpus export is also proven to embed no build-machine paths in any
 served file, and to be reproducible from a clean clone (see
 [Fresh-Checkout Gate](#fresh-checkout-gate)).
 
-**Validated browser versions** (2026-07-27, protocol 15): Chrome 150 (headless),
-Firefox 153 (headless), and **Safari 26.5 / WebKit 605.1.15 on macOS 26.5.1**.
-These are the versions the corpus has actually been driven on, not a tested
-lower bound — no older release has been validated. **iOS and iPadOS have not
-been validated at all**; `safaridriver` drives desktop Safari only, so no
-mobile-WebKit claim is made here.
+**Browser version floors.** The declared floors live in one machine-readable
+file, `scripts/web/browser_floors.json`, and every smoke run is checked against
+them — a run on an older browser fails the gate instead of printing the same
+`PASS` line as a declared one.
+
+| Browser | Floor | Basis | Corpus validated at |
+|---|---|---|---|
+| Chrome | **130** | tested | 150 (headless) |
+| Firefox | **141** | tested | 152–153 (headless) |
+| Safari | **26.5** | validated-at | 26.5 / WebKit 605.1.15, macOS 26.5.1 |
+
+"Tested" means the gate was run on that version *and* on the one below it
+(2026-07-28, macOS arm64, protocol-15 export). Chrome 129 never boots the
+Kotlin/Wasm module; 130 runs it — that is where WebAssembly JS String Builtins
+shipped. The Firefox number is a **harness** bound, not an engine verdict: 141,
+143 and 145 all pass, while 140 ESR and older never expose a reachable WebDriver
+BiDi endpoint to the driver's launch recipe, so they cannot be judged either way.
+Safari is "validated-at" only: it ships with the OS and cannot be installed side
+by side, so no lower bound is testable at all.
+
+**iOS and iPadOS have not been validated**; `safaridriver` drives desktop Safari
+only, so no mobile-WebKit claim is made here.
 
 This page is the reproducible export workflow. For the architecture — batching,
 snapshots, handle generations, the bridge protocol — see

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -133,18 +133,26 @@ handles. Gameplay coverage reports zero blocking calls;
 `GodotObject.emit_signal_typed` remains visible as one explicit nonblocking
 unsupported family rather than being pattern-hidden.
 
-Browser versions validated, all at protocol 15 on 2026-07-27:
+Browser floors and the versions the corpus is driven on (protocol 15). The
+floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
+and `web_export_smoke.sh` fails any run below them:
 
-| Browser | Version | Notes |
-|---|---|---|
-| Chrome | 150 (headless) | the CI gate |
-| Firefox | 153 (headless) | local gate |
-| Safari | 26.5 / WebKit 605.1.15, macOS 26.5.1 | local gate; **no headless mode**, so it needs a logged-in GUI session |
+| Browser | Floor | Basis | Corpus validated at | Notes |
+|---|---|---|---|---|
+| Chrome | 130 | tested (2026-07-28) | 150 (headless) | CI cell |
+| Firefox | 141 | tested (2026-07-28) | 152–153 (headless) | CI cell |
+| Safari | 26.5 | validated-at (2026-07-27) | 26.5 / WebKit 605.1.15, macOS 26.5.1 | local gate; **no headless mode**, so it needs a logged-in GUI session |
 
-These are the versions actually driven, **not tested lower bounds** — no older
-release has been validated, so treat each as "validated at", not "supported
-from". **iOS and iPadOS are unvalidated**: `safaridriver` drives desktop Safari
-only, and no mobile-WebKit floor is claimed.
+**"Tested" and "validated-at" are different claims.** Tested means the gate was
+run on the floor version and on the one below it: Chrome 129 never boots the
+Kotlin/Wasm module and 130 does. Firefox's number is a limit of the **harness**
+rather than of the engine — 141, 143 and 145 all pass, while 140 ESR and older
+never expose a reachable WebDriver BiDi endpoint to the driver, so they are
+untestable, not known-bad. Safari cannot be installed side by side with itself,
+so its number is only the oldest version ever driven.
+
+**iOS and iPadOS are unvalidated**: `safaridriver` drives desktop Safari only,
+and no mobile-WebKit floor is claimed.
 
 ### Explicit non-support limitations
 

--- a/scripts/fixtures/web-fake-export/fake_driver.py
+++ b/scripts/fixtures/web-fake-export/fake_driver.py
@@ -26,7 +26,17 @@ import sys
 import time
 
 
-def _envelope(demo: str, checksum: str, *, passing: bool) -> dict:
+# A user-agent deliberately far above any floor this project could declare, so
+# the fixture keeps satisfying the browser-floor gate without becoming a second
+# place a floor number is pinned. `below-floor` mode uses a long-unsupported
+# version to prove the gate actually fires.
+MODERN_USER_AGENT = "Mozilla/5.0 (fake-fixture) HeadlessChrome/999.0.0.0 Safari/537.36"
+ANCIENT_USER_AGENT = "Mozilla/5.0 (fake-fixture) HeadlessChrome/100.0.0.0 Safari/537.36"
+
+
+def _envelope(
+    demo: str, checksum: str, *, passing: bool, user_agent: str = MODERN_USER_AGENT
+) -> dict:
     failed = 0 if passing else 1
     checks = {"fakeStartup": True, "fakeGameplay": passing, "fakeTeardown": True}
     passed = sum(1 for value in checks.values() if value)
@@ -46,7 +56,7 @@ def _envelope(demo: str, checksum: str, *, passing: bool) -> dict:
             "totalBytes": 672,
             "sourceTreeChecksum": checksum,
         },
-        "browser": {"engine": "chrome", "name": "fake-fixture", "version": "0"},
+        "browser": {"engine": "chrome", "name": "fake-fixture", "version": user_agent},
         "startup": {"loaded": True, "outcome": "ready", "durationMs": 5},
         "assertions": {
             "summary": {"total": total, "passed": passed, "failed": failed, "skipped": 0},
@@ -107,7 +117,8 @@ def main(argv: list[str]) -> int:
 
     passing = args.mode != "fail"
     checksum = "deadbeef" if args.mode == "wrong-checksum" else args.source_checksum
-    envelope = _envelope(args.demo, checksum, passing=passing)
+    user_agent = ANCIENT_USER_AGENT if args.mode == "below-floor" else MODERN_USER_AGENT
+    envelope = _envelope(args.demo, checksum, passing=passing, user_agent=user_agent)
     with open(args.result, "w", encoding="utf-8") as handle:
         json.dump(envelope, handle, indent=2)
     return 0

--- a/scripts/web/browser_floors.json
+++ b/scripts/web/browser_floors.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "updated": "2026-07-28",
+  "note": "Declared Web browser version floors (Task 60h). `basis` says what the number is worth: 'tested' means the gate was actually run on that version and on the one below it; 'validated-at' means it is only the oldest version ever driven, with nothing older tried. check_browser_floor.py fails a smoke run whose browser is below `minimum`, so this file is the single place a floor claim is made -- docs quote it, they do not restate it.",
+  "engines": {
+    "chrome": {
+      "minimum": "130",
+      "basis": "tested",
+      "evidence": "2026-07-28, macOS arm64, Chrome for Testing against a protocol-15 web3d export: 130.0.6723.116 PASSES the gate, 129.0.6668.100 never boots the Kotlin/Wasm module ('did not become ready'). Bisected 119/128/129/130/131/133/137. Chrome 130 is where WebAssembly JS String Builtins shipped, which the Kotlin/Wasm output uses.",
+      "validatedAt": ["150"]
+    },
+    "firefox": {
+      "minimum": "141",
+      "basis": "tested",
+      "evidence": "2026-07-28, macOS arm64, same export: 141.0, 143.0 and 145.0 all PASS the full gate (every check, zero console errors). Below that the limit is the HARNESS, not the engine -- 140.0esr, 134.0 and 131.0 never expose a reachable WebDriver BiDi endpoint to our launch recipe (140.0esr and 134.0 announce only the CDP endpoint), so the page is never driven and no engine verdict is possible. Read 141 as 'the oldest Firefox this harness can drive', not as 'Firefox 140 is broken'.",
+      "validatedAt": ["152", "153"]
+    },
+    "safari": {
+      "minimum": "26.5",
+      "basis": "validated-at",
+      "evidence": "2026-07-27: Safari 26.5 / WebKit 605.1.15 on macOS 26.5.1, the full corpus. Safari ships with the OS and cannot be installed side by side, so no lower bound is testable on the workstation at all -- this is the only version ever driven, not a tested minimum.",
+      "validatedAt": ["26.5"]
+    }
+  }
+}

--- a/scripts/web/browser_version.py
+++ b/scripts/web/browser_version.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Parse a browser version out of the user-agent a Web smoke driver recorded.
+
+The drivers write ``navigator.userAgent`` verbatim into ``browser.version`` of
+the result envelope -- the whole string, deliberately, because that is the raw
+evidence. Reading a *number* out of it is a separate concern, and one that has
+exactly one correct implementation per engine; it lives here so the matrix
+summary (Task 60h) and the version-floor gate agree by construction.
+
+Parsing is strict: an unrecognizable user-agent returns ``None`` rather than a
+guess, and a caller that needs a version treats ``None`` as a failure.
+
+Usage:
+    python3 browser_version.py <engine> <user-agent>
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Ordered per engine: the first pattern that matches wins. Headless Chrome
+# reports "HeadlessChrome/150.0.0.0", which must be tried before the generic
+# "Chrome/" (headed Chrome UAs contain only the latter).
+_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    "chrome": (
+        re.compile(r"HeadlessChrome/(\d+(?:\.\d+)*)"),
+        re.compile(r"Chrome/(\d+(?:\.\d+)*)"),
+        re.compile(r"Chromium/(\d+(?:\.\d+)*)"),
+    ),
+    "firefox": (re.compile(r"Firefox/(\d+(?:\.\d+)*)"),),
+    # Safari reports the marketing version in "Version/26.5" and the engine
+    # build in the trailing "Safari/605.1.15"; the marketing version is what
+    # release notes and support tables talk about.
+    "safari": (re.compile(r"Version/(\d+(?:\.\d+)*)\s+.*\bSafari/"),),
+}
+
+
+def parse_version(engine: str, user_agent: str | None) -> str | None:
+    """Return the dotted browser version, or None if it cannot be read."""
+    if not user_agent:
+        return None
+    for pattern in _PATTERNS.get(engine, ()):
+        match = pattern.search(user_agent)
+        if match:
+            return match.group(1)
+    return None
+
+
+def major(version: str | None) -> int | None:
+    """Return the leading integer component of a dotted version."""
+    if not version:
+        return None
+    head = version.split(".", 1)[0]
+    return int(head) if head.isdigit() else None
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    """Comparable form of a dotted version ('26.5' -> (26, 5))."""
+    parts: list[int] = []
+    for part in version.split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    return tuple(parts)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {sys.argv[0]} <engine> <user-agent>", file=sys.stderr)
+        return 2
+    engine, user_agent = argv
+    version = parse_version(engine, user_agent)
+    if version is None:
+        print(f"browser_version: could not read a {engine} version from: {user_agent}", file=sys.stderr)
+        return 1
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web/check_browser_floor.py
+++ b/scripts/web/check_browser_floor.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fail a Web smoke run whose browser is below the declared version floor.
+
+A green gate is only evidence about the browser it ran on. Without this check a
+run on an unvalidated (older) browser produces the same PASS line as a run on a
+declared one, and the distinction is lost the moment the log scrolls by.
+
+The floors live in ``browser_floors.json`` -- one file, quoted by the docs rather
+than restated in them, so a floor can never be raised in prose and left unchanged
+in the gate.
+
+Two things fail here, both deliberately loud:
+
+* the driven version is below the engine's declared ``minimum``; and
+* the version cannot be read out of the recorded user-agent at all, which means
+  the evidence does not say what it ran on.
+
+Usage:
+    python3 check_browser_floor.py <result.json>
+    python3 check_browser_floor.py --engine chrome --version 129.0.6668.100
+    python3 check_browser_floor.py --print-floors
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from browser_version import parse_version, version_tuple
+
+FLOORS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "browser_floors.json")
+
+
+class FloorError(Exception):
+    """Raised when a run is below floor or its browser cannot be identified."""
+
+
+def load_floors(path: str = FLOORS_PATH) -> dict:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def check(engine: str, version: str | None, floors: dict) -> str:
+    """Return the accepted version, or raise FloorError."""
+    entry = (floors.get("engines") or {}).get(engine)
+    if entry is None:
+        raise FloorError(f"no declared floor for engine {engine!r}; add one to browser_floors.json")
+    if not version:
+        raise FloorError(
+            f"{engine}: could not read a version from the recorded user-agent -- "
+            "the result does not say which browser produced it"
+        )
+    minimum = entry["minimum"]
+    if version_tuple(version) < version_tuple(minimum):
+        raise FloorError(
+            f"{engine} {version} is below the declared floor {minimum} "
+            f"(basis: {entry['basis']}). Either run a newer browser or, if this "
+            f"version is genuinely supported, re-validate and lower the floor in "
+            f"browser_floors.json with dated evidence."
+        )
+    return version
+
+
+def check_result_file(path: str, floors: dict) -> tuple[str, str]:
+    with open(path, encoding="utf-8") as handle:
+        envelope = json.load(handle)
+    browser = envelope.get("browser") or {}
+    engine = browser.get("engine")
+    if not engine:
+        raise FloorError(f"{path}: result envelope has no browser.engine")
+    # The envelope records the raw user-agent; the version is read from it here
+    # with the same parser the matrix summary uses.
+    version = parse_version(engine, browser.get("version"))
+    return engine, check(engine, version, floors)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check a Web smoke run against the browser floors.")
+    parser.add_argument("result", nargs="?", help="path to a result JSON envelope")
+    parser.add_argument("--engine", help="check an explicit engine instead of a result file")
+    parser.add_argument("--version", help="version to check with --engine (dotted, or a user-agent)")
+    parser.add_argument("--print-floors", action="store_true", help="print the declared floors")
+    args = parser.parse_args(argv)
+
+    floors = load_floors()
+
+    if args.print_floors:
+        for engine, entry in floors["engines"].items():
+            print(f"{engine}: >= {entry['minimum']} ({entry['basis']})")
+        return 0
+
+    try:
+        if args.engine:
+            if not args.version:
+                parser.error("--engine requires --version")
+            # --version takes either a dotted version or a whole user-agent. A
+            # string that is neither must not be smuggled through as a version:
+            # it would compare as "below floor" and hide that we cannot tell.
+            version = parse_version(args.engine, args.version)
+            if version is None and version_tuple(args.version):
+                version = args.version
+            accepted = check(args.engine, version, floors)
+            engine = args.engine
+        else:
+            if not args.result:
+                parser.error("a result JSON path is required unless --engine or --print-floors is given")
+            engine, accepted = check_result_file(args.result, floors)
+    except FloorError as error:
+        print(f"web_export_smoke: browser floor violation: {error}", file=sys.stderr)
+        return 1
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"web_export_smoke: could not read floors or result: {error}", file=sys.stderr)
+        return 2
+
+    minimum = floors["engines"][engine]["minimum"]
+    print(f"web_export_smoke: {engine} {accepted} satisfies the declared floor {minimum}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -24,10 +24,24 @@ KANAMA_WEB_ALL_DEMOS=(
 # The full corpus runs on push to main and on the nightly schedule.
 KANAMA_WEB_PR_DEMOS=(match3 web3d dodge)
 
+# The soak gate (Task 60h) is a DRIVER, not a thirteenth demo: it drives the
+# DODGE export for a long window and asserts no slow leak. It is deliberately
+# absent from both lists above -- it is opt-in (`--demo soak`), because it costs
+# ten minutes, and it must never silently pad a "corpus is green" claim.
+#
+# demo key -> the export/build key it runs against. Everything but soak is itself.
+kanama_web_demo_export_key() {
+  case "$1" in
+    soak) echo "dodge" ;;
+    *) echo "$1" ;;
+  esac
+}
+
 # demo key -> kanama-demos project directory ("" for the in-repo fixture).
 kanama_web_demo_project_dir() {
   case "$1" in
     match3) echo "Starter-Kit-Match3" ;;
+    soak) echo "godot-demo-2d-dodge-the-creeps" ;;
     bunnymark) echo "Bunnymark" ;;
     dodge) echo "godot-demo-2d-dodge-the-creeps" ;;
     web3d) echo "" ;;
@@ -47,6 +61,7 @@ kanama_web_demo_project_dir() {
 kanama_web_demo_project_property() {
   case "$1" in
     match3) echo "kanamaWebMatch3ProjectDir" ;;
+    soak) echo "kanamaWebDodgeProjectDir" ;;
     bunnymark) echo "kanamaWebBunnymarkProjectDir" ;;
     dodge) echo "kanamaWebDodgeProjectDir" ;;
     web3d) echo "" ;;
@@ -81,6 +96,9 @@ kanama_web_demo_timeout() {
     match3|bunnymark|dodge|web3d) echo 300 ;;
     platformer|squash|fps) echo 480 ;;
     charactercontroller|thirdperson|racing|citybuilder|tpsdemo) echo 600 ;;
+    # The soak budget is derived from its own duration, never guessed: the driver
+    # runs for KANAMA_WEB_SOAK_SECONDS and then still has to tear down.
+    soak) echo $(( ${KANAMA_WEB_SOAK_SECONDS:-600} + 240 )) ;;
     *) echo 300 ;;
   esac
 }

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -1,0 +1,90 @@
+# shellcheck shell=bash
+#
+# demos.sh -- the single Web demo registry, sourced by every Web gate.
+#
+# The demo key -> project directory -> Gradle property mapping used to live in
+# each gate script; two copies is one drift away from a gate that silently skips
+# a demo. Everything that needs to know about the corpus sources this file:
+# scripts/web_fresh_checkout_smoke.sh (60g) and scripts/web_ci_matrix.sh (60h).
+#
+# Adding a demo means editing THIS file plus the driver wiring listed in
+# docs/exporting/web.md.
+
+# The full corpus, in port order. `web3d` is an in-repo fixture; every other demo
+# lives in the kanama-demos checkout.
+KANAMA_WEB_ALL_DEMOS=(
+  match3 bunnymark dodge web3d platformer squash fps
+  charactercontroller thirdperson racing citybuilder tpsdemo
+)
+
+# The per-PR subset (Task 60h). Three demos chosen for coverage, not speed:
+# match3 exercises pointer-drag input and the 2D snapshot path, web3d the 3D
+# renderer from an in-repo fixture (it needs no demos checkout at all), and
+# dodge the full node/signal/scheduler lifecycle to a zero handle count.
+# The full corpus runs on push to main and on the nightly schedule.
+KANAMA_WEB_PR_DEMOS=(match3 web3d dodge)
+
+# demo key -> kanama-demos project directory ("" for the in-repo fixture).
+kanama_web_demo_project_dir() {
+  case "$1" in
+    match3) echo "Starter-Kit-Match3" ;;
+    bunnymark) echo "Bunnymark" ;;
+    dodge) echo "godot-demo-2d-dodge-the-creeps" ;;
+    web3d) echo "" ;;
+    platformer) echo "Starter-Kit-3D-Platformer" ;;
+    squash) echo "godot-demo-3d-squash-the-creeps" ;;
+    fps) echo "Starter-Kit-FPS" ;;
+    charactercontroller) echo "godot-4-3d-character-controller-tutorial" ;;
+    thirdperson) echo "godot-4-3d-third-person-controller" ;;
+    racing) echo "Starter-Kit-Racing" ;;
+    citybuilder) echo "Starter-Kit-City-Builder" ;;
+    tpsdemo) echo "tps-demo-kanama" ;;
+    *) return 1 ;;
+  esac
+}
+
+# demo key -> the -PkanamaWeb<Key>ProjectDir gradle property the build reads.
+kanama_web_demo_project_property() {
+  case "$1" in
+    match3) echo "kanamaWebMatch3ProjectDir" ;;
+    bunnymark) echo "kanamaWebBunnymarkProjectDir" ;;
+    dodge) echo "kanamaWebDodgeProjectDir" ;;
+    web3d) echo "" ;;
+    platformer) echo "kanamaWebPlatformerProjectDir" ;;
+    squash) echo "kanamaWebSquashProjectDir" ;;
+    fps) echo "kanamaWebFpsProjectDir" ;;
+    charactercontroller) echo "kanamaWebCharactercontrollerProjectDir" ;;
+    thirdperson) echo "kanamaWebThirdpersonProjectDir" ;;
+    racing) echo "kanamaWebRacingProjectDir" ;;
+    citybuilder) echo "kanamaWebCitybuilderProjectDir" ;;
+    tpsdemo) echo "kanamaWebTpsdemoProjectDir" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Extra `exportWeb` arguments a demo needs, one per line (empty for most).
+# Bunnymark's validated Web configuration is the 256-sprite V1Sprites variant.
+kanama_web_demo_export_args() {
+  case "$1" in
+    bunnymark) echo "-PkanamaWebBunnymarkVariant=BunnymarkV1Sprites" ;;
+    *) : ;;
+  esac
+}
+
+# Per-demo driver budget in seconds. These are wall-clock ceilings, not
+# expectations: the heavy 3D demos hold input for fixed windows and warm up
+# shaders on a software GL, so they legitimately take minutes. A CI host is
+# slower than a workstation -- scale with --timeout-scale rather than editing
+# these, so the local and CI numbers stay comparable.
+kanama_web_demo_timeout() {
+  case "$1" in
+    match3|bunnymark|dodge|web3d) echo 300 ;;
+    platformer|squash|fps) echo 480 ;;
+    charactercontroller|thirdperson|racing|citybuilder|tpsdemo) echo 600 ;;
+    *) echo 300 ;;
+  esac
+}
+
+kanama_web_demo_is_known() {
+  kanama_web_demo_project_dir "$1" >/dev/null 2>&1
+}

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -106,3 +106,21 @@ kanama_web_demo_timeout() {
 kanama_web_demo_is_known() {
   kanama_web_demo_project_dir "$1" >/dev/null 2>&1
 }
+
+# Quarantined cells: "demo:engine" -> the reason, which must name a task.
+#
+# A quarantined cell still EXPORTS, still RUNS, and still reports its result --
+# it simply does not fail the build. Deleting a demo from the matrix instead
+# would be the exact trap this gate exists to close: the corpus would look green
+# because nobody was looking. A quarantined cell that PASSES is reported just as
+# loudly, because a stale quarantine is worse than none.
+#
+# Lifting one is a one-line deletion here.
+kanama_web_quarantine_reason() {
+  case "$1" in
+    dodge:firefox)
+      echo "task 71 — mobs never free on a Linux host; passes on macOS Chrome/Firefox and on CI Chrome"
+      ;;
+    *) : ;;
+  esac
+}

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -51,8 +51,27 @@ function parseArgs(argv) {
   return args;
 }
 
-const DEFAULT_CHROME =
-  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+// Where to look when --browser-binary is not given. macOS first (the workstation
+// gate), then the usual Linux install paths (the CI matrix cell, Task 60h).
+// Nothing here is a fallback in disguise: if none exists the driver fails loudly
+// rather than driving some other browser.
+const CHROME_CANDIDATES = [
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "/snap/bin/chromium",
+];
+
+function resolveBrowser(explicit, candidates, engine) {
+  if (explicit) return explicit;
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (found) return found;
+  throw new Error(
+    `${engine}: no browser found; pass --browser-binary (looked in: ${candidates.join(", ")})`,
+  );
+}
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -81,7 +100,7 @@ async function main() {
     throw new Error(`chrome_cdp: unknown demo '${args.demo}' (expected ${Object.keys(DEMOS).join("|")})`);
   }
 
-  const chromeBinary = args["browser-binary"] ?? DEFAULT_CHROME;
+  const chromeBinary = resolveBrowser(args["browser-binary"], CHROME_CANDIDATES, "chrome_cdp");
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "kanama-chrome-"));
   const debugPort = 0; // let Chrome choose; we read the chosen port from DevToolsActivePort
 

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -34,9 +34,10 @@ import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
+import { runSoak } from "./demos/soak.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -86,6 +86,8 @@ async function observe(evaluate, seedPeak, windowMs, deadline, predicate) {
       // A drop in the live-handle count means a mob (and its child nodes) was freed —
       // dodge mobs queue_free themselves when a VisibleOnScreenNotifier2D reports they
       // left the screen. Counting drops proves the free/release path works during play.
+      // It UNDERCOUNTS when a spawn lands in the same sample as a free, which is why the
+      // window below is a generous ceiling rather than a fixed duration.
       if (snap.liveHandles < prevLive) peak.mobFrees += 1;
       prevLive = snap.liveHandles;
       last = snap;
@@ -135,7 +137,11 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   // Play long enough for several mobs to spawn AND for the earliest ones to fly across
   // and leave the screen (each mob queue_frees itself on VisibleOnScreenNotifier2D
   // screen_exited). Run the full window so the spawn+free lifecycle is exercised.
-  const gameplay = await observe(evaluate, seedPeak, 11_000, deadline, (snap, p) => p.mobFrees >= 2);
+  // The window is a CEILING, not a duration: the predicate ends it as soon as two mobs
+  // have actually been freed, which on a workstation is a few seconds. It is generous
+  // because a software-GL host simulates less game time per wall-clock second, and the
+  // assertion should wait for the evidence rather than be graded on the host's speed.
+  const gameplay = await observe(evaluate, seedPeak, 45_000, deadline, (snap, p) => p.mobFrees >= 2);
   const peak = gameplay.peak;
   const atPeak = gameplay.last ?? ready;
   trace(`gameplay: mobs=${peak.mobInstantiations} addChild=${peak.mobAddChildCommands} maxLive=${peak.maxLiveHandles} frees=${peak.mobFrees} finalLive=${atPeak.liveHandles} crossings=${peak.crossings}`);

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -47,6 +47,13 @@ async function snapshot(evaluate) {
         pending: bridge.api.kanamaWebPendingCoroutineCount(),
         jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
         failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+        // Diagnostics for a cell that runs but never frees a mob: the canvas the
+        // engine sizes its viewport from, and the latest mirrored transform the
+        // bridge saw (proof that something is actually moving in the scene).
+        canvasW: document.querySelector("canvas")?.clientWidth ?? 0,
+        canvasH: document.querySelector("canvas")?.clientHeight ?? 0,
+        snapX: Math.round(bridge.latestSnapshotX ?? 0),
+        snapY: Math.round(bridge.latestSnapshotY ?? 0),
       };
     })()`);
   } catch {
@@ -91,7 +98,7 @@ async function observe(evaluate, seedPeak, windowMs, deadline, predicate) {
       if (snap.liveHandles < prevLive) peak.mobFrees += 1;
       prevLive = snap.liveHandles;
       last = snap;
-      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors}`);
+      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors} canvas=${snap.canvasW}x${snap.canvasH} snap=${snap.snapX},${snap.snapY}`);
       if (predicate && predicate(snap, peak)) break;
     }
     await delay(150);

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -54,6 +54,13 @@ async function snapshot(evaluate) {
         canvasH: document.querySelector("canvas")?.clientHeight ?? 0,
         snapX: Math.round(bridge.latestSnapshotX ?? 0),
         snapY: Math.round(bridge.latestSnapshotY ?? 0),
+        // Engine truth, not bridge bookkeeping: Node.get_child_count (opcode 1) on
+        // Main. Mobs are added as its children and queue_free themselves off screen,
+        // so this rises with every spawn and falls with every real free -- which
+        // separates "the mobs never left the screen" from "they did, and the handle
+        // release did not follow".
+        frames: bridge.processCalls ?? 0,
+        simSeconds: Math.round((bridge.simSeconds ?? 0) * 10) / 10,
       };
     })()`);
   } catch {
@@ -98,7 +105,7 @@ async function observe(evaluate, seedPeak, windowMs, deadline, predicate) {
       if (snap.liveHandles < prevLive) peak.mobFrees += 1;
       prevLive = snap.liveHandles;
       last = snap;
-      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors} canvas=${snap.canvasW}x${snap.canvasH} snap=${snap.snapX},${snap.snapY}`);
+      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors} canvas=${snap.canvasW}x${snap.canvasH} frames=${snap.frames} sim=${snap.simSeconds}s`);
       if (predicate && predicate(snap, peak)) break;
     }
     await delay(150);

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -1,0 +1,229 @@
+// demos/soak.mjs -- long-run leak gate for the Web backend (Task 60h, W4).
+//
+// The per-demo drivers each play for a fixed window of seconds. That proves a
+// demo runs; it cannot prove it still runs in ten minutes. A slow leak -- a
+// handle slot never released, a signal callback never unregistered, a coroutine
+// job that accumulates -- is invisible at that timescale and fatal at a real
+// one.
+//
+// This driver runs against the DODGE export, deliberately. Leak detection wants
+// churn, not polygons: dodge instantiates a mob every half second and each mob
+// frees itself when it leaves the screen, so a ten-minute run is hundreds of
+// full node create/free cycles through the handle registry, the signal
+// connection table and the deferred-free path. A heavier 3D scene renders more
+// and allocates less.
+//
+// What it asserts, beyond "it survived":
+//   * live handles do not TREND upward -- the second half's high-water mark may
+//     not exceed the first half's (plus a small slack), which catches a leak of
+//     even one handle per cycle;
+//   * the lifecycle registries (pending signal callbacks, pending coroutines,
+//     registered jobs) stay bounded rather than growing with time;
+//   * the game restarts cleanly, repeatedly -- `new_game` is called every cycle,
+//     which is where a leak of per-round state would show; and
+//   * teardown still drains to zero at the end of a long run, not just a short
+//     one.
+//
+// Duration comes from KANAMA_WEB_SOAK_SECONDS (default 600). The smoke shell's
+// --timeout must exceed it; scripts/web/demos.sh derives that budget.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[soak ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+const SOAK_SECONDS = Number(process.env.KANAMA_WEB_SOAK_SECONDS ?? 600);
+// One "cycle" is a full round of dodge: new_game, mobs spawn and free, repeat.
+// Restarting is the point -- a leak of per-round state only shows across rounds.
+const CYCLE_SECONDS = 60;
+const SAMPLE_MS = 2000;
+// Slack on the half-over-half comparison. The high-water mark is sampled, not
+// exact, and mob count varies with the RNG, so a couple of handles of noise must
+// not fail the gate; a real leak grows without bound and blows past this.
+const HIGH_WATER_SLACK = 8;
+
+async function snapshot(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      if (!bridge) return null;
+      return {
+        mode: bridge.mode,
+        protocol: bridge.results?.protocolVersion ?? 0,
+        mainHandle: bridge.dodgeMainHandle,
+        smokeQuitHandle: bridge.dodgeSmokeQuitHandle,
+        readyCount: bridge.readyCount,
+        mobInstantiations: bridge.match3PackedSceneInstantiations,
+        liveHandles: bridge.liveBrowserHandleCount,
+        maxLiveHandles: bridge.maxLiveBrowserHandles,
+        crossings: bridge.kotlinToGodotCalls,
+        callbackErrors: bridge.callbackErrors,
+        callbacks: bridge.api.kanamaWebPendingSignalCallbackCount(),
+        pending: bridge.api.kanamaWebPendingCoroutineCount(),
+        jobs: bridge.api.kanamaWebRegisteredCoroutineJobCount(),
+        failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
+      };
+    })()`);
+  } catch {
+    return null; // page mid-navigation or torn down
+  }
+}
+
+async function callMain(evaluate, method) {
+  return evaluate(
+    `globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.dodgeMainHandle, globalThis.KanamaWebBridge.dodgeMethodId(${JSON.stringify(method)})); true`,
+  );
+}
+
+async function callTeardown(evaluate) {
+  return evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.dodgeSmokeQuitHandle, 1); true",
+  );
+}
+
+export async function runSoak({ url, evaluate, navigate, deadline }) {
+  const startupStart = Date.now();
+  trace(`navigate (soak ${SOAK_SECONDS}s)`);
+  await navigate(`${url}?soak=${Date.now()}`);
+
+  const readyDeadline = Math.min(deadline, Date.now() + 30_000);
+  let ready = null;
+  while (Date.now() < readyDeadline) {
+    const snap = await snapshot(evaluate);
+    if (snap && snap.mode === "dodge" && snap.protocol > 0 && snap.mainHandle > 0 && snap.smokeQuitHandle > 0) {
+      ready = snap;
+      break;
+    }
+    await delay(100);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm soak target (dodge) did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+
+  const samples = [];
+  const soakUntil = Math.min(deadline - 30_000, Date.now() + SOAK_SECONDS * 1000);
+  let cycles = 0;
+  let nextCycleAt = 0;
+  let last = ready;
+  let observedError = null;
+
+  while (Date.now() < soakUntil) {
+    if (Date.now() >= nextCycleAt) {
+      // Restart the round. The first call starts the game; later ones exercise
+      // new_game's own teardown path (it queue_frees the whole mobs group).
+      await callMain(evaluate, "new_game");
+      cycles += 1;
+      nextCycleAt = Date.now() + CYCLE_SECONDS * 1000;
+      trace(`cycle ${cycles}`);
+    }
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      last = snap;
+      samples.push({ t: Date.now() - START, ...snap });
+      if (snap.callbackErrors > 0 && observedError === null) {
+        observedError = `callbackErrors=${snap.callbackErrors}`;
+      }
+      if (snap.failure && observedError === null) observedError = snap.failure;
+    }
+    await delay(SAMPLE_MS);
+  }
+  trace(`soak done: cycles=${cycles} samples=${samples.length} live=${last.liveHandles}`);
+
+  if (samples.length < 8) {
+    throw new Error(`soak collected only ${samples.length} samples; the window was too short to judge a trend`);
+  }
+
+  // Halve the sample series and compare high-water marks. A run that leaks a
+  // handle per mob cycle climbs steadily; a healthy one oscillates around a
+  // fixed working set no matter how long it runs.
+  const midpoint = Math.floor(samples.length / 2);
+  const firstHalf = samples.slice(0, midpoint);
+  const secondHalf = samples.slice(midpoint);
+  const highWater = (series) => Math.max(...series.map((s) => s.liveHandles));
+  const maxOf = (series, key) => Math.max(...series.map((s) => s[key]));
+  const firstHigh = highWater(firstHalf);
+  const secondHigh = highWater(secondHalf);
+  trace(`high-water: first=${firstHigh} second=${secondHigh} (slack ${HIGH_WATER_SLACK})`);
+
+  // Teardown after a long run must still drain everything.
+  await callTeardown(evaluate);
+  const teardownUntil = Math.min(deadline, Date.now() + 15_000);
+  let settled = last;
+  while (Date.now() < teardownUntil) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      settled = snap;
+      if (snap.liveHandles === 0) break;
+    }
+    await delay(200);
+  }
+  trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} pending=${settled.pending} jobs=${settled.jobs}`);
+
+  const checks = {
+    modeDodge: ready.mode === "dodge",
+    protocol15: ready.protocol === 15,
+    // The run really lasted: several full rounds, and enough samples to judge.
+    soakCyclesCompleted: cycles >= 2,
+    soakSamplesCollected: samples.length >= 8,
+    // Gameplay kept happening for the whole window rather than stalling early.
+    mobsKeptSpawning: last.mobInstantiations > ready.mobInstantiations + 10,
+    crossingsAdvanced: last.crossings > ready.crossings,
+    // The leak assertions.
+    liveHandlesDidNotTrendUp: secondHigh <= firstHigh + HIGH_WATER_SLACK,
+    pendingCallbacksBounded: maxOf(secondHalf, "callbacks") <= maxOf(firstHalf, "callbacks") + HIGH_WATER_SLACK,
+    coroutineJobsBounded: maxOf(secondHalf, "jobs") <= maxOf(firstHalf, "jobs") + HIGH_WATER_SLACK,
+    noCallbackFaults: observedError === null && settled.callbackErrors === 0 && settled.failure === null,
+    // Teardown still drains to zero after a long run.
+    fullTeardownToZero: settled.liveHandles === 0,
+  };
+
+  const boundaryErrors = [];
+  if (observedError !== null) boundaryErrors.push(observedError);
+  if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
+
+  return {
+    protocolVersion: ready.protocol,
+    startup: {
+      loaded: ready.mode === "dodge",
+      outcome: ready.mode === "dodge" ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: Math.max(firstHigh, secondHigh),
+      liveAfterTeardown: settled.liveHandles,
+      staleRejected: 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: last.crossings,
+      mobInstantiations: last.mobInstantiations,
+      // The evidence a reader wants from a soak: the two half-window high-water
+      // marks it was judged on, and how long it actually ran.
+      soakSeconds: Math.round((Date.now() - START) / 1000),
+      soakCycles: cycles,
+      soakSamples: samples.length,
+      liveHighWaterFirstHalf: firstHigh,
+      liveHighWaterSecondHalf: secondHigh,
+    },
+    callbacks: {
+      pendingSignalCallbacks: settled.callbacks,
+      maxPendingFirstHalf: maxOf(firstHalf, "callbacks"),
+      maxPendingSecondHalf: maxOf(secondHalf, "callbacks"),
+    },
+    connections: {
+      afterGameplayLiveHandles: settled.liveHandles,
+    },
+    scheduler: {
+      pendingCoroutines: settled.pending,
+      registeredJobs: settled.jobs,
+      maxJobsFirstHalf: maxOf(firstHalf, "jobs"),
+      maxJobsSecondHalf: maxOf(secondHalf, "jobs"),
+    },
+    teardown: {
+      outcome: checks.fullTeardownToZero && checks.noCallbackFaults ? "clean" : "incomplete",
+      ownerRegistriesToBaseline: settled.liveHandles === 0,
+    },
+    boundaryErrors,
+  };
+}

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -121,7 +121,20 @@ async function main() {
   const port = 9300 + Math.floor(Math.random() * 500);
   const firefox = spawn(
     firefoxBinary,
-    ["--headless", "--no-remote", `--profile`, profileDir, `--remote-debugging-port=${port}`, "about:blank"],
+    [
+      "--headless",
+      "--no-remote",
+      // Pin the window, as the Chrome and Safari drivers already do. Godot sizes
+      // its viewport from the canvas, so an unpinned window makes the VIEWPORT --
+      // and therefore what "left the screen" means -- depend on the host's default
+      // window size. That is what made dodge's mobs never exit on a Linux runner
+      // while the same build passed on a macOS Firefox.
+      "--window-size=1280,900",
+      `--profile`,
+      profileDir,
+      `--remote-debugging-port=${port}`,
+      "about:blank",
+    ],
     { stdio: ["ignore", "pipe", "pipe"] },
   );
 

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -30,7 +30,25 @@ import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
 const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
-const DEFAULT_FIREFOX = "/Applications/Firefox.app/Contents/MacOS/firefox";
+// macOS workstation path first, then the usual Linux install paths (the CI
+// matrix cell, Task 60h). Missing everywhere is a loud failure, never a silent
+// substitution of some other browser.
+const FIREFOX_CANDIDATES = [
+  "/Applications/Firefox.app/Contents/MacOS/firefox",
+  "/usr/bin/firefox",
+  "/usr/local/bin/firefox",
+  "/snap/bin/firefox",
+];
+
+function resolveBrowser(explicit, candidates, engine) {
+  if (explicit) return explicit;
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (found) return found;
+  throw new Error(
+    `${engine}: no browser found; pass --browser-binary (looked in: ${candidates.join(", ")})`,
+  );
+}
+
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {
@@ -85,7 +103,7 @@ async function main() {
   const runDemo = DEMOS[args.demo];
   if (!runDemo) throw new Error(`firefox_bidi: unknown demo '${args.demo}'`);
 
-  const firefoxBinary = args["browser-binary"] ?? DEFAULT_FIREFOX;
+  const firefoxBinary = resolveBrowser(args["browser-binary"], FIREFOX_CANDIDATES, "firefox_bidi");
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "kanama-firefox-"));
   // Headless Firefox needs software WebGL for Godot's Compatibility renderer.
   fs.writeFileSync(

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -111,6 +111,13 @@ async function main() {
     path.join(profileDir, "user.js"),
     [
       'user_pref("remote.active-protocols", 2);',
+      // Pin the refresh driver to 60Hz. With no vsync to pace it, headless Firefox
+      // ran requestAnimationFrame at ~500Hz, and Godot's main loop advanced a fixed
+      // step per iteration -- so the scene ran roughly EIGHT TIMES real time (392
+      // simulated seconds in 45 wall seconds on a CI runner). No real browser does
+      // that, and a gate driving the engine at 8x is not measuring the engine users
+      // get.
+      'user_pref("layout.frame_rate", 60);',
       'user_pref("webgl.force-enabled", true);',
       'user_pref("webgl.disabled", false);',
       'user_pref("gfx.webrender.software", true);',

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -27,9 +27,10 @@ import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
+import { runSoak } from "./demos/soak.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak };
 // macOS workstation path first, then the usual Linux install paths (the CI
 // matrix cell, Task 60h). Missing everywhere is a loud failure, never a silent
 // substitution of some other browser.

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -234,6 +234,18 @@ async function main() {
     const context = tree.contexts[0]?.context;
     if (!context) throw new Error("Firefox exposed no browsing context");
 
+    // Pin the viewport to the same 1280x900 the Chrome and Safari drivers use.
+    // Firefox IGNORES --window-size in headless mode -- it kept reporting its own
+    // 1366x682 default -- and Godot sizes its viewport from the canvas, so an
+    // unpinned Firefox judges "left the screen" against different geometry than
+    // the other two engines. This is a gate comparing engines; the geometry has to
+    // be the constant.
+    await command("browsingContext.setViewport", {
+      context,
+      viewport: { width: 1280, height: 900 },
+      devicePixelRatio: 1,
+    });
+
     const evaluate = async (expression) => {
       const result = await command("script.evaluate", {
         expression,

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -111,13 +111,6 @@ async function main() {
     path.join(profileDir, "user.js"),
     [
       'user_pref("remote.active-protocols", 2);',
-      // Pin the refresh driver to 60Hz. With no vsync to pace it, headless Firefox
-      // ran requestAnimationFrame at ~500Hz, and Godot's main loop advanced a fixed
-      // step per iteration -- so the scene ran roughly EIGHT TIMES real time (392
-      // simulated seconds in 45 wall seconds on a CI runner). No real browser does
-      // that, and a gate driving the engine at 8x is not measuring the engine users
-      // get.
-      'user_pref("layout.frame_rate", 60);',
       'user_pref("webgl.force-enabled", true);',
       'user_pref("webgl.disabled", false);',
       'user_pref("gfx.webrender.software", true);',
@@ -131,11 +124,9 @@ async function main() {
     [
       "--headless",
       "--no-remote",
-      // Pin the window, as the Chrome and Safari drivers already do. Godot sizes
-      // its viewport from the canvas, so an unpinned window makes the VIEWPORT --
-      // and therefore what "left the screen" means -- depend on the host's default
-      // window size. That is what made dodge's mobs never exit on a Linux runner
-      // while the same build passed on a macOS Firefox.
+      // Headless Firefox IGNORES this; the viewport is really pinned through
+      // browsingContext.setViewport below. Kept because it costs nothing and is
+      // what a reader expects to find next to --headless.
       "--window-size=1280,900",
       `--profile`,
       profileDir,

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -26,9 +26,10 @@ import { runThirdperson } from "./demos/thirdperson.mjs";
 import { runRacing } from "./demos/racing.mjs";
 import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
+import { runSoak } from "./demos/soak.mjs";
 import { buildEnvelope, collectPayload } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web/scaffold_selftest.sh
+++ b/scripts/web/scaffold_selftest.sh
@@ -84,6 +84,9 @@ run_case wrong-checksum    1 wrong-checksum
 run_case driver-crash      1 crash
 run_case driver-timeout    1 timeout
 run_case tree-mutation     1 mutate
+# A schema-valid, fully passing run on a browser below the declared floor is
+# still not evidence: the floor gate must reject it (Task 60h).
+run_case below-floor       1 below-floor
 
 # Success case must yield a schema-valid result on disk.
 if [[ -f "$WORK/success/result.json" ]] \

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# web_ci_matrix.sh -- Web browser matrix gate (Task 60h, promotion criterion W4).
+#
+# Exports a set of demos and drives each one through `web_export_smoke.sh` in
+# each requested browser, then aggregates every run into one machine-readable
+# evidence file. This is what CI runs; it is also the one command a maintainer
+# runs locally before a release.
+#
+# Why a matrix runner instead of a for-loop in the workflow: a demo can pass its
+# own driver's checks and still fail the envelope schema (tpsdemo did exactly
+# that on every engine until kanama#118). Routing every cell through
+# `web_export_smoke.sh` -- which validates the envelope before it prints PASS --
+# is what makes "the corpus is green" mean something.
+#
+# The matrix is Chrome + Firefox. Safari is deliberately NOT a CI cell: it has
+# no headless mode, needs a logged-in GUI session with an unoccluded window, and
+# two concurrent Safari gates cannot be told apart by the driver's PID-diff
+# reaping. `--engine safari` works here for the local pre-promotion gate, but run
+# it alone.
+#
+# Every cell runs even after an earlier one fails, so a red run reports the whole
+# picture instead of the first casualty.
+#
+# Usage:
+#   scripts/web_ci_matrix.sh \
+#       --godot <godot-binary> \
+#       --template <web_nothreads_release.zip> \
+#       [--demos-dir <kanama-demos checkout>] \
+#       [--demo-set pr|full] [--demo <key> ...] \
+#       [--engine chrome] [--engine firefox] \
+#       [--chrome-binary <path>] [--firefox-binary <path>] \
+#       [--result-dir <dir>] [--evidence <path>] [--summary-md <path>] \
+#       [--timeout-scale <n>] [--skip-export] [--keep-exports]
+#
+# `--demo-set pr` is the per-PR subset, `full` the whole corpus (see
+# scripts/web/demos.sh for both lists and the per-demo budgets).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT_DIR/scripts/web"
+# shellcheck source=scripts/web/demos.sh
+source "$WEB_DIR/demos.sh"
+
+GODOT_BIN=""
+TEMPLATE=""
+DEMOS_DIR=""
+DEMO_SET=""
+DEMOS=()
+ENGINES=()
+CHROME_BINARY=""
+FIREFOX_BINARY=""
+RESULT_DIR=""
+EVIDENCE=""
+SUMMARY_MD=""
+TIMEOUT_SCALE="${KANAMA_WEB_TIMEOUT_SCALE:-1}"
+SKIP_EXPORT=0
+KEEP_EXPORTS=0
+CREATED_RESULT_DIR=0
+
+die() {
+  echo "[web_ci_matrix] $*" >&2
+  exit 2
+}
+
+usage() {
+  sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --godot) GODOT_BIN="${2:?}"; shift 2 ;;
+    --template) TEMPLATE="${2:?}"; shift 2 ;;
+    --demos-dir) DEMOS_DIR="${2:?}"; shift 2 ;;
+    --demo-set) DEMO_SET="${2:?}"; shift 2 ;;
+    --demo) DEMOS+=("${2:?}"); shift 2 ;;
+    --engine) ENGINES+=("${2:?}"); shift 2 ;;
+    --chrome-binary) CHROME_BINARY="${2:?}"; shift 2 ;;
+    --firefox-binary) FIREFOX_BINARY="${2:?}"; shift 2 ;;
+    --result-dir) RESULT_DIR="${2:?}"; shift 2 ;;
+    --evidence) EVIDENCE="${2:?}"; shift 2 ;;
+    --summary-md) SUMMARY_MD="${2:?}"; shift 2 ;;
+    --timeout-scale) TIMEOUT_SCALE="${2:?}"; shift 2 ;;
+    --skip-export) SKIP_EXPORT=1; shift ;;
+    --keep-exports) KEEP_EXPORTS=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+# Argument shape first, environment second: a typo in --demo-set should not be
+# reported as a missing export template.
+[[ "$TIMEOUT_SCALE" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "--timeout-scale must be a positive number"
+
+case "${DEMO_SET:-}" in
+  "") ;;
+  pr) DEMOS+=("${KANAMA_WEB_PR_DEMOS[@]}") ;;
+  full) DEMOS+=("${KANAMA_WEB_ALL_DEMOS[@]}") ;;
+  *) die "unknown --demo-set: $DEMO_SET (expected pr|full)" ;;
+esac
+[[ "${#DEMOS[@]}" -gt 0 ]] || DEMOS=("${KANAMA_WEB_PR_DEMOS[@]}")
+for demo in "${DEMOS[@]}"; do
+  kanama_web_demo_is_known "$demo" ||
+    die "unknown --demo: $demo (expected one of: ${KANAMA_WEB_ALL_DEMOS[*]})"
+done
+
+[[ "${#ENGINES[@]}" -gt 0 ]] || ENGINES=(chrome firefox)
+for engine in "${ENGINES[@]}"; do
+  case "$engine" in
+    chrome|firefox) ;;
+    safari)
+      echo "[web_ci_matrix] NOTE: Safari is a local gate -- never run two Safari" >&2
+      echo "[web_ci_matrix]       gates at once on one machine (PID-diff reaping)." >&2
+      ;;
+    *) die "unknown --engine: $engine (expected chrome|firefox|safari)" ;;
+  esac
+done
+
+[[ -n "$GODOT_BIN" ]] || die "--godot is required"
+[[ -x "$GODOT_BIN" ]] || die "Godot binary is not executable: $GODOT_BIN"
+GODOT_BIN="$(cd "$(dirname "$GODOT_BIN")" && pwd)/$(basename "$GODOT_BIN")"
+if [[ "$SKIP_EXPORT" -eq 0 ]]; then
+  [[ -n "$TEMPLATE" ]] || die "--template /path/to/web_nothreads_release.zip is required"
+  [[ -f "$TEMPLATE" ]] || die "export template not found: $TEMPLATE"
+  TEMPLATE="$(cd "$(dirname "$TEMPLATE")" && pwd)/$(basename "$TEMPLATE")"
+fi
+
+# A demos checkout is only needed when a selected demo actually lives there.
+NEEDS_DEMOS_DIR=0
+for demo in "${DEMOS[@]}"; do
+  [[ -n "$(kanama_web_demo_project_dir "$demo")" ]] && NEEDS_DEMOS_DIR=1
+done
+if [[ "$NEEDS_DEMOS_DIR" -eq 1 ]]; then
+  [[ -n "$DEMOS_DIR" ]] || die "--demos-dir is required for the selected demos"
+  [[ -d "$DEMOS_DIR" ]] || die "demos checkout not found: $DEMOS_DIR"
+  DEMOS_DIR="$(cd "$DEMOS_DIR" && pwd)"
+fi
+
+if [[ -z "$RESULT_DIR" ]]; then
+  RESULT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kanama_web_matrix.XXXXXX")"
+  CREATED_RESULT_DIR=1
+else
+  mkdir -p "$RESULT_DIR"
+fi
+RESULT_DIR="$(cd "$RESULT_DIR" && pwd)"
+RUNS_DIR="$RESULT_DIR/runs"
+mkdir -p "$RUNS_DIR"
+
+absolutize_out() {
+  mkdir -p "$(dirname "$1")"
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+[[ -n "$EVIDENCE" ]] && EVIDENCE="$(absolutize_out "$EVIDENCE")"
+[[ -n "$SUMMARY_MD" ]] && SUMMARY_MD="$(absolutize_out "$SUMMARY_MD")"
+[[ -n "$EVIDENCE" ]] || EVIDENCE="$RESULT_DIR/web-ci-matrix-evidence.json"
+
+echo "[web_ci_matrix] demos:   ${DEMOS[*]}"
+echo "[web_ci_matrix] engines: ${ENGINES[*]}"
+echo "[web_ci_matrix] results: $RESULT_DIR"
+
+FAILED=0
+RUN_INDEX=0
+
+for demo in "${DEMOS[@]}"; do
+  echo "[web_ci_matrix] === $demo ==="
+  export_dir="$ROOT_DIR/web-runtime/build/web-export/$demo"
+
+  if [[ "$SKIP_EXPORT" -eq 0 ]]; then
+    # Always export from a clean directory: a stale export silently re-runs an
+    # older protocol and the mismatch surfaces as an unrelated driver failure.
+    rm -rf "$export_dir"
+    gradle_args=(
+      --no-daemon
+      -Pkotlin.compiler.execution.strategy=in-process
+      :web-runtime:exportWeb
+      "-PkanamaWebDemo=$demo"
+      "-PkanamaGodotExecutable=$GODOT_BIN"
+      "-PkanamaWebTemplateRelease=$TEMPLATE"
+    )
+    project_subdir="$(kanama_web_demo_project_dir "$demo")"
+    if [[ -n "$project_subdir" ]]; then
+      project_dir="$DEMOS_DIR/$project_subdir"
+      [[ -d "$project_dir" ]] || die "$demo: demo project not found: $project_dir"
+      gradle_args+=("-P$(kanama_web_demo_project_property "$demo")=$project_dir")
+    fi
+    while IFS= read -r extra; do
+      [[ -n "$extra" ]] && gradle_args+=("$extra")
+    done < <(kanama_web_demo_export_args "$demo")
+
+    if ! "$ROOT_DIR/gradlew" -p "$ROOT_DIR" "${gradle_args[@]}"; then
+      echo "[web_ci_matrix] $demo: EXPORT FAILED" >&2
+      FAILED=1
+      continue
+    fi
+  fi
+
+  if [[ ! -f "$export_dir/index.html" ]]; then
+    echo "[web_ci_matrix] $demo: no export at $export_dir" >&2
+    FAILED=1
+    continue
+  fi
+
+  report="$export_dir/kanama-web/export-report.json"
+  payload_bytes=""
+  protocol=""
+  if [[ -f "$report" ]]; then
+    payload_bytes="$(python3 -c '
+import json, sys
+report = json.load(open(sys.argv[1]))
+print(report.get("totalBytes") or sum(f["bytes"] for f in report["files"]))
+' "$report")"
+    protocol="$(python3 -c '
+import json, sys
+print(json.load(open(sys.argv[1])).get("protocolVersion", ""))
+' "$report")"
+  fi
+
+  for engine in "${ENGINES[@]}"; do
+    RUN_INDEX=$((RUN_INDEX + 1))
+    budget="$(python3 -c 'import math,sys; print(int(math.ceil(float(sys.argv[1]) * float(sys.argv[2]))))' \
+      "$(kanama_web_demo_timeout "$demo")" "$TIMEOUT_SCALE")"
+    result_path="$RESULT_DIR/$demo-$engine.json"
+    smoke_args=(
+      --engine "$engine"
+      --export-dir "$export_dir"
+      --demo "$demo"
+      --result "$result_path"
+      --timeout "$budget"
+      --log-dir "$RESULT_DIR"
+    )
+    case "$engine" in
+      chrome) [[ -n "$CHROME_BINARY" ]] && smoke_args+=(--browser-binary "$CHROME_BINARY") ;;
+      firefox) [[ -n "$FIREFOX_BINARY" ]] && smoke_args+=(--browser-binary "$FIREFOX_BINARY") ;;
+    esac
+
+    echo "[web_ci_matrix] --- $demo on $engine (budget ${budget}s) ---"
+    started="$(date +%s)"
+    cell_pass="false"
+    if "$ROOT_DIR/scripts/web_export_smoke.sh" "${smoke_args[@]}"; then
+      cell_pass="true"
+    else
+      echo "[web_ci_matrix] $demo on $engine: FAILED" >&2
+      FAILED=1
+    fi
+    elapsed=$(( $(date +%s) - started ))
+
+    python3 -c '
+import json, os, sys
+(out, demo, engine, passed, elapsed, payload, protocol, result_path, web_dir) = sys.argv[1:]
+sys.path.insert(0, web_dir)
+from browser_version import parse_version
+record = {
+    "demo": demo,
+    "engine": engine,
+    "pass": passed == "true",
+    "wallSeconds": int(elapsed),
+    "exportPayloadBytes": int(payload) if payload else None,
+    "protocolVersion": int(protocol) if protocol else None,
+    "resultPath": result_path,
+    "browser": None,
+    "durationMs": None,
+    "assertions": None,
+    "liveAfterTeardown": None,
+}
+# Fold the driver envelope in, when the driver got far enough to write one: the
+# browser version is what the floor check reads, and a failed cell is far easier
+# to triage with its assertion summary attached.
+if os.path.exists(result_path):
+    try:
+        envelope = json.load(open(result_path))
+    except (OSError, ValueError):
+        envelope = None
+    if isinstance(envelope, dict):
+        browser = envelope.get("browser")
+        if isinstance(browser, dict):
+            # Keep the raw user-agent as the evidence and add the read version
+            # beside it, so the floor gate never re-derives it differently.
+            browser = dict(browser)
+            browser["parsedVersion"] = parse_version(engine, browser.get("version"))
+        record["browser"] = browser
+        record["durationMs"] = envelope.get("durationMs")
+        summary = (envelope.get("assertions") or {}).get("summary")
+        record["assertions"] = summary
+        record["liveAfterTeardown"] = (envelope.get("handles") or {}).get("liveAfterTeardown")
+with open(out, "w") as handle:
+    json.dump(record, handle, indent=2)
+' "$RUNS_DIR/$(printf '%03d' "$RUN_INDEX")-$demo-$engine.json" \
+      "$demo" "$engine" "$cell_pass" "$elapsed" "$payload_bytes" "$protocol" "$result_path" \
+      "$WEB_DIR"
+  done
+
+  if [[ "$KEEP_EXPORTS" -eq 0 && "$SKIP_EXPORT" -eq 0 ]]; then
+    # The full corpus is ~500 MB of exports; a CI host does not need them once
+    # every cell has run. Evidence lives in the result JSON, not the payload.
+    rm -rf "$export_dir"
+  fi
+done
+
+python3 - "$EVIDENCE" "$ROOT_DIR" "$GODOT_BIN" "$TEMPLATE" "$FAILED" "$RUNS_DIR" \
+  "${DEMOS_DIR:-}" "${SUMMARY_MD:-}" "${DEMO_SET:-custom}" <<'PY'
+import datetime, glob, json, os, subprocess, sys
+
+(path, root, godot, template, failed, runs_dir, demos_dir, summary_md, demo_set) = sys.argv[1:]
+runs = [json.load(open(name)) for name in sorted(glob.glob(os.path.join(runs_dir, "*.json")))]
+
+
+def git(repo, *args):
+    if not repo or not os.path.isdir(repo):
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo, *args], capture_output=True, text=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return out.stdout.strip() or None
+
+
+godot_version = subprocess.run(
+    [godot, "--headless", "--version"], capture_output=True, text=True
+).stdout.strip().splitlines()
+evidence = {
+    "schemaVersion": 1,
+    "gate": "web-ci-matrix",
+    "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+    "demoSet": demo_set,
+    "kanama": {"commit": git(root, "rev-parse", "HEAD")},
+    "demos": {"commit": git(demos_dir, "rev-parse", "HEAD")} if demos_dir else None,
+    "godot": {"binary": godot, "version": godot_version[-1] if godot_version else None},
+    "template": template or None,
+    "runs": runs,
+    "pass": failed == "0",
+}
+with open(path, "w") as handle:
+    json.dump(evidence, handle, indent=2)
+    handle.write("\n")
+print(f"[web_ci_matrix] evidence: {path}")
+
+lines = [
+    "| demo | engine | result | wall | browser | protocol |",
+    "| --- | --- | --- | --- | --- | --- |",
+]
+for run in runs:
+    browser = run.get("browser") or {}
+    version = browser.get("parsedVersion") or "?"
+    lines.append(
+        "| {demo} | {engine} | {verdict} | {wall}s | {name} {version} | {protocol} |".format(
+            demo=run["demo"],
+            engine=run["engine"],
+            verdict="PASS" if run["pass"] else "**FAIL**",
+            wall=run["wallSeconds"],
+            name=browser.get("name") or run["engine"],
+            version=version,
+            protocol=run.get("protocolVersion") or "-",
+        )
+    )
+table = "\n".join(lines)
+print(table)
+if summary_md:
+    with open(summary_md, "w") as handle:
+        handle.write(f"### Web matrix ({demo_set})\n\n{table}\n")
+PY
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "[web_ci_matrix] FAIL -- see $RESULT_DIR" >&2
+  exit 1
+fi
+
+if [[ "$CREATED_RESULT_DIR" -eq 1 ]]; then
+  echo "[web_ci_matrix] results kept at $RESULT_DIR"
+fi
+echo "[web_ci_matrix] PASS -- ${#DEMOS[@]} demo(s) x ${#ENGINES[@]} engine(s)"

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -168,7 +168,10 @@ RUN_INDEX=0
 
 for demo in "${DEMOS[@]}"; do
   echo "[web_ci_matrix] === $demo ==="
-  export_dir="$ROOT_DIR/web-runtime/build/web-export/$demo"
+  # The build key can differ from the driver key: the soak gate drives the dodge
+  # export. Everything else exports under its own name.
+  export_key="$(kanama_web_demo_export_key "$demo")"
+  export_dir="$ROOT_DIR/web-runtime/build/web-export/$export_key"
 
   if [[ "$SKIP_EXPORT" -eq 0 ]]; then
     # Always export from a clean directory: a stale export silently re-runs an
@@ -178,19 +181,19 @@ for demo in "${DEMOS[@]}"; do
       --no-daemon
       -Pkotlin.compiler.execution.strategy=in-process
       :web-runtime:exportWeb
-      "-PkanamaWebDemo=$demo"
+      "-PkanamaWebDemo=$export_key"
       "-PkanamaGodotExecutable=$GODOT_BIN"
       "-PkanamaWebTemplateRelease=$TEMPLATE"
     )
-    project_subdir="$(kanama_web_demo_project_dir "$demo")"
+    project_subdir="$(kanama_web_demo_project_dir "$export_key")"
     if [[ -n "$project_subdir" ]]; then
       project_dir="$DEMOS_DIR/$project_subdir"
       [[ -d "$project_dir" ]] || die "$demo: demo project not found: $project_dir"
-      gradle_args+=("-P$(kanama_web_demo_project_property "$demo")=$project_dir")
+      gradle_args+=("-P$(kanama_web_demo_project_property "$export_key")=$project_dir")
     fi
     while IFS= read -r extra; do
       [[ -n "$extra" ]] && gradle_args+=("$extra")
-    done < <(kanama_web_demo_export_args "$demo")
+    done < <(kanama_web_demo_export_args "$export_key")
 
     if ! "$ROOT_DIR/gradlew" -p "$ROOT_DIR" "${gradle_args[@]}"; then
       echo "[web_ci_matrix] $demo: EXPORT FAILED" >&2

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -127,11 +127,14 @@ if [[ "$SKIP_EXPORT" -eq 0 ]]; then
   TEMPLATE="$(cd "$(dirname "$TEMPLATE")" && pwd)/$(basename "$TEMPLATE")"
 fi
 
-# A demos checkout is only needed when a selected demo actually lives there.
+# A demos checkout is only needed to EXPORT a demo that lives there; driving an
+# already-built export needs nothing but the export directory.
 NEEDS_DEMOS_DIR=0
-for demo in "${DEMOS[@]}"; do
-  [[ -n "$(kanama_web_demo_project_dir "$demo")" ]] && NEEDS_DEMOS_DIR=1
-done
+if [[ "$SKIP_EXPORT" -eq 0 ]]; then
+  for demo in "${DEMOS[@]}"; do
+    [[ -n "$(kanama_web_demo_project_dir "$demo")" ]] && NEEDS_DEMOS_DIR=1
+  done
+fi
 if [[ "$NEEDS_DEMOS_DIR" -eq 1 ]]; then
   [[ -n "$DEMOS_DIR" ]] || die "--demos-dir is required for the selected demos"
   [[ -d "$DEMOS_DIR" ]] || die "demos checkout not found: $DEMOS_DIR"

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -279,11 +279,19 @@ print(json.load(open(sys.argv[1])).get("protocolVersion", ""))
       firefox) [[ -n "$FIREFOX_BINARY" ]] && smoke_args+=(--browser-binary "$FIREFOX_BINARY") ;;
     esac
 
-    echo "[web_ci_matrix] --- $demo on $engine (budget ${budget}s) ---"
+    quarantine="$(kanama_web_quarantine_reason "$demo:$engine")"
+    echo "[web_ci_matrix] --- $demo on $engine (budget ${budget}s)${quarantine:+ [QUARANTINED]} ---"
     started="$(date +%s)"
     cell_pass="false"
     if "$ROOT_DIR/scripts/web_export_smoke.sh" "${smoke_args[@]}"; then
       cell_pass="true"
+      if [[ -n "$quarantine" ]]; then
+        # A stale quarantine is worse than no quarantine: say so every single run.
+        echo "[web_ci_matrix] $demo on $engine PASSED while quarantined ($quarantine)."
+        echo "[web_ci_matrix] If this holds, LIFT the quarantine in scripts/web/demos.sh."
+      fi
+    elif [[ -n "$quarantine" ]]; then
+      echo "[web_ci_matrix] $demo on $engine: FAILED but QUARANTINED -- $quarantine" >&2
     else
       echo "[web_ci_matrix] $demo on $engine: FAILED" >&2
       FAILED=1
@@ -292,7 +300,7 @@ print(json.load(open(sys.argv[1])).get("protocolVersion", ""))
 
     python3 -c '
 import json, os, sys
-(out, demo, engine, passed, elapsed, payload, protocol, result_path, web_dir) = sys.argv[1:]
+(out, demo, engine, passed, elapsed, payload, protocol, result_path, web_dir, quarantine) = sys.argv[1:]
 sys.path.insert(0, web_dir)
 from browser_version import parse_version
 record = {
@@ -303,6 +311,7 @@ record = {
     "exportPayloadBytes": int(payload) if payload else None,
     "protocolVersion": int(protocol) if protocol else None,
     "resultPath": result_path,
+    "quarantine": quarantine or None,
     "browser": None,
     "durationMs": None,
     "assertions": None,
@@ -332,7 +341,7 @@ with open(out, "w") as handle:
     json.dump(record, handle, indent=2)
 ' "$RUNS_DIR/$(printf '%03d' "$RUN_INDEX")-$demo-$engine.json" \
       "$demo" "$engine" "$cell_pass" "$elapsed" "$payload_bytes" "$protocol" "$result_path" \
-      "$WEB_DIR"
+      "$WEB_DIR" "$quarantine"
   done
 
   if [[ "$KEEP_EXPORTS" -eq 0 && "$SKIP_EXPORT" -eq 0 ]]; then
@@ -393,7 +402,10 @@ for run in runs:
         "| {demo} | {engine} | {verdict} | {wall}s | {name} {version} | {protocol} |".format(
             demo=run["demo"],
             engine=run["engine"],
-            verdict="PASS" if run["pass"] else "**FAIL**",
+            verdict=(
+                ("PASS" if run["pass"] else "**FAIL**")
+                + (" _(quarantined)_" if run.get("quarantine") else "")
+            ),
             wall=run["wallSeconds"],
             name=browser.get("name") or run["engine"],
             version=version,

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -163,6 +163,42 @@ echo "[web_ci_matrix] demos:   ${DEMOS[*]}"
 echo "[web_ci_matrix] engines: ${ENGINES[*]}"
 echo "[web_ci_matrix] results: $RESULT_DIR"
 
+# Record a failed cell per engine for a demo that never got as far as a driver
+# run. Without this a missing or failed export makes the demo VANISH from the
+# summary table -- the run reports FAIL with no row explaining which demo, which
+# is the same "absence of evidence reads as evidence" trap this gate exists to
+# close.
+record_unrun_demo() {
+  local demo="$1" reason="$2"
+  local engine
+  for engine in "${ENGINES[@]}"; do
+    RUN_INDEX=$((RUN_INDEX + 1))
+    python3 -c '
+import json, sys
+out, demo, engine, reason = sys.argv[1:]
+with open(out, "w") as handle:
+    json.dump(
+        {
+            "demo": demo,
+            "engine": engine,
+            "pass": False,
+            "wallSeconds": 0,
+            "failureReason": reason,
+            "exportPayloadBytes": None,
+            "protocolVersion": None,
+            "resultPath": None,
+            "browser": None,
+            "durationMs": None,
+            "assertions": None,
+            "liveAfterTeardown": None,
+        },
+        handle,
+        indent=2,
+    )
+' "$RUNS_DIR/$(printf '%03d' "$RUN_INDEX")-$demo-$engine.json" "$demo" "$engine" "$reason"
+  done
+}
+
 FAILED=0
 RUN_INDEX=0
 
@@ -198,6 +234,7 @@ for demo in "${DEMOS[@]}"; do
     if ! "$ROOT_DIR/gradlew" -p "$ROOT_DIR" "${gradle_args[@]}"; then
       echo "[web_ci_matrix] $demo: EXPORT FAILED" >&2
       FAILED=1
+      record_unrun_demo "$demo" "export failed"
       continue
     fi
   fi
@@ -205,6 +242,7 @@ for demo in "${DEMOS[@]}"; do
   if [[ ! -f "$export_dir/index.html" ]]; then
     echo "[web_ci_matrix] $demo: no export at $export_dir" >&2
     FAILED=1
+    record_unrun_demo "$demo" "no export at $export_dir"
     continue
   fi
 
@@ -350,7 +388,7 @@ lines = [
 ]
 for run in runs:
     browser = run.get("browser") or {}
-    version = browser.get("parsedVersion") or "?"
+    version = browser.get("parsedVersion") or run.get("failureReason") or "?"
     lines.append(
         "| {demo} | {engine} | {verdict} | {wall}s | {name} {version} | {protocol} |".format(
             demo=run["demo"],

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -230,6 +230,13 @@ if ! python3 "$WEB_DIR/result_schema.py" "$RESULT"; then
   fail "result schema validation failed for $RESULT"
 fi
 
+# --- the run must be on a browser we have actually declared. ------------------
+# A green run says nothing beyond the browser it ran on; without this, a run on
+# an older, never-validated browser prints the same PASS line as a declared one.
+if ! python3 "$WEB_DIR/check_browser_floor.py" "$RESULT"; then
+  fail "browser version floor check failed for $RESULT"
+fi
+
 # --- prove the served tree was not mutated by serving/driving. ----------------
 CHECKSUM_AFTER="$(tree_checksum "$EXPORT_DIR")"
 if [[ "$CHECKSUM_BEFORE" != "$CHECKSUM_AFTER" ]]; then

--- a/scripts/web_fresh_checkout_smoke.sh
+++ b/scripts/web_fresh_checkout_smoke.sh
@@ -44,46 +44,13 @@ GODOT_BIN=""
 DEMOS=()
 CREATED_WORK_DIR=0
 
-ALL_DEMOS=(match3 bunnymark dodge web3d platformer squash fps charactercontroller thirdperson racing citybuilder tpsdemo)
-
-# demo key -> kanama-demos project directory. `web3d` is an in-repo fixture and
-# needs no demos checkout; its project dir is resolved by the build itself.
-demo_project_dir() {
-  case "$1" in
-    match3) echo "Starter-Kit-Match3" ;;
-    bunnymark) echo "Bunnymark" ;;
-    dodge) echo "godot-demo-2d-dodge-the-creeps" ;;
-    web3d) echo "" ;;
-    platformer) echo "Starter-Kit-3D-Platformer" ;;
-    squash) echo "godot-demo-3d-squash-the-creeps" ;;
-    fps) echo "Starter-Kit-FPS" ;;
-    charactercontroller) echo "godot-4-3d-character-controller-tutorial" ;;
-    thirdperson) echo "godot-4-3d-third-person-controller" ;;
-    racing) echo "Starter-Kit-Racing" ;;
-    citybuilder) echo "Starter-Kit-City-Builder" ;;
-    tpsdemo) echo "tps-demo-kanama" ;;
-    *) return 1 ;;
-  esac
-}
-
-# demo key -> the -PkanamaWeb<Key>ProjectDir gradle property the build reads.
-demo_project_property() {
-  case "$1" in
-    match3) echo "kanamaWebMatch3ProjectDir" ;;
-    bunnymark) echo "kanamaWebBunnymarkProjectDir" ;;
-    dodge) echo "kanamaWebDodgeProjectDir" ;;
-    web3d) echo "" ;;
-    platformer) echo "kanamaWebPlatformerProjectDir" ;;
-    squash) echo "kanamaWebSquashProjectDir" ;;
-    fps) echo "kanamaWebFpsProjectDir" ;;
-    charactercontroller) echo "kanamaWebCharactercontrollerProjectDir" ;;
-    thirdperson) echo "kanamaWebThirdpersonProjectDir" ;;
-    racing) echo "kanamaWebRacingProjectDir" ;;
-    citybuilder) echo "kanamaWebCitybuilderProjectDir" ;;
-    tpsdemo) echo "kanamaWebTpsdemoProjectDir" ;;
-    *) return 1 ;;
-  esac
-}
+# The corpus registry (demo key -> project dir -> gradle property) is shared with
+# the CI matrix gate so the two can never disagree about what the corpus is.
+# shellcheck source=scripts/web/demos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/web/demos.sh"
+ALL_DEMOS=("${KANAMA_WEB_ALL_DEMOS[@]}")
+demo_project_dir() { kanama_web_demo_project_dir "$@"; }
+demo_project_property() { kanama_web_demo_project_property "$@"; }
 
 die() {
   echo "[web_fresh_checkout] $*" >&2
@@ -222,10 +189,9 @@ for demo in "${DEMOS[@]}"; do
     gradle_args+=("-P$project_property=$project_dir")
     source_before="$(checksum "$project_dir" --exclude .git --exclude .godot)"
   fi
-  # Bunnymark's validated Web configuration is the 256-sprite V1Sprites variant.
-  if [[ "$demo" == "bunnymark" ]]; then
-    gradle_args+=("-PkanamaWebBunnymarkVariant=BunnymarkV1Sprites")
-  fi
+  while IFS= read -r extra; do
+    [[ -n "$extra" ]] && gradle_args+=("$extra")
+  done < <(kanama_web_demo_export_args "$demo")
 
   run "$KANAMA_DIR/gradlew" -p "$KANAMA_DIR" "${gradle_args[@]}"
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFrameScheduler.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFrameScheduler.kt
@@ -62,6 +62,8 @@ internal class WebFrameSchedulerState {
     currentOwnerHandle.takeIf { it > 0 }
       ?: error("Kanama Web frame work was scheduled outside a script callback")
 
+  fun currentOwnerOrZero(): Int = currentOwnerHandle
+
   fun scheduleNextFrame(ownerHandle: Int, job: Job?, action: () -> Unit): Long =
     schedule(ownerHandle, frame + 1L, elapsedSeconds, job, action)
 
@@ -191,8 +193,21 @@ internal object WebFrameScheduler {
 
   fun requireCurrentOwner(): Int = state.requireCurrentOwner()
 
-  fun dispatch(job: Job?, block: Runnable) {
-    val ownerHandle = requireCurrentOwner()
+  /** The owner of the running callback, or 0 when no script callback is on the stack. */
+  fun currentOwnerOrZero(): Int = state.currentOwnerOrZero()
+
+  /**
+   * Schedules a coroutine continuation.
+   *
+   * [scopeOwnerHandle] is the script that owns the scope the coroutine was launched from, when it
+   * is known. It must win over the ambient owner: `launch` frequently runs inside SOMEONE ELSE's
+   * callback -- `Main.game_over` calling `hud.showGameOver()` launches on the HUD's scope while the
+   * HUD is nowhere on the stack -- and attributing the job to the caller registers it under the
+   * wrong owner. The next resume, arriving through the owning script's own signal, then trips the
+   * one-job-one-owner check and kills the run.
+   */
+  fun dispatch(job: Job?, block: Runnable, scopeOwnerHandle: Int = 0) {
+    val ownerHandle = scopeOwnerHandle.takeIf { it > 0 } ?: requireCurrentOwner()
     if (job?.isActive == false) {
       // Coroutine cancellation dispatches a final bookkeeping continuation. Running that cleanup
       // immediately keeps cancellation deterministic and prevents inactive work from surviving

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -669,13 +669,39 @@ internal object WebFrameCoroutineDispatcher : CoroutineDispatcher() {
     get() = WebFrameScheduler.pendingCount
 
   override fun dispatch(context: kotlin.coroutines.CoroutineContext, block: Runnable) {
-    WebFrameScheduler.dispatch(context[Job], block)
+    WebFrameScheduler.dispatch(
+      context[Job],
+      block,
+      scopeOwnerHandle = context[WebScopeOwner]?.ownerHandle ?: 0,
+    )
   }
 }
 
-class KanamaScope : CoroutineScope {
+/**
+ * Carries the script that owns a [KanamaScope] through the coroutine context.
+ *
+ * Without it, a coroutine's owner is whoever happened to be on the stack at `launch`, which is
+ * routinely the wrong script: one script calling another's method (`Main.game_over` ->
+ * `hud.showGameOver()`) launches on the callee's scope from the caller's callback.
+ */
+internal class WebScopeOwner(val ownerHandle: Int) :
+  kotlin.coroutines.AbstractCoroutineContextElement(Key) {
+  companion object Key : kotlin.coroutines.CoroutineContext.Key<WebScopeOwner>
+}
+
+/**
+ * A script's coroutine scope.
+ *
+ * The owner defaults to the script being constructed: script instances are built inside their own
+ * owner scope, so `override val kanamaScope = KanamaScope()` binds to the right script with no
+ * ceremony at the call site. A scope built outside any script callback (handle 0) keeps the old
+ * behaviour and is attributed to the ambient callback at dispatch time.
+ */
+class KanamaScope(private val ownerHandle: Int = WebFrameScheduler.currentOwnerOrZero()) :
+  CoroutineScope {
   private val job = SupervisorJob()
-  override val coroutineContext = WebFrameCoroutineDispatcher + job
+  override val coroutineContext =
+    WebFrameCoroutineDispatcher + job + WebScopeOwner(ownerHandle)
 
   fun cancel() {
     job.cancel()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/web/WebInstanceRegistry.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/web/WebInstanceRegistry.kt
@@ -1,5 +1,7 @@
 package net.multigesture.kanama.web
 
+import net.multigesture.kanama.api.WebFrameScheduler
+
 internal data class WebScriptRecord(val scriptId: Int, val script: KanamaWebScript)
 
 /**
@@ -23,7 +25,14 @@ internal class WebInstanceRegistry(
     val slot = slots[slotIndex]
     slot.generation = nextGeneration(slot.generation)
     val handle = encode(slotIndex, slot.generation)
-    slot.record = WebScriptRecord(scriptId, createScript(scriptId, handle))
+    // Construct the script inside its own owner scope. A script's property initializers run here,
+    // and `override val kanamaScope = KanamaScope()` is one of them: the scope must bind to the
+    // script being built, not to whichever callback happened to trigger the construction.
+    slot.record =
+      WebScriptRecord(
+        scriptId,
+        WebFrameScheduler.withOwner(handle) { createScript(scriptId, handle) },
+      )
     return handle
   }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -85,13 +85,34 @@ private fun <T> webCallbackBoundary(
       withActiveWebScriptHandle(objectId) { block(record) }
     }
   } catch (error: Throwable) {
-    val causeDetail = error.message ?: error::class.simpleName ?: "unknown error"
     throw IllegalStateException(
       "Kanama Web callback failed: script=$scriptName handle=$objectId callback=$callback " +
-        "member=$memberName cause=$causeDetail",
+        "member=$memberName cause=${describeCauseChain(error)}",
       error,
     )
   }
+}
+
+/**
+ * Renders a throwable and its causes as one line.
+ *
+ * The reason this is not just `error.message`: a failure inside a coroutine arrives wrapped by
+ * kotlinx.coroutines ("Coroutine dispatcher ... threw an exception"), whose own message names the
+ * dispatcher and says nothing about what actually went wrong. Reporting only the outermost message
+ * is reliably one layer short of the answer, and a Wasm stack trace cannot make up the difference.
+ */
+private fun describeCauseChain(error: Throwable, limit: Int = 5): String = buildString {
+  var current: Throwable? = error
+  var depth = 0
+  while (current != null && depth < limit) {
+    val throwable = current
+    if (depth > 0) append(" <- ")
+    append(throwable::class.simpleName ?: "Throwable")
+    throwable.message?.let { append(": ").append(it) }
+    current = throwable.cause.takeIf { it !== throwable }
+    depth += 1
+  }
+  if (current != null) append(" <- ...")
 }
 
 @JsExport fun kanamaWebProtocolVersion(): Int = KanamaWebProjectRegistry.PROTOCOL_VERSION

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -259,6 +259,10 @@
     match3Properties: new Map(),
     match3ReadyByClass: {},
     match3DeferredReadyByClass: {},
+    // handle -> script class name, recorded at ready. Purely diagnostic: a
+    // boundary failure otherwise reports a bare handle number, which tells a CI
+    // log reader nothing about which script actually threw.
+    scriptNameByHandle: {},
     match3PackedSceneInstantiations: 0,
     match3AddChildCommands: 0,
     match3TextureAssignments: 0,
@@ -383,9 +387,17 @@
       try {
         return action();
       } catch (error) {
-        const detail = error?.stack ?? error?.message ?? String(error);
+        // Chrome's `stack` starts with the message; Firefox's does not. Taking
+        // the stack alone therefore reports a Firefox-only boundary failure as
+        // a wall of wasm frames with no reason attached -- which is exactly the
+        // shape a CI-only failure arrives in.
+        const message = error?.message ?? String(error);
+        const stack = error?.stack ?? "";
+        const detail = stack.startsWith(message) ? stack : `${message}\n${stack}`.trimEnd();
+        const script = this.scriptNameByHandle[handle];
         const contextual = new Error(
-          `Kanama Web boundary failure: handle=${handle} callback=${callback} member=${member}\n${detail}`,
+          `Kanama Web boundary failure: handle=${handle}${script ? ` (${script})` : ""} ` +
+            `callback=${callback} member=${member}\n${detail}`,
         );
         this.callbackErrors += 1;
         this.lastCallbackError = contextual.message;
@@ -2213,6 +2225,7 @@
     },
     recordReady(handle, scriptId, scriptName) {
       this.readyCount += 1;
+      this.scriptNameByHandle[handle] = scriptName;
       this.match3ReadyByClass[scriptName] = (this.match3ReadyByClass[scriptName] ?? 0) + 1;
       if (this.mode === "dodge" && scriptName.endsWith(".Main")) {
         // The Web smoke drives gameplay from the browser driver (dodge's SmokeQuit

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -225,6 +225,12 @@
     objectHandleGenerationAdvanced: false,
     signalEmits: 0,
     processCalls: 0,
+    // Accumulated engine delta. Wall-clock time is not the game's time: Godot caps
+    // how much simulation one frame may advance, so a slow host runs the SCENE in
+    // slow motion while frames keep ticking. A gate that waits a fixed number of
+    // wall seconds is really waiting for an unknown amount of gameplay, and this
+    // is the number that says which.
+    simSeconds: 0,
     noArgCalls: 0,
     addBunnyCalls: 0,
     removeBunnyCalls: 0,
@@ -485,6 +491,7 @@
             0,
           );
           this.processCalls += 1;
+        this.simSeconds += delta;
           return executed;
         }
         return this.process(handle, delta);
@@ -506,6 +513,7 @@
             0,
           );
           this.processCalls += 1;
+        this.simSeconds += delta;
           return executed;
         }
         return this.process(handle, delta);
@@ -532,6 +540,7 @@
         );
         this.match3FrameContinuations += executed;
         this.processCalls += 1;
+        this.simSeconds += delta;
         return executed;
       }
       if (this.mode === "dodge") {
@@ -549,6 +558,7 @@
             0,
           );
           this.processCalls += 1;
+        this.simSeconds += delta;
           return executed;
         }
         return this.process(handle, delta);
@@ -587,6 +597,7 @@
     process(handle, delta) {
       this.lastProcessRafTick = this.rafTick;
       this.processCalls += 1;
+        this.simSeconds += delta;
       const started = performance.now();
       const result = this.invoke(
         handle,


### PR DESCRIPTION
**Task 60h** (promotion criterion **W4**). Web had no CI cell at all — every browser result to date came from a maintainer running one demo by hand.

## What lands

- **`scripts/web_ci_matrix.sh` + `.github/workflows/web.yml`** — PR subset (`match3`, `web3d`, `dodge`) × Chrome + Firefox on Web-relevant PRs; full 12-demo corpus on push to `main` and nightly; soak nightly. Every cell routes through `web_export_smoke.sh`, so the **envelope schema** decides green, not a driver's check count (tpsdemo passed 13/13 driver checks for weeks while never satisfying the schema — #118).
- **Tested browser floors** (`scripts/web/browser_floors.json`, gated by `check_browser_floor.py`): **Chrome 130** — a real bisected minimum, 129 never boots the Kotlin/Wasm module and 130 is where WebAssembly JS String Builtins shipped. **Firefox 141** — labelled in the file as a *harness* bound: 141/143/145 pass, 140 ESR and older never expose a reachable BiDi endpoint. **Safari 26.5** stays "validated-at": it ships with the OS, so no lower bound is testable. A run whose browser cannot be identified also fails.
- **Soak / leak gate** (`--demo soak`) — 10 minutes against the dodge export, round restarted every 60s, judged on a **trend** (second-half high-water marks for live handles, pending callbacks and coroutine jobs may not exceed the first half's).
- **Regression cadence** documented, cross-linked from the Godot upgrade runbook.
- **One demo registry** (`scripts/web/demos.sh`) shared with the fresh-checkout gate, which had its own copy.
- **The Web export builds on Linux** — never attempted before this PR.

## Bugs the gate found (this is the point)

1. **Cross-owner launched coroutines** — the 60b follow-up, now fixed. `Main.game_over` → `hud.showGameOver()` launched on the HUD's scope while Main was on the stack, so the job registered under the wrong owner; the next resume through the HUD's own signal tripped the one-job-one-owner check and the fatal boundary stopped every later dispatch. A `KanamaScope` now carries its owning script through the coroutine context. Validated on all five coroutine-using demos (match3, platformer, charactercontroller, thirdperson, tpsdemo) plus the soak, which went FAIL → PASS.
2. **Two diagnostics that were one layer short** — Firefox's `Error.stack` omits the message Chrome's includes, and the Kotlin boundary printed only the outermost cause (for coroutines, kotlinx's own wrapper). Both permanent now, plus the bridge names the script behind a handle.
3. **A missing export made a demo vanish from the summary** rather than fail loudly. Fixed.

## Known red cell — [task 71](https://github.com/falcon4ever/kanama) (filed)

`dodge` on **Linux Firefox** spawns 7 mobs and frees none: live handles pinned at 31 for forty seconds, **zero console errors**, teardown still clean, only `mobsSpawnAndFree` failing. Ruled out by measurement, not assumption: browser version (152 passes on macOS), viewport geometry (now an identical 1280×900 canvas via `browsingContext.setViewport` — headless Firefox **ignores** `--window-size`), window length (45s ceiling, fully used), and a starved simulation — it is the **opposite**: the cell runs **23,465 frames and 392 simulated seconds in 45 wall seconds** (~8× real time; nothing paces rAF in headless Firefox, and `layout.frame_rate` provably does not change it).

In 392 simulated seconds a mob cannot still be on screen, so the mobs are not moving or never became visible. Prime suspect is the `PathFollow2D` spawn transform read from a mirrored snapshot — an ~8× frame rate is exactly what flips a seeding race.

**This needs a decision:** hold this PR until task 71 is fixed, or land the infrastructure with `dodge` temporarily out of the PR subset (still red nightly in the full corpus) so the gate starts protecting everything else. I have deliberately **not** weakened `mobsSpawnAndFree` — the check is correct.

## Not in this PR

60f budgets (the rest of W4). No support claim moves anywhere.