### PR TITLE
Web phone testing: serve --https, secure-context refusal, load progress (task 70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ browser floors and measured per-engine performance budgets, and Safari passes
 the same gate as a local pre-release check (it has no headless mode). It is
 still **not a Supported target**: single-thread Compatibility renderer only, a
 source-checkout export (no packaged addon), and desktop browsers only
-(iOS/iPadOS WebKit unvalidated). See the
+(iOS/iPadOS hand-checked on device, not gated). See the
 [Web export guide](docs/exporting/web.md) and
 [Web Internals](docs/contributing/web-internals.md) for the architecture.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -173,18 +173,26 @@ python3 scripts/web/serve_export.py web-runtime/build/web-export/match3
 ### Testing On A Phone Or Tablet
 
 Loopback is the default so an export server is never reachable from the network
-unless asked for. `--lan` binds every interface and prints the address to open on
-the device:
+unless asked for. `--lan` binds every interface — and **must be combined with
+`--https`**, because Godot's Web export requires a secure context: `127.0.0.1`
+is one, but a LAN address over plain HTTP is not, and the engine never starts
+on the device (measured: a fatal error in audio-worklet init right after
+"starting Godot…"; the page now refuses up front instead). `--https` serves
+with a cached self-signed certificate — accept the device's one-time warning
+(iOS Safari: Show Details → visit this website):
 
 ```sh
-python3 scripts/web/serve_export.py --lan web-runtime/build/web-export/match3
-# prints PORT=<n> and LAN=http://<this-machine>:<n>/
+python3 scripts/web/serve_export.py --lan --https web-runtime/build/web-export/match3
+# prints PORT=<n> and LAN=https://<this-machine>:<n>/
 ```
 
-This is the **only** way to exercise iOS or iPadOS: `safaridriver` drives desktop
-Safari only, so mobile WebKit cannot be automated and has to be hand-checked on a
-real device with the phone on the same network. Nothing on mobile WebKit is
-validated today — see Known Limitations.
+Hand-checking on a device on the same network is the standard recipe. Safari on
+a USB-connected iPhone or iPad can additionally be driven over WebDriver:
+enable Settings → Safari → Advanced → Remote Automation on the device, keep it
+unlocked, and create a `safaridriver` session with `platformName: iOS`, the
+device UDID (`xcrun xctrace list devices`), and `acceptInsecureCerts: true` —
+one session per device at a time. No automated iOS gate exists yet, and mobile
+WebKit remains hand-validated, not gated — see Known Limitations.
 
 ## Run The Export Smoke
 
@@ -461,9 +469,11 @@ commits, per-demo checksums, payload sizes, protocol version and driver results.
   they run unattended; `safaridriver` drives a real Safari window on a logged-in
   GUI session. The Safari gate is therefore a **local** gate, not a CI cell, and
   two Safari runs must not be started concurrently on one machine.
-- **Safari on iOS/iPadOS is unvalidated.** Every iOS browser is WebKit, but
-  `safaridriver` covers desktop Safari only. No mobile-WebKit version floor is
-  claimed.
+- **Safari on iOS/iPadOS is hand-checked only, and no mobile-WebKit version
+  floor is claimed.** Every iOS browser is WebKit. `safaridriver` can drive
+  Safari on a USB-connected device (see Testing On A Phone Or Tablet), but no
+  automated iOS gate exists and mobile WebKit is not part of the validated
+  claim.
 - **Lifecycle virtuals are limited to what the proxy dispatches**: `_ready`,
   `_process`, `_physics_process`, `_draw`, `_exit_tree`, `_input`, and
   `_unhandled_input`. Anything else — `@OnEnterTree` in particular — is rejected

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ ownership, signals, and wrapper coverage. For existing GDScript projects, use
 | Windows | Supported (4.7 stable) |
 | Android | Supported (4.7 stable); debug ≥ Android 9, release ≥ Android 13 (Pixel 7 / Moto g 5G / S10+ / Pixel 3 XL) |
 | iOS | Supported (4.7 stable, Kotlin/Native); device-validated iPhone 12 / 15 Pro |
-| Web | Experimental (Kotlin/Wasm preview, 4.7 stable); 12-demo corpus in Chrome/Firefox CI + a local Safari gate; source-checkout export, desktop browsers only, not Supported |
+| Web | Experimental (Kotlin/Wasm preview, 4.7 stable); 12-demo corpus in Chrome/Firefox CI + a local Safari gate; source-checkout export, desktop browsers only (iOS hand-checked, ungated), not Supported |
 
 See [Version Support](reference/version-support.md) for exact Godot, JDK,
 smoke-test, and packaging boundaries.

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -13,7 +13,7 @@ page records the platforms and engine versions validated for it.
 | Linux x86_64 | Supported (4.7 stable) | Full local CI, native bootstrap preflight, strict docs, all 11 demo builds, the nine-demo desktop smoke matrix, TPS checked smoke, distribution packaging, and desktop-kit/store-addon install smokes passed on Ubuntu 25.04 with Godot `4.7.stable.official.5b4e0cb0f` and OpenJDK 25.0.2 (2026-07-13/14). The resource-loader/saver teardown fix is required. Packaged desktop exports remain a separate release-readiness track. |
 | Windows x86_64 | Supported (4.7 stable) | Full local revalidation on the 4.7 stable console binary (2026-07-13): demo audits, script builds, imports, the nine-demo desktop runtime smoke, the TPS smoke, and the packaged desktop-kit + store-addon install smokes all passed. Gradle commands that build the native bootstrap run from a VS 2022 developer environment (VsDevCmd); Git Bash runs the smoke scripts. |
 | iOS (Kotlin/Native backend) | Supported (4.7 stable) | Promoted from Experimental 2026-07-14 (§7 mobile promotion bar B1–B4 MET). The iOS backend runs full Kanama project scripts via a C shim + Kotlin/Native static `.xcframework`, using the same wrapper generator as desktop/Android (no JVM on device). Full device gate (9-demo matrix + fresh-project install path) passed on two models: **iPhone 12** (iOS 26.5, 2026-06-25; 0 guardrail failures) + **iPhone 15 Pro** (iOS 26.5, 2026-07-10, full-breadth wrapper runtime), both on 4.7 stable iOS templates. Packaged `.xcframework` addon is runtime-only (compiling project scripts needs the Kanama checkout; ~199.5 MB debug / ~87.6 MB release static `.a`). No mobile hot reload. One FPS Audio autoload follow-up + task-26 multiplayer UI polish tracked as non-blocking — see [exporting/ios.md](../exporting/ios.md). |
-| Web | Experimental (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs a twelve-demo production-export corpus in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge, with a reproducible source-checkout export workflow ([guide](../exporting/web.md)). **Not a Supported target: source-checkout export only (no packaged addon), single-thread Compatibility renderer, desktop browsers only (iOS/iPadOS WebKit unvalidated).** See §Web below. |
+| Web | Experimental (4.7 stable) | Kotlin/Wasm backend (no on-device JVM); runs a twelve-demo production-export corpus in Chrome/Firefox/Safari through a generated proxy + versioned JS bridge, with a reproducible source-checkout export workflow ([guide](../exporting/web.md)). **Not a Supported target: source-checkout export only (no packaged addon), single-thread Compatibility renderer, desktop browsers only (iOS/iPadOS hand-checked on device, not gated).** See §Web below. |
 
 Validated support is only claimed after the matching smoke path passes.
 Use the
@@ -151,8 +151,15 @@ never expose a reachable WebDriver BiDi endpoint to the driver, so they are
 untestable, not known-bad. Safari cannot be installed side by side with itself,
 so its number is only the oldest version ever driven.
 
-**iOS and iPadOS are unvalidated**: `safaridriver` drives desktop Safari only,
-and no mobile-WebKit floor is claimed.
+**iOS and iPadOS are hand-checked, not gated, and no mobile-WebKit floor is
+claimed.** A device pass (2026-08-03, iPhone 15 Pro, Safari/WebKit
+26.5.2/605.1.15, served over HTTPS — Godot Web exports require a secure
+context) had 11 of the 12 corpus demos boot and render with zero console
+errors; dodge and match3 were hand-played with working audio and lock/unlock
+resume, and tps-demo exceeds the per-tab memory budget during load.
+`safaridriver` can drive Safari on a USB-connected device (Remote Automation),
+but no automated iOS gate exists, so none of this is "tested" in the sense
+above — mobile WebKit stays outside the validated claim.
 
 ### Explicit non-support limitations
 
@@ -162,7 +169,7 @@ and no mobile-WebKit floor is claimed.
 - Godot **Compatibility renderer, single-thread** only.
 - No Web editor, no hot reload, no threads, no Kotlin/JS path.
 - Safari has **no headless mode**, so the Safari gate is a local GUI gate rather
-  than a CI cell; iOS/iPadOS WebKit is unvalidated.
+  than a CI cell; iOS/iPadOS WebKit is hand-checked only, not gated.
 - One defect is tracked openly rather than solved: on one Linux CI host,
   spawned mobs never receive `VisibleOnScreenNotifier2D.screen_exited` and are
   never freed (task 71; the affected matrix cells are quarantined, not hidden).

--- a/scripts/web/serve_export.py
+++ b/scripts/web/serve_export.py
@@ -11,7 +11,12 @@ NOT sent: the preview backend is the single-thread Compatibility renderer, which
 does not require cross-origin isolation.
 
 Usage:
-    python3 serve_export.py <export-dir>
+    python3 serve_export.py [--lan] [--https] <export-dir>
+
+``--https`` serves over TLS with a cached self-signed certificate. It exists
+for phone testing: Godot's Web export requires a secure context, ``127.0.0.1``
+is one but a LAN address over plain HTTP is not, so ``--lan`` without
+``--https`` cannot start the engine on a device (task 70).
 """
 
 from __future__ import annotations
@@ -19,6 +24,8 @@ from __future__ import annotations
 import http.server
 import os
 import socket
+import ssl
+import subprocess
 import sys
 import threading
 import time
@@ -77,13 +84,52 @@ def _lan_address() -> str | None:
         return None
 
 
+def _ensure_self_signed_cert(address: str) -> tuple[str, str]:
+    """Return (cert, key) paths for ``address``, generating them if missing.
+
+    Certificates are cached per address under ~/.cache/kanama-web-serve so a
+    device that accepted the certificate once does not see a fresh warning on
+    every run. Self-signed is the point: Godot's Web export requires a secure
+    context (task 70 — over plain LAN HTTP it never starts), and a tap-through
+    warning on the device is the cheap way to get one on a LAN.
+    """
+    cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "kanama-web-serve")
+    os.makedirs(cache_dir, exist_ok=True)
+    cert = os.path.join(cache_dir, f"cert-{address}.pem")
+    key = os.path.join(cache_dir, f"key-{address}.pem")
+    if os.path.isfile(cert) and os.path.isfile(key):
+        return cert, key
+    san = f"subjectAltName=IP:{address},IP:127.0.0.1,DNS:localhost"
+    try:
+        subprocess.run(
+            [
+                "openssl", "req", "-x509", "-newkey", "rsa:2048",
+                "-keyout", key, "-out", cert, "-days", "30", "-nodes",
+                "-subj", f"/CN={address}", "-addext", san,
+            ],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        print(
+            "serve_export: --https needs the openssl CLI to generate a"
+            " self-signed certificate and it was not found on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.decode(errors="replace") if error.stderr else ""
+        print(f"serve_export: certificate generation failed:\n{stderr}", file=sys.stderr)
+        raise SystemExit(2) from None
+    return cert, key
+
+
 def main(argv: list[str]) -> int:
-    lan = False
-    args = [arg for arg in argv if arg != "--lan"]
-    if len(args) != len(argv):
-        lan = True
+    lan = "--lan" in argv
+    https = "--https" in argv
+    args = [arg for arg in argv if arg not in ("--lan", "--https")]
     if len(args) != 1:
-        print("usage: serve_export.py [--lan] <export-dir>", file=sys.stderr)
+        print("usage: serve_export.py [--lan] [--https] <export-dir>", file=sys.stderr)
         return 2
 
     export_dir = args[0]
@@ -104,6 +150,19 @@ def main(argv: list[str]) -> int:
 
     server = http.server.ThreadingHTTPServer((host, port), handler)
 
+    scheme = "http"
+    if https:
+        # A phone can only run the export over a secure context (Godot refuses,
+        # or dies in audio-worklet init, without one — task 70), and a LAN IP is
+        # never one over plain HTTP. 127.0.0.1 is always secure, so --https is
+        # only *required* together with --lan; it works alone for parity.
+        cert_address = (_lan_address() or "127.0.0.1") if lan else "127.0.0.1"
+        cert, key = _ensure_self_signed_cert(cert_address)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cert, key)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        scheme = "https"
+
     # The smoke shell owns this server and stops it in its cleanup trap — but if
     # the shell is SIGKILLed or its terminal goes away, nothing reaches us and
     # this process holds its port forever. Watch for being reparented away from
@@ -121,9 +180,27 @@ def main(argv: list[str]) -> int:
     print(f"PORT={port}", flush=True)
     if lan:
         address = _lan_address()
-        where = f"http://{address}:{port}/" if address else f"http://<this-machine>:{port}/"
+        where = (
+            f"{scheme}://{address}:{port}/"
+            if address
+            else f"{scheme}://<this-machine>:{port}/"
+        )
         print(f"LAN={where}", flush=True)
         print(f"serve_export: open {where} on the device", flush=True)
+        if https:
+            print(
+                "serve_export: the certificate is self-signed -- accept the"
+                " device's one-time warning (iOS Safari: Show Details -> visit"
+                " this website)",
+                flush=True,
+            )
+        else:
+            print(
+                "serve_export: NOTE plain HTTP is not a secure context on a"
+                " LAN address; Godot Web exports will not start on the device."
+                " Pass --https for phone testing (task 70).",
+                flush=True,
+            )
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/web-runtime/src/webSpikeGodot/assets/shell.html
+++ b/web-runtime/src/webSpikeGodot/assets/shell.html
@@ -60,11 +60,40 @@
     <script src="kanama-web-spike.js"></script>
     <script src="kanama-web-bridge.js"></script>
     <script>
-      const engine = new Engine($GODOT_CONFIG);
-      globalThis
-        .bootstrapKanamaWeb(globalThis["web-runtime"])
-        .then(() => engine.startGame())
-        .catch((error) => globalThis.failKanamaWeb(error));
+      const kanamaBootStatus = document.getElementById("kanama-status");
+      if (!window.isSecureContext) {
+        // Godot's Web export requires a secure context; starting it here dies
+        // inside engine init (audio-worklet setup) with an unreadable wasm
+        // stack. 127.0.0.1 is always secure; a LAN address over plain HTTP is
+        // not. Refuse up front the way stock Godot's loader does (task 70).
+        document.body.dataset.status = "fail";
+        kanamaBootStatus.dataset.kind = "fail";
+        kanamaBootStatus.textContent =
+          "Not a secure context: Godot Web exports cannot start on " +
+          location.origin +
+          ". Serve over HTTPS (scripts/web/serve_export.py --lan --https) " +
+          "or open via 127.0.0.1.";
+      } else {
+        const config = $GODOT_CONFIG;
+        const megabytes = (bytes) => (bytes / (1024 * 1024)).toFixed(1);
+        config.onProgress = (current, total) => {
+          // Narrate the engine download/instantiate phase; Godot stops
+          // reporting once it starts and the bridge owns the line after that.
+          // Without this a large pck reads as a silent hang (task 70).
+          if (!total || document.body.dataset.status !== "loading") return;
+          kanamaBootStatus.textContent =
+            "Kotlin/Wasm ready; starting Godot… " +
+            megabytes(current) +
+            " / " +
+            megabytes(total) +
+            " MB";
+        };
+        const engine = new Engine(config);
+        globalThis
+          .bootstrapKanamaWeb(globalThis["web-runtime"])
+          .then(() => engine.startGame())
+          .catch((error) => globalThis.failKanamaWeb(error));
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## What

Every change here is a measured finding from the 2026-08-03 iPhone session (task 70 §Second device evidence): Godot's Web export requires a **secure context** — `127.0.0.1` is one, a LAN address over plain HTTP is not — so the documented `--lan` phone recipe could never start the engine on a device. It failed as a raw fatal in `_godot_audio_init` (AudioWorklet is secure-context-only) or, before this PR's shell change, as an apparently silent hang.

- **`serve_export.py --https`** — TLS with a per-address self-signed certificate cached under `~/.cache/kanama-web-serve` (the device's tap-through happens once, not per run). Plain `--lan` now prints a warning that Godot cannot start on a device without `--https`.
- **`shell.html` refuses insecure contexts up front**, with the remedy in the message, the way stock Godot's loader does — instead of crashing with an unreadable wasm stack.
- **`shell.html` narrates the engine download** via `EngineConfig.onProgress` ("Kotlin/Wasm ready; starting Godot… 12.3 / 39.7 MB") — a large pck previously read as a silent hang; this is what made tps-demo's iOS memory-kill look like a mystery.
- **Docs**: §Testing On A Phone Or Tablet teaches `--lan --https` plus the on-device safaridriver recipe (`platformName: iOS` + device UDID + `acceptInsecureCerts`, Remote Automation toggle, one session per device); the Known Limitations bullet no longer claims safaridriver is desktop-only, which the device session disproved. The iOS scoping — hand-validated, ungated, no floor claimed — is unchanged.

## Validation

- Insecure path: headless Chrome over a LAN address renders the refusal, no engine start, no crash.
- Secure path: headless Chrome over loopback shows the progress narration and boots normally.
- `web_export_smoke: PASS` on **chrome + firefox** against a rebuilt squash export with the new shell.
- `--https` live-tested: TLS fetch 200, `application/wasm` MIME preserved; `mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)