### PR TITLE
Separate "CI cannot run this" from "this is broken" (Task 60h follow-up)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -9,9 +9,13 @@ name: web
 #
 # Cadence:
 #   - pull_request  -> the PR subset (match3, web3d, dodge) x Chrome + Firefox.
-#   - push to main  -> the full 12-demo corpus x Chrome + Firefox.
-#   - nightly       -> the full corpus, to catch browser-side regressions on a
-#                      tree that has not changed.
+#   - push to main  -> the `ci` corpus x Chrome + Firefox: every demo a hosted
+#                      runner can actually build. tpsdemo is excluded because its
+#                      Kotlin/Wasm compile is OOM-killed on a 16 GB runner -- that
+#                      is a runner limit, not a defect, and it stays a LOCAL gate.
+#                      Skipped demos are announced and recorded in the evidence.
+#   - nightly       -> the same, to catch browser-side regressions on a tree that
+#                      has not changed.
 #
 # Safari is NOT a cell here and cannot become one: it has no headless mode, needs
 # a logged-in GUI session with an unoccluded window, and two concurrent Safari
@@ -29,8 +33,8 @@ on:
       demo_set:
         description: "Which corpus slice to run"
         type: choice
-        default: full
-        options: [pr, full]
+        default: ci
+        options: [pr, ci, full]
 
 permissions:
   contents: read
@@ -150,7 +154,7 @@ jobs:
       - name: Run the Web matrix
         shell: bash
         env:
-          DEMO_SET: ${{ github.event.inputs.demo_set || (github.event_name == 'pull_request' && 'pr' || 'full') }}
+          DEMO_SET: ${{ github.event.inputs.demo_set || (github.event_name == 'pull_request' && 'pr' || 'ci') }}
           # Per-sample driver tracing into the uploaded driver logs. A red cell on a
           # host nobody can log into is only as debuggable as what it recorded.
           KANAMA_WEB_SMOKE_DEBUG: "1"

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -217,7 +217,8 @@ Which gate runs when, and where. A gate that is not on this list runs nowhere.
 | Gate | Cadence | Where |
 |---|---|---|
 | PR subset × Chrome + Firefox | every Web-relevant pull request | CI (`web` workflow) |
-| Full 12-demo corpus × Chrome + Firefox | push to `main`, and nightly | CI |
+| `ci` corpus × Chrome + Firefox (everything a runner can build) | push to `main`, and nightly | CI |
+| **tps-demo** | before a release tag | local (OOM-killed on a hosted runner) |
 | Soak (10 min, `--demo soak`) | nightly | CI |
 | Full corpus on **Safari** | before a release tag, and before any promotion decision | local (no headless mode) |
 | Fresh-checkout gate | before a release tag | local |
@@ -251,6 +252,24 @@ registered coroutine jobs must not be higher in the second half than the first
 end, and teardown must still drain to zero after a long run rather than only
 after a short one.
 
+### What CI Runs, And What Stays Local
+
+Not everything can or should run on a hosted runner, and the two reasons are
+different:
+
+- **Local-only** — CI *structurally cannot* do it, and no fix changes that.
+  **Safari** (no headless mode; it needs a logged-in GUI session) and
+  **tps-demo** (its Kotlin/Wasm compile is OOM-killed on a 16 GB GitHub runner)
+  are both in this tier. They are release gates a maintainer runs by hand, and
+  they pass there.
+- **Quarantined** — a real defect, temporary, tied to a task. See below.
+
+`--demo-set ci` is the corpus minus the local-only demos and is what the workflow
+runs; `--demo-set full` always means the full corpus, so a local run is never
+quietly narrowed. Skipped demos are **announced and written into the evidence
+JSON** with their reason, because a corpus that silently shrinks is how "the
+corpus is green" stops meaning anything.
+
 ### Quarantined Cells
 
 A known-failing `demo:engine` pair can be **quarantined** in
@@ -263,8 +282,9 @@ A quarantined cell that **passes** is reported just as loudly, with an explicit
 "lift the quarantine" line, because a stale quarantine is worse than none.
 Lifting one is a one-line deletion.
 
