### PR TITLE
Desktop export: jlink-bundled Java runtime (task 63, first slice)

### DIFF
--- a/bootstrap/bootstrap.c
+++ b/bootstrap/bootstrap.c
@@ -14,8 +14,9 @@
  *
  * libjvm is dlopen'd at runtime (rather than linked at build time)
  * so the bootstrap library doesn't bake in an absolute path to a
- * specific Java install. JAVA_HOME is consulted first; platform-specific
- * fallbacks are best-effort only.
+ * specific Java install. An app-relative bundled `runtime/` image
+ * (exported games, task 63 / issue #102) is probed first, then
+ * JAVA_HOME; platform-specific fallbacks are best-effort only.
  */
 
 #if defined(__linux__) && !defined(_GNU_SOURCE)
@@ -116,6 +117,8 @@ static void print_missing_jvm_diagnostic(void) {
 #ifndef __ANDROID__
     const char *java_home = getenv("JAVA_HOME");
     fprintf(stderr, "[kanama] error: libjvm not found. Kanama desktop runtime requires a JDK 25+ install.\n");
+    fprintf(stderr, "[kanama] no bundled runtime%s%s found next to the Kanama bootstrap library.\n",
+            PATH_SEP, jvm_relative_lib_path());
     if (java_home && *java_home) {
         char expected[1024];
         build_java_home_jvm_path(expected, sizeof expected, java_home);
@@ -128,8 +131,99 @@ static void print_missing_jvm_diagnostic(void) {
 #endif
 }
 
+/* Directory containing this bootstrap library. Anchor on the library, not
+ * the executable: kanama.gdextension already anchors everything on it, and
+ * Godot decides where the executable lives per platform. */
+static int find_self_library_dir(char *out, size_t out_size) {
+#ifdef _WIN32
+    HMODULE module = NULL;
+    if (!GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCSTR)find_self_library_dir,
+            &module
+        )) {
+        return -1;
+    }
+    char lib_path[1024];
+    DWORD len = GetModuleFileNameA(module, lib_path, sizeof lib_path);
+    if (len == 0 || len >= sizeof lib_path) {
+        return -1;
+    }
+#else
+    Dl_info info;
+    if (dladdr((void *)find_self_library_dir, &info) == 0 || info.dli_fname == NULL) {
+        return -1;
+    }
+    char lib_path[1024];
+    strncpy(lib_path, info.dli_fname, sizeof lib_path - 1);
+    lib_path[sizeof lib_path - 1] = '\0';
+#endif
+    path_parent_in_place(lib_path);
+    int n = snprintf(out, out_size, "%s", lib_path);
+    if (n < 0 || (size_t)n >= out_size) {
+        return -1;
+    }
+    return 0;
+}
+
+/* Task 63 (issue #102): exported games ship a jlink-trimmed `runtime/` image
+ * that the bootstrap finds app-relative, so players never install a JDK.
+ * Probe `runtime/<platform jvm layout>` in the bootstrap library's own
+ * directory and up to two parents (mirroring the kanama.jar walk), plus a
+ * `Resources/` subdirectory at each level, BEFORE the JAVA_HOME/dev-fallback
+ * chain: a bundled runtime, when present, always wins; with none present the
+ * dev workflow is unchanged. Expected layouts:
+ *   windows: <dir>\runtime\bin\server\jvm.dll
+ *   linux:   <dir>/runtime/lib/server/libjvm.so
+ *   macOS:   <dir>/runtime/lib/server/libjvm.dylib
+ *            (exported .app: the dylib is in Contents/Frameworks and the
+ *            payload in Contents/Resources/ next to the .pck — the parent
+ *            walk's Resources probe finds it there. codesign seals
+ *            Resources/ by hash but rejects jars/loose runtime files as
+ *            "nested code" under Frameworks/ or Contents/, so Resources is
+ *            the only .app location that stays re-sealable after assembly.)
+ */
+static const char *find_bundled_runtime_jvm(void) {
+    static char path[2048];
+    char search_dir[1024];
+    if (find_self_library_dir(search_dir, sizeof search_dir) != 0) {
+        return NULL;
+    }
+    for (int depth = 0; depth < 3; depth++) {
+        int n = snprintf(path, sizeof path, "%s%sruntime%s%s",
+                         search_dir, PATH_SEP, PATH_SEP, jvm_relative_lib_path());
+        if (n < 0 || (size_t)n >= sizeof path) {
+            return NULL;
+        }
+        if (access(path, F_OK) == 0) {
+            return path;
+        }
+        n = snprintf(path, sizeof path, "%s%sResources%sruntime%s%s",
+                     search_dir, PATH_SEP, PATH_SEP, PATH_SEP, jvm_relative_lib_path());
+        if (n < 0 || (size_t)n >= sizeof path) {
+            return NULL;
+        }
+        if (access(path, F_OK) == 0) {
+            return path;
+        }
+        char before_parent[1024];
+        strncpy(before_parent, search_dir, sizeof before_parent - 1);
+        before_parent[sizeof before_parent - 1] = '\0';
+        path_parent_in_place(search_dir);
+        if (strcmp(search_dir, before_parent) == 0 || search_dir[0] == '\0') {
+            break;
+        }
+    }
+    return NULL;
+}
+
 static const char *find_jvm_lib(void) {
     static char path[1024];
+    const char *bundled = find_bundled_runtime_jvm();
+    if (bundled) {
+        fprintf(stderr, "[kanama] bundled runtime: %s\n", bundled);
+        return bundled;
+    }
     const char *java_home = getenv("JAVA_HOME");
     if (java_home && *java_home) {
         build_java_home_jvm_path(path, sizeof path, java_home);
@@ -174,40 +268,25 @@ static const char *find_jvm_lib(void) {
     return NULL;
 }
 
-/* Find kanama.jar next to our own native library or in the addon root. */
+/* Find kanama.jar next to our own native library or in the addon root.
+ * Mirrors find_bundled_runtime_jvm's walk: each level is probed directly and
+ * through a `Resources/` subdirectory (exported macOS .app payload location,
+ * see the task 63 comment above). */
 static int find_jar_next_to_self(char *out, size_t out_size) {
-#ifdef _WIN32
-    HMODULE module = NULL;
-    if (!GetModuleHandleExA(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-            (LPCSTR)find_jar_next_to_self,
-            &module
-        )) {
-        return -1;
-    }
-    char dll_path[1024];
-    DWORD len = GetModuleFileNameA(module, dll_path, sizeof dll_path);
-    if (len == 0 || len >= sizeof dll_path) {
-        return -1;
-    }
-    char *dir = path_parent_in_place(dll_path);
-#else
-    Dl_info info;
-    if (dladdr((void *)find_jar_next_to_self, &info) == 0 || info.dli_fname == NULL) {
-        return -1;
-    }
-    char dylib_path[1024];
-    strncpy(dylib_path, info.dli_fname, sizeof dylib_path - 1);
-    dylib_path[sizeof dylib_path - 1] = '\0';
-    char *dir = path_parent_in_place(dylib_path);
-#endif
-
     char search_dir[1024];
-    strncpy(search_dir, dir, sizeof search_dir - 1);
-    search_dir[sizeof search_dir - 1] = '\0';
+    if (find_self_library_dir(search_dir, sizeof search_dir) != 0) {
+        return -1;
+    }
 
     for (int depth = 0; depth < 3; depth++) {
         int n = snprintf(out, out_size, "%s%skanama.jar", search_dir, PATH_SEP);
+        if (n < 0 || (size_t)n >= out_size) {
+            return -1;
+        }
+        if (access(out, F_OK) == 0) {
+            return 0;
+        }
+        n = snprintf(out, out_size, "%s%sResources%skanama.jar", search_dir, PATH_SEP, PATH_SEP);
         if (n < 0 || (size_t)n >= out_size) {
             return -1;
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -714,6 +714,95 @@ tasks.register("packageDistributions") {
   dependsOn("packageDesktopKit", "packageStoreNativeArtifact", "packageStoreAddon")
 }
 
+// ---------------------------------------------------------------------------
+// Task 63 (issue #102) — bundled jlink runtime for exported desktop games.
+//
+// Exported games are unpack-and-play: they ship a jlink-trimmed `runtime/`
+// image that the native bootstrap probes app-relative BEFORE JAVA_HOME (see
+// bootstrap/bootstrap.c). The module set below is pinned from what kanama.jar
+// needs — one recipe for every Kanama game, never recomputed per project.
+// Recompute only when kanama.jar's bundled dependency set changes:
+//   <jdk-25>/bin/jdeps --print-module-deps --ignore-missing-deps \
+//     build/libs/kanama.jar <scripts>/kanama-scripts.jar
+// Pinned 2026-08-03 (0.4.x): java.base, java.instrument, jdk.unsupported
+// (FFM lives in java.base; java.instrument + jdk.unsupported come from the
+// bundled kotlinx-coroutines debug agent + Unsafe usage). The rare game that
+// pulls an extra JDK module (e.g. java.net.http, jdk.localedata, or
+// jdk.jdwp.agent for JDWP-debugging an exported build) adds it with
+//   -PkanamaRuntimeAdditionalModules=java.net.http,jdk.localedata
+// The default path must require nothing from the user.
+// ---------------------------------------------------------------------------
+val kanamaRuntimePinnedModules = listOf("java.base", "java.instrument", "jdk.unsupported")
+val kanamaRuntimeAdditionalModules =
+  providers.gradleProperty("kanamaRuntimeAdditionalModules").orElse("")
+val gameRuntimeImageDir = layout.buildDirectory.dir("game-runtime/runtime")
+
+fun hostJvmServerLibraryRelativePath(): String {
+  val osName = System.getProperty("os.name").lowercase()
+  return when {
+    osName.contains("mac") || osName.contains("darwin") -> "lib/server/libjvm.dylib"
+    osName.contains("windows") -> "bin/server/jvm.dll"
+    else -> "lib/server/libjvm.so"
+  }
+}
+
+tasks.register<Exec>("jlinkGameRuntime") {
+  group = "distribution"
+  description =
+    "Build the jlink-trimmed Java runtime image bundled with exported desktop games (host platform)."
+
+  val toolchainService = project.extensions.getByType<JavaToolchainService>()
+  val jdkHome =
+    toolchainService
+      .launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
+      .map { it.metadata.installationPath }
+  val runtimeModules =
+    kanamaRuntimeAdditionalModules.map { extra ->
+      val additional = extra.split(',').map(String::trim).filter(String::isNotEmpty)
+      (kanamaRuntimePinnedModules + additional).distinct().joinToString(",")
+    }
+
+  inputs.property("kanamaRuntimeModules", runtimeModules)
+  inputs.property("kanamaRuntimeJdkHome", jdkHome.map { it.asFile.absolutePath })
+  outputs.dir(gameRuntimeImageDir)
+
+  doFirst {
+    // jlink refuses to write into an existing directory, and Gradle pre-creates
+    // declared output directories — clear it right before running.
+    gameRuntimeImageDir.get().asFile.deleteRecursively()
+    val jlinkName =
+      if (System.getProperty("os.name").lowercase().contains("windows")) "jlink.exe" else "jlink"
+    commandLine(
+      jdkHome.get().asFile.resolve("bin/$jlinkName").absolutePath,
+      "--add-modules",
+      runtimeModules.get(),
+      "--output",
+      gameRuntimeImageDir.get().asFile.absolutePath,
+      "--strip-debug",
+      "--no-header-files",
+      "--no-man-pages",
+      "--compress",
+      "zip-6",
+    )
+  }
+
+  doLast {
+    val imageDir = gameRuntimeImageDir.get().asFile
+    val serverLib = imageDir.resolve(hostJvmServerLibraryRelativePath())
+    if (!serverLib.isFile) {
+      throw GradleException(
+        "jlink runtime image completed but ${serverLib.absolutePath} was not created"
+      )
+    }
+    val sizeMb =
+      imageDir.walkTopDown().filter { it.isFile }.map { it.length() }.sum() / (1024L * 1024L)
+    logger.lifecycle(
+      "[kanama] game runtime image: ${imageDir.absolutePath} " +
+        "($sizeMb MB, modules=${runtimeModules.get()})"
+    )
+  }
+}
+
 val xcodeDeveloperDir =
   providers
     .gradleProperty("kanamaXcodeDeveloperDir")

--- a/docs/exporting/desktop.md
+++ b/docs/exporting/desktop.md
@@ -109,10 +109,11 @@ All other package jobs use read-only repository permissions.
 
 ## Runtime Requirements
 
-Desktop Kanama needs a JDK 25+ distribution that contains `libjvm`. The native
-bootstrap checks `JAVA_HOME` first, then platform fallback locations. The
-optional `addons/kanama_tools` editor plugin runs the same preflight and warns
-inside Godot if it cannot find `libjvm`.
+Desktop Kanama development needs a JDK 25+ distribution that contains
+`libjvm`. The native bootstrap checks for a bundled app-relative `runtime/`
+image first (exported games, see below), then `JAVA_HOME`, then platform
+fallback locations. The optional `addons/kanama_tools` editor plugin runs the
+same preflight and warns inside Godot if it cannot find `libjvm`.
 
 Native bootstrap libraries are generated build artifacts. Source repositories
 ignore `kanama_bootstrap.dll`, `libkanama_bootstrap.so`, and
@@ -129,17 +130,59 @@ xattr -dr com.apple.quarantine /absolute/path/to/project
 
 ## Exported Games
 
-Exported desktop game packaging is still a separate release-readiness track.
-An exported game must include or locate:
+The decided end state (issue #102) is **unpack-and-play**: exported desktop
+games ship a bundled, jlink-trimmed JVM runtime that the native bootstrap
+finds app-relative, so players never install a JDK. The system JDK stays the
+**developer** path — like C# development needs the .NET SDK while Godot/.NET
+exports bundle the .NET runtime.
 
-- the platform bootstrap library referenced by `kanama.gdextension`,
-- `kanama.jar`,
-- the project `kanama-scripts.jar`,
-- a compatible JDK/JVM runtime or a documented system-JDK requirement, and
-- platform-specific JVM loading paths handled by the bootstrap library.
+Status: the same-OS flow below is implemented and smoke-validated on macOS
+arm64. Windows and Linux exports (the v1 distribution targets) plus
+cross-platform runtime production (exporting a Windows game from a macOS
+machine) are still open; until then, treat desktop exported-game packaging as
+release-readiness work in progress, not a support claim.
 
-The desktop kits validate editor/runtime onboarding. They do not yet claim a
-complete exported-game packaging story.
+An exported game needs four pieces next to each other: the platform bootstrap
+library referenced by `kanama.gdextension` (Godot's export copies it),
+`kanama.jar`, the project `kanama-scripts.jar`, and the `runtime/` image.
+Assembly is three steps:
+
+```sh
+./gradlew jlinkGameRuntime
+# export the game from Godot (editor or `godot --headless --export-release ...`)
+scripts/export_game_assemble.sh \
+  --scripts-jar /path/to/project/addons/kanama/kanama-scripts.jar \
+  /path/to/exported-game
+```
+
+`jlinkGameRuntime` builds `build/game-runtime/runtime` from the local JDK
+25+ with a pinned module set (`java.base`, `java.instrument`,
+`jdk.unsupported` — about 31 MB on macOS arm64, one recipe for every Kanama
+game). A game that needs an extra JDK module adds
+`-PkanamaRuntimeAdditionalModules=java.net.http,...`; the default path
+requires nothing.
+
+`export_game_assemble.sh` anchors on the exported bootstrap library and
+places the payload where the bootstrap probes before `JAVA_HOME`:
+next to the library on Windows/Linux, and inside `Contents/Resources/` for a
+macOS `.app` (the bundle location that survives re-signing). On macOS it also
+re-seals the bundle ad-hoc, because adding files after Godot's export breaks
+the code signature.
+
+macOS export presets need two things for the embedded JVM: the
+`Import ETC2 ASTC` VRAM compression project setting (any universal/arm64
+export), and the `allow_jit_code_execution`,
+`allow_unsigned_executable_memory`, and `disable_library_validation`
+codesign entitlements — without them the hardened runtime kills the JVM at
+startup. Distribution-grade signing/notarization of the bundled runtime is
+the separate macOS notarization track.
+
+`scripts/export_game_smoke.sh /path/to/godot` proves the whole story on the
+host platform: it exports the example project, assembles the runtime, and
+launches the export headless with `JAVA_HOME` unset and `PATH` stripped,
+asserting the game boots from the app-relative runtime. The desktop kits
+still validate editor/runtime onboarding only; the export smoke is the
+exported-game gate.
 
 ## Android Track
 

--- a/scripts/export_game_assemble.sh
+++ b/scripts/export_game_assemble.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Task 63 (issue #102) — assemble an exported desktop game into an
+# unpack-and-play layout: place the jlink runtime image, kanama.jar, and the
+# project kanama-scripts.jar next to the exported Kanama bootstrap library so
+# players never install a JDK.
+#
+# Godot's export copies the gdextension bootstrap library into the export but
+# knows nothing about the jars or the runtime image; this script is the v1
+# assembly step (a `kanama_tools` export plugin automating it is a later
+# upgrade). The bootstrap probes `runtime/<jvm layout>` app-relative BEFORE
+# JAVA_HOME (bootstrap/bootstrap.c), so the assembled game prefers its bundled
+# runtime wherever it is unpacked.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/export_game_assemble.sh [options] /absolute/path/to/exported-game
+
+  exported-game: the exported macOS .app bundle, or the export directory that
+                 contains the exported binary (Windows/Linux).
+
+Options:
+  --runtime DIR       jlink runtime image produced by `./gradlew jlinkGameRuntime`
+                      (default: <repo>/build/game-runtime/runtime)
+  --kanama-jar FILE   Kanama runtime jar (default: <repo>/build/libs/kanama.jar)
+  --scripts-jar FILE  The project's compiled kanama-scripts.jar (required).
+  --help, -h          Show this help.
+EOF
+}
+
+runtime_dir="$ROOT_DIR/build/game-runtime/runtime"
+kanama_jar="$ROOT_DIR/build/libs/kanama.jar"
+scripts_jar=""
+export_target=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime)
+      runtime_dir="${2:-}"
+      shift 2
+      ;;
+    --kanama-jar)
+      kanama_jar="${2:-}"
+      shift 2
+      ;;
+    --scripts-jar)
+      scripts_jar="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "[export_game_assemble] unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -n "$export_target" ]]; then
+        echo "[export_game_assemble] unexpected extra argument: $1" >&2
+        usage
+        exit 2
+      fi
+      export_target="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$export_target" || -z "$scripts_jar" ]]; then
+  echo "[export_game_assemble] exported-game path and --scripts-jar are required" >&2
+  usage
+  exit 2
+fi
+if [[ ! -d "$export_target" ]]; then
+  echo "[export_game_assemble] exported game not found: $export_target" >&2
+  exit 2
+fi
+if [[ ! -f "$kanama_jar" ]]; then
+  echo "[export_game_assemble] kanama.jar not found: $kanama_jar (run ./gradlew jar)" >&2
+  exit 2
+fi
+if [[ ! -f "$scripts_jar" ]]; then
+  echo "[export_game_assemble] scripts jar not found: $scripts_jar" >&2
+  exit 2
+fi
+
+# The runtime image must contain the platform server JVM library. v1 is a
+# same-OS assembly: the image, the export, and the host are one platform.
+jvm_server_lib=""
+for candidate in lib/server/libjvm.dylib lib/server/libjvm.so bin/server/jvm.dll; do
+  if [[ -f "$runtime_dir/$candidate" ]]; then
+    jvm_server_lib="$candidate"
+    break
+  fi
+done
+if [[ -z "$jvm_server_lib" ]]; then
+  echo "[export_game_assemble] no server JVM library under: $runtime_dir" >&2
+  echo "[export_game_assemble] run: ./gradlew jlinkGameRuntime" >&2
+  exit 2
+fi
+
+# Anchor everything on the exported bootstrap library: the bootstrap resolves
+# kanama.jar, kanama-scripts.jar, and runtime/ relative to its own location
+# (own directory, then up to two parents, each level also probed through a
+# Resources/ subdirectory), so wherever Godot placed it is what the payload is
+# anchored to. Windows/Linux: payload sits right next to the library (and the
+# exported binary). macOS: Godot puts the dylib in Contents/Frameworks, but
+# codesign treats jars and loose runtime files as unsigned "nested code"
+# under Frameworks/ or Contents/, so the payload goes into
+# Contents/Resources/ (next to the exported .pck) where the bundle seal
+# hashes it as plain resources — still inside the bootstrap's probe walk.
+bootstrap_lib="$(
+  find "$export_target" \
+    \( -name libkanama_bootstrap.dylib \
+       -o -name libkanama_bootstrap.so \
+       -o -name kanama_bootstrap.dll \) \
+    -type f -print | head -n 1
+)"
+if [[ -z "$bootstrap_lib" ]]; then
+  echo "[export_game_assemble] no Kanama bootstrap library inside: $export_target" >&2
+  echo "[export_game_assemble] export the game from Godot first; the Kanama gdextension must be part of the export" >&2
+  exit 1
+fi
+dest_dir="$(dirname "$bootstrap_lib")"
+if [[ "$(basename "$dest_dir")" == "Frameworks" && -f "$dest_dir/../Info.plist" ]]; then
+  dest_dir="$(cd "$dest_dir/.." && pwd)/Resources"
+  mkdir -p "$dest_dir"
+fi
+
+echo "[export_game_assemble] bootstrap: $bootstrap_lib"
+cp "$kanama_jar" "$dest_dir/kanama.jar"
+cp "$scripts_jar" "$dest_dir/kanama-scripts.jar"
+rm -rf "$dest_dir/runtime"
+cp -R "$runtime_dir" "$dest_dir/runtime"
+
+if [[ ! -f "$dest_dir/runtime/$jvm_server_lib" ]]; then
+  echo "[export_game_assemble] assembly failed: missing $dest_dir/runtime/$jvm_server_lib" >&2
+  exit 1
+fi
+
+echo "[export_game_assemble] assembled:"
+echo "  $dest_dir/kanama.jar"
+echo "  $dest_dir/kanama-scripts.jar"
+echo "  $dest_dir/runtime/$jvm_server_lib"
+
+case "$bootstrap_lib" in
+  *.dylib)
+    # Godot signs the .app during export (hardened runtime); adding the
+    # payload afterwards breaks the bundle seal and macOS SIGKILLs the app at
+    # launch. Re-seal ad-hoc, preserving the export's entitlements (a Kanama
+    # game needs allow_jit_code_execution / allow_unsigned_executable_memory /
+    # disable_library_validation for the embedded JVM — enable them in the
+    # macOS export preset). Distribution-grade signing/notarization of the
+    # bundled runtime is a separate, pre-existing release track (task 63
+    # non-goal): this reseal is for locally-built and unzip-and-play testing
+    # flows, not notarized distribution.
+    app_bundle="$export_target"
+    case "$app_bundle" in
+      *.app) ;;
+      *) app_bundle="$(cd "$(dirname "$bootstrap_lib")/../.." && pwd)" ;;
+    esac
+    if command -v codesign >/dev/null 2>&1; then
+      codesign --force --sign - --preserve-metadata=entitlements,flags,identifier "$app_bundle"
+      echo "[export_game_assemble] re-sealed (ad-hoc): $app_bundle"
+    else
+      echo "[export_game_assemble] warning: codesign not found; the modified .app will not launch until re-signed" >&2
+    fi
+    echo "[export_game_assemble] note: macOS distribution signing/notarization is a separate release track"
+    ;;
+esac
+
+echo "[export_game_assemble] DONE"

