### PR TITLE
Web API: extension helpers become members (task 64 option A, parcel 1)

### DIFF
--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -9,7 +9,6 @@ import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
 import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
-import net.multigesture.kanama.backend.NodeBackendContractProbe
 import net.multigesture.kanama.backend.RigidBody3DBackendContractProbe
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebObjectId
@@ -216,11 +215,11 @@ open class RigidBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
     }
 }
 
-/** Enable or disable the node's physics processing (the tutorial pauses the player on win). */
-fun Node.setPhysicsProcess(enable: Boolean) {
-  NodeBackendContractProbe(backendHandle).setPhysicsProcess(enable)
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.setPhysicsProcess(enable: Boolean) = setPhysicsProcess(enable)
 
-/** World-space rotation basis derived from the synchronous global-rotation read (scale-1 rigs). */
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Node3D.globalBasis: Basis
-  get() = Basis.fromEuler(globalRotation)
+  get() = globalBasis

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCityBuilderApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCityBuilderApi.kt
@@ -7,7 +7,6 @@ import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotBasis
 import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
 import net.multigesture.kanama.backend.GodotTransform3D
-import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.GodotVector3i
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors
@@ -27,8 +26,6 @@ private fun Basis.toBackend(): GodotBasis =
 
 private fun Vector3.toBackend(): GodotVector3 =
   GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
-
-private fun GodotVector3.toApi(): Vector3 = Vector3(x.toDouble(), y.toDouble(), z.toDouble())
 
 /** City-Builder surface: the runtime-built structure grid. */
 class GridMap(godotObject: GodotHandle) : Node3D(godotObject) {
@@ -196,70 +193,46 @@ class Mesh internal constructor(godotObject: GodotHandle) : Resource(godotObject
   }
 }
 
-fun PackedScene.getState(): SceneState? =
-  GodotBackendCalls.invokeNoArgsRetHandle(
-      InitialGodotCallDescriptors.PACKEDSCENE_GET_STATE,
-      backendHandle,
-    )
-    ?.let { SceneState(WebObjectId(it.backendToken().toInt())) }
+/** Import-compat alias for shared demo sources; delegates to the [PackedScene] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun PackedScene.getState(): SceneState? = getState()
 
-fun MeshInstance3D.getMesh(): Mesh? =
-  GodotBackendCalls.invokeNoArgsRetHandle(
-      InitialGodotCallDescriptors.MESHINSTANCE3D_GET_MESH,
-      backendHandle,
-    )
-    ?.let { Mesh(WebObjectId(it.backendToken().toInt())) }
+/**
+ * Import-compat alias for shared demo sources; delegates to the [MeshInstance3D] member (task 64).
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun MeshInstance3D.getMesh(): Mesh? = getMesh()
 
-fun Camera3D.projectRayOrigin(screenPoint: Vector2): Vector3 =
-  GodotBackendCalls.invokeVector2RetVector3(
-      InitialGodotCallDescriptors.CAMERA3D_PROJECT_RAY_ORIGIN,
-      backendHandle,
-      GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
-    )
-    .toApi()
+/** Import-compat alias for shared demo sources; delegates to the [Camera3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Camera3D.projectRayOrigin(screenPoint: Vector2): Vector3 = projectRayOrigin(screenPoint)
 
-fun Camera3D.projectRayNormal(screenPoint: Vector2): Vector3 =
-  GodotBackendCalls.invokeVector2RetVector3(
-      InitialGodotCallDescriptors.CAMERA3D_PROJECT_RAY_NORMAL,
-      backendHandle,
-      GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
-    )
-    .toApi()
+/** Import-compat alias for shared demo sources; delegates to the [Camera3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Camera3D.projectRayNormal(screenPoint: Vector2): Vector3 = projectRayNormal(screenPoint)
 
-/** Fresh viewport-space pointer position (no snapshot mirrors pointer state). */
-fun Viewport.getMousePosition(): Vector2 =
-  GodotBackendCalls.invokeNoArgsRetVector2(
-      InitialGodotCallDescriptors.VIEWPORT_GET_MOUSE_POSITION,
-      backendHandle,
-    )
-    .let { Vector2(it.x.toDouble(), it.y.toDouble()) }
+/** Import-compat alias for shared demo sources; delegates to the [Viewport] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Viewport.getMousePosition(): Vector2 = getMousePosition()
 
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Node.findChildren(
   pattern: String,
   type: String = "",
   recursive: Boolean = true,
   owned: Boolean = true,
-): List<Node> =
-  GodotBackendCalls.invokeStringStringBoolBoolRetHandleList(
-      InitialGodotCallDescriptors.NODE_FIND_CHILDREN,
-      backendHandle,
-      pattern,
-      type,
-      recursive,
-      owned,
-    )
-    .map { Node(it) }
+): List<Node> = findChildren(pattern, type, recursive, owned)
 
-fun GodotObject.isClass(name: String): Boolean =
-  GodotObjectBackendContractProbe(backendHandle).isClass(name)
+/** Import-compat alias for shared demo sources; delegates to the [GodotObject] member (task 64). */
+fun GodotObject.isClass(name: String): Boolean = isClass(name)
 
+/** Web-only erasure helper for the ported corpus (no desktop counterpart; stays an extension). */
 fun GodotObject.asObject(): GodotObject = this
 
+/** Import-compat alias for shared demo sources; delegates to the [Input] member (task 64). */
 fun Input.isActionJustReleased(action: String): Boolean =
-  GodotBackendCalls.invokeStringNameRetBoolSingleton(
-    InitialGodotCallDescriptors.INPUT_IS_ACTION_JUST_RELEASED,
-    action,
-  )
+  isActionJustReleased(action, exactMatch = false)
 
 object ResourceSaver {
   /** Persists [resource]; scripted resources pull current Kotlin values before serializing. */
@@ -272,14 +245,13 @@ object ResourceSaver {
     )
 }
 
-/** Generic resource load (scripted resources resolve to their hydrated script handle). */
+/** Import-compat alias for shared demo sources; delegates to the [ResourceLoader] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun ResourceLoader.load(
   path: String,
   typeHint: String = "",
   cacheMode: Long = ResourceLoader.CACHE_MODE_REUSE,
-): Resource? =
-  net.multigesture.kanama.backend.ResourceLoaderBackendContractProbe.load(path, typeHint, cacheMode)
-    ?.let { Resource(WebObjectId(it.backendToken().toInt())) }
+): Resource? = load(path, typeHint, cacheMode)
 
 /** An owned scripted resource created from Kotlin; release via [close] when handed off. */
 class OwnedScriptResource<out T>

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
@@ -82,6 +82,14 @@ class MeshInstance3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject)
     VisualInstance3DBackendContractProbe(backendHandle).setLayerMask(mask)
   }
 
