### PR TITLE
Docs: state the actual Web evidence (12-demo corpus, CI matrix, floors, budgets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,16 @@ project scripts needs the Kanama checkout), and there is no mobile hot reload �
 see the [iOS export guide](docs/exporting/ios.md) and
 [Version Support](docs/reference/version-support.md).
 
-A **Kotlin/Wasm Web backend is Experimental (preview)**. It runs Bunnymark and
-Match3 as production Godot Web exports across Chrome, Firefox, and Safari through
-a generated proxy and a versioned JavaScript bridge, with no on-device JVM. It is
-**not a Supported target**: single-thread Compatibility renderer only, a
-source-checkout export (no packaged addon), and a two-demo corpus. See the
+A **Kotlin/Wasm Web backend is Experimental (preview)**. The full twelve-demo
+corpus — Bunnymark and Match3 through FPS, Racing, City-Builder, and tps-demo —
+runs as production Godot Web exports through a generated proxy and a versioned
+JavaScript bridge, with no on-device JVM. Chrome and Firefox gate the corpus in
+CI (Linux; full corpus plus a ten-minute leak soak nightly) against tested
+browser floors and measured per-engine performance budgets, and Safari passes
+the same gate as a local pre-release check (it has no headless mode). It is
+still **not a Supported target**: single-thread Compatibility renderer only, a
+source-checkout export (no packaged addon), and desktop browsers only
+(iOS/iPadOS WebKit unvalidated). See the
 [Web export guide](docs/exporting/web.md) and
 [Web Internals](docs/contributing/web-internals.md) for the architecture.
 

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -114,13 +114,16 @@ ktfmt reflow but catches any changed arm, opcode, extern, or guard.
 Android, and iOS also consume (via the generated `InitialGodotCallDescriptors`).
 Those backends call Godot in-process and do none of Web's caching; folding Web-only
 snapshot/handle rules into the shared file would stop it being neutral and over-fit
-it to the two-demo corpus. Option A keeps the shared model clean.
+it to the Web demo corpus. Option A keeps the shared model clean.
 
 **When to reconsider Option B:** if the hand-written bookkeeping companion grows
-faster than the generated dispatch as the corpus expands (60b–60e) — i.e. if
-"admitting a family" routinely means non-trivial new hand-written state rather than
-a near-mechanical hook wiring — revisit encoding a Web-side (not shared-model)
-policy layer so more of the bookkeeping generates. Record any such change here.
+faster than the generated dispatch — i.e. if "admitting a family" routinely means
+non-trivial new hand-written state rather than a near-mechanical hook wiring —
+revisit encoding a Web-side (not shared-model) policy layer so more of the
+bookkeeping generates. Through the full twelve-demo corpus (protocol 15, 286
+opcodes) that did not happen: the largest single admission (tps-demo) brought in
+61 opcodes with exactly one new extern, so Option A stands. Record any change
+here.
 
 ### Batching, snapshots, and handle generations
 
@@ -188,11 +191,16 @@ is released).
 
 ## Validation Fixtures
 
-The current fixtures are per-browser driver scripts plus machine-readable JSON
-results (Bunnymark and Match3, one file per browser) with matching screenshots.
-A run is not green from page load alone — it must satisfy gameplay assertions,
-final state, the crossing budget, handle/callback/scheduler teardown, console
-error checks, and protocol-version match.
+The current fixtures are per-demo driver scripts
+(`scripts/web/drivers/demos/*.mjs`, one per corpus demo, shared by the
+Chrome/Firefox/Safari engine drivers) plus machine-readable JSON results, one
+per demo × browser cell, validated against a versioned envelope schema by
+`web_export_smoke.sh`; `web_ci_matrix.sh` aggregates the cells into a single
+evidence JSON. A run is not green from page load alone — it must satisfy
+gameplay assertions, final state, the crossing budget,
+handle/callback/scheduler teardown, console error checks, and protocol-version
+match, and the harness's own `web_export_smoke: PASS` line (not a driver's
+check count) is what decides green.
 
 Browser-specific notes:
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -462,5 +462,15 @@ commits, per-demo checksums, payload sizes, protocol version and driver results.
   Kotlin/JS production path.
 - A packaged/addon install path (exporting without the Kanama checkout) is not
   yet available; the current workflow is a source-checkout export.
