### PR TITLE
Bump DEMOS_REF to the platformer single-source slice (kanama-demos#25)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: 6f8ba32a935ac6dee5a2f0e60f6ab33aedb5c503
+  DEMOS_REF: d9f62f1fad44e7779b3177f3bb85db31d41dcb5a
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#25 (platformer partial single-sourcing; validation in that PR). Subset CI runs against the new pin here; the push to main runs the full corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)