+  /** The instance's Mesh resource as a tracked handle. */
+  fun getMesh(): Mesh? =
+    GodotBackendCalls.invokeNoArgsRetHandle(
+        net.multigesture.kanama.backend.InitialGodotCallDescriptors.MESHINSTANCE3D_GET_MESH,
+        backendHandle,
+      )
+      ?.let { Mesh(WebObjectId(it.backendToken().toInt())) }
+
   /** Web supports only clearing an override (material baked null in the family). */
   fun setSurfaceOverrideMaterial(surface: Long, material: Nothing?) {
     NodeBackendContractProbe(backendHandle) // keep receiver-liveness semantics uniform
@@ -134,35 +142,20 @@ class InputEventMouseMotion private constructor(godotObject: GodotHandle) :
 
 
 
-/** get_children/find_children walks backed by get_child_count + get_child. */
-fun Node.getChildren(): List<GodotObject> {
-  val probe = NodeBackendContractProbe(backendHandle)
-  return (0 until probe.getChildCount()).mapNotNull { index ->
-    probe.getChild(index)?.let { GodotObject(WebObjectId(it.backendToken().toInt())) }
-  }
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+fun Node.getChildren(): List<GodotObject> = getChildren(includeInternal = false)
 
 /**
- * Recursive class-filtered child walk (pattern is baked to "*", the only value the FPS
- * passes): returns every descendant whose Godot class matches [type].
+ * Import-compat alias for shared demo sources; delegates to the engine-backed [Node] member
+ * (task 64), which supersedes the first-port manual class-filtered walk.
  */
-fun Node.findChildren(pattern: String, type: String): List<GodotObject> {
-  require(pattern == "*") { "Web find_children supports only the \"*\" pattern" }
-  val found = mutableListOf<GodotObject>()
-  fun walk(node: GodotObject) {
-    Node(node.handle).getChildren().forEach { child ->
-      if (GodotObjectBackendContractProbe(child.backendHandle).isClass(type)) found.add(child)
-      walk(child)
-    }
-  }
-  walk(GodotObject(handle))
-  return found
-}
+fun Node.findChildren(pattern: String, type: String): List<GodotObject> =
+  findChildren(pattern, type, recursive = true, owned = true)
 
-fun Node.hasMethod(method: String): Boolean =
-  NodeBackendContractProbe(backendHandle).hasMethod(method)
+/** Import-compat alias for shared demo sources; delegates to the [GodotObject] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.hasMethod(method: String): Boolean = hasMethod(method)
 
-/** Dynamic one-Double-argument method call (FPS damage(amount) on ray hits). */
-fun Node.call(method: String, value: Double) {
-  NodeBackendContractProbe(backendHandle).callDouble(method, value)
-}
+/** Import-compat alias for shared demo sources; delegates to the [GodotObject] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.call(method: String, value: Double) = call(method, value)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -10,8 +10,10 @@ import net.multigesture.kanama.backend.CanvasItemInputBackendContractProbe
 import net.multigesture.kanama.backend.CanvasItemBackendContractProbe
 import net.multigesture.kanama.backend.GodotColor
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
+import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
 import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector2i
+import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 import net.multigesture.kanama.backend.Node2DBackendContractProbe
 import net.multigesture.kanama.backend.NodeBackendContractProbe
@@ -23,6 +25,7 @@ import net.multigesture.kanama.types.Color
 import net.multigesture.kanama.types.Rect2
 import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector2i
+import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.KanamaWebScript
 import net.multigesture.kanama.web.WebObjectId
 import net.multigesture.kanama.web.webScriptInstance
@@ -43,6 +46,31 @@ open class GodotObject internal constructor(internal val backendHandle: BackendG
   /** Returns true when both wrappers refer to the same Godot object instance. */
   fun isSameInstance(other: GodotObject): Boolean =
     backendHandle.backendToken() == other.backendHandle.backendToken()
+
+  /** Engine-side class check (the Web bridge carries no class metadata client-side). */
+  fun isClass(className: String): Boolean =
+    GodotObjectBackendContractProbe(backendHandle).isClass(className)
+
+  fun hasMethod(method: String): Boolean = NodeBackendContractProbe(backendHandle).hasMethod(method)
+
+  /**
+   * Dynamic one-Double-argument method call (the FPS's damage(amount) on ray hits). Web models
+   * desktop's variadic `call` as the typed argument shapes the corpus dispatches.
+   */
+  fun call(method: String, value: Double) {
+    NodeBackendContractProbe(backendHandle).callDouble(method, value)
+  }
+
+  /** Dynamic two-Vector3 dispatch (the corpus's damage(impact, force) convention). */
+  fun call(method: String, first: Vector3, second: Vector3) {
+    GodotBackendCalls.invokeStringNameVector3Vector3Arg(
+      InitialGodotCallDescriptors.OBJECT_CALL_VECTOR3_VECTOR3,
+      backendHandle,
+      method,
+      GodotVector3(first.x.toFloat(), first.y.toFloat(), first.z.toFloat()),
+      GodotVector3(second.x.toFloat(), second.y.toFloat(), second.z.toFloat()),
+    )
+  }
 
   fun signal(name: String): GodotSignal = GodotSignal(this, name)
 
@@ -155,6 +183,50 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
       value,
     )
   }
