### PR TITLE
Web: compile gameplay from a merged kotlin-src + web/kotlin-src view (Task 64)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: 535082f3a7b806ab9def598207ee1bd21498f415
+  DEMOS_REF: 34856ffc2d48f44143f9f138a94e44f8978bc5dd
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -70,18 +70,31 @@ typed commands over a JavaScript bridge rather than as direct FFI.
 
 ## Web-Compatible Project Scripts
 
-A project's JVM/desktop scripts are **not** directly Wasm-compatible: they take a
-`java.lang.foreign.MemorySegment` script-constructor handle and may use JVM-only
-pointer APIs. The Web export therefore uses a Wasm-compatible source set kept
-next to the JVM sources at **`<project>/web/kotlin-src/`**:
+The Web export compiles gameplay from a **merged view** of two directories in
+the project checkout:
 
-- the script constructor takes a neutral `GodotHandle` instead of
-  `MemorySegment`;
-- raw pointer identity (`handle.address()`) is replaced by `isSameInstance()`.
+1. **`<project>/kotlin-src/`** — the shared script root, the same files the
+   desktop build compiles. A script is directly Wasm-compatible when written
+   portably: the constructor takes `GodotHandle` (a typealias for
+   `MemorySegment` on the JVM, so desktop semantics are unchanged); numeric
+   reads of vector fields go through `.toDouble()` where the value is passed
+   as a parameter (desktop fields are single-precision `real_t`, Web's are
+   `Double` — mixed arithmetic widens automatically, bare parameter passes do
+   not); raw pointer identity (`handle.address()`) is replaced by
+   `isSameInstance()`; and no JVM-only APIs are used.
+2. **`<project>/web/kotlin-src/`** — per-file overrides. A file here replaces
+   the same-named shared file in the Web build. Use it for scripts that are
+   genuinely platform-different (a smoke hook, a capability stub), not for
+   copies.
 
