### PR TITLE
Bump DEMOS_REF to the fps single-source slice (kanama-demos#27)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: c79fd51ed6639208ea0c936614989dc36bd9d3a3
+  DEMOS_REF: 6f72ba2c6e7504d7df589d4c33366638438ee30f
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#27 — fps migrated (3 converged, 5 overrides with named API-gap reasons; proxies byte-identical; desktop stash-compare identical line-for-line; both-engine wrapper PASS). Seven of twelve demos single-sourced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)