+- **One defect is unexplained, not solved (task 71).** On one Linux CI host,
+  spawned mobs in two demos travel far off screen yet
+  `VisibleOnScreenNotifier2D.screen_exited` never fires, so they are never
+  freed and live handles plateau. Five hypotheses have been eliminated by
+  measurement across three hosts, and a plain-GDScript control shows the
+  notifier itself firing on that host under Chrome — nothing measured
+  implicates the Kanama backend, but "not our bug" has not been earned either.
+  The affected cells are quarantined, not hidden (see Quarantined Cells above).
+  If enemies accumulate without despawning in a Web export, check that task
+  before assuming a project bug.
 - Not a Supported target: no support claim, and the corpus/browser matrix and
   budgets are still being hardened.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ ownership, signals, and wrapper coverage. For existing GDScript projects, use
 | Windows | Supported (4.7 stable) |
 | Android | Supported (4.7 stable); debug ≥ Android 9, release ≥ Android 13 (Pixel 7 / Moto g 5G / S10+ / Pixel 3 XL) |
 | iOS | Supported (4.7 stable, Kotlin/Native); device-validated iPhone 12 / 15 Pro |
-| Web | Experimental (Kotlin/Wasm preview, 4.7 stable); source-checkout export, 2-demo corpus, not Supported |
+| Web | Experimental (Kotlin/Wasm preview, 4.7 stable); 12-demo corpus in Chrome/Firefox CI + a local Safari gate; source-checkout export, desktop browsers only, not Supported |
 
 See [Version Support](reference/version-support.md) for exact Godot, JDK,
 smoke-test, and packaging boundaries.

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -163,6 +163,11 @@ and no mobile-WebKit floor is claimed.
 - No Web editor, no hot reload, no threads, no Kotlin/JS path.
 - Safari has **no headless mode**, so the Safari gate is a local GUI gate rather
   than a CI cell; iOS/iPadOS WebKit is unvalidated.
+- One defect is tracked openly rather than solved: on one Linux CI host,
+  spawned mobs never receive `VisibleOnScreenNotifier2D.screen_exited` and are
+  never freed (task 71; the affected matrix cells are quarantined, not hidden).
+  Nothing measured implicates the Kanama backend, but it has not been ruled
+  out — see [Exporting → Web](../exporting/web.md) Known Limitations.
 - Reproducible export builds currently require
   `--no-daemon -Pkotlin.compiler.execution.strategy=in-process` (Kotlin daemon
   builds exhausted memory).


### PR DESCRIPTION
## What

Docs-only. The README and `docs/index.md` still said the Web backend "runs Bunnymark and Match3" with a "two-demo corpus". It has been the full twelve-demo corpus at protocol 15 for days — Chrome + Firefox as CI cells on Linux (full corpus on main/nightly plus the 10-minute soak), Safari as a local pre-release gate — with tested browser floors (Chrome 130 / Firefox 141) and measured per-engine performance budgets.

- **README.md / docs/index.md** — replace the two-demo claim with the actual evidence; the **Experimental label is deliberately untouched** (the label decision is separate and open).
- **docs/exporting/web.md, docs/reference/version-support.md** — name task 71 in the user-facing Known Limitations: on one Linux CI host `VisibleOnScreenNotifier2D.screen_exited` never fires for spawned mobs, and it is UNEXPLAINED, not solved. A user who hits it should find it documented rather than discover it.
- **docs/contributing/web-internals.md** — the Option A/B generator rationale no longer dates itself to the two-demo era (and records that Option A held through the full corpus: tps-demo admitted 61 opcodes with one extern); Validation Fixtures now describes the per-demo driver + envelope-schema harness instead of "Bunnymark and Match3, one file per browser".

The source-checkout-only limitation survives in every touched file.

## Validation

- `mkdocs build --strict` passes.
- Sweep for `two-demo` / `2-demo` / "runs Bunnymark and Match3" across README + docs/ comes back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)