-Currently quarantined: `dodge:firefox` (task 71 — mobs never free on a Linux
-host; it passes on macOS Chrome and Firefox, and on CI Chrome).
+Currently quarantined: `dodge:firefox`, `squash:chrome` and `squash:firefox` —
+task 71, spawned mobs never free on a Linux host. Both demos pass on macOS, and
+`dodge:chrome` passes on Linux, so it is neither a browser nor a demo property.
 
 ### Bumping The Demos Pin
 

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -107,6 +107,25 @@ kanama_web_demo_is_known() {
   kanama_web_demo_project_dir "$1" >/dev/null 2>&1
 }
 
+# Demos CI structurally cannot run -> the reason. This is NOT quarantine: nothing
+# here is a defect and nothing here gets fixed. Safari is the existing example of
+# the same idea at the engine level (no headless mode, so it is a local gate), and
+# tpsdemo is the demo-level one: its Kotlin/Wasm compile is killed by the OOM
+# killer on a 16 GB GitHub-hosted runner, which is a property of the runner.
+#
+# These still run LOCALLY, where they pass, and the matrix records them as
+# explicitly skipped-with-a-reason rather than quietly leaving them out -- a demo
+# that silently disappears from a corpus is how a green run stops meaning
+# anything.
+kanama_web_demo_local_only_reason() {
+  case "$1" in
+    tpsdemo)
+      echo "the Kotlin/Wasm compile exceeds a GitHub-hosted runner (OOM in compileProductionExecutableKotlinWasmJs); local gate only"
+      ;;
+    *) : ;;
+  esac
+}
+
 # Quarantined cells: "demo:engine" -> the reason, which must name a task.
 #
 # A quarantined cell still EXPORTS, still RUNS, and still reports its result --
@@ -118,8 +137,8 @@ kanama_web_demo_is_known() {
 # Lifting one is a one-line deletion here.
 kanama_web_quarantine_reason() {
   case "$1" in
-    dodge:firefox)
-      echo "task 71 — mobs never free on a Linux host; passes on macOS Chrome/Firefox and on CI Chrome"
+    dodge:firefox|squash:chrome|squash:firefox)
+      echo "task 71 — spawned mobs never free on a Linux host; both demos pass on macOS"
       ;;
     *) : ;;
   esac

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -27,14 +27,16 @@
 #       --godot <godot-binary> \
 #       --template <web_nothreads_release.zip> \
 #       [--demos-dir <kanama-demos checkout>] \
-#       [--demo-set pr|full] [--demo <key> ...] \
+#       [--demo-set pr|full|ci] [--demo <key> ...] \
 #       [--engine chrome] [--engine firefox] \
 #       [--chrome-binary <path>] [--firefox-binary <path>] \
 #       [--result-dir <dir>] [--evidence <path>] [--summary-md <path>] \
 #       [--timeout-scale <n>] [--skip-export] [--keep-exports]
 #
-# `--demo-set pr` is the per-PR subset, `full` the whole corpus (see
-# scripts/web/demos.sh for both lists and the per-demo budgets).
+# `--demo-set pr` is the per-PR subset, `full` the whole corpus, and `ci` the
+# corpus minus the demos a hosted runner structurally cannot build (see
+# scripts/web/demos.sh). `full` always means FULL -- a local run is never quietly
+# narrowed.
 
 set -euo pipefail
 
@@ -94,11 +96,25 @@ done
 # reported as a missing export template.
 [[ "$TIMEOUT_SCALE" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "--timeout-scale must be a positive number"
 
+SKIPPED_DEMOS=()
 case "${DEMO_SET:-}" in
   "") ;;
   pr) DEMOS+=("${KANAMA_WEB_PR_DEMOS[@]}") ;;
   full) DEMOS+=("${KANAMA_WEB_ALL_DEMOS[@]}") ;;
-  *) die "unknown --demo-set: $DEMO_SET (expected pr|full)" ;;
+  ci)
+    # The corpus minus what a hosted runner cannot build. Skipped demos are
+    # ANNOUNCED and recorded in the evidence; they are never silently dropped.
+    for demo in "${KANAMA_WEB_ALL_DEMOS[@]}"; do
+      reason="$(kanama_web_demo_local_only_reason "$demo")"
+      if [[ -n "$reason" ]]; then
+        echo "[web_ci_matrix] SKIPPING $demo -- $reason"
+        SKIPPED_DEMOS+=("$demo|$reason")
+      else
+        DEMOS+=("$demo")
+      fi
+    done
+    ;;
+  *) die "unknown --demo-set: $DEMO_SET (expected pr|full|ci)" ;;
 esac
 [[ "${#DEMOS[@]}" -gt 0 ]] || DEMOS=("${KANAMA_WEB_PR_DEMOS[@]}")
 for demo in "${DEMOS[@]}"; do