-The `web/` directory is the export's Kotlin script root, so files under
-`web/kotlin-src/` resolve to `res://kotlin-src/*.kt` and match the scene script
-attachments. (Single-sourcing JVM and Web scripts is planned future work.)
+A desktop-only script that must keep its `res://kotlin-src/` path (for example
+one selected by path at runtime, like Bunnymark's benchmark variants) is listed
+in `<project>/web/kotlin-src-excludes.txt`, one kotlin-src-relative path per
+line; the merge skips it and fails loudly on a stale or contradictory entry.
+Anything a shared script calls that the Web API surface does not model yet
+fails the Web compile — that is the fail-loud coverage gate working as
+intended. Files under the merged root resolve to `res://kotlin-src/*.kt` and
+match the scene script attachments on both platforms.
 
 ## Build The Web Scripts
 

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -14,36 +14,97 @@ val webScriptSourceRoot =
 // otherwise it is derived from the selected demo's checkout as <projectDir>/web,
 // where the committed web/kotlin-src/*.kt live. This keeps exportWeb free of any
 // second workstation path -- pointing at the demo checkout is enough.
-val extraWebScriptSourceRoot: File? =
+val webDemoKey: String = providers.gradleProperty("kanamaWebDemo").orElse("match3").get()
+val webDemoProjectDir: File? =
+    when (webDemoKey) {
+        "match3" -> "kanamaWebMatch3ProjectDir"
+        "bunnymark" -> "kanamaWebBunnymarkProjectDir"
+        "dodge" -> "kanamaWebDodgeProjectDir"
+        "web3d" -> "kanamaWebWeb3dProjectDir"
+        "platformer" -> "kanamaWebPlatformerProjectDir"
+        "squash" -> "kanamaWebSquashProjectDir"
+        "fps" -> "kanamaWebFpsProjectDir"
+        "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
+        "thirdperson" -> "kanamaWebThirdpersonProjectDir"
+        "racing" -> "kanamaWebRacingProjectDir"
+        "citybuilder" -> "kanamaWebCitybuilderProjectDir"
+        "tpsdemo" -> "kanamaWebTpsdemoProjectDir"
+        else -> null
+    }
+        ?.let { providers.gradleProperty(it).orNull }
+        ?.let(rootProject::file)
+val explicitWebScriptSourceRoot: File? =
     providers.gradleProperty("kanamaWebExtraScriptSourceDir").orNull?.let(rootProject::file)
-        ?: run {
-            val demo = providers.gradleProperty("kanamaWebDemo").orElse("match3").get()
-            val projectDirProperty =
-                when (demo) {
-                    "match3" -> "kanamaWebMatch3ProjectDir"
-                    "bunnymark" -> "kanamaWebBunnymarkProjectDir"
-                    "dodge" -> "kanamaWebDodgeProjectDir"
-                    "web3d" -> "kanamaWebWeb3dProjectDir"
-                    "platformer" -> "kanamaWebPlatformerProjectDir"
-                    "squash" -> "kanamaWebSquashProjectDir"
-                    "fps" -> "kanamaWebFpsProjectDir"
-                    "charactercontroller" -> "kanamaWebCharactercontrollerProjectDir"
-                    "thirdperson" -> "kanamaWebThirdpersonProjectDir"
-                    "racing" -> "kanamaWebRacingProjectDir"
-                    "citybuilder" -> "kanamaWebCitybuilderProjectDir"
-                    "tpsdemo" -> "kanamaWebTpsdemoProjectDir"
-                    else -> null
+val extraWebScriptSourceRoot: File? =
+    explicitWebScriptSourceRoot
+        ?: webDemoProjectDir?.resolve("web")?.takeIf { it.resolve("kotlin-src").isDirectory }
+        ?: layout.projectDirectory
+            .dir("src/web3dSmoke/web")
+            .asFile
+            .takeIf { webDemoKey == "web3d" && it.resolve("kotlin-src").isDirectory }
+
+// Task 64 (single-source scripts): when the demo checkout also has the shared
+// desktop script root <projectDir>/kotlin-src, the Wasm build compiles a MERGED
+// view instead of web/kotlin-src alone -- the shared root is copied first and
+// web/kotlin-src is overlaid on top, so a file present in both resolves to the
+// web copy (per-target override) and a file present only in the shared root
+// reaches the Web build unchanged. A demo with no shared root, or an explicit
+// -PkanamaWebExtraScriptSourceDir, keeps the single-root behavior unchanged.
+// Desktop-only scripts that must stay at their res://kotlin-src/ paths (e.g.
+// Bunnymark's benchmark variants, selected by path at runtime) are listed in
+// <projectDir>/web/kotlin-src-excludes.txt, one kotlin-src-relative path per
+// line; the merge skips them and fails loudly on a stale or contradictory
+// entry. The merged layout keeps the kotlin-src/ prefix so the processor
+// derives the same res://kotlin-src/*.kt resource paths as before.
+val sharedWebScriptSourceRoot: File? =
+    if (explicitWebScriptSourceRoot != null) null
+    else webDemoProjectDir?.resolve("kotlin-src")?.takeIf { it.isDirectory }
+val mergedWebScriptRoot = layout.buildDirectory.dir("web-merged-scripts/$webDemoKey")
+val mergeWebGameplayScripts: TaskProvider<Task>? =
+    if (sharedWebScriptSourceRoot != null && extraWebScriptSourceRoot != null) {
+        tasks.register("mergeWebGameplayScripts") {
+            group = "build"
+            description =
+                "Merges the shared kotlin-src with web/kotlin-src overrides (Task 64)."
+            val excludesFile = extraWebScriptSourceRoot.resolve("kotlin-src-excludes.txt")
+            inputs.dir(sharedWebScriptSourceRoot)
+            inputs.dir(extraWebScriptSourceRoot)
+            outputs.dir(mergedWebScriptRoot)
+            doLast {
+                val webOverrideDir = extraWebScriptSourceRoot.resolve("kotlin-src")
+                val excludes: List<String> =
+                    if (excludesFile.isFile) {
+                        excludesFile
+                            .readLines()
+                            .map { it.trim() }
+                            .filter { it.isNotEmpty() && !it.startsWith("#") }
+                    } else emptyList()
+                excludes.forEach { entry ->
+                    check(sharedWebScriptSourceRoot.resolve(entry).isFile) {
+                        "kotlin-src-excludes.txt lists '$entry' but kotlin-src/$entry does not exist"
+                    }
+                    check(!webOverrideDir.resolve(entry).isFile) {
+                        "kotlin-src-excludes.txt lists '$entry' but web/kotlin-src/$entry exists too -- " +
+                            "an excluded file cannot also be overridden"
+                    }
                 }
-            projectDirProperty
-                ?.let { providers.gradleProperty(it).orNull }
-                ?.let(rootProject::file)
-                ?.resolve("web")
-                ?.takeIf { it.resolve("kotlin-src").isDirectory }
-                ?: layout.projectDirectory
-                    .dir("src/web3dSmoke/web")
-                    .asFile
-                    .takeIf { demo == "web3d" && it.resolve("kotlin-src").isDirectory }
+                val out = mergedWebScriptRoot.get().asFile
+                out.deleteRecursively()
+                val target = out.resolve("kotlin-src")
+                copy {
+                    from(sharedWebScriptSourceRoot) {
+                        include("**/*.kt")
+                        excludes.forEach { exclude(it) }
+                    }
+                    into(target)
+                }
+                copy {
+                    from(webOverrideDir) { include("**/*.kt") }
+                    into(target)
+                }
+            }
         }
+    } else null
 
 kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
@@ -70,7 +131,11 @@ kotlin {
             }
         }
         val wasmJsMain by getting {
-            extraWebScriptSourceRoot?.let(kotlin::srcDir)
+            if (mergeWebGameplayScripts != null) {
+                kotlin.srcDir(files(mergedWebScriptRoot).builtBy(mergeWebGameplayScripts))
+            } else {
+                extraWebScriptSourceRoot?.let(kotlin::srcDir)
+            }
         }
     }
 }