--- a/scripts/export_game_smoke.sh
+++ b/scripts/export_game_smoke.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Task 63 (issue #102) — exported-game smoke: prove the unpack-and-play story.
+#
+# Exports the example project as a real desktop game, assembles the bundled
+# jlink runtime with scripts/export_game_assemble.sh, then launches the export
+# headless with JAVA_HOME unset and PATH stripped of any JDK. The run must
+# boot from the APP-RELATIVE bundled runtime (asserted on the bootstrap's
+# logged libjvm path, which is probed before JAVA_HOME and every dev
+# fallback), construct a Kanama script, and tear down clean. This is the
+# artifact that turns "we bundled a JVM" into "exported-game support".
+#
+# Host-platform, same-OS v1: validated on macOS arm64; the Linux branch is a
+# best-effort hook for the CI wiring that lands with the Windows/Linux slice.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/export_game_smoke.sh [options] /absolute/path/to/godot_binary
+
+Requires the matching Godot export templates to be installed (the same
+version as the Godot binary).
+
+Options:
+  --work-dir DIR   Existing empty or non-existing workspace dir.
+  --keep-work-dir  Do not delete a generated temporary workspace.
+  --help, -h       Show this help.
+EOF
+}
+
+work_dir=""
+keep_work_dir=0
+godot_bin=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --work-dir)
+      work_dir="${2:-}"
+      shift 2
+      ;;
+    --keep-work-dir)
+      keep_work_dir=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "[export_game_smoke] unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -n "$godot_bin" ]]; then
+        echo "[export_game_smoke] unexpected extra argument: $1" >&2
+        usage
+        exit 2
+      fi
+      godot_bin="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$godot_bin" ]]; then
+  usage
+  exit 2
+fi
+if [[ ! -x "$godot_bin" ]]; then
+  echo "[export_game_smoke] Godot binary is not executable: $godot_bin" >&2
+  exit 2
+fi
+
+host_arch="x86_64"
+if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then
+  host_arch="arm64"
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    preset_name="macOS"
+    preset_platform="macOS"
+    export_artifact="KanamaExportSmoke.app"
+    # The official macOS export template ships a universal binary only.
+    preset_arch="universal"
+    ;;
+  Linux)
+    preset_name="Linux"
+    preset_platform="Linux"
+    export_artifact="kanama_export_smoke.$host_arch"
+    preset_arch="$host_arch"
+    ;;
+  *)
+    echo "[export_game_smoke] unsupported host OS for the v1 smoke: $(uname -s)" >&2
+    exit 2
+    ;;
+esac
+
+created_work_dir=0
+if [[ -z "$work_dir" ]]; then
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/kanama_export_game_smoke.XXXXXX")"
+  created_work_dir=1
+else
+  mkdir -p "$work_dir"
+fi
+# Canonicalize: the bootstrap logs dladdr-resolved real paths (macOS: /var is
+# a symlink to /private/var), and the log assertions compare path prefixes.
+work_dir="$(cd "$work_dir" && pwd -P)"
+
+cleanup() {
+  if [[ "$created_work_dir" -eq 1 && "$keep_work_dir" != "1" ]]; then
+    rm -rf "$work_dir" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[export_game_smoke] workspace: $work_dir"
+
+# 1. Build the pieces: bootstrap + kanama.jar + example scripts jar (synced
+#    into example_project/addons/kanama) and the jlink runtime image.
+"$ROOT_DIR/gradlew" --no-daemon -p "$ROOT_DIR" syncExampleAddonJar jlinkGameRuntime >/dev/null
+
+# 2. Stage an exportable copy of the example project. The smoke boots
+#    self_smoke.tscn (script construction + wrapper call) instead of the full
+#    editor smoke suite: main.gd's probe fixtures assume an editor-flow
+#    filesystem, not a packed export.
+project_dir="$work_dir/project"
+mkdir -p "$project_dir"
+rsync -a --exclude .godot --exclude .DS_Store "$ROOT_DIR/example_project/" "$project_dir/"
+mkdir -p "$project_dir/.godot"
+printf 'res://addons/kanama/kanama.gdextension\n' > "$project_dir/.godot/extension_list.cfg"
+python3 - "$project_dir/project.godot" <<'EOF'
+import re, sys
+path = sys.argv[1]
+text = open(path).read()
+text, n = re.subn(r'run/main_scene="[^"]*"', 'run/main_scene="res://self_smoke.tscn"', text)
+assert n == 1, "run/main_scene not found in project.godot"
+# Universal/arm64 exports require the ETC2 ASTC VRAM texture format.
+if "import_etc2_astc" not in text:
+    text += '\n[rendering]\n\ntextures/vram_compression/import_etc2_astc=true\n'
+open(path, "w").write(text)
+EOF
+
+# The macOS entitlements are required for the embedded JVM: without
+# allow_jit_code_execution/allow_unsigned_executable_memory the hardened
+# runtime aborts JNI_CreateJavaVM (pthread_jit_write_protect_np SIGTRAP), and
+# without disable_library_validation the ad-hoc-signed export may not dlopen
+# the Temurin-signed libjvm.
+macos_options=""
+if [[ "$preset_platform" == "macOS" ]]; then
+  macos_options="$(cat <<'EOF'
+export/distribution_type=0
+codesign/codesign=1
+codesign/entitlements/allow_jit_code_execution=true
+codesign/entitlements/allow_unsigned_executable_memory=true
+codesign/entitlements/disable_library_validation=true
+application/bundle_identifier="net.multigesture.kanama.exportsmoke"
+EOF
+)"
+fi
+
+cat > "$project_dir/export_presets.cfg" <<EOF
+[preset.0]
+
+name="$preset_name"
+platform="$preset_platform"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path=""
+patches=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.0.options]
+
+binary_format/architecture="$preset_arch"
+$macos_options
+EOF
+
+# 3. Import, then export the game.
+export_dir="$work_dir/export"
+mkdir -p "$export_dir"
+import_log="$work_dir/godot.import.log"
+export_log="$work_dir/godot.export.log"
+"$godot_bin" --headless --import --path "$project_dir" >"$import_log" 2>&1 || {
+  echo "[export_game_smoke] project import failed; log tail:" >&2
+  tail -n 40 "$import_log" >&2
+  exit 1
+}
+if ! "$godot_bin" --headless --path "$project_dir" --export-release "$preset_name" \
+    "$export_dir/$export_artifact" >"$export_log" 2>&1; then
+  echo "[export_game_smoke] export failed; log tail:" >&2
+  tail -n 40 "$export_log" >&2
+  exit 1
+fi
+
+# 4. Assemble the unpack-and-play layout (runtime image + jars) into the
+#    export.
+case "$preset_platform" in
+  macOS) assemble_target="$export_dir/$export_artifact" ;;
+  *) assemble_target="$export_dir" ;;
+esac
+"$ROOT_DIR/scripts/export_game_assemble.sh" \
+  --scripts-jar "$ROOT_DIR/example_project/addons/kanama/kanama-scripts.jar" \
+  "$assemble_target"
+
+# 5. Launch the export with no reachable dev JDK: JAVA_HOME unset and PATH
+#    stripped. The bootstrap probes the bundled runtime BEFORE JAVA_HOME and
+#    the hardcoded dev fallbacks, so the logged libjvm path inside the export
+#    is the proof the bundled runtime booted the game (a dev JDK existing
+#    elsewhere on the machine never gets consulted first).
+case "$preset_platform" in
+  macOS) game_bin="$export_dir/$export_artifact/Contents/MacOS/Kanama Test" ;;
+  *) game_bin="$export_dir/$export_artifact" ;;
+esac
+if [[ ! -x "$game_bin" ]]; then
+  echo "[export_game_smoke] exported game binary not found: $game_bin" >&2
+  exit 1
+fi
+log_file="$work_dir/game.log"
+run_status=0
+(
+  unset JAVA_HOME
+  export PATH="/usr/bin:/bin"
+  exec "$game_bin" --headless --quit --verbose
+) >"$log_file" 2>&1 || run_status=$?
+if [[ "$run_status" -ne 0 ]]; then
+  echo "[export_game_smoke] exported game exited with status $run_status; log tail:" >&2
+  tail -n 60 "$log_file" >&2
+  exit 1
+fi
+
+smoke_fail() {
+  local kind="$1" pattern="$2"
+  echo "[export_game_smoke] $kind: $pattern" >&2
+  echo "[export_game_smoke] log tail:" >&2
+  tail -n 60 "$log_file" >&2
+  echo >&2
+  echo "[export_game_smoke] FAIL -- $kind: $pattern" >&2
+  echo "[export_game_smoke] full log: $log_file" >&2
+  exit 1
+}
+
+check() {
+  local pattern="$1"
+  if ! grep -Eq -- "$pattern" "$log_file"; then
+    smoke_fail "missing pattern" "$pattern"
+  fi
+}
+
+check_absent() {
+  local pattern="$1"
+  if grep -Eq -- "$pattern" "$log_file"; then
+    smoke_fail "unexpected pattern" "$pattern"
+  fi
+}
+
+export_dir_regex="$(printf '%s' "$export_dir" | sed 's/[.[\*^$()+?{|]/\\&/g')"
+
+# The bundled runtime inside the export booted the JVM...
+check "\\[kanama\\] bundled runtime: $export_dir_regex/.*runtime/"
+check "\\[kanama\\] using libjvm: $export_dir_regex/.*runtime/"
+# ...and kanama.jar was resolved app-relative too, not from the checkout.
+check "\\[kanama\\] jar: $export_dir_regex/"
+check_absent "checked JAVA_HOME"
+check_absent "error: libjvm not found"
+# A Kanama script constructed against the packed .kt resource and ran.
+check "SelfSmoke self_class=Node3D same_object=true"
+# Clean teardown.
+check "destroyed [0-9]+/[0-9]+ tracked KanamaScript object\\(s\\)"
+check "unregistered [0-9]+ extension class\\(es\\)"
+
+echo "[export_game_smoke] PASS"