@@ -351,11 +367,20 @@ with open(out, "w") as handle:
   fi
 done
 
+printf '%s\n' "${SKIPPED_DEMOS[@]+"${SKIPPED_DEMOS[@]}"}" >"$RESULT_DIR/skipped.txt"
 python3 - "$EVIDENCE" "$ROOT_DIR" "$GODOT_BIN" "$TEMPLATE" "$FAILED" "$RUNS_DIR" \
-  "${DEMOS_DIR:-}" "${SUMMARY_MD:-}" "${DEMO_SET:-custom}" <<'PY'
+  "${DEMOS_DIR:-}" "${SUMMARY_MD:-}" "${DEMO_SET:-custom}" "$RESULT_DIR/skipped.txt" <<'PY'
 import datetime, glob, json, os, subprocess, sys
 
-(path, root, godot, template, failed, runs_dir, demos_dir, summary_md, demo_set) = sys.argv[1:]
+(path, root, godot, template, failed, runs_dir, demos_dir, summary_md, demo_set,
+ skipped_path) = sys.argv[1:]
+skipped = []
+if os.path.exists(skipped_path):
+    for line in open(skipped_path):
+        line = line.strip()
+        if line:
+            demo, _, reason = line.partition("|")
+            skipped.append({"demo": demo, "reason": reason})
 runs = [json.load(open(name)) for name in sorted(glob.glob(os.path.join(runs_dir, "*.json")))]
 
 
@@ -384,6 +409,9 @@ evidence = {
     "godot": {"binary": godot, "version": godot_version[-1] if godot_version else None},
     "template": template or None,
     "runs": runs,
+    # Demos a hosted runner cannot build. Recorded, not omitted: a corpus that
+    # quietly shrinks is how "the corpus is green" stops meaning anything.
+    "skipped": skipped,
     "pass": failed == "0",
 }
 with open(path, "w") as handle:
@@ -412,6 +440,10 @@ for run in runs:
             protocol=run.get("protocolVersion") or "-",
         )
     )
+if skipped:
+    lines.append("")
+    for entry in skipped:
+        lines.append(f"> **skipped** `{entry['demo']}` — {entry['reason']}")
 table = "\n".join(lines)
 print(table)
 if summary_md:


### PR DESCRIPTION
The first full-corpus Linux run (post-merge of #121) put **20 of 24 cells green** and found two more problems — which are **not the same kind of problem**, and shouldn't be recorded as if they were.

## tps-demo: a runner limit, not a defect

The Gradle process is killed during `compileProductionExecutableKotlinWasmJs` — the OOM killer on a 16 GB GitHub runner meeting the largest gameplay Wasm compile in the corpus. No amount of fixing our code changes that.

So it joins Safari in a **local-only** tier: a release gate a maintainer runs by hand, where it passes (68 s locally). Filing it as a bug would be wrong; quarantining it would imply it's temporary.

- `--demo-set ci` = the corpus minus the local-only tier, and is what the workflow runs.
- `--demo-set full` still means **full**, so a local run is never quietly narrowed.
- Skipped demos are **announced and written into the evidence JSON** with their reason. A corpus that silently shrinks is how "the corpus is green" stops meaning anything.

## squash: task 71 was mis-scoped

I filed task 71 as Firefox-specific. It isn't — **`squash` fails on both engines**. The two cells may even fail for opposite reasons: Chrome is starved on a software GL (354 physics calls in 17 s, ~20/s) and produces too few spawns, while Firefox runs fast (11,760 calls) and still frees nothing. Both with zero console errors and a clean teardown, exactly like dodge.

Quarantined alongside `dodge:firefox`, all naming task 71, which is widened and renamed accordingly.

## Result

`main` goes green, with three cells visibly quarantined and one demo visibly skipped — nothing hidden.

| Tier | Members | Meaning |
|---|---|---|
| CI cells | Chrome, Firefox | block the build |
| Local-only | Safari, tps-demo | CI structurally cannot; run by hand before a release |
| Quarantined | `dodge:firefox`, `squash:chrome`, `squash:firefox` | real defects, tracked in task 71 |