### PR TITLE
SPIKE (task 75): does a desktop Kotlin/Native backend work? — it does, with measurements

### DIFF
--- a/ios-runtime/build.gradle.kts
+++ b/ios-runtime/build.gradle.kts
@@ -33,6 +33,8 @@ val kanamaPrecision = providers.gradleProperty("kanamaPrecision").orElse("single
 kotlin {
     iosArm64()
     iosSimulatorArm64()
+    // SPIKE (task 75): desktop Kotlin/Native probe. Reuses the iosMain source set verbatim.
+    macosArm64()
 
     targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
         compilations.getByName("main") {
@@ -47,6 +49,30 @@ kotlin {
         binaries {
             staticLib {
                 baseName = "kanama_ios_runtime"
+            }
+        }
+
+        // SPIKE (task 75): desktop GDExtension needs a SHARED library, and only
+        // Kotlin/Native's own linker invocation knows the platform framework set its
+        // platform.darwin/posix caches need. So we let K/N link the dylib and feed it the
+        // pre-compiled C shim object, instead of hand-linking the static lib with clang.
+        if (konanTarget.name == "macos_arm64") {
+            binaries {
+                sharedLib {
+                    baseName = "kanama_macos_kn"
+                    // Match the shim's optimization level to the K/N build type, so a release
+                    // measurement is not silently contaminated by an -O0 shim.
+                    val shimObject =
+                        rootProject.layout.projectDirectory
+                            .file("spike-macos-kn/build/kanama_shim_${buildType.name.lowercase()}.o")
+                            .asFile
+                    if (shimObject.exists()) {
+                        linkerOpts(shimObject.absolutePath)
+                    }
+                    // kanama_entry is referenced by nothing inside the K/N graph; force it in
+                    // and keep it exported.
+                    linkerOpts("-u", "_kanama_entry")
+                }
             }
         }
     }
@@ -67,6 +93,11 @@ kotlin {
             iosScriptDirs(configuredIosScriptDirs.orNull).forEach { kotlin.srcDir(file(it)) }
         }
         val iosSimulatorArm64Main by getting {
+            dependsOn(iosMain)
+            iosScriptDirs(configuredIosScriptDirs.orNull).forEach { kotlin.srcDir(file(it)) }
+        }
+        // SPIKE (task 75)
+        val macosArm64Main by getting {
             dependsOn(iosMain)
             iosScriptDirs(configuredIosScriptDirs.orNull).forEach { kotlin.srcDir(file(it)) }
         }
@@ -91,6 +122,8 @@ tasks.configureEach {
 dependencies {
     add("kspIosArm64", project(":processor"))
     add("kspIosSimulatorArm64", project(":processor"))
+    // SPIKE (task 75)
+    add("kspMacosArm64", project(":processor"))
 }
 
 ksp {

--- a/kanama-common-api/build.gradle.kts
+++ b/kanama-common-api/build.gradle.kts
@@ -5,6 +5,8 @@ kotlin {
   jvmToolchain(25)
   iosArm64()
   iosSimulatorArm64()
+  // SPIKE (task 75)
+  macosArm64()
 
   @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
   wasmJs { browser() }
@@ -14,6 +16,8 @@ kotlin {
     val iosMain by creating { dependsOn(commonMain) }
     val iosArm64Main by getting { dependsOn(iosMain) }
     val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+    // SPIKE (task 75)
+    val macosArm64Main by getting { dependsOn(iosMain) }
     commonTest.dependencies { implementation(kotlin("test")) }
   }
 }

--- a/spike-macos-kn/.gitignore
+++ b/spike-macos-kn/.gitignore
@@ -1,0 +1,4 @@
+build/
+*/.godot/
+*/addons/kanama/*.dylib
+*/addons/kanama/*.jar

--- a/spike-macos-kn/bench-jvm/addons/kanama/kanama.gdextension
+++ b/spike-macos-kn/bench-jvm/addons/kanama/kanama.gdextension
@@ -1,0 +1,17 @@
+[configuration]
+
+entry_symbol = "kanama_entry"
+compatibility_minimum = "4.7"
+
+[libraries]
+
+macos.debug = "res://addons/kanama/libkanama_bootstrap.dylib"
+macos.release = "res://addons/kanama/libkanama_bootstrap.dylib"
+linux.debug.x86_64 = "res://addons/kanama/libkanama_bootstrap.so"
+linux.release.x86_64 = "res://addons/kanama/libkanama_bootstrap.so"
+linux.debug.arm64 = "res://addons/kanama/libkanama_bootstrap.so"
+linux.release.arm64 = "res://addons/kanama/libkanama_bootstrap.so"
+windows.debug.x86_64 = "res://addons/kanama/kanama_bootstrap.dll"
+windows.release.x86_64 = "res://addons/kanama/kanama_bootstrap.dll"
+ios.debug.arm64 = "res://addons/kanama/bin/ios/kanama_ios.debug.xcframework"
+ios.release.arm64 = "res://addons/kanama/bin/ios/kanama_ios.release.xcframework"

--- a/spike-macos-kn/bench-jvm/addons/kanama/kanama.gdextension.uid
+++ b/spike-macos-kn/bench-jvm/addons/kanama/kanama.gdextension.uid
@@ -1,0 +1,1 @@
+uid://b1scuxgrolltm

--- a/spike-macos-kn/bench-jvm/kotlin-src/BenchScript.kt
+++ b/spike-macos-kn/bench-jvm/kotlin-src/BenchScript.kt
@@ -1,0 +1,48 @@
+package net.multigesture.kanama.spike
+
+import kotlin.time.TimeSource
+import net.multigesture.kanama.annotations.OnProcess
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.GD
+import net.multigesture.kanama.api.GodotHandle
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.Node3D
+import net.multigesture.kanama.types.Vector3
+
+// Task 75 spike — JVM vs Kotlin/Native wrapper-call benchmark.
+// ONE source file, compiled unchanged for both backends. Each frame runs a
+// fixed number of Vector3 set/get round-trips through the generated Node3D
+// wrapper, so the measured cost is the ptrcall marshalling path (Panama/FFM on
+// desktop JVM, the C shim on Kotlin/Native) and not engine work.
+@ScriptClass(attachTo = "Node3D")
+class BenchScript(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3D) {
+    private var frame = 0
+
+    @OnReady
+    fun ready() {
+        GD.print("[bench] READY iterations=$ITERATIONS frames=$FRAMES")
+    }
+
+    @OnProcess
+    fun process(delta: Double) {
+        frame++
+        val mark = TimeSource.Monotonic.markNow()
+        var acc = 0f
+        var i = 0
+        while (i < ITERATIONS) {
+            self.setPosition(Vector3(i.toFloat(), 0f, 0f))
+            acc += self.getPosition().x
+            i++
+        }
+        val ns = mark.elapsedNow().inWholeNanoseconds
+        // 2 wrapper calls per iteration (one set, one get).
+        val perCallNs = ns.toDouble() / (ITERATIONS * 2).toDouble()
+        GD.print("[bench] frame=$frame totalUs=${ns / 1000} perCallNs=$perCallNs checksum=$acc")
+    }
+
+    companion object {
+        const val ITERATIONS = 50_000
+        const val FRAMES = 120
+    }
+}

--- a/spike-macos-kn/bench-jvm/main.tscn
+++ b/spike-macos-kn/bench-jvm/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://kotlin-src/BenchScript.kt" id="1"]
+
+[node name="BenchRoot" type="Node3D"]
+script = ExtResource("1")

--- a/spike-macos-kn/bench-jvm/project.godot
+++ b/spike-macos-kn/bench-jvm/project.godot
@@ -1,0 +1,11 @@
+config_version=5
+
+[application]
+
+config/name="kanama-bench"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.7")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"

--- a/spike-macos-kn/bench-kn/addons/kanama/kanama.gdextension
+++ b/spike-macos-kn/bench-kn/addons/kanama/kanama.gdextension
@@ -1,0 +1,9 @@
+[configuration]
+
+entry_symbol = "kanama_entry"
+compatibility_minimum = "4.7"
+
+[libraries]
+
+macos.debug = "res://addons/kanama/libkanama_macos_kn.dylib"
+macos.release = "res://addons/kanama/libkanama_macos_kn.dylib"

--- a/spike-macos-kn/bench-kn/kotlin-src/BenchScript.kt
+++ b/spike-macos-kn/bench-kn/kotlin-src/BenchScript.kt
@@ -1,0 +1,48 @@
+package net.multigesture.kanama.spike
+
+import kotlin.time.TimeSource
+import net.multigesture.kanama.annotations.OnProcess
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.GD
+import net.multigesture.kanama.api.GodotHandle
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.Node3D
+import net.multigesture.kanama.types.Vector3
+
+// Task 75 spike — JVM vs Kotlin/Native wrapper-call benchmark.
+// ONE source file, compiled unchanged for both backends. Each frame runs a
+// fixed number of Vector3 set/get round-trips through the generated Node3D
+// wrapper, so the measured cost is the ptrcall marshalling path (Panama/FFM on
+// desktop JVM, the C shim on Kotlin/Native) and not engine work.
+@ScriptClass(attachTo = "Node3D")
+class BenchScript(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3D) {
+    private var frame = 0
+
+    @OnReady
+    fun ready() {
+        GD.print("[bench] READY iterations=$ITERATIONS frames=$FRAMES")
+    }
+
+    @OnProcess
+    fun process(delta: Double) {
+        frame++
+        val mark = TimeSource.Monotonic.markNow()
+        var acc = 0f
+        var i = 0
+        while (i < ITERATIONS) {
+            self.setPosition(Vector3(i.toFloat(), 0f, 0f))
+            acc += self.getPosition().x
+            i++
+        }
+        val ns = mark.elapsedNow().inWholeNanoseconds
+        // 2 wrapper calls per iteration (one set, one get).
+        val perCallNs = ns.toDouble() / (ITERATIONS * 2).toDouble()
+        GD.print("[bench] frame=$frame totalUs=${ns / 1000} perCallNs=$perCallNs checksum=$acc")
+    }
+
+    companion object {
+        const val ITERATIONS = 50_000
+        const val FRAMES = 120
+    }
+}

--- a/spike-macos-kn/bench-kn/main.tscn
+++ b/spike-macos-kn/bench-kn/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://kotlin-src/BenchScript.kt" id="1"]
+
+[node name="BenchRoot" type="Node3D"]
+script = ExtResource("1")

--- a/spike-macos-kn/bench-kn/project.godot
+++ b/spike-macos-kn/bench-kn/project.godot
@@ -1,0 +1,11 @@
+config_version=5
+
+[application]
+
+config/name="kanama-bench"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.7")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"

--- a/spike-macos-kn/bench-src/kotlin-src/BenchScript.kt
+++ b/spike-macos-kn/bench-src/kotlin-src/BenchScript.kt
@@ -1,0 +1,48 @@
+package net.multigesture.kanama.spike
+
+import kotlin.time.TimeSource
+import net.multigesture.kanama.annotations.OnProcess
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.GD
+import net.multigesture.kanama.api.GodotHandle
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.Node3D
+import net.multigesture.kanama.types.Vector3
+
+// Task 75 spike — JVM vs Kotlin/Native wrapper-call benchmark.
+// ONE source file, compiled unchanged for both backends. Each frame runs a
+// fixed number of Vector3 set/get round-trips through the generated Node3D
+// wrapper, so the measured cost is the ptrcall marshalling path (Panama/FFM on
+// desktop JVM, the C shim on Kotlin/Native) and not engine work.
+@ScriptClass(attachTo = "Node3D")
+class BenchScript(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3D) {
+    private var frame = 0
+
+    @OnReady
+    fun ready() {
+        GD.print("[bench] READY iterations=$ITERATIONS frames=$FRAMES")
+    }
+
+    @OnProcess
+    fun process(delta: Double) {
+        frame++
+        val mark = TimeSource.Monotonic.markNow()
+        var acc = 0f
+        var i = 0
+        while (i < ITERATIONS) {
+            self.setPosition(Vector3(i.toFloat(), 0f, 0f))
+            acc += self.getPosition().x
+            i++
+        }
+        val ns = mark.elapsedNow().inWholeNanoseconds
+        // 2 wrapper calls per iteration (one set, one get).
+        val perCallNs = ns.toDouble() / (ITERATIONS * 2).toDouble()
+        GD.print("[bench] frame=$frame totalUs=${ns / 1000} perCallNs=$perCallNs checksum=$acc")
+    }
+
+    companion object {
+        const val ITERATIONS = 50_000
+        const val FRAMES = 120
+    }
+}

--- a/spike-macos-kn/bench_stats.py
+++ b/spike-macos-kn/bench_stats.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Task 75 spike — summarize a bench run log ([bench] frame= lines)."""
+import re
+import statistics
+import sys
+
+path = sys.argv[1]
+label = sys.argv[2] if len(sys.argv) > 2 else path
+
+per_call = []
+for line in open(path, errors="replace"):
+    m = re.search(r"\[bench\] frame=(\d+) totalUs=(\d+) perCallNs=([\d.]+)", line)
+    if m:
+        per_call.append((int(m.group(1)), float(m.group(3))))
+
+if not per_call:
+    print(f"{label}: no bench frames found")
+    sys.exit(1)
+
+vals = [v for _, v in per_call]
+warm = [v for f, v in per_call if f > 30]  # discard first 30 frames
+
+print(f"== {label} ==")
+print(f"frames           : {len(vals)}")
+print(f"frame 1 (cold)   : {vals[0]:.2f} ns/call")
+print(f"frame 2          : {vals[1]:.2f} ns/call")
+print(f"frame 5          : {vals[4]:.2f} ns/call" if len(vals) > 4 else "")
+print(f"warm mean (f>30) : {statistics.mean(warm):.2f} ns/call")
+print(f"warm median      : {statistics.median(warm):.2f} ns/call")
+print(f"warm min / max   : {min(warm):.2f} / {max(warm):.2f} ns/call")
+print(f"warm stdev       : {statistics.pstdev(warm):.2f} ns/call")
+print(f"cold penalty     : {vals[0] / statistics.median(warm):.2f}x frame-1 vs warm median")

--- a/spike-macos-kn/build_dylib.sh
+++ b/spike-macos-kn/build_dylib.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Task 75 spike — stage B: build a macOS arm64 GDExtension .dylib from the
+# iOS C shim + the Kotlin/Native macosArm64 runtime.
+#
+# Two steps, because only Kotlin/Native's own linker invocation knows the
+# platform framework set its platform.darwin / platform.posix caches need:
+#   1. clang compiles the shim to a .o here
+#   2. Gradle's linkDebugSharedMacosArm64 links that .o into the K/N dylib
+#      (see the SPIKE block in ios-runtime/build.gradle.kts)
+#
+# Usage: spike-macos-kn/build_dylib.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/spike-macos-kn/build"
+SDK="$(xcrun --sdk macosx --show-sdk-path)"
+MIN_MACOS=13.0
+
+mkdir -p "$OUT"
+
+MODE="${1:-debug}"
+case "$MODE" in
+  debug)   COPT="-O0"; GRADLE_TASK="linkDebugSharedMacosArm64";   BINDIR="debugShared" ;;
+  release) COPT="-O2"; GRADLE_TASK="linkReleaseSharedMacosArm64"; BINDIR="releaseShared" ;;
+  *) echo "usage: $0 [debug|release]" >&2; exit 2 ;;
+esac
+shift || true
+
+echo "==> [1/2] compiling shim (macOS arm64, $MODE, $COPT)"
+clang -arch arm64 \
+  -isysroot "$SDK" \
+  -mmacosx-version-min="$MIN_MACOS" \
+  "$COPT" \
+  -fvisibility=hidden \
+  -I "$ROOT/gdextension" \
+  -c "$ROOT/ios/bootstrap/kanama_ios_shim.c" \
+  -o "$OUT/kanama_shim_$MODE.o"
+ls -lh "$OUT/kanama_shim_$MODE.o"
+
+echo "==> [2/2] linking dylib via Kotlin/Native"
+(cd "$ROOT" && ./gradlew ":ios-runtime:$GRADLE_TASK" --console=plain "$@")
+
+DYLIB="$ROOT/ios-runtime/build/bin/macosArm64/$BINDIR/libkanama_macos_kn.dylib"
+echo "==> result"
+ls -lh "$DYLIB"
+echo "-- kanama_entry exported?"
+nm -gU "$DYLIB" | grep "kanama_entry" || echo "   !! NOT EXPORTED"

--- a/spike-macos-kn/probe-project/addons/kanama/kanama.gdextension
+++ b/spike-macos-kn/probe-project/addons/kanama/kanama.gdextension
@@ -1,0 +1,9 @@
+[configuration]
+
+entry_symbol = "kanama_entry"
+compatibility_minimum = "4.7"
+
+[libraries]
+
+macos.debug = "res://addons/kanama/libkanama_macos_kn.dylib"
+macos.release = "res://addons/kanama/libkanama_macos_kn.dylib"

--- a/spike-macos-kn/probe-project/kotlin-src/ProbeScript.kt
+++ b/spike-macos-kn/probe-project/kotlin-src/ProbeScript.kt
@@ -1,0 +1,31 @@
+package net.multigesture.kanama.spike
+
+import net.multigesture.kanama.annotations.OnProcess
+import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.ScriptClass
+import net.multigesture.kanama.api.GD
+import net.multigesture.kanama.api.GodotHandle
+import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.Node
+
+// Task 75 spike — stage D probe. Deliberately minimal: prove a Kanama script
+// loads, its @OnReady fires, and a wrapper call reaches Godot on a desktop
+// Kotlin/Native GDExtension.
+@ScriptClass(attachTo = "Node")
+class ProbeScript(godotObject: GodotHandle) : KanamaScript<Node>(godotObject, ::Node) {
+    private var ticks: Long = 0
+
+    @OnReady
+    fun ready() {
+        GD.print("[kanama][spike] ProbeScript READY on desktop Kotlin/Native")
+        GD.print("[kanama][spike] self.name=" + self.getName())
+    }
+
+    @OnProcess
+    fun process(delta: Double) {
+        ticks += 1
+        if (ticks == 3L) {
+            GD.print("[kanama][spike] ProbeScript PROCESS tick 3 delta=" + delta)
+        }
+    }
+}

--- a/spike-macos-kn/probe-project/main.tscn
+++ b/spike-macos-kn/probe-project/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://kotlin-src/ProbeScript.kt" id="1"]
+
+[node name="ProbeRoot" type="Node"]
+script = ExtResource("1")

--- a/spike-macos-kn/probe-project/project.godot
+++ b/spike-macos-kn/probe-project/project.godot
@@ -1,0 +1,11 @@
+config_version=5
+
+[application]
+
+config/name="kanama-kn-probe"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.7")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"

--- a/spike-macos-kn/run_probe.sh
+++ b/spike-macos-kn/run_probe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Task 75 spike — stages C/D: load the Kotlin/Native dylib as a desktop
+# GDExtension and run the probe scene headless.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GODOT="${KANAMA_GODOT_BIN:-/Applications/Godot.app/Contents/MacOS/Godot}"
+PROJ="$ROOT/spike-macos-kn/probe-project"
+DYLIB="$ROOT/ios-runtime/build/bin/macosArm64/debugShared/libkanama_macos_kn.dylib"
+
+[ -f "$DYLIB" ] || { echo "missing dylib: $DYLIB (run build_dylib.sh)" >&2; exit 1; }
+
+mkdir -p "$PROJ/addons/kanama"
+cp "$DYLIB" "$PROJ/addons/kanama/libkanama_macos_kn.dylib"
+
+echo "==> godot: $("$GODOT" --version)"
+echo "==> running headless (60 frames)"
+"$GODOT" --headless --path "$PROJ" --quit-after 60 2>&1
+echo "==> exit=$?"


### PR DESCRIPTION
> **Draft / spike — not for merge.** This branch exists to answer one question with
> numbers instead of argument. Nothing here is production shape and the `// SPIKE`
> markers say so.

## Why

[#102](https://github.com/falcon4ever/kanama/issues/102) asked what the end state is for
shipping desktop games. The answer there is a bundled jlink runtime (unpack-and-play, no
player install). In a follow-up comment, @fkrauthan asked a fair question:

> Have you considered shipping the desktop binaries using Kotlin native (at least as an
> option) as well? Sounds like the project supports kotlin native already for iOS builds
> so I would assume enabling it for Desktop builds should be possible as well?

The premise is correct and better-informed than most drive-by suggestions: `ios-runtime`
**is** Kotlin/Native, the generated Godot wrappers **are** shared source across backends,
and Kotlin/Native does have `macosArm64` / `linuxX64` / `mingwX64` targets. Nobody had
actually tried it, so this branch does.

## Result: it works

All probe stages pass on macOS arm64 against Godot 4.7 stable. A real Kanama script loads
on a desktop Kotlin/Native GDExtension, `@OnReady` fires, `self.getName()` returns through
a generated wrapper, `@OnProcess` ticks:

```
[kanama][ios][kn] created script instance handle=3 script=2 path=res://kotlin-src/ProbeScript.kt
[kanama][spike] ProbeScript READY on desktop Kotlin/Native
[kanama][spike] self.name=ProbeRoot
[kanama][spike] ProbeScript PROCESS tick 3 delta=6.35e-4
```

Cost to get there: **~20 lines of Gradle across two files, zero Kotlin source changes.**
`ios-runtime/src/iosMain` has no `platform.*` imports at all — the Kotlin side of the iOS
backend is *cinterop*-shaped, not iOS-shaped, so it compiled for `macos_arm64` verbatim.

| Stage | Result |
|---|---|
| A — runtime compiles for `macosArm64` | PASS — 2m34s clean, 202.7 MB debug `.a` |
| B — shim + runtime link into a `.dylib` | PASS — 1m41s, 134.8 MB debug / 48.4 MB release, `_kanama_entry` exported |
| C — Godot loads it | PASS — init levels 0–3, script language + `.kt` loader registered, self-tests 69/70 ptrcall + 117/118 ObjectCalls |
| D — a Kanama script runs | PASS — see above |
| E — measured against the JVM backend | see below |

## Measured: JVM vs Kotlin/Native

One benchmark script (`spike-macos-kn/bench-src/kotlin-src/BenchScript.kt`) compiled
**unchanged** for both backends. 50,000 `Node3D` `setPosition`/`getPosition` round-trips per
frame (100k wrapper calls/frame), 130 frames, `--headless`, Godot 4.7 stable, macOS arm64.
Timing via `kotlin.time.TimeSource.Monotonic` inside the script, so it measures the
marshalling path (Panama/FFM vs C shim), not engine work. Two full repeat runs per backend,
reproducible to within ~3%.

| Metric | Desktop JVM (Panama/FFM) | Desktop K/N (release) | K/N (debug) |
|---|---|---|---|
| Frame 1 (cold) | 472–493 ns/call | **106–108 ns/call** | 1871 ns/call |
| Warm median (frames >30) | **57.6–59.3 ns/call** | 104.6–105.1 ns/call | 1676 ns/call |
| Warm stdev | 4.21 ns | **1.55 ns** | 24.2 ns |
| Cold penalty (f1 ÷ warm) | 8.2–8.6× | **1.02–1.03×** | 1.12× |
| Process startup | 0.55–0.57 s | **0.36–0.51 s** | — |
| 130-frame wall clock | **1.5 s** | 2.1 s | 24.7 s |

- **Steady state: the JVM wins by ~1.8×.** C2 beats Kotlin/Native's AOT codegen on this
  marshalling path, well outside noise.
- **Cold: Kotlin/Native wins frame 1 by ~4.5×** with essentially no warmup curve, and has
  **~2.7× more stable frame timing** — the more interesting property for a game.
- **But the JVM catches up almost immediately** — ~86 ns/call by frame 2, ahead by frame 3.
  Total warmup cost at this deliberately brutal workload is **~40 ms, once.**
- **`-O0` is a trap worth naming.** The debug K/N build measures 28× slower than the JVM.
  Anyone benchmarking this without checking `buildType` will conclude Kotlin/Native is
  catastrophic. It isn't; it's unoptimized. (The spike's build script now ties the shim's
  `-O0`/`-O2` to the K/N build type so a release measurement can't be contaminated.)

### Size

| | Desktop JVM | Desktop K/N |
|---|---|---|
| Runtime | `kanama.jar` 11.5 MB + bootstrap 34 KB | `libkanama_macos_kn.dylib` 48.4 MB release (141 MB debug) |
| Player prerequisite | a JVM — 50–90 MB jlink image | none |
| **Shipped total** | **~62–102 MB** | **~48 MB** |

Roughly 1.3–2× smaller. Real, but that's a 50 MB vs 100 MB download — not a decision-maker.

### Iteration cost — the number that actually settles it

Same change (edit one project script, rebuild what the game loads):

| Backend | Command | Wall clock |
|---|---|---|
| Desktop JVM | `installAddonJar` | **8 s** |
| Desktop K/N | `linkDebugSharedMacosArm64` | **2 m 13 s** |

**~16× slower per script edit**, and that's the *debug* link — release took **22 m 37 s**.
Not a tuning problem: a script change invalidates the KSP registry → invalidates the
whole-program Kotlin/Native compilation → forces a relink that regenerates and compiles a
~500k-line `api.cpp`. And this compares against a JVM path that mostly doesn't rebuild at
all: `KanamaHotReload` swaps `kanama-scripts.jar` through a `ChildFirstClassLoader` with no
editor restart.

---

## Pros and cons

### For a game developer using Kanama

**Pros of a Kotlin/Native desktop backend**

- No JVM anywhere in the player's path — nothing to bundle, no `JAVA_HOME` skew, no
  "player's broken Java install breaks the game" class of bug report.
- ~2× smaller download.
- No JIT warmup: the first frame costs the same as the thousandth. No first-level hitching,
  and **2.7× steadier frame times** — the one performance property that genuinely favours a
  game engine.
- Faster process start (~0.15–0.2 s).
- Same runtime model as the iOS backend, so a game already targeting iOS is living within
  these constraints anyway — one mental model instead of two.

**Cons — and these are Kotlin/Native's limitations, not Kanama's**

- **No JVM library ecosystem.** This is the big one. Only KMP-compatible libraries are
  reachable — no arbitrary Maven jars. Analytics SDKs, Steamworks wrappers, JDBC, Jackson/
  Gson, Netty, Apache Commons, most vendor SDKs: all gone. `README.md` sells "Kotlin,
  Gradle, coroutines, and the JVM ecosystem"; this keeps the first three.
- **No `java.*` at all** — `java.io.File`, `java.nio`, `java.time`,
  `java.util.concurrent`. Shared code touching any of it stops compiling.
- **No meaningful reflection**, so reflection-based serialization/DI/config frameworks are
  out; everything must be codegen.
- **No dynamic class loading** → no hot reload, and no runtime plugin/mod loading. If you
  wanted user mods as compiled Kotlin, that door closes.
- **~16× slower edit→run loop**, minutes per iteration, and a ~22-minute release link.
- **Weaker tooling.** Debugging is LLDB rather than attaching IntelliJ's JVM debugger; no
  JFR, async-profiler, VisualVM, or the JVM heap-analysis tooling.
- **Less mature GC and concurrency story** than the JVM's, with fewer tuning knobs.
- Slightly slower steady-state wrapper calls (~1.8×).

### For Kanama as a project

**Pros**

- Near-zero new architecture: it reuses the existing generator, the `ObjectCalls` seam, and
  the C shim as-is. The wrapper layer is already backend-neutral and it shows.
- Proves the AOT path on a platform where debugging is cheap — the plausible **stepping
  stone to consoles**, where a JVM can never go. This is the strongest long-term argument.
- A second independent implementation of the same wrapper contract *on desktop* is a good
  differential-testing oracle: run a demo on both and diff, without needing a device.
- Would remove the `libjvm` discovery/bootstrap machinery from that export path.

**Cons**

- **Permanently doubles the desktop matrix** (3 platforms × 2 runtimes) on top of an
  already four-backend convergence discipline (JVM desktop, ART/PanamaPort Android, K/N
  iOS, Kotlin/Wasm Web) that `AGENTS.md` treats as a hard gate.
- **Windows is the wrong platform to be weakest on.** Windows is the export priority, and
  `mingwX64` is Kotlin/Native's least-supported target. The shim is C built only against
  Apple SDKs today; K/N + MinGW/MSVC linkage is the roughest corner of the toolchain. This
  probe deliberately picked the *easiest* case — a macOS pass says very little about Windows.
- **The editor is a much bigger surface than a headless run.**
  `KanamaIosScriptLanguage::_init`, `::_frame` and `::_finish` already log *"Required
  virtual method must be overridden"*; the editor exercises far more of
  `ScriptLanguageExtension` than this probe did.
- **Mobile-acceptable parity gaps become desktop regressions**: `Map` properties are
  unsupported on the Kotlin/Native backend, `DirAccess` and `MethodTweener` are unemitted,
  plus 12 hand-written + 9 sugar sites and conservative per-method skips. The JVM desktop
  backend has none of these.
- A 22-minute release link would be felt in CI.
- It doesn't answer #102 — the jlink bundle already does, for a fraction of the work.

## Recommendation: park with data

Not "rule out", and definitely not "productionize".

The feasibility question is settled in @fkrauthan's favour. What the numbers say is that
everything the change buys is real but small — ~2× smaller download, ~0.1 s faster start,
steadier frames — while the JVM is faster where it counts most of the time and the
iteration loop gets 16× worse, before counting hot reload, which is structural rather than
fixable. Desktop unpack-and-play is a packaging problem, and it already has a cheaper answer.

Keeping the branch and the numbers on file for the console case, where a JVM cannot follow.

## What's in this branch

- `ios-runtime/build.gradle.kts` — `macosArm64()` target, `macosArm64Main` source set,
  `kspMacosArm64`, and a macOS-only `sharedLib` binary that links the C shim object and
  forces `-u _kanama_entry`.
- `kanama-common-api/build.gradle.kts` — `macosArm64()` target + source set. **Required**,
  not optional: without it the build fails at variant resolution.
- `spike-macos-kn/` — `build_dylib.sh`, `run_probe.sh`, `bench_stats.py`, the shared
  benchmark script, and three small Godot projects (probe + one bench project per backend).

Two traps that cost time and would cost it again:

1. A desktop GDExtension needs a **shared** library. Hand-linking the K/N static lib with
   `clang -dynamiclib` fails on an open-ended tail of `platform.posix` / `platform.darwin`
   cinterop-cache symbols (`res_9_vinit`, `setauclass`, `at_encoder_*`, `compression_*`).
   Only Kotlin/Native's own linker invocation knows its platform framework set, so K/N has
   to drive the link and be handed the shim `.o` — iOS never hit this because it ships a
   static lib that Xcode links into the app.
2. A fresh Godot project ignores a `.gdextension` unless it is listed in
   `.godot/extension_list.cfg`. Without it the run is silently extension-less and presents
   as *"No loader found for resource: res://….kt"*.

Probe was run on the 0.4.0 release tree; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