### PR DESCRIPTION
First coherent slice of task 63 (issue #102): exported desktop games become unpack-and-play by shipping a jlink-trimmed JVM runtime that the native bootstrap finds app-relative — players never install a JDK, and the system JDK stays the developer path.

## What this slice covers

- **D1 — app-relative libjvm probe** (`bootstrap/bootstrap.c`): the bootstrap now probes `runtime/<platform jvm layout>` anchored on its own library location (own dir + two parents, each level also through a `Resources/` subdirectory for the exported macOS `.app` layout) **before** the `JAVA_HOME` → hardcoded-fallback chain. No bundled runtime present → dev behavior unchanged. The self-location logic is deduped into `find_self_library_dir`, shared with the `kanama.jar` walk (which gained the same `Resources/` probe). Windows/Linux/macOS layouts are all handled in the C code.
- **D2 — `jlinkGameRuntime`** (Gradle): builds `build/game-runtime/runtime` from the JDK 25 toolchain with a **pinned** module set computed via jdeps over `kanama.jar` + a project scripts jar: `java.base,java.instrument,jdk.unsupported` (~31 MB on macOS arm64, zip-6). One recipe for every Kanama game; `-PkanamaRuntimeAdditionalModules=...` is the escape hatch (default empty). Temurin 25 links from the run-time image (JEP 493), so no jmods install is needed.
- **D3 (v1 script) — `scripts/export_game_assemble.sh`**: places `runtime/` + `kanama.jar` + `kanama-scripts.jar` in the exported game, anchored on wherever Godot put the exported bootstrap library. macOS `.app`: payload goes to `Contents/Resources/` (codesign rejects jars/loose runtime files as unsigned "nested code" under `Frameworks/` or `Contents/`), then the bundle is re-sealed ad-hoc — assembly after Godot's signed export otherwise gets the app SIGKILLed at launch.
- **D4 (host smoke) — `scripts/export_game_smoke.sh`**: exports the example project (booting `self_smoke.tscn`), assembles per D3, launches the export headless with `JAVA_HOME` unset and `PATH=/usr/bin:/bin`, and asserts: logged libjvm + jar paths resolve **inside the export**, `checked JAVA_HOME` absent, script constructs against the packed `.kt`, clean teardown, exit 0.
- **Docs**: `docs/exporting/desktop.md`'s Exported Games section now states the decided end state, the working same-OS flow, and the macOS export-preset requirements (ETC2 ASTC + `allow_jit_code_execution` / `allow_unsigned_executable_memory` / `disable_library_validation` entitlements — without them the hardened runtime aborts `JNI_CreateJavaVM` with a `pthread_jit_write_protect_np` SIGTRAP).

## Deliberately deferred

- **Windows + Linux export runs and CI wiring** (the spec's v1 distribution bar): the smoke has a Linux branch as a reasonable hook, but only macOS arm64 is validated here; Windows needs a runner. Cross-target runtime production from jmods (macOS machine → Windows/Linux runtime) is the spec's v1.1.
- **D5 close-out**: README / `docs/reference/version-support.md` "separate release-readiness track" wording, kanama-tasks bookkeeping, and the issue #102 reply stay with the close-out pass (a draft reply was prepared separately for the maintainer).
- **Non-goals per spec**: macOS notarization of the bundled runtime (the assemble script's ad-hoc reseal is for local/testing flows only), jpackage installers, GraalVM, launcher-managed runtimes.
- `jlinkGameRuntime` is not part of `packageDistributions` (kits/addons are unchanged shapes).

## Validation (macOS arm64, Godot 4.7.stable.official.5b4e0cb0f, Temurin 25.0.3)

| Gate | Command | Result |
| --- | --- | --- |
| Runtime image | `./gradlew --no-daemon jlinkGameRuntime` | PASS — 31 MB, `modules=java.base,java.instrument,jdk.unsupported`, `lib/server/libjvm.dylib` present |
| Modules knob | `./gradlew --no-daemon jlinkGameRuntime -PkanamaRuntimeAdditionalModules=java.net.http` then `runtime/bin/java --list-modules` | PASS — 4 modules incl. `java.net.http@25.0.3` |
| Exported-game smoke | `scripts/export_game_smoke.sh /Applications/Godot.app/Contents/MacOS/Godot` | **PASS** — export → assemble → run with `JAVA_HOME` unset + `PATH=/usr/bin:/bin`; log shows `[kanama] bundled runtime: …/KanamaExportSmoke.app/Contents/Resources/runtime/lib/server/libjvm.dylib`, `[kanama] jar: …/Contents/Resources/kanama.jar`, `SelfSmoke self_class=Node3D same_object=true`, `destroyed 22/22 tracked KanamaScript object(s)`, exit 0 |
| Dev regression | `scripts/runtime_smoke.sh /Applications/Godot.app/Contents/MacOS/Godot` | PASS (no `runtime/` present → dev chain unchanged) |
| Kit packaging | `./gradlew --no-daemon packageDesktopKit` + `scripts/package_install_smoke.sh --desktop-kit build/distributions/kanama-desktop-kit-v0.4.0-macos-arm64.zip <godot>` | PASS (incl. Godot launch) |
| Native build | `./gradlew --no-daemon buildNativeBootstrap` | PASS |
| Format / docs | `./gradlew --no-daemon ktfmtCheck` and `mkdocs build --strict` | PASS |

Note on the bundled-runtime proof: the dev machine has Temurin at the hardcoded macOS fallback path, so "JVM unreachable" cannot be made literal here — the load-bearing assertion is the bootstrap's logged dlopen path, which resolves inside the `.app` and is probed *before* `JAVA_HOME` and every fallback; `checked JAVA_HOME` is asserted absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
