### PR TITLE
Bump DEMOS_REF to the convergence re-pass (kanama-demos#30)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,7 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: 9272ec19131589ed601cc0980137bec60c880af4
+  DEMOS_REF: f4d1476dafdfe1abdd87bbb06944bd495c669992
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
Pins the corpus at kanama-demos#30 — the task-64 re-pass converging 9 of the 10 overrides unlocked by kanama#144/#146 (racing Vehicle; fps Player/Audio/Enemy; citybuilder Builder/View/DataMap/DataStructure/Structure). Per-demo validation in that PR: 3-leg desktop baselines, byte-identical proxies, six wrapper PASS lines at protocol 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)