### PR TITLE
Let a spawned script own its own lifetime (Task 72)

### DIFF
--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -172,6 +172,20 @@
         "crossingsPerTick": 0.83,
         "ticksObserved": 96
       }
+    },
+    "soak": {
+      "maxPayloadBytes": 49000000,
+      "maxStartupMs": 8000,
+      "maxCrossingsPerTick": 1.0,
+      "minTicksForVerdict": 1000,
+      "measuredOn": "2026-07-30, macOS arm64, Chrome 150 headless, protocol 15, 270s run",
+      "note": "The soak gate drives the dodge export, so its payload budget is dodge's. Its crossings/tick is the most trustworthy ratio in the file -- ~95k ticks, so the fixed startup cost is fully amortised -- which is why its floor for a verdict is 1000 ticks rather than 30.",
+      "measured": {
+        "payloadBytes": 42190629,
+        "startupMs": 1278,
+        "crossingsPerTick": 0.22,
+        "ticksObserved": 94701
+      }
     }
   }
 }

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -69,6 +69,8 @@ async function snapshot(evaluate) {
         failure: globalThis.KanamaWebFailure?.stack ?? globalThis.KanamaWebFailure?.message ?? null,
         // What is live, by handle kind. A leak count alone says "something grew";
         // this says WHICH kind grew, which turns a hunt into a lookup.
+        readyDebug: (bridge.readyDebug ?? []).join(" "),
+        sfWho: (bridge.sfWho ?? []).join(" "),
         liveByKind: (() => {
           const counts = {};
           for (const slot of bridge.browserHandleSlots ?? []) {
@@ -141,7 +143,7 @@ export async function runSoak({ url, evaluate, navigate, deadline }) {
       // Per-sample trace: when this gate fails, the SHAPE of the growth is the
       // whole diagnosis (a step at each restart means the restart path leaks; a
       // steady climb means ordinary gameplay does).
-      trace(`live=${snap.liveHandles} max=${snap.maxLiveHandles} mobs=${snap.mobInstantiations} callbacks=${snap.callbacks} jobs=${snap.jobs} | ${snap.liveByKind}`);
+      trace(`live=${snap.liveHandles} max=${snap.maxLiveHandles} mobs=${snap.mobInstantiations} callbacks=${snap.callbacks} jobs=${snap.jobs} | ${snap.liveByKind}\n   READY ${snap.readyDebug}\n   SFWHO ${snap.sfWho}`);
       if (snap.callbackErrors > 0 && observedError === null) {
         observedError = `callbackErrors=${snap.callbackErrors}`;
       }

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -389,7 +389,19 @@
 
     invoke(handle, callback, member, action, fallback) {
       const previousOwner = this.activeOwnerHandle;
-      if (handle > 0) this.activeOwnerHandle = this.ownerForHandle(handle);
+      // A script with its own proxy owns its OWN lifetime, whatever the routing map
+      // says. Those are two different questions and `handleOwners` answers both:
+      // the PackedScene instantiate path deliberately re-points a spawned root at
+      // the proxy that instantiated it, so calls route through the spawner. Reading
+      // that as the LIFETIME owner meant everything a spawned script acquired was
+      // billed to its spawner -- dodge's mobs charged their SpriteFrames and node
+      // lookups to the scene root, which outlives them, so nothing was released
+      // until full teardown (task 72: one handle leaked per mob, forever).
+      if (handle > 0) {
+        this.activeOwnerHandle = this.applyCallbacks.has(handle)
+          ? handle
+          : this.ownerForHandle(handle);
+      }
       try {
         return action();
       } catch (error) {


### PR DESCRIPTION
Fixes the handle leak the soak gate found on its **first two unattended nightly runs**.

## The measurement

```
liveHandlesDidNotTrendUp: FAIL
live-handle high-water: first half 47 → second half 87
604s, 10 cycles, 67 mob instantiations, ZERO console errors, clean teardown
```

Reproduced locally to identical numbers. A **short run cannot see it** — the original 140 s validation passed at 27 → 31 — which is precisely why the soak gate exists.

## How it was found

Two statistical approaches failed: dodge stops spawning at game-over, so each cycle produces ~7 mobs regardless of cycle length (6.7 vs 7.1 across two runs), and per-cycle and per-mob rates fitted equally well. Breaking the live-handle table down **by kind** answered it in one run — `SpriteFrames` tracked mob instantiations exactly 1:1 and never decreased while `Node` stayed flat.

## The cause — a conflation, not a slip

`handleOwners` answers **two different questions with one map**:

1. *which proxy do I route calls through* — the PackedScene instantiate path deliberately re-points a spawned root at the proxy that instantiated it, and that is correct for routing; and
2. *whose lifetime does this handle share* — what the release sweep reads.

So everything a spawned script acquired was billed to its **spawner**. Dodge's mobs charged their SpriteFrames and node lookups to the scene root, which outlives them, so nothing was released until full teardown. Scene scripts own themselves and were fine — only spawned ones leaked, which is why every demo looked clean.

Confirmed by measurement rather than inference:

```
ready(65537)->owner65537   Player     ✓ owns itself
ready(65540)->owner65540   Main       ✓
ready(65541)->owner65540   Mob        ✗ owned by MAIN
ready(131079)->owner65540  Mob        ✗
```

## The fix

Routing is left exactly as it was. Inside `invoke`, a script that has its own proxy is now its own **lifetime** owner, so what it acquires is released when it is freed.

A speculative earlier attempt — re-owning allocations made during `create()` — was tried and **reverted**: it changed nothing, which was itself the evidence that ruled out that theory.

## Also here

Budgets the `soak` demo, which #124 left out: an unbudgeted demo failed the budget gate even with a passing envelope, and the nightly would have hit it. Its ratio is the most trustworthy in the file (~95k ticks fully amortise the fixed startup cost), so its verdict floor is 1000 ticks rather than 30.

## Validation

- 300 s soak **FAIL → PASS**: SpriteFrames absent from the live table entirely, high-water 31 → 29, zero console errors.
- Full **12-demo corpus green on Chrome**, including the four demos that spawn scenes at runtime.