### PR TITLE
Bump DEMOS_REF to the citybuilder + charactercontroller slices (kanama-demos#28+#29)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: 6f72ba2c6e7504d7df589d4c33366638438ee30f
+  DEMOS_REF: bb80261be0b3d4bc45380e175707cd899f98958d
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: bb80261be0b3d4bc45380e175707cd899f98958d
+  DEMOS_REF: 9272ec19131589ed601cc0980137bec60c880af4
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#28 — citybuilder's task-64 audit: zero files converge (all seven web overrides justified by source-cited API gaps, including a newly identified third structural limit: no portable KanamaScript<Resource> self-factory). The demos diff is convention sidecars only; validation in that PR (proxies byte-identical, desktop baseline both ways, both-engine wrapper PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)