### PR TITLE
Teach one close() rule instead of four overlapping ones (Task 67)

### DIFF
--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -56,6 +56,13 @@ rather than the public ptrcall wrapper surface.
 
 ## RefCounted Return Ownership
 
+> This section is the **ABI** truth, for contributors. The rule a *game
+> developer* needs — and the owned / borrowed / engine-owned / node categories it
+> produces — lives in
+> [Godot API → Resource Ownership](../game-dev/godot-api.md#resource-ownership).
+> Keep the two in step: this page explains **why** the `+1` exists, that page
+> explains **what to do about it**.
+
 Engine methods whose return type derives from `RefCounted` hand the ptrcall
 caller a **+1 reference through the return slot**. This holds for every such
 method: Godot's `PtrToArg<Ref<T>>::encode` copy-assigns into the slot and

--- a/docs/game-dev/godot-api.md
+++ b/docs/game-dev/godot-api.md
@@ -140,8 +140,80 @@ Object/Resource conversions.
 
 ## Resource Ownership
 
-Godot `Resource` and `RefCounted` wrappers returned by Kanama APIs are
-closeable Kotlin handles. When you load a temporary resource and hand it to a
+**`close()` means "release my reference", never "destroy this object".** It calls
+Godot's `unreference()` and destroys the object **only** if that dropped the
+count to zero. Every rule below falls out of that one sentence: closing is safe
+exactly when someone else still holds a reference, and destructive only when you
+are the last owner.
+
+Reading a resource off a node and closing it:
+
+```kotlin
+val mesh = meshInstance.getMesh()   // refcount 2 — the +1 is yours
+mesh?.close()                       // refcount 1 — mesh alive, the node unaffected
+```
+
+`getMesh()` does **not** create a new mesh; it hands you the same object with one
+more reference. Never closing it is the leak — the count stays at 2 forever and
+Godot reports `Leaked instance: ArrayMesh` at shutdown.
+
+Compare a resource you created and never handed off:
+
+```kotlin
+val material = StandardMaterial3D.create()   // refcount 1 — you are the ONLY owner
+material.close()                             // refcount 0 — destroyed; later use is a crash
+```
+
+Same call, different outcome, because the number of other owners differs.
+
+### Which category is it?
+
+| Category | What it covers | What to do |
+|---|---|---|
+| **Owned** | `X.create()`, `ResourceLoader.load…`, every `RefCounted`-typed method return **including plain getters**, and `@ScriptProperty` reads of resource-typed fields and collections | `close()` it, or `use { }` |
+| **Borrowed view** | A wrapper *you* mint around a handle you already have: `Resource.fromHandle(...)`, `Resource.fromObject(...)`, a script-class constructor wrapping an existing handle | **Never** `close()` — it releases a reference you never took |
+| **Engine-owned, live** | A `createTween()` still running, anything assigned into the scene tree, a resource handed to a sink that took its own reference | Use the Godot lifecycle (`kill()`, `queueFree()`), not `close()` |
+| **Nodes and plain `Object`s** | Anything not `RefCounted` — no refcount exists, and `GodotObject` has no `close()` | `Node.queueFree()` |
+
+The awkward-looking case — a getter you must close — is the common one, and it is
+safe precisely because the node still holds its own reference.
+
+`@ScriptProperty` reads are **owned**: the generated registrar takes its own
+reference when it reads a resource out of a property, an `Array`, or a
+`Dictionary`, and releases it when Godot frees the script instance. You do not
+need to close a property field you keep; you do close a temporary you read out
+of one and discard.
+
+### Two cleanups in one function
+
+Nodes are **not** reference-counted, so `close()` does not apply to them at all.
+Saving part of a scene therefore needs two different cleanups in the same
+function — one per category:
+
+```kotlin
+val scene = PackedScene.create()   // refcount 1 — you are the only owner
+scene.pack(someNode)               // serializes someNode and its OWNED sub-nodes
+ResourceSaver.save(scene, "user://thing.tscn")
+scene.close()                      // refcount 0 — released; the file is already written
+someNode.queueFree()               // a Node: no refcount, free it through Godot
+```
+
+`ResourceSaver.save` does not take ownership of the scene — the wrapper is still
+live after it returns, which is what makes `close()` yours to call (and what
+issue #81 got wrong; `scripts/runtime_smoke.sh` asserts the refcount and liveness
+after `save` precisely to keep that fixed).
+
+Two traps worth knowing:
+
+- **`pack()` serializes only *owned* sub-nodes.** A node you built and parented
+  but never gave an owner (`child.setOwner(root)`) saves as a bare root with
+  nothing under it.
+- **`queueFree()` is the only exposed free path** for nodes — `Object.free()` is
+  not wrapped, deliberately.
+
+### Temporaries handed to a node
+
+When you load a temporary resource and hand it to a
 Godot node, release the temporary wrapper with `use` or `close` after the node
 has accepted the value:
 
@@ -180,9 +252,9 @@ return closeable wrappers. If you only need to inspect the value, close the
 temporary wrapper immediately:
 
 ```kotlin
-val current = crosshair.texture
+val current = crosshair.texture   // refcount 2 — the +1 is yours
 check(current != null)
-current?.close()
+current?.close()                  // refcount 1 — the node keeps its own
 ```
 
 For gameplay animation, prefer `node.createTween()` over

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -221,7 +221,13 @@ Use `NodePath` only when the original script intentionally exposed a path value:
 var viewPath: NodePath = NodePath("../View")
 ```
 
-## Resource Ownership
+## Releasing Resources You Create
+
+The one rule, and the categories it produces, live in
+[Godot API → Resource Ownership](godot-api.md#resource-ownership):
+**`close()` releases your reference, it does not destroy the object.** This
+section covers the case you hit most while writing gameplay — a resource you
+created yourself — and why the JVM cannot clean it up for you.
 
 Godot `Resource` and `RefCounted` wrappers returned by Kanama APIs are
 closeable Kotlin handles. When you load a temporary resource and hand it to a

--- a/docs/game-dev/style-guide.md
+++ b/docs/game-dev/style-guide.md
@@ -286,6 +286,12 @@ keep it in `kanamaScope`; if it only touches global engine state such as
 
 ## Godot-Owned Resources
 
+This is the **exception** to the ownership rule in
+[Godot API → Resource Ownership](godot-api.md#resource-ownership), not a
+contradiction of it. Closing is safe when another owner still holds a reference;
+the cases below are the ones where you may be the **last** owner, so releasing
+your reference destroys a live object.
+
 Do not call `close()` on a Godot object that the scene tree still needs. In
 particular, `createTween()` returns a live Godot `Tween`; after scheduling
 work with `tweenProperty`, `tweenMethod`, or `tweenCallback`, let Godot own the


### PR DESCRIPTION
Docs only. No API, generator or demo changes.

## The problem

Four pages told a reader overlapping things, and two read as **direct opposites**:

- `godot-api.md` — close the `Sprite2D.texture` you just read
- `style-guide.md` — do **not** close a material the tree still needs
- `wrapper-maintenance.md` — read-backs are owned returns and must be closed too

All three are defensible, and a reader still had no rule. Observed live: this confused a user into asking whether `getMesh()` *instantiates* a new mesh. It does not — same object, `+1` on its refcount.

## The reconciling sentence

**`close()` releases *my* reference; it never destroys the object.** It calls `unreference()` and destroys only if that dropped the count to zero. So closing is safe exactly when someone else still holds a reference, and destructive only when you are the last owner — and both existing rules fall out of it:

```kotlin
val mesh = meshInstance.getMesh()   // refcount 2 — the +1 is yours
mesh?.close()                       // refcount 1 — mesh alive, node unaffected

val material = StandardMaterial3D.create()  // refcount 1 — you are the ONLY owner
material.close()                            // refcount 0 — destroyed; later use is a crash
```

`godot-api.md` becomes canonical (model + refcount walk-throughs + a four-category table); `style-guide.md` is reframed as **the exception** with a cross-link instead of a blanket contradiction; `properties-resources.md` keeps its create/GC-comparison material and links to the rule rather than re-deriving it (its duplicate `## Resource Ownership` heading is retitled); `wrapper-maintenance.md` stays the ABI page with a pointer to which page answers which question.

## The open question, settled by reading the code — and it corrects the task's own guess

The task asked whether the public API can hand a user a **borrowing** wrapper they'd mistake for an owned one, and warned that getting this wrong is worse than the ambiguity (it underflows the refcount).

It cannot, for property reads: the KSP processor emits the **`...Retained`** variant readers for `@ScriptProperty` object, array and dictionary reads, so those wrappers take their own `+1` **balanced by `close()`**. They are *owned*, not borrowed as the task file assumed. The only borrowing surface is a wrapper the user mints deliberately — `Resource.fromHandle`, `Resource.fromObject`.

## Also: the category that was documented nowhere

Nodes aren't reference-counted, `queueFree()` is the only exposed free path (`Object.free()` is deliberately unwrapped), and saving a scene needs **two cleanups in one function**. That example is written against the flow `runtime_smoke.sh` actually asserts (issue #81: create → pack → save, with refcount and liveness checked *after* save).

A first draft of it used `Node3D.create()` / `MeshInstance3D.create()` — neither exists. Every API in every example is now checked against its real signature.