@@ -80,11 +145,20 @@ dependencies {
 }
 
 ksp {
+    val gameplayScriptRoot =
+        if (mergeWebGameplayScripts != null) mergedWebScriptRoot.get().asFile
+        else extraWebScriptSourceRoot
     val scriptRoots =
-        listOfNotNull(webScriptSourceRoot.asFile, extraWebScriptSourceRoot)
+        listOfNotNull(webScriptSourceRoot.asFile, gameplayScriptRoot)
             .joinToString(System.getProperty("path.separator")) { it.absolutePath }
     arg("kanamaScriptRoots", scriptRoots)
     arg("kanamaRuntimeTarget", "web")
+}
+
+// The KSP task consumes the merged gameplay sources; the srcDir's builtBy covers the
+// Kotlin compilation, this covers KSP's own source snapshot.
+mergeWebGameplayScripts?.let { merge ->
+    tasks.matching { it.name == "kspKotlinWasmJs" }.configureEach { dependsOn(merge) }
 }
 
 val webSpikeSourceProject = layout.projectDirectory.dir("src/webSpikeGodot/project")


### PR DESCRIPTION
## What

The single-source half of task 64. When the demo checkout also has the shared desktop script root `<projectDir>/kotlin-src`, the Wasm build compiles a **merged view**: the shared root is copied first and `web/kotlin-src` is overlaid on top — a file present in both resolves to the web copy (per-file override), a file present only in the shared root reaches the Web build unchanged. A portably-written script is therefore compiled by both targets from one copy. Demos with no shared root, or an explicit `-PkanamaWebExtraScriptSourceDir`, keep the single-root behavior byte-for-byte.

Desktop-only scripts that must keep their `res://kotlin-src/` paths (Bunnymark's benchmark variants are selected by path at runtime) are listed in the demo's `web/kotlin-src-excludes.txt`; the merge skips them and fails loudly on a stale or contradictory entry. The merged layout keeps the `kotlin-src/` prefix, so the processor derives identical `res://` paths.

`docs/exporting/web.md` §Web-Compatible Project Scripts now teaches the merged model and the portable-spelling rules (GodotHandle ctor, `.toDouble()` on bare Float-field parameter passes, `isSameInstance()`, no JVM-only APIs) instead of the copy-the-sources workflow.

## Why it's safe for the whole corpus

10 of 11 external demos have full web override coverage (verified file-by-file), so the merge is a no-op for them — proven for squash pre-migration: merged dir identical to `web/kotlin-src`, export green. Bunnymark is the one demo with desktop-only files; its excludes manifest is in kanama-demos#23.

## Validation

- Pre-migration no-op: squash export with merge active, merged dir == `web/kotlin-src`, build green.
- Post-migration (against kanama-demos#23): merged root = 4 shared + SmokeQuit override; **generated proxies byte-identical to the pre-migration snapshot**; `web_export_smoke: PASS` on chrome + firefox for squash and bunnymark; desktop compile + headless smoke green on the converged sources.
- `mkdocs build --strict` covered by the docs CI job.

## Merge order

kanama-demos#23 first; then this PR gets a `DEMOS_REF` bump to that merge commit before landing (a kanama main with merge logic + the old pin would redden the full-corpus bunnymark cell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)