### PR TITLE
Bump DEMOS_REF to the match3 single-source slice (kanama-demos#26)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: d9f62f1fad44e7779b3177f3bb85db31d41dcb5a
+  DEMOS_REF: c79fd51ed6639208ea0c936614989dc36bd9d3a3
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#26 — match3 fully converged (zero overrides; first demo on the #136 shared-root-only merge path in production). Validation in that PR: byte-exact web-copy convergence (token-diff proven), desktop smoke baseline both ways, proxies byte-identical, both-engine wrapper PASS. Match3's smoke is in the PR subset, so this PR's CI exercises the migrated demo directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)