### PR TITLE
Task 74 settled: the Firefox per-tick asymmetry is a headless-rAF artifact

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -303,10 +303,17 @@ starting, or start doing per-frame work at the module boundary.
 
 **Why per engine.** The ratio is engine-stable across most of the corpus — Chrome
 vs Firefox: bunnymark 2.22/1.97, dodge 0.19/0.20, fps 1.10/1.02 — but *not* for
-the input-heavy demos, where Firefox does several times the boundary work
+the input-heavy demos, where Firefox reports several times the boundary work
 (charactercontroller 4.50/**19.58**, thirdperson 1.15/**6.01**). Budgets are
-therefore measured and declared per engine. That asymmetry is itself an open
-question, not a settled property.
+therefore measured and declared per engine. The asymmetry itself is settled
+(task 74): nothing paces `requestAnimationFrame` in headless Firefox, so
+render-frame-driven (`_process`) command emission multiplies freely while
+physics-driven work tracks the wall-capped physics step — a per-opcode
+histogram shows the multiplier concentrated in per-render-frame emissions,
+with physics-driven calls at exactly the tick ratio on both engines. The
+number is a property of the headless environment, not of Firefox as users run
+it (display-paced, it sits near Chrome); per-engine budgets bound regressions
+within each environment's own baseline.
 
 **Why the headline budget is per tick rather than per second.** Godot's Web main
 loop is paced by `requestAnimationFrame` and advances a fixed step per iteration,

--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "updated": "2026-07-30",
-  "note": "Web performance budgets (Task 60f). Every number was MEASURED; each demo records the runs it came from. WHAT IS GATED CHANGED after the first Firefox baseline (see `gatingPolicy`): payload and crossings-per-tick are gated, startup is recorded but NOT gated.",
+  "note": "Web performance budgets (Task 60f). Every number was MEASURED; each demo records the runs it came from. WHAT IS GATED CHANGED after the first Firefox baseline (see `gatingPolicy`): payload and crossings-per-tick are gated, startup is recorded but NOT gated. Firefox's higher crossings-per-tick on _process-heavy demos is a SETTLED headless-environment artifact, not an engine defect (task 74, 2026-08-03): nothing paces requestAnimationFrame in headless Firefox, so render-frame-driven command emission multiplies while physics-driven work tracks the wall-capped physics step; a display-paced Firefox sits near Chrome. Per-engine budgets bound regressions within each environment's own baseline.",
   "headroom": "payload +15% (asset growth, not a texture reimport); startup 3x with an 8s floor; crossings/tick 2x with a 2.0 floor -- the ratio is diluted by tick count, so 2x absorbs host variation while a real regression (per-frame work reaching the cross-module path) multiplies it several times over.",
   "knownExceptions": {
     "tpsdemo": "638 MB served payload, 570 MB of it upstream demo assets in index.pck. It RUNS, but nobody would download it: this is far outside any sane web budget, and the number below records reality rather than blessing it. Fixing it is asset work in the demo (texture compression, trimming), which 60f explicitly puts out of scope -- budgets are not met by editing gameplay or scene content."


### PR DESCRIPTION
## What

Documentation of a settled investigation — no behavior changes.

The task-74 question was whether Firefox genuinely does 4–5× the per-tick boundary work on input-held demos or the metric measures the harness. A per-opcode histogram (bridge copy patched to count every queued command, driven by the unmodified smoke on both engines, thirdperson) answers it:

| call | Chrome | Firefox | ratio |
|---|---|---|---|
| opcode 1000 — the spike page's per-render-frame heartbeat | 464 | 7255 | **15.6×** |
| Node3D.set_rotation / set_scale (`@OnProcess`-driven visuals) | 102 / 88 | 515 / 272 | 5.0× / 3.1× |
| CharacterBody3D.set_velocity, AnimationNodeStateMachinePlayback.travel (physics-driven) | — | — | **1.8–2.0× = exactly the tick ratio** |

Physics-commands-per-physics-tick is engine-equal (0.227 vs 0.247). The multiplier is entirely render-frame-driven work: **nothing paces `requestAnimationFrame` in headless Firefox** (independently measured in task 71; `layout.frame_rate` does not change it), so `_process` emission free-runs over a wall-capped physics denominator. Not an engine defect, not the input transport (outliers span both transports); a display-paced real Firefox sits near Chrome. Host-sensitivity (CI 12.13 vs local 19.58) follows too — the free-run rate is whatever the host can do.

Changes: `budgets.json`'s note and web.md's §Performance Budgets "open question" sentence now record the mechanism. Per-engine budgets remain the gate, as the bound on regressions within each environment's own baseline. Full evidence in kanama-tasks 74.

## Validation

`mkdocs build --strict` green; a squash chrome smoke passes with the updated budgets file (note-only change, checker unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)