### PR TITLE
Web: fix the merged script root's KSP wiring; activate on the shared root

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -39,8 +39,8 @@ BiDi endpoint to the driver's launch recipe, so they cannot be judged either way
 Safari is "validated-at" only: it ships with the OS and cannot be installed side
 by side, so no lower bound is testable at all.
 
-**iOS and iPadOS have not been validated**; `safaridriver` drives desktop Safari
-only, so no mobile-WebKit claim is made here.
+**iOS and iPadOS are hand-checked only, not gated** — no mobile-WebKit claim is
+made here (see Known Limitations and Testing On A Phone Or Tablet).
 
 This page is the reproducible export workflow. For the architecture — batching,
 snapshots, handle generations, the bridge protocol — see

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -43,37 +43,45 @@ val extraWebScriptSourceRoot: File? =
             .asFile
             .takeIf { webDemoKey == "web3d" && it.resolve("kotlin-src").isDirectory }
 
-// Task 64 (single-source scripts): when the demo checkout also has the shared
+// Task 64 (single-source scripts): when the demo checkout has the shared
 // desktop script root <projectDir>/kotlin-src, the Wasm build compiles a MERGED
-// view instead of web/kotlin-src alone -- the shared root is copied first and
-// web/kotlin-src is overlaid on top, so a file present in both resolves to the
-// web copy (per-target override) and a file present only in the shared root
-// reaches the Web build unchanged. A demo with no shared root, or an explicit
-// -PkanamaWebExtraScriptSourceDir, keeps the single-root behavior unchanged.
-// Desktop-only scripts that must stay at their res://kotlin-src/ paths (e.g.
-// Bunnymark's benchmark variants, selected by path at runtime) are listed in
-// <projectDir>/web/kotlin-src-excludes.txt, one kotlin-src-relative path per
-// line; the merge skips them and fails loudly on a stale or contradictory
-// entry. The merged layout keeps the kotlin-src/ prefix so the processor
-// derives the same res://kotlin-src/*.kt resource paths as before.
+// view -- the shared root is copied first and web/kotlin-src (IF present) is
+// overlaid on top, so a file present in both resolves to the web copy
+// (per-target override) and a file present only in the shared root reaches the
+// Web build unchanged. A fully-converged demo may have NO web/kotlin-src left
+// at all (git prunes the emptied directory); the merge activates on the shared
+// root alone, so convergence can never turn the script root off. A demo with
+// no shared root, or an explicit -PkanamaWebExtraScriptSourceDir, keeps the
+// single-root behavior unchanged. Desktop-only scripts that must stay at their
+// res://kotlin-src/ paths (e.g. Bunnymark's benchmark variants, selected by
+// path at runtime) are listed in <projectDir>/web/kotlin-src-excludes.txt, one
+// kotlin-src-relative path per line; the merge skips them and fails loudly on
+// a stale or contradictory entry. The merged layout keeps the kotlin-src/
+// prefix so the processor derives the same res://kotlin-src/*.kt resource
+// paths as before.
 val sharedWebScriptSourceRoot: File? =
     if (explicitWebScriptSourceRoot != null) null
     else webDemoProjectDir?.resolve("kotlin-src")?.takeIf { it.isDirectory }
+val webOverrideParentDir: File? =
+    if (explicitWebScriptSourceRoot != null) null else webDemoProjectDir?.resolve("web")
 val mergedWebScriptRoot = layout.buildDirectory.dir("web-merged-scripts/$webDemoKey")
 val mergeWebGameplayScripts: TaskProvider<Task>? =
