### PR TITLE
Bump DEMOS_REF to the second single-source batch (kanama-demos#24)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: 34856ffc2d48f44143f9f138a94e44f8978bc5dd
+  DEMOS_REF: 6f8ba32a935ac6dee5a2f0e60f6ab33aedb5c503
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#24 (dodge, racing partial, bunnymark single-sourced — validation in that PR and kanama#136). CI on this PR runs the subset against the new pin; the push to main runs the full corpus with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)