+
+  /**
+   * All children as tracked handles, walked over get_child_count + get_child. Web supports only
+   * Godot's default include_internal=false (the child-indexing family bakes it).
+   */
+  fun getChildren(includeInternal: Boolean = false): List<Node> {
+    require(!includeInternal) { "Web get_children supports only include_internal=false" }
+    val probe = NodeBackendContractProbe(backendHandle)
+    return (0 until probe.getChildCount()).mapNotNull { index -> probe.getChild(index)?.let(::Node) }
+  }
+
+  /** Matching descendants as tracked handles (engine-side find_children). */
+  fun findChildren(
+    pattern: String,
+    type: String = "",
+    recursive: Boolean = true,
+    owned: Boolean = true,
+  ): List<Node> =
+    GodotBackendCalls.invokeStringStringBoolBoolRetHandleList(
+        InitialGodotCallDescriptors.NODE_FIND_CHILDREN,
+        backendHandle,
+        pattern,
+        type,
+        recursive,
+        owned,
+      )
+      .map(::Node)
+
+  /** Enable or disable the node's physics processing (e.g. pausing the player on win). */
+  fun setPhysicsProcess(enable: Boolean) {
+    NodeBackendContractProbe(backendHandle).setPhysicsProcess(enable)
+  }
+
+  /** Web adaptation: the corpus runs the default 60 Hz fixed physics tick. */
+  fun getPhysicsProcessDeltaTime(): Double = 1.0 / 60.0
+
+  fun setProcess(enable: Boolean) {
+    GodotBackendCalls.invokeBoolArg(InitialGodotCallDescriptors.NODE_SET_PROCESS, backendHandle, enable)
+  }
+
+  /** Web no-ops: generated proxies dispatch input only to scripts that declare handlers. */
+  fun setProcessInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+
+  fun setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
 }
 
 open class CanvasItem internal constructor(backendHandle: BackendGodotHandle) : Node(backendHandle) {
@@ -303,6 +375,13 @@ class Texture2D internal constructor(private var resourceHandle: BackendGodotHan
 
 object ResourceLoader {
   const val CACHE_MODE_REUSE = 1L
+
+  /** Generic resource load (scripted resources resolve to their hydrated script handle). */
+  fun load(
+    path: String,
+    typeHint: String = "",
+    cacheMode: Long = CACHE_MODE_REUSE,
+  ): Resource? = ResourceLoaderBackendContractProbe.load(path, typeHint, cacheMode)?.let(::Resource)
 
   @ManualGodotLifetimeApi
   fun loadTexture2D(path: String, cacheMode: Long = CACHE_MODE_REUSE): Texture2D? =

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -297,6 +297,14 @@ class Viewport(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()) {
       )
       ?.let { Camera3D(WebObjectId(it.backendToken().toInt())) }
 
+  /** Fresh viewport-space pointer position (no snapshot mirrors pointer state). */
+  fun getMousePosition(): Vector2 =
+    GodotBackendCalls.invokeNoArgsRetVector2(
+        InitialGodotCallDescriptors.VIEWPORT_GET_MOUSE_POSITION,
+        backendHandle,
+      )
+      .let { Vector2(it.x.toDouble(), it.y.toDouble()) }
+
   fun getVisibleRect(): Rect2 =
     ViewportBackendContractProbe(backendHandle).visibleRect.let { rect ->
       Rect2(
@@ -428,6 +436,14 @@ class PackedScene internal constructor(backendHandle: BackendGodotHandle) : Reso
 
   fun instantiate(): GodotObject? =
     PackedSceneBackendContractProbe(backendHandle).instantiate()?.let(::GodotObject)
+
+  /** The recorded scene contents (mesh extraction without instantiating). */
+  fun getState(): SceneState? =
+    GodotBackendCalls.invokeNoArgsRetHandle(
+        InitialGodotCallDescriptors.PACKEDSCENE_GET_STATE,
+        backendHandle,
+      )
+      ?.let { SceneState(WebObjectId(it.backendToken().toInt())) }
 }
 
 class Tween internal constructor(backendHandle: BackendGodotHandle) : GodotObject(backendHandle) {
@@ -593,6 +609,15 @@ object Input {
 
   fun isActionJustPressed(action: String): Boolean =
     InputBackendContractProbe.isActionJustPressed(action)
+
+  /** exact_match is baked to Godot's default false on Web (the StringName family carries it). */
+  fun isActionJustReleased(action: String, exactMatch: Boolean = false): Boolean {
+    require(!exactMatch) { "Web is_action_just_released supports only exact_match=false" }
+    return GodotBackendCalls.invokeStringNameRetBoolSingleton(
+      InitialGodotCallDescriptors.INPUT_IS_ACTION_JUST_RELEASED,
+      action,
+    )
+  }
 
   fun actionPress(action: String) {
     InputActionBackendContractProbe.actionPress(action)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -7,6 +7,7 @@ import net.multigesture.kanama.backend.DirectionalLight3DBackendContractProbe
 import net.multigesture.kanama.backend.EnvironmentBackendContractProbe
 import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
+import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
@@ -15,11 +16,23 @@ import net.multigesture.kanama.backend.Node3DBackendContractProbe
 import net.multigesture.kanama.backend.OSBackendContractProbe
 import net.multigesture.kanama.backend.RenderingServerBackendContractProbe
 import net.multigesture.kanama.backend.WorldEnvironmentBackendContractProbe
+import net.multigesture.kanama.types.Transform3D
+import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebObjectId
 
 private fun BackendGodotHandle.bool3(descriptor: net.multigesture.kanama.backend.GodotCallDescriptor, value: Boolean) =
   GodotBackendCalls.invokeBoolArg(descriptor, this, value)
+
+private fun composeBasis(rotation: Vector3, scale: Vector3): Basis {
+  val rotationBasis = Basis.fromEuler(rotation)
+  // Node basis = R * S: columns scaled (Godot composes scale on the right of rotation).
+  return Basis(
+    rotationBasis.getColumn(0) * scale.x,
+    rotationBasis.getColumn(1) * scale.y,
+    rotationBasis.getColumn(2) * scale.z,
+  )
+}
 
 /**
  * Web API surface for the 3D rendering foundation (Task 60c).
@@ -133,6 +146,57 @@ open class Node3D(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()
       Node3DBackendContractProbe(backendHandle)
         .setGlobalRotation(GodotVector3(value.x.toFloat(), value.y.toFloat(), value.z.toFloat()))
     }
+
+  /** The node's local rotation+scale basis; writes decompose to the two snapshot families. */
+  var basis: Basis
+    get() = composeBasis(rotation, scale)
+    set(value) {
+      rotation = value.getEuler()
+      scale = value.getScale()
+    }
+
+  /** The node's local transform (basis + origin over the mirrored snapshots). */
+  var transform: Transform3D
+    get() = Transform3D(basis, position)
+    set(value) {
+      position = value.origin
+      basis = value.basis
+    }
+
+  /** The node's world transform; rotation/origin cross synchronously, global scale assumed 1. */
+  var globalTransform: Transform3D
+    get() = Transform3D(Basis.fromEuler(globalRotation), globalPosition)
+    set(value) {
+      globalPosition = value.origin
+      globalRotation = value.basis.getEuler()
+    }
+
+  /**
+   * World-space rotation basis over the synchronous global-rotation reads (scale-1 rigs, the
+   * same contract as [globalTransform]); writes decompose to the global-rotation family.
+   */
+  var globalBasis: Basis
+    get() = Basis.fromEuler(globalRotation)
+    set(value) {
+      globalRotation = value.getEuler()
+    }
+
+  /**
+   * Orient the forward axis at [target] from the current position — -Z by default, +Z when
+   * [useModelFront] (the desktop signature; rides look_at_from_position, task 64).
+   */
+  fun lookAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false) {
+    lookAtFromPosition(globalPosition, target, up, useModelFront)
+  }
+
+  /** Node3D visibility read (synchronous immediate). */
+  fun isVisible(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(D.NODE3D_IS_VISIBLE, backendHandle)
+
+  /** Godot's rotate_object_local: right-multiply the local basis by an axis-angle rotation. */
+  fun rotateObjectLocal(axis: Vector3, angle: Double) {
+    basis = basis * Basis.fromAxisAngle(axis, angle)
+  }
 }
 
 class GPUParticles3D(godotObject: GodotHandle) : GeometryInstance3D(godotObject) {
@@ -196,7 +260,25 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())
 
-class Camera3D(godotObject: GodotHandle) : Node3D(godotObject)
+class Camera3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  /** World-space origin of the ray through the given screen point. */
+  fun projectRayOrigin(screenPoint: Vector2): Vector3 =
+    GodotBackendCalls.invokeVector2RetVector3(
+        D.CAMERA3D_PROJECT_RAY_ORIGIN,
+        backendHandle,
+        GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
+      )
+      .let { Vector3(it.x.toDouble(), it.y.toDouble(), it.z.toDouble()) }
+
+  /** World-space direction of the ray through the given screen point. */
+  fun projectRayNormal(screenPoint: Vector2): Vector3 =
+    GodotBackendCalls.invokeVector2RetVector3(
+        D.CAMERA3D_PROJECT_RAY_NORMAL,
+        backendHandle,
+        GodotVector2(screenPoint.x.toFloat(), screenPoint.y.toFloat()),
+      )
+      .let { Vector3(it.x.toDouble(), it.y.toDouble(), it.z.toDouble()) }
+}
 
 /** 3D physics body base (Task 60d). */
 open class PhysicsBody3D(godotObject: GodotHandle) : Node3D(godotObject)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
@@ -22,56 +22,42 @@ import net.multigesture.kanama.web.WebObjectId
 /** FPS-era alias: the pure-Kotlin Basis moved in with the value types. */
 typealias Basis = net.multigesture.kanama.types.Basis
 
-private fun composeBasis(rotation: Vector3, scale: Vector3): Basis {
-  val rotationBasis = Basis.fromEuler(rotation)
-  // Node basis = R * S: columns scaled (Godot composes scale on the right of rotation).
-  return Basis(
-    rotationBasis.getColumn(0) * scale.x,
-    rotationBasis.getColumn(1) * scale.y,
-    rotationBasis.getColumn(2) * scale.z,
-  )
-}
-
-/** The node's local rotation+scale basis; writes decompose to the two snapshot families. */
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Node3D.basis: Basis
-  get() = composeBasis(rotation, scale)
+  get() = basis
   set(value) {
-    rotation = value.getEuler()
-    scale = value.getScale()
+    basis = value
   }
 
-/** The node's local transform (basis + origin over the mirrored snapshots). */
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Node3D.transform: Transform3D
-  get() = Transform3D(basis, position)
+  get() = transform
   set(value) {
-    position = value.origin
-    basis = value.basis
+    transform = value
   }
 
-/** The node's world transform; rotation/origin cross synchronously, global scale assumed 1. */
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Node3D.globalTransform: Transform3D
-  get() = Transform3D(Basis.fromEuler(globalRotation), globalPosition)
+  get() = globalTransform
   set(value) {
-    globalPosition = value.origin
-    globalRotation = value.basis.getEuler()
+    globalTransform = value
   }
 
-/**
- * Orient the forward axis at [target] from the current position — -Z by default, +Z when
- * [useModelFront] (the desktop signature; rides look_at_from_position, task 64).
- */
-fun Node3D.lookAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false) {
-  lookAtFromPosition(globalPosition, target, up, useModelFront)
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node3D.lookAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false) =
+  lookAt(target, up, useModelFront)
 
-/** Node3D visibility read (synchronous immediate). */
-fun Node3D.isVisible(): Boolean =
-  GodotBackendCalls.invokeNoArgsRetBool(D.NODE3D_IS_VISIBLE, backendHandle)
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node3D.isVisible(): Boolean = isVisible()
 
-/** Godot's rotate_object_local: right-multiply the local basis by an axis-angle rotation. */
-fun Node3D.rotateObjectLocal(axis: Vector3, angle: Double) {
-  basis = basis * Basis.fromAxisAngle(axis, angle)
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node3D.rotateObjectLocal(axis: Vector3, angle: Double) = rotateObjectLocal(axis, angle)
 
 private fun Vector3.toGodot(): GodotVector3 = GodotVector3(x.toFloat(), y.toFloat(), z.toFloat())
 
@@ -209,25 +195,22 @@ fun Area3D.getOverlappingBodies(): List<GodotObject> =
     GodotObject(WebObjectId(it.backendToken().toInt()))
   }
 
-/** Dynamic two-Vector3 dispatch (the corpus's damage(impact, force) convention). */
-fun GodotObject.call(method: String, first: Vector3, second: Vector3) {
-  GodotBackendCalls.invokeStringNameVector3Vector3Arg(
-    D.OBJECT_CALL_VECTOR3_VECTOR3,
-    backendHandle,
-    method,
-    first.toGodot(),
-    second.toGodot(),
-  )
-}
+/** Import-compat alias for shared demo sources; delegates to the [GodotObject] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun GodotObject.call(method: String, first: Vector3, second: Vector3) =
+  call(method, first, second)
 
-fun Node.setProcess(enable: Boolean) {
-  GodotBackendCalls.invokeBoolArg(D.NODE_SET_PROCESS, backendHandle, enable)
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.setProcess(enable: Boolean) = setProcess(enable)
 
-/** Web no-ops: generated proxies dispatch input only to scripts that declare handlers. */
-fun Node.setProcessInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.setProcessInput(enable: Boolean) = setProcessInput(enable)
 
-fun Node.setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.setProcessUnhandledInput(enable: Boolean) = setProcessUnhandledInput(enable)
 
 object ProjectSettings {
   /** Float-valued setting read (x1000 integer transport; millis precision). */
@@ -238,8 +221,9 @@ object ProjectSettings {
     )
 }
 
-/** Web adaptation: the corpus runs the default 60 Hz fixed physics tick. */
-fun Node.getPhysicsProcessDeltaTime(): Double = 1.0 / 60.0
+/** Import-compat alias for shared demo sources; delegates to the [Node] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.getPhysicsProcessDeltaTime(): Double = getPhysicsProcessDeltaTime()
 
 object Time {
   private val origin = kotlin.time.TimeSource.Monotonic.markNow()


### PR DESCRIPTION
Implements the DECIDED option A of task 64's extension-vs-member convention (2026-08-04): the Web API's catalogued top-level extension helpers become MEMBERS on the web wrapper classes, matching desktop's shape, so shared demo sources can spell `self.basis`, `self.findChildren(...)`, `Input.isActionJustReleased(...)` etc. with no web-only import lines. The old extensions stay temporarily as one-line import-compat delegations to the members, so every already-ported `web/kotlin-src` file keeps compiling and behaving identically.

Parcel 1 = Builder's eleven + the Player-file tier (the catalogued 16) + the same-file siblings on those receivers. No emitter, bridge, protocol, generated-dispatch, or contract change — API-layer only.

## Helper-by-helper

| Helper | Member added on | Old extension | Desktop signature (src/main/kotlin/net/multigesture/kanama/api) | Match |
|---|---|---|---|---|
| `basis` | `Node3D` (`var basis: Basis`) | delegates (WebThirdPersonApi) | Node3D.kt:54 `var basis: Basis` | YES |
| `globalBasis` | `Node3D` (`var globalBasis: Basis`) | delegates (WebCharacterApi; was `val`) | Node3D.kt:90 `var globalBasis: Basis` | YES — web gains desktop's setter through the existing global-rotation write family (same scale-1 contract as `globalTransform`); the compat extension stays read-only as before |
| `globalTransform` | `Node3D` (`var globalTransform: Transform3D`) | delegates (WebThirdPersonApi) | Node3D.kt:24 `var globalTransform: Transform3D` | YES |
| `transform` (sibling) | `Node3D` (`var transform: Transform3D`) | delegates (WebThirdPersonApi) | Node3D.kt:18 `var transform: Transform3D` | YES |
| `lookAt` (sibling) | `Node3D` | delegates (WebThirdPersonApi) | Node3D.kt:884 `fun lookAt(target: Vector3, up: Vector3 = Vector3.UP, useModelFront: Boolean = false)` | YES |
| `isVisible` (sibling) | `Node3D` | delegates (WebThirdPersonApi) | Node3D.kt:652 `fun isVisible(): Boolean` | YES |
| `rotateObjectLocal` (sibling) | `Node3D` | delegates (WebThirdPersonApi) | Node3D.kt:780 `fun rotateObjectLocal(axis: Vector3, angle: Double)` | YES |
| `getPhysicsProcessDeltaTime` | `Node` | delegates (WebThirdPersonApi) | Node.kt:757 `fun getPhysicsProcessDeltaTime(): Double` | YES (web adaptation: fixed 60 Hz tick, unchanged) |
| `setPhysicsProcess` | `Node` | delegates (WebCharacterApi) | Node.kt:829 `fun setPhysicsProcess(enable: Boolean)` | YES |
| `setProcess` (sibling) | `Node` | delegates (WebThirdPersonApi) | Node.kt:816 `fun setProcess(enable: Boolean)` | YES |
| `setProcessInput` / `setProcessUnhandledInput` (siblings) | `Node` (web no-ops, unchanged semantics) | delegate (WebThirdPersonApi) | Node.kt:840/878 `fun setProcessInput(enable: Boolean)` etc. | YES |
| `findChildren` | `Node` (`List<Node>`) | BOTH old extensions delegate: the 4-param (WebCityBuilderApi, identical signature) and the 2-arg FPS form (WebFpsApi) | Node.kt:139 `fun findChildren(pattern: String, type: String = "", recursive: Boolean = true, owned: Boolean = true): List<Node>` | YES — the FPS first-port manual class-filtered walk is superseded by the engine `find_children` family with desktop's defaults (`owned = true`); desktop's identical `Player.kt` call site already used engine semantics, and the fps chrome smoke below covers it |
| `getChildren` | `Node` (`List<Node>`) | delegates (WebFpsApi, returns `List<GodotObject>` as before — covariant) | Node.kt:71 `fun getChildren(includeInternal: Boolean = false): List<Node>` | YES — `includeInternal = true` fails loud (`require`); the web child-indexing family bakes Godot's default, and the corpus never passes it |
| `getMesh` | `MeshInstance3D` | delegates (WebCityBuilderApi) | MeshInstance3D.kt:46 `fun getMesh(): Mesh?` | YES |
| `getMousePosition` | `Viewport` | delegates (WebCityBuilderApi) | Viewport.kt:905 `fun getMousePosition(): Vector2` | YES |
| `getState` | `PackedScene` | delegates (WebCityBuilderApi) | PackedScene.kt:53 `fun getState(): SceneState?` | YES |
| `isClass` | `GodotObject` | delegates (WebCityBuilderApi; keeps its old `name` param name) | GodotObject.kt:27 `fun isClass(className: String): Boolean` | YES — member uses desktop's `className` |
| `hasMethod` (sibling) | `GodotObject` | delegates (WebFpsApi, receiver `Node`) | GodotObject.kt:97 `fun hasMethod(method: String): Boolean` | YES — member placed on GodotObject, desktop's declaring class (the dispatch family is `OBJECT_HAS_METHOD`); Node call sites resolve via inheritance |
| `call(String, Double)` / `call(String, Vector3, Vector3)` (siblings) | `GodotObject` | delegate (WebFpsApi / WebThirdPersonApi) | GodotObject.kt:188 `fun call(method: String, vararg args: Any?): Any?` | PARTIAL — desktop's shape is variadic; a web member cannot honor arbitrary-arg dispatch (only the two admitted `OBJECT_CALL_*` typed families exist), so web adds the typed subsets as members, consistent with the pre-existing typed `call(String, String)` Node member. Positional call sites compile on both platforms; the signatures are deliberately NOT claimed identical |
| `load` | `object ResourceLoader` | delegates (WebCityBuilderApi) | ResourceLoader.kt:253 `fun load(path: String, typeHint: String = "", cacheMode: Long = CACHE_MODE_REUSE): Resource?` | YES (`CACHE_MODE_REUSE = 1L` on both) |
| `Input.isActionJustReleased` | `object Input` | delegates (WebCityBuilderApi) | Input.kt:210 `fun isActionJustReleased(action: String, exactMatch: Boolean = false): Boolean` | YES — `exactMatch = true` fails loud (the admitted StringName family carries only the action; the engine-side call uses Godot's default `false`) |
| `asObject` | — (BLOCKED) | unchanged extension | no desktop counterpart anywhere in `src/main/kotlin/net/multigesture/kanama/` | N/A — web-only erasure helper from the ported corpus; memberizing it would not unlock shared sources (they cannot call it on desktop). Stays an extension, KDoc'd as such |

Every delegating extension is annotated `@Suppress("EXTENSION_SHADOWED_BY_MEMBER")`; before suppression the compiler emitted, for each of the 22 shadowed declarations, a warning naming exactly the new member as its shadow — the direct proof that all call sites now resolve member-first.

## Deliberately skipped (reported, not touched)

- `GodotObject.kotlinScriptInstance()` — an extension on BOTH platforms (desktop `ScriptInstances.kt`), already portable; unchanged.
- WebThirdPersonApi extensions on receivers the catalogue does not name: `PhysicsBody3D.moveAndCollide` / `addCollisionExceptionWith` / `setAxisLock`, `CollisionObject3D.setCollisionLayerValue`, `RayCast3D.addException`, `Area3D.getOverlappingBodies` — sized for the thirdperson/tps follow-up parcel.
- ALL WebTpsApi extensions (~55) — parcel 2, riding the tps migration per the decided plan. That includes its siblings on catalogue receivers (`Node.getName/setName/hasNode/getNode/propagateSet/getChild/getMultiplayer/getWindow`; `GodotObject.isQueuedForDeletion/isInsideTree/callDeferred/hasSignal/set×5/getVector2`; `Node3D.show/orthonormalize/getWorld3d`; `Viewport.getCamera3d/setInputAsHandled`; `Camera3D.makeCurrent`; `MeshInstance3D.getSurfaceOverrideMaterial`; `Input.getActionStrength`; `ResourceLoader.loadLightmapGIData/loadThreaded*`).
- Observation, out of scope: the pre-existing web `Input.isActionPressed`/`isActionJustPressed` members lack desktop's `exactMatch` parameter — a parity item for a later parcel.

## Gate evidence

- `:web-runtime:compileKotlinWasmJs` — BUILD SUCCESSFUL (no new warnings after the intentional-shadow suppressions).
- `:web-runtime:checkWebBackendDispatch` — green (no contract or dispatch change; zero new opcodes).
- `ktfmtFormat` + `ktfmtCheck` — green.
- Behavior identity, proven on the EXISTING corpus web sources (whose import lines still name the extensions — which now delegate): fresh `kanama-demos` clone at origin/main (9272ec1), one-time headless `--import` per demo (Godot 4.7 stable official), `rm -rf` of each export dir, full `exportWeb` (protocol 15) + chrome smoke, judged on the wrapper's own line:
  - citybuilder — `web_export_smoke: PASS` (payload 42.3MB, startup 1735ms, 0.84 crossings/tick) — Builder's eleven imports all exercise delegations
  - thirdperson — `web_export_smoke: PASS` (payload 105.8MB, startup 4994ms, 1.16 crossings/tick) — the Player-tier imports (basis/transform/globalTransform/lookAt/isVisible/rotateObjectLocal/setProcess/setPhysicsProcess/call/hasMethod/getChildren)
  - fps — `web_export_smoke: PASS` (payload 50.0MB, startup 1798ms, 1.1 crossings/tick) — run as extra insurance for the one deliberate behavior change (the 2-arg `findChildren` reroute to the engine family)

Exports ran at protocol 15; this branch predates #145 (protocol 16), which is expected — the files are disjoint and this PR's claim is behavior-identity of the API layer.

DO NOT merge without Laurence's approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