-    if (sharedWebScriptSourceRoot != null && extraWebScriptSourceRoot != null) {
+    if (sharedWebScriptSourceRoot != null) {
         tasks.register("mergeWebGameplayScripts") {
             group = "build"
             description =
                 "Merges the shared kotlin-src with web/kotlin-src overrides (Task 64)."
-            val excludesFile = extraWebScriptSourceRoot.resolve("kotlin-src-excludes.txt")
+            val overrideDir = webOverrideParentDir?.resolve("kotlin-src")
+            val excludesFile = webOverrideParentDir?.resolve("kotlin-src-excludes.txt")
             inputs.dir(sharedWebScriptSourceRoot)
-            inputs.dir(extraWebScriptSourceRoot)
+            // files() tolerates absent paths, so an override-less or
+            // excludes-less demo still has a stable, content-tracked input set.
+            inputs.files(listOfNotNull(overrideDir, excludesFile))
             outputs.dir(mergedWebScriptRoot)
             doLast {
-                val webOverrideDir = extraWebScriptSourceRoot.resolve("kotlin-src")
+                val overrideActive = overrideDir?.isDirectory == true
                 val excludes: List<String> =
-                    if (excludesFile.isFile) {
+                    if (excludesFile?.isFile == true) {
                         excludesFile
                             .readLines()
                             .map { it.trim() }
@@ -83,7 +91,7 @@ val mergeWebGameplayScripts: TaskProvider<Task>? =
                     check(sharedWebScriptSourceRoot.resolve(entry).isFile) {
                         "kotlin-src-excludes.txt lists '$entry' but kotlin-src/$entry does not exist"
                     }
-                    check(!webOverrideDir.resolve(entry).isFile) {
+                    check(!overrideActive || !overrideDir!!.resolve(entry).isFile) {
                         "kotlin-src-excludes.txt lists '$entry' but web/kotlin-src/$entry exists too -- " +
                             "an excluded file cannot also be overridden"
                     }
@@ -98,9 +106,14 @@ val mergeWebGameplayScripts: TaskProvider<Task>? =
                     }
                     into(target)
                 }
-                copy {
-                    from(webOverrideDir) { include("**/*.kt") }
-                    into(target)
+                if (overrideActive) {
+                    copy {
+                        from(overrideDir) { include("**/*.kt") }
+                        into(target)
+                    }
+                }
+                check(target.isDirectory && target.listFiles()?.any { it.extension == "kt" } == true) {
+                    "merged web script root is empty -- no gameplay scripts would be compiled"
                 }
             }
         }
@@ -132,7 +145,12 @@ kotlin {
         }
         val wasmJsMain by getting {
             if (mergeWebGameplayScripts != null) {
-                kotlin.srcDir(files(mergedWebScriptRoot).builtBy(mergeWebGameplayScripts))
+                // A plain directory srcDir (not a files().builtBy() wrapper): KSP
+                // snapshots source-set dirs by content, and the wrapper form was
+                // measured to drop the gameplay sources from the KSP task's inputs
+                // entirely -- proxies then came out of the build cache without any
+                // demo scripts. Task dependencies are declared explicitly below.
+                kotlin.srcDir(mergedWebScriptRoot)
             } else {
                 extraWebScriptSourceRoot?.let(kotlin::srcDir)
             }
@@ -155,10 +173,15 @@ ksp {
     arg("kanamaRuntimeTarget", "web")
 }
 
-// The KSP task consumes the merged gameplay sources; the srcDir's builtBy covers the
-// Kotlin compilation, this covers KSP's own source snapshot.
+// Both consumers of the merged gameplay sources need the explicit dependency:
+// the srcDir above is a plain directory (deliberately -- see the comment there),
+// so nothing else orders the merge before KSP or the Kotlin compilation.
 mergeWebGameplayScripts?.let { merge ->
-    tasks.matching { it.name == "kspKotlinWasmJs" }.configureEach { dependsOn(merge) }
+    tasks.configureEach {
+        if (name == "kspKotlinWasmJs" || name == "compileKotlinWasmJs") {
+            dependsOn(merge)
+        }
+    }
 }
 
 val webSpikeSourceProject = layout.projectDirectory.dir("src/webSpikeGodot/project")


### PR DESCRIPTION
## What

Two defects in the task-64 merge wiring, caught by the corpus batch migration's proxy-identity gate when bunnymark's KSP output came back with **no gameplay proxies at all** (spike scripts only):

1. **`files(dir).builtBy(mergeTask)` as a srcDir doesn't reach KSP.** Measured: the KSP task neither scheduled the merge (absent from "Tasks to be executed") nor tracked the merged sources as inputs — so its build-cache key ignored gameplay, and a cache restore could return a proxy set with no demo scripts. Now: plain directory-provider srcDir (content-tracked, as the pre-merge `web/` root always was) + explicit `dependsOn` on both `kspKotlinWasmJs` and `compileKotlinWasmJs`.
2. **A fully-converged demo turned its own script root off.** The merge only activated when `web/kotlin-src` existed; deleting a demo's last override file lets git prune the directory, silently deactivating the merge. Now the merge activates on the shared `kotlin-src` alone, override dir + excludes manifest are optional inputs, and an empty merged root is a **hard error** rather than a silent no-script build.

Why CI never saw it: fresh full-pipeline builds happened to order the merge before KSP and had no cache to restore stale outputs from. The failure needed an incremental/isolated invocation — exactly what local development does.

Also fixes one missed "iOS not validated / safaridriver desktop-only" sentence in web.md's Current Status (different phrasing than the #134 sweep's grep).

## Validation

Clean `--no-build-cache` runs: merge scheduled with KSP, bunnymark proxy emitted; re-exports of racing → bunnymark → dodge (the exact reproducing sequence) all **byte-identical to pre-migration proxy snapshots**; six both-engine smokes running on the batch demos alongside this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)