### PR TITLE
Probe whether task 71's mobs are actually moving

### DIFF
--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -45,6 +45,31 @@ async function snapshot(evaluate) {
         // handle per mob is as visible across seven mobs as across seven hundred.
         // Task 72 leaked exactly that and still took a ten-minute nightly soak to
         // surface, because the absolute growth is what needs time, not the ratio.
+        // Are the mobs MOVING? (task 71). The mob proxy has no get_position arm,
+        // but it does have opcode 27, CanvasItem.get_local_mouse_position, which is
+        // the pointer expressed in the node's local space. The pointer never moves
+        // in a driven run, so this value changes exactly as the NODE moves -- a
+        // motion probe that needs no protocol change.
+        //
+        // It splits task 71 in half: if these sweep while frees stays 0, the mobs
+        // move and VisibleOnScreenNotifier2D is not reporting them off-screen; if
+        // they are frozen, it is physics or the velocity write.
+        mobPositions: (() => {
+          const out = [];
+          for (const [key, name] of Object.entries(bridge.scriptNameByHandle ?? {})) {
+            if (!String(name).endsWith(".Mob") || out.length >= 3) continue;
+            const handle = Number(key);
+            try {
+              if (bridge.api.kanamaWebIsLive(handle) !== 1) continue;
+              const x = bridge.immediateNoArgsVector2X(27, handle);
+              const y = bridge.immediateNoArgsVector2Y();
+              out.push(handle + ":" + Math.round(x) + "," + Math.round(y));
+            } catch (e) {
+              out.push(handle + ":err");
+            }
+          }
+          return out.join(" ");
+        })(),
         liveByKind: (() => {
           const counts = {};
           for (const slot of bridge.browserHandleSlots ?? []) {
@@ -118,7 +143,7 @@ async function observe(evaluate, seedPeak, windowMs, deadline, predicate) {
       if (snap.liveHandles < prevLive) peak.mobFrees += 1;
       prevLive = snap.liveHandles;
       last = snap;
-      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors} canvas=${snap.canvasW}x${snap.canvasH} frames=${snap.frames} sim=${snap.simSeconds}s`);
+      trace(`mobs=${snap.mobInstantiations} addChild=${snap.mobAddChildCommands} live=${snap.liveHandles} max=${snap.maxLiveHandles} frees=${peak.mobFrees} crossings=${snap.crossings} errs=${snap.callbackErrors} canvas=${snap.canvasW}x${snap.canvasH} frames=${snap.frames} sim=${snap.simSeconds}s mobs@ ${snap.mobPositions}`);
       if (predicate && predicate(snap, peak)) break;
     }
     await delay(150);


### PR DESCRIPTION
Diagnostic only — one driver file.

Task 71 is stuck between two explanations that produce **identical logs**:

1. the mobs are **frozen** (physics, or the velocity write never lands), or
2. they are **moving fine** and `VisibleOnScreenNotifier2D` never reports them off-screen — and that notifier is served by the *rendering* server, the one part of this path that plausibly varies with the GL stack.

Neither an arm64 nor an x86_64 Linux box reproduces the bug (the latter on genuine Mesa/llvmpipe, with screenshots showing mobs moving and freeing), so the question has to be answered **on the CI runner**.

## The probe

The mob proxy has no `get_position` arm, but it does have **opcode 27**, `CanvasItem.get_local_mouse_position` — the pointer expressed in the node's local space. The pointer never moves in a driven run, so that value changes **exactly as the node moves**. A motion probe for free: no protocol bump, no new opcode family, no export change.

The dodge driver traces up to three live `Mob` handles per sample.

## Validated where things are healthy

Locally on Chrome, mobs sweep as expected:

```
mobs@ 65541:-350,276
mobs@ 65541:-563,276  65542:630,-200  65543:704,-40
mobs@ 65541:-759,276  65542:429,-200  65544:321,-643
```

## What its output will settle

- **Sweeping while `frees=0`** → transform and physics exonerated; the notifier is the culprit.
- **Frozen** → the velocity write is next.

`dodge:firefox` stays quarantined, so this PR's own CI run produces the data without gating anything.