### PR TITLE
Task 64 emitter parcel: NodePath + hint metadata on Web, initializer-parser fix, fail-loud property guards

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,10 +50,9 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  # Task 64: literal property defaults (kanama-demos#31) — required by this branch's
-  # expression-default guard. Set to the branch head; update to the MERGE commit of
-  # kanama-demos#31 before this PR leaves draft.
-  DEMOS_REF: d02fa5472d9581ea61c14d7538893e82901d2573
+  # Task 64: literal property defaults (kanama-demos#31 merge) — required by the
+  # expression-default guard this branch introduces.
+  DEMOS_REF: 0a354360078fbde394e445deda11eeb7bf65a90a
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,7 +50,10 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  DEMOS_REF: f4d1476dafdfe1abdd87bbb06944bd495c669992
+  # Task 64: literal property defaults (kanama-demos#31) — required by this branch's
+  # expression-default guard. Set to the branch head; update to the MERGE commit of
+  # kanama-demos#31 before this PR leaves draft.
+  DEMOS_REF: d02fa5472d9581ea61c14d7538893e82901d2573
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -96,6 +96,15 @@ fails the Web compile — that is the fail-loud coverage gate working as
 intended. Files under the merged root resolve to `res://kotlin-src/*.kt` and
 match the scene script attachments on both platforms.
 
+`@ScriptProperty`/`@Export` declarations are portable including `NodePath`
+properties and hint metadata (a `PropertyHint.RANGE` hint reaches the generated
+proxy as `@export_range(...)`). Two Web-specific rules fail the build loudly
+instead of silently mis-hydrating: a property default must be spelled as a
+plain literal (`1.0471975511965976`, not `Mathf.PI / 3.0` — the proxy re-emits
+the default into GDScript and pushes it back into Kotlin at hydration), and a
+property type or hint outside the supported Web set is rejected with an error
+naming the property.
+
 ## Build The Web Scripts
 
 `buildWebScripts` generates the GDScript proxy bundle (proxies + manifest +

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -118,6 +118,9 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
       for (message in WebScriptCodeEmitter.undispatchedVirtualErrors(model, env.options)) {
         env.logger.error("[kanama:ksp] $message", symbol)
       }
+      for (message in WebScriptCodeEmitter.unsupportedWebPropertyErrors(model, env.options)) {
+        env.logger.error("[kanama:ksp] $message", symbol)
+      }
       symbol.containingFile?.let {
         aggregatorSources += it
         scriptAggregatorSources += it
@@ -2068,7 +2071,7 @@ private fun scriptPropertyDefaultLiteral(
   val start = (location.lineNumber - 1).coerceIn(0, sourceLines.lastIndex)
   val declarationLine = findPropertyDeclarationLine(sourceLines, start, propertyName) ?: return null
   val declaration = collectPropertyDeclaration(sourceLines, declarationLine)
-  val initializer = extractPropertyInitializer(declaration) ?: return null
+  val initializer = extractPropertyInitializer(declaration, propertyName) ?: return null
   enumFqName?.let {
     return normalizeEnumDefaultLiteral(initializer, it, enumEntries)
   }
@@ -2119,7 +2122,7 @@ private fun findPropertyDeclarationLine(
   return (first..last).firstOrNull { declarationPattern.containsMatchIn(lines[it]) }
 }
 
-private fun collectPropertyDeclaration(lines: List<String>, start: Int): String {
+internal fun collectPropertyDeclaration(lines: List<String>, start: Int): String {
   val parts = mutableListOf<String>()
   var parenDepth = 0
   for (i in start..(start + 8).coerceAtMost(lines.lastIndex)) {
@@ -2147,8 +2150,15 @@ private fun stripLineComment(line: String): String {
   return line
 }
 
-private fun extractPropertyInitializer(declaration: String): String? {
-  val eq = declaration.indexOf('=')
+internal fun extractPropertyInitializer(declaration: String, propertyName: String): String? {
+  // The collected declaration can start with a one-line annotation carrying arguments
+  // (`@Export(hint = PropertyHint.RANGE, hintString = "0,100,1") var numberOfJumps: Long = 2`),
+  // so the initializer's `=` is the first one AFTER the `var`/`val <name>` keyword — taking the
+  // first `=` in the whole string used to land inside the annotation and shipped a null
+  // defaultLiteral for every one-line annotated declaration.
+  val declarationStart =
+    Regex("""\b(?:var|val)\s+${Regex.escape(propertyName)}\b""").find(declaration) ?: return null
+  val eq = declaration.indexOf('=', startIndex = declarationStart.range.last + 1)
   if (eq < 0) return null
   return declaration.substring(eq + 1).trim().removeSuffix(";").trim().takeIf { it.isNotEmpty() }
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -53,6 +53,147 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "function would never run in a Web build; $advice."
         }
     }
+
+    // Godot PropertyHint ids the Web emitter reasons about (mirrors annotations/PropertyHint).
+    private const val PROPERTY_HINT_RANGE = 1
+    private const val PROPERTY_HINT_RESOURCE_TYPE = 17
+    private const val PROPERTY_HINT_TYPE_STRING = 23
+    private const val PROPERTY_HINT_NODE_TYPE = 34
+
+    private val RANGE_HINT_NUMBER = Regex("""[-+]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][-+]?\d+)?""")
+
+    /** The normalized NodePath default literal shape produced by the processor. */
+    private val NODE_PATH_DEFAULT =
+      Regex("""net\.multigesture\.kanama\.types\.NodePath\((".*")\)""")
+
+    /**
+     * Parses a Godot RANGE hint string (`"min,max[,step][,option...]"`) into `@export_range`
+     * argument spellings — leading numeric parts stay bare, trailing option flags (`or_greater`,
+     * `suffix:m`, ...) are quoted — or null when the string has no `min,max` numeric prefix. Shared
+     * by the emitter and [unsupportedWebPropertyErrors] so the accepted grammar cannot drift from
+     * what actually reaches the proxy.
+     */
+    internal fun rangeExportArguments(hintString: String): List<String>? {
+      val parts = hintString.split(',').map { it.trim() }
+      if (parts.size < 2 || parts.any { it.isEmpty() }) return null
+      val bounds = parts.takeWhile { RANGE_HINT_NUMBER.matches(it) }
+      if (bounds.size < 2) return null
+      return bounds + parts.drop(bounds.size).map { "\"$it\"" }
+    }
+
+    /**
+     * Errors for `@ScriptProperty`/`@Export` declarations a Web build would mishandle (task 64,
+     * mirroring [undispatchedVirtualErrors]): a property type without the full Web arm set
+     * (declaration, push, pull, registry accessors) used to emit non-compiling registry code or
+     * silently drop values; an expression default used to hydrate the type default over the Kotlin
+     * initializer; an unexpressible hint used to vanish from the proxy. Each is a build error
+     * naming the script, the property, and the fix. Empty on every non-Web target.
+     */
+    fun unsupportedWebPropertyErrors(
+      model: ScriptModel,
+      options: Map<String, String>,
+    ): List<String> {
+      if (!isWebTarget(options)) return emptyList()
+      val errors = mutableListOf<String>()
+      for (property in model.properties) {
+        val where = "${model.simpleName}.${property.kotlinName}"
+        val supported =
+          when {
+            property.enumFqName != null || property.narrow != null -> false
+            else ->
+              when (property.type) {
+                TypeMapping.STRING,
+                TypeMapping.INT,
+                TypeMapping.FLOAT,
+                TypeMapping.BOOL,
+                TypeMapping.VECTOR2,
+                TypeMapping.VECTOR2I,
+                TypeMapping.VECTOR3,
+                TypeMapping.NODE_PATH -> true
+                TypeMapping.OBJECT ->
+                  property.objectWrapperFqName != null || property.customScriptFqName != null
+                TypeMapping.ARRAY ->
+                  property.arrayElementString ||
+                    property.arrayElementWrapperFqName != null ||
+                    property.arrayElementCustomScriptFqName != null
+                else -> false
+              }
+          }
+        if (!supported) {
+          val declared =
+            when {
+              property.enumFqName != null -> property.enumFqName
+              property.narrow != null -> "narrow ${property.narrow}"
+              else -> property.type.toString()
+            }
+          errors +=
+            "$where: @ScriptProperty type '$declared' has no full Kanama Web property arm set " +
+              "(declaration/push/pull/registry); a Web build would emit broken or silently " +
+              "dropped property code. Use a Web-supported property type " +
+              "(String, Long, Double, Boolean, Vector2, Vector2i, Vector3, NodePath, a wrapped " +
+              "object/script type, or a supported List) or keep the property off the Web target."
+          continue
+        }
+        val defaultDrivesProxy =
+          when (property.type) {
+            TypeMapping.STRING,
+            TypeMapping.INT,
+            TypeMapping.FLOAT,
+            TypeMapping.BOOL,
+            TypeMapping.VECTOR2,
+            TypeMapping.VECTOR2I,
+            TypeMapping.VECTOR3,
+            TypeMapping.NODE_PATH -> true
+            else -> false
+          }
+        if (defaultDrivesProxy && property.defaultLiteral == null) {
+          errors +=
+            "$where: the property initializer is not a plain literal, so the Web proxy would " +
+              "declare (and hydrate) the type default instead of the Kotlin value. Spell the " +
+              "default as a literal (e.g. `1.0471975511965976` instead of `Mathf.PI / 3.0`)."
+        }
+        when (property.hint) {
+          0 -> Unit
+          PROPERTY_HINT_RANGE -> {
+            val rangeType = property.type == TypeMapping.INT || property.type == TypeMapping.FLOAT
+            if (!rangeType) {
+              errors +=
+                "$where: PropertyHint.RANGE is only expressible for int/float exports on the " +
+                  "Web target (GDScript @export_range); this property is ${property.type}."
+            } else if (rangeExportArguments(property.hintString) == null) {
+              errors +=
+                "$where: RANGE hintString '${property.hintString}' is not 'min,max[,step]" +
+                  "[,option...]' with numeric bounds, so it cannot be emitted as " +
+                  "@export_range; fix the hintString."
+            }
+          }
+          // Structural hints are already carried by the typed GDScript declaration the proxy
+          // emits (e.g. `@export var scene: PackedScene`, `@export var list: Array[Texture2D]`):
+          // Godot re-derives the same resource/node/typed-array hint from the type, so nothing
+          // is lost in the .gd.
+          PROPERTY_HINT_RESOURCE_TYPE,
+          PROPERTY_HINT_NODE_TYPE ->
+            if (property.type != TypeMapping.OBJECT) {
+              errors +=
+                "$where: hint ${property.hint} is only valid on object/resource exports; " +
+                  "it cannot be expressed in the Web proxy for ${property.type}."
+            }
+          PROPERTY_HINT_TYPE_STRING ->
+            if (property.type != TypeMapping.ARRAY) {
+              errors +=
+                "$where: hint ${property.hint} is only valid on typed-array exports; " +
+                  "it cannot be expressed in the Web proxy for ${property.type}."
+            }
+          else ->
+            errors +=
+              "$where: property hint ${property.hint} (hintString '${property.hintString}') " +
+                "has no Kanama Web proxy emission; it would be silently dropped from the " +
+                "generated .gd. Use a supported hint (RANGE, or the structural resource/node/" +
+                "typed-array hints) or remove it for the Web target."
+        }
+      }
+      return errors
+    }
   }
 
   data class ProxySource(
@@ -516,6 +657,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName}"
           )
         }
+        if (property.type == TypeMapping.NODE_PATH) {
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName}.path"
+          )
+        }
       }
       appendLine("        else -> unknown(\"property\", propertyId)")
       appendLine("      }")
@@ -536,6 +682,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         if (property.type == TypeMapping.STRING && property.isMutable) {
           appendLine(
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = value"
+          )
+        }
+        if (property.type == TypeMapping.NODE_PATH && property.isMutable) {
+          appendLine(
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = net.multigesture.kanama.types.NodePath(value)"
           )
         }
       }
@@ -831,6 +982,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         val expression =
           when {
             property.type == TypeMapping.STRING -> access
+            property.type == TypeMapping.NODE_PATH -> "$access.path"
             property.type == TypeMapping.INT -> "$access.toString()"
             property.type == TypeMapping.FLOAT -> "$access.toString()"
             property.type == TypeMapping.BOOL -> "if ($access) \"1\" else \"0\""
@@ -1011,7 +1163,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     if (model.signals.isNotEmpty()) appendLine()
     model.properties.forEach { property ->
       appendPropertyGroup(property)
-      appendLine("@export var ${property.godotName}: ${gdType(property)} = ${gdDefault(property)}")
+      appendLine(
+        "${exportAnnotation(property)} var ${property.godotName}: ${gdType(property)} = ${gdDefault(property)}"
+      )
     }
 
     appendLine()
@@ -1144,6 +1298,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         TypeMapping.STRING ->
           appendLine(
             "\t_kanama_bridge.setStringProperty(_kanama_handle, ${index + 1}, ${property.godotName})"
+          )
+        // A NodePath is its plain path string on the wire everywhere (protocol unchanged);
+        // the Kotlin registry rewraps it into the web NodePath value class.
+        TypeMapping.NODE_PATH ->
+          appendLine(
+            "\t_kanama_bridge.setStringProperty(_kanama_handle, ${index + 1}, String(${property.godotName}))"
           )
         TypeMapping.INT ->
           appendLine(
@@ -3523,6 +3683,23 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       else -> property.type.kotlinType
     }
 
+  /**
+   * The export annotation for a property declaration. A RANGE hint becomes GDScript's dedicated
+   * `@export_range(...)` form (that is how hint metadata reaches the proxy — task 64); structural
+   * resource/node/typed-array hints are already carried by the typed declaration and keep the plain
+   * `@export`. Any other nonzero hint was rejected loudly by [unsupportedWebPropertyErrors] before
+   * emission, so nothing is ever silently dropped here.
+   */
+  private fun exportAnnotation(property: ScriptPropertyModel): String {
+    if (property.hint != PROPERTY_HINT_RANGE) return "@export"
+    val arguments =
+      rangeExportArguments(property.hintString)
+        ?: error(
+          "unreachable: RANGE hintString '${property.hintString}' passed the Web property guard"
+        )
+    return "@export_range(${arguments.joinToString(", ")})"
+  }
+
   private fun StringBuilder.appendPropertyGroup(property: ScriptPropertyModel) {
     fun appendGroup(annotation: String, group: ScriptPropertyGroupModel?) {
       if (group == null) return
@@ -3560,7 +3737,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           TypeMapping.BOOL,
           TypeMapping.VECTOR2,
           TypeMapping.VECTOR2I,
-          TypeMapping.VECTOR3 -> true
+          TypeMapping.VECTOR3,
+          TypeMapping.NODE_PATH -> true
           TypeMapping.OBJECT ->
             property.customScriptFqName != null || property.objectWrapperFqName != null
           TypeMapping.ARRAY ->
@@ -3576,6 +3754,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine("\tvar $packed := String(_kanama_bridge.getPackedProperty(_kanama_handle, $id))")
       when {
         property.type == TypeMapping.STRING -> appendLine("\t$name = $packed")
+        property.type == TypeMapping.NODE_PATH -> appendLine("\t$name = NodePath($packed)")
         property.type == TypeMapping.INT -> appendLine("\t$name = int($packed)")
         property.type == TypeMapping.FLOAT -> appendLine("\t$name = float($packed)")
         property.type == TypeMapping.BOOL -> appendLine("\t$name = $packed == \"1\"")
@@ -3642,6 +3821,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       property.type == TypeMapping.ARRAY -> "Array"
       property.objectWrapperFqName != null -> gdObjectType(property.objectWrapperFqName)
       property.customScriptFqName != null -> property.customScriptFqName.substringAfterLast('.')
+      // Typed at the PROPERTY declaration only: method signatures keep Variant for these
+      // (their unsupported-method fallback bodies `return null`, which a typed Vector3/NodePath
+      // return would turn into a GDScript compile error).
+      property.type == TypeMapping.VECTOR3 -> "Vector3"
+      property.type == TypeMapping.NODE_PATH -> "NodePath"
       else -> gdType(property.type)
     }
 
@@ -3668,11 +3852,38 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       TypeMapping.INT -> property.defaultLiteral?.removeSuffix("L") ?: "0"
       TypeMapping.FLOAT -> property.defaultLiteral?.removeSuffix("f")?.removeSuffix("F") ?: "0.0"
       TypeMapping.BOOL -> property.defaultLiteral ?: "false"
-      TypeMapping.VECTOR2 -> "Vector2.ZERO"
-      TypeMapping.VECTOR2I -> "Vector2i.ZERO"
+      TypeMapping.NODE_PATH -> "NodePath(${nodePathDefaultString(property.defaultLiteral)})"
+      TypeMapping.VECTOR2 -> vectorGdDefault(property.defaultLiteral, "Vector2")
+      TypeMapping.VECTOR2I -> vectorGdDefault(property.defaultLiteral, "Vector2i")
+      TypeMapping.VECTOR3 -> vectorGdDefault(property.defaultLiteral, "Vector3")
       TypeMapping.ARRAY -> "[]"
       else -> "null"
     }
+
+  /**
+   * The quoted path from a normalized NodePath default literal
+   * (`net.multigesture.kanama.types.NodePath("../View")` -> `"../View"`), or `""` when there is
+   * none. The literal's quoted segment is a plain Kotlin string literal, which spells the same way
+   * in GDScript.
+   */
+  private fun nodePathDefaultString(defaultLiteral: String?): String =
+    defaultLiteral?.let { NODE_PATH_DEFAULT.matchEntire(it)?.groupValues?.get(1) } ?: "\"\""
+
+  /**
+   * The GDScript spelling of a normalized vector default literal: `<fq>.ZERO` -> `<Simple>.ZERO`,
+   * `<fq>(args)` -> `<Simple>(args)` with Kotlin numeric suffixes stripped. A property with no
+   * normalized literal falls back to `<Simple>.ZERO` (also the pre-task-64 spelling, which ignored
+   * the literal entirely — honoring it keeps the pushed hydration value in sync with the Kotlin
+   * initializer).
+   */
+  private fun vectorGdDefault(defaultLiteral: String?, simpleClass: String): String {
+    if (defaultLiteral == null) return "$simpleClass.ZERO"
+    if (defaultLiteral.endsWith(".ZERO")) return "$simpleClass.ZERO"
+    val args = defaultLiteral.substringAfter('(').substringBeforeLast(')')
+    val gdArgs =
+      args.split(',').joinToString(", ") { it.trim().trimEnd('f', 'F', 'd', 'D', 'l', 'L') }
+    return "$simpleClass($gdArgs)"
+  }
 
   private fun gdDefault(type: TypeMapping): String =
     when (type) {

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/PropertyInitializerParsingTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/PropertyInitializerParsingTest.kt
@@ -1,0 +1,67 @@
+package net.multigesture.kanama.processor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Task 64: the default-literal source parser. The shipped bug: [extractPropertyInitializer] took
+ * the FIRST `=` of the collected declaration, so a one-line annotated declaration (`@Export(hint =
+ * PropertyHint.RANGE, ...) var x: Long = 2`) yielded annotation-argument garbage, normalized to
+ * null, and the Web proxy hydrated the type default (fps `number_of_jumps` = 0) over the Kotlin
+ * initializer.
+ */
+class PropertyInitializerParsingTest {
+
+  private fun initializerOf(name: String, vararg lines: String): String? =
+    extractPropertyInitializer(collectPropertyDeclaration(lines.toList(), 0), name)
+
+  @Test
+  fun oneLineAnnotatedDeclarationSkipsAnnotationArguments() {
+    assertEquals(
+      "2",
+      initializerOf(
+        "numberOfJumps",
+        "@Export(hint = PropertyHint.RANGE, hintString = \"0,100,1\") var numberOfJumps: Long = 2",
+      ),
+    )
+    assertEquals(
+      "3.0",
+      initializerOf(
+        "lifetimeRandom",
+        "@ScriptProperty(name = \"lifetime_random\") var lifetimeRandom = 3.0",
+      ),
+    )
+    assertEquals(
+      "emptyList()",
+      initializerOf(
+        "forceLoop",
+        "@ScriptProperty(name = \"_force_loop\") var forceLoop: List<String> = emptyList()",
+      ),
+    )
+    assertEquals(
+      "null",
+      initializerOf(
+        "cameraBase",
+        "@ScriptProperty(name = \"camera_base\") var cameraBase: Node3D? = null",
+      ),
+    )
+  }
+
+  @Test
+  fun plainDeclarationsStillParse() {
+    assertEquals("8.0", initializerOf("moveSpeed", "var moveSpeed = 8.0"))
+    assertEquals("2", initializerOf("jumps", "var jumps: Long = 2"))
+    assertEquals("a == b", initializerOf("flag", "val flag = a == b"))
+    // Trailing line comments are stripped before collection.
+    assertEquals(
+      "1.0471975511965976",
+      initializerOf("tiltUpperLimit", "var tiltUpperLimit = 1.0471975511965976 // Mathf.PI / 3.0"),
+    )
+  }
+
+  @Test
+  fun declarationsWithoutInitializersYieldNull() {
+    assertEquals(null, initializerOf("node", "lateinit var node: Node3D"))
+    assertEquals(null, initializerOf("other", "var mismatchedName = 1"))
+  }
+}

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -546,4 +546,245 @@ class WebScriptCodeEmitterTest {
       )
     }
   }
+
+  // ---- Task 64: NodePath / hint metadata / Vector3 completion / property guards ----
+
+  private fun task64Property(
+    kotlinName: String,
+    godotName: String,
+    type: TypeMapping,
+    hint: Int = 0,
+    hintString: String = "",
+    defaultLiteral: String? = null,
+    enumFqName: String? = null,
+    narrow: NarrowScalar? = null,
+  ) =
+    ScriptPropertyModel(
+      kotlinName = kotlinName,
+      godotName = godotName,
+      type = type,
+      isMutable = true,
+      hint = hint,
+      hintString = hintString,
+      defaultLiteral = defaultLiteral,
+      enumFqName = enumFqName,
+      enumEntries = if (enumFqName != null) listOf("A", "B") else emptyList(),
+      narrow = narrow,
+    )
+
+  private fun task64Model(properties: List<ScriptPropertyModel>) =
+    ScriptModel(
+      simpleName = "Task64Script",
+      fqName = "net.multigesture.kanama.web.Task64Script",
+      attachTo = "Node3D",
+      isTool = false,
+      isGlobalClass = false,
+      properties = properties,
+      toolButtons = emptyList(),
+      virtuals = emptyList(),
+      methods = emptyList(),
+      signals = emptyList(),
+    )
+
+  @Test
+  fun emitsNodePathRangeAndVector3PropertyArms() {
+    val model =
+      task64Model(
+        listOf(
+          task64Property(
+            "viewPath",
+            "view",
+            TypeMapping.NODE_PATH,
+            defaultLiteral = "net.multigesture.kanama.types.NodePath(\"../View\")",
+          ),
+          task64Property(
+            "numberOfJumps",
+            "number_of_jumps",
+            TypeMapping.INT,
+            hint = 1,
+            hintString = "0,100,1",
+            defaultLiteral = "2",
+          ),
+          task64Property(
+            "sensitivity",
+            "sensitivity",
+            TypeMapping.FLOAT,
+            hint = 1,
+            hintString = "0.0,1.0,0.01,or_greater",
+            defaultLiteral = "0.25",
+          ),
+          task64Property(
+            "spawnOffset",
+            "spawn_offset",
+            TypeMapping.VECTOR3,
+            defaultLiteral = "net.multigesture.kanama.types.Vector3(1.0, 2.0, 3.0)",
+          ),
+          task64Property(
+            "restPoint",
+            "rest_point",
+            TypeMapping.VECTOR3,
+            defaultLiteral = "net.multigesture.kanama.types.Vector3.ZERO",
+          ),
+        )
+      )
+    assertTrue(
+      WebScriptCodeEmitter.unsupportedWebPropertyErrors(model, webOptions).isEmpty(),
+      "the supported fixtures must pass the Web property guard",
+    )
+
+    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(model, "res://Task64Script.kt")))
+    val proxy = emitter.proxySources().single { it.sourceResourcePath.isNotEmpty() }.source
+
+    // Declarations: NodePath with its literal default, RANGE hints as @export_range (numeric
+    // parts bare, option flags quoted), Vector3 typed with the Kotlin literal honored.
+    assertTrue(proxy.contains("@export var view: NodePath = NodePath(\"../View\")"))
+    assertTrue(proxy.contains("@export_range(0, 100, 1) var number_of_jumps: int = 2"))
+    assertTrue(
+      proxy.contains("@export_range(0.0, 1.0, 0.01, \"or_greater\") var sensitivity: float = 0.25")
+    )
+    assertTrue(proxy.contains("@export var spawn_offset: Vector3 = Vector3(1.0, 2.0, 3.0)"))
+    assertTrue(proxy.contains("@export var rest_point: Vector3 = Vector3.ZERO"))
+
+    // Push (engine -> Kotlin at hydration): NodePath rides the string channel as its path.
+    assertTrue(proxy.contains("_kanama_bridge.setStringProperty(_kanama_handle, 1, String(view))"))
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.setVector3Property(_kanama_handle, 4, spawn_offset.x, spawn_offset.y, spawn_offset.z)"
+      )
+    )
+
+    // Pull (save-time sync): the packed string rewraps into a GDScript NodePath.
+    assertTrue(proxy.contains("view = NodePath(_kanama_packed_1)"))
+
+    // Kotlin registry: setter rewraps into the web NodePath value class; getter and packed
+    // getter unwrap the path.
+    val registry = emitter.registrySource()
+    assertTrue(
+      registry.contains(
+        "(script as Task64Script).viewPath = net.multigesture.kanama.types.NodePath(value)"
+      )
+    )
+    assertTrue(registry.contains("(script as Task64Script).viewPath.path"))
+  }
+
+  @Test
+  fun rejectsExpressionDefaultsOnWebTargets() {
+    val model =
+      task64Model(listOf(task64Property("tiltUpperLimit", "tilt_upper_limit", TypeMapping.FLOAT)))
+    val errors = WebScriptCodeEmitter.unsupportedWebPropertyErrors(model, webOptions)
+    assertEquals(1, errors.size)
+    assertTrue(errors.single().contains("Task64Script.tiltUpperLimit"))
+    assertTrue(errors.single().contains("Spell the default as a literal"))
+    // Non-Web targets keep the old behavior (the JVM/iOS emitters do not consume the
+    // proxy default), so the guard must stay silent there.
+    assertTrue(WebScriptCodeEmitter.unsupportedWebPropertyErrors(model, emptyMap()).isEmpty())
+  }
+
+  @Test
+  fun rejectsPropertyTypesWithoutFullWebArmSets() {
+    val unsupported =
+      listOf(
+        task64Property("stats", "stats", TypeMapping.DICTIONARY, defaultLiteral = "emptyMap()"),
+        task64Property("gridCell", "grid_cell", TypeMapping.VECTOR3I, defaultLiteral = "x"),
+        task64Property(
+          "mode",
+          "mode",
+          TypeMapping.INT,
+          defaultLiteral = "0",
+          enumFqName = "demo.Mode",
+        ),
+        task64Property(
+          "narrowValue",
+          "narrow_value",
+          TypeMapping.FLOAT,
+          defaultLiteral = "1f",
+          narrow = NarrowScalar.FLOAT32,
+        ),
+      )
+    for (property in unsupported) {
+      val errors =
+        WebScriptCodeEmitter.unsupportedWebPropertyErrors(task64Model(listOf(property)), webOptions)
+      assertEquals(1, errors.size, "expected exactly one error for ${property.kotlinName}")
+      assertTrue(errors.single().contains("Task64Script.${property.kotlinName}"))
+      assertTrue(errors.single().contains("no full Kanama Web property arm set"))
+    }
+  }
+
+  @Test
+  fun rejectsInexpressibleHintsLoudly() {
+    // RANGE on a non-numeric export.
+    val rangeOnString =
+      task64Model(
+        listOf(
+          task64Property(
+            "label",
+            "label",
+            TypeMapping.STRING,
+            hint = 1,
+            hintString = "0,1",
+            defaultLiteral = "\"x\"",
+          )
+        )
+      )
+    assertTrue(
+      WebScriptCodeEmitter.unsupportedWebPropertyErrors(rangeOnString, webOptions)
+        .single()
+        .contains("only expressible for int/float")
+    )
+
+    // RANGE without a numeric min,max prefix.
+    val badRange =
+      task64Model(
+        listOf(
+          task64Property(
+            "jumps",
+            "jumps",
+            TypeMapping.INT,
+            hint = 1,
+            hintString = "lots",
+            defaultLiteral = "1",
+          )
+        )
+      )
+    assertTrue(
+      WebScriptCodeEmitter.unsupportedWebPropertyErrors(badRange, webOptions)
+        .single()
+        .contains("cannot be emitted as")
+    )
+
+    // A hint with no Web emission at all (e.g. MULTILINE_TEXT = 4) must never be dropped
+    // silently.
+    val unknownHint =
+      task64Model(
+        listOf(
+          task64Property(
+            "notes",
+            "notes",
+            TypeMapping.STRING,
+            hint = 4,
+            hintString = "",
+            defaultLiteral = "\"\"",
+          )
+        )
+      )
+    assertTrue(
+      WebScriptCodeEmitter.unsupportedWebPropertyErrors(unknownHint, webOptions)
+        .single()
+        .contains("no Kanama Web proxy emission")
+    )
+    assertTrue(WebScriptCodeEmitter.unsupportedWebPropertyErrors(unknownHint, emptyMap()).isEmpty())
+  }
+
+  @Test
+  fun parsesRangeHintStrings() {
+    assertEquals(listOf("0", "100", "1"), WebScriptCodeEmitter.rangeExportArguments("0,100,1"))
+    assertEquals(
+      listOf("0.0", "1.0", "0.01", "\"or_greater\""),
+      WebScriptCodeEmitter.rangeExportArguments("0.0,1.0,0.01,or_greater"),
+    )
+    assertEquals(listOf("-4", "4"), WebScriptCodeEmitter.rangeExportArguments("-4,4"))
+    assertEquals(null, WebScriptCodeEmitter.rangeExportArguments("lots"))
+    assertEquals(null, WebScriptCodeEmitter.rangeExportArguments("1"))
+    assertEquals(null, WebScriptCodeEmitter.rangeExportArguments("1,,2"))
+  }
 }

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -105,6 +105,17 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   );
   trace(`enterTreeProbe: mask=${enterTreeProbe} enterTreeCalls=${ready.enterTreeCalls}`);
 
+  // Task 64 property-push proof: Main.property_probe (method#7, Int->Int) returns a mask —
+  // bit 1 = the scene-exported NodePath (NodePath("Spinner"), never the default) was pushed
+  // into Kotlin, bit 2 = the scene value 47 of the RANGE-hinted one-line-annotated export
+  // arrived, bit 4 = the pushed NodePath resolves a live node. A healthy run returns 7.
+  const propertyProbe = Number(
+    await evaluate(
+      "globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, 7, 0)",
+    ),
+  );
+  trace(`propertyProbe: mask=${propertyProbe}`);
+
   // Observe the render running: the spinner's _process advances processCalls and its
   // Node3D.rotation mutations advance appliedCommands each frame.
   const seed = {
@@ -179,6 +190,13 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
     enterTreeDispatched: ready.enterTreeCalls >= 1 && (enterTreeProbe & 1) === 1,
     // 66b: exported property visible at _enter_tree (bit 2) AND it ran before _ready (bit 4).
     enterTreePropertyOrdering: enterTreeProbe === 7,
+    // Task 64: the scene-exported NodePath value was pushed into the Kotlin instance.
+    nodePathPropertyPushed: (propertyProbe & 1) === 1,
+    // Task 64: the scene value of the RANGE-hinted one-line-annotated export arrived in Kotlin
+    // (initializer parser + hint emission end to end).
+    rangeHintPropertyPushed: (propertyProbe & 2) === 2,
+    // Task 64: the pushed NodePath resolves a live node through the NodePath accessor overload.
+    nodePathResolvesNode: (propertyProbe & 4) === 4,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,
     transformCommandsApplied: peak.appliedCommands >= ready.appliedCommands + 10,

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -259,6 +259,11 @@ val webGameplayCoverageSources =
         layout.projectDirectory.file(
             "src/commonMain/kotlin/net/multigesture/kanama/api/WebDodgeApi.kt"
         ),
+        // Task 64: AnimationPlayer.getCurrentAnimation rides the generic tier; its marker
+        // lives in the platformer wrapper file.
+        layout.projectDirectory.file(
+            "src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt"
+        ),
         // Task 76: the web3d fixture exercises the generic callv fallback; its
         // genericWebGameplayFallback markers populate the report's slow-path bucket.
         layout.projectDirectory.file("src/web3dSmoke/web/kotlin-src/Main.kt"),

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -22,6 +22,7 @@ import net.multigesture.kanama.backend.ResourceLoaderBackendContractProbe
 import net.multigesture.kanama.backend.SignalBackendContractProbe
 import net.multigesture.kanama.backend.Sprite2DBackendContractProbe
 import net.multigesture.kanama.types.Color
+import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Rect2
 import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector2i
@@ -140,8 +141,14 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
   fun <T : GodotObject> getAsOrNull(path: String, ctor: (GodotHandle) -> T): T? =
     getNodeOrNull(path)?.let { ctor(it.handle) }
 
+  fun <T : GodotObject> getAsOrNull(path: NodePath, ctor: (GodotHandle) -> T): T? =
+    getAsOrNull(path.path, ctor)
+
   fun <T : GodotObject> requireAs(path: String, ctor: (GodotHandle) -> T): T =
     getAsOrNull(path, ctor) ?: error("Required node '$path' was not found")
+
+  fun <T : GodotObject> requireAs(path: NodePath, ctor: (GodotHandle) -> T): T =
+    requireAs(path.path, ctor)
 
   fun getTree(): SceneTree =
     SceneTree(
@@ -470,3 +477,12 @@ internal expect fun releaseWebConstructedObject(handle: Int)
 internal expect fun releaseWebTrackedObject(handle: Int)
 
 internal expect fun isWebBrowserHandleLive(handle: Int): Boolean
+
+/**
+ * Immediate generic call (task-76 `callv` tier) expecting a String result. The wasmJs actual
+ * routes through `WebExperimentalGenericCall.callImmediate` — commonMain wrappers cannot see the
+ * wasmJs source set directly, and this keeps the generic transport's single extern as the only
+ * crossing. Wrapper call sites carry a [genericWebGameplayFallback] marker so the coverage
+ * report's slow-path bucket stays honest.
+ */
+internal expect fun webGenericImmediateStringCall(target: GodotObject, method: String): String

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -256,6 +256,16 @@ class AnimationPlayer(godotObject: GodotHandle) : Node(godotObject.toBackendHand
   fun getAnimation(name: String): Animation? =
     GodotBackendCalls.invokeNodePathRetHandle(D.ANIMATIONMIXER_GET_ANIMATION, backendHandle, name)
       ?.let { Animation(WebObjectId(it.backendToken().toInt())) }
+
+  /**
+   * The name of the currently playing animation (GDScript's `current_animation` read; empty when
+   * nothing plays). No typed opcode carries this string read, so it rides the task-76 generic
+   * `callv` tier through the engine's `get_current_animation` property getter.
+   */
+  fun getCurrentAnimation(): String {
+    genericWebGameplayFallback("AnimationPlayer.get_current_animation")
+    return webGenericImmediateStringCall(this, "get_current_animation")
+  }
 }
 
 open class Control(godotObject: GodotHandle) : CanvasItem(godotObject.toBackendHandle())

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/NodePath.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/NodePath.kt
@@ -1,0 +1,19 @@
+package net.multigesture.kanama.types
+
+/**
+ * A pre-parsed scene tree path. Kanama value types are immutable snapshots; assign a new value back
+ * to the Godot property after changing components.
+ *
+ * Web mirror of the desktop `net.multigesture.kanama.types.NodePath`: the same shape at the same
+ * fully-qualified name, so `@ScriptProperty` NodePath declarations compile unchanged for the
+ * Kotlin/Wasm target. On the wire a NodePath is its plain [path] string.
+ *
+ * Generated from Godot docs: NodePath
+ */
+value class NodePath(val path: String) {
+  override fun toString(): String = path
+
+  companion object {
+    val EMPTY = NodePath("")
+  }
+}

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/api/WebGodotApi.wasmJs.kt
@@ -57,3 +57,6 @@ internal actual fun releaseWebTrackedObject(handle: Int) {
   check(released == 1) { "Unknown or already released Kanama Web object handle=$handle" }
   unregisterWebBrowserHandle(handle, WebBrowserHandleKind.OBJECT)
 }
+
+internal actual fun webGenericImmediateStringCall(target: GodotObject, method: String): String =
+  net.multigesture.kanama.web.WebExperimentalGenericCall.callImmediate(target, method).asString()

--- a/web-runtime/src/web3dSmoke/main.tscn
+++ b/web-runtime/src/web3dSmoke/main.tscn
@@ -42,6 +42,8 @@ size = Vector3(0.6, 0.6, 0.6)
 [node name="Web3D" type="Node3D"]
 script = ExtResource("1_main")
 enter_tree_greeting = "web3d-enter-tree"
+spinner_path = NodePath("Spinner")
+probe_range_value = 47
 
 [node name="Environment" type="WorldEnvironment" parent="."]
 environment = SubResource("Env_1")

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -2,9 +2,11 @@ package web3d
 
 import kotlin.math.PI
 import kotlin.math.abs
+import net.multigesture.kanama.annotations.Export
 import net.multigesture.kanama.annotations.OnEnterTree
 import net.multigesture.kanama.annotations.OnProcess
 import net.multigesture.kanama.annotations.OnReady
+import net.multigesture.kanama.annotations.PropertyHint
 import net.multigesture.kanama.annotations.RegisterFunction
 import net.multigesture.kanama.annotations.ScriptClass
 import net.multigesture.kanama.annotations.ScriptProperty
@@ -24,6 +26,7 @@ import net.multigesture.kanama.api.ResourceLoader
 import net.multigesture.kanama.api.WorldEnvironment
 import net.multigesture.kanama.api.genericWebGameplayFallback
 import net.multigesture.kanama.api.lookAt
+import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebExperimentalGenericCall
 
@@ -45,6 +48,21 @@ import net.multigesture.kanama.web.WebExperimentalGenericCall
 class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3D) {
   /** Overridden in main.tscn to [ENTER_TREE_EXPORTED] — never the default — for the 66b proof. */
   @ScriptProperty var enterTreeGreeting: String = "unset"
+
+  /**
+   * Task-64 NodePath push proof: overridden in main.tscn to `NodePath("Spinner")` — never the
+   * default — and [propertyProbe] both compares the pushed path and resolves a live node
+   * through the NodePath [net.multigesture.kanama.api.Node] accessor overloads.
+   */
+  @ScriptProperty var spinnerPath: NodePath = NodePath("")
+
+  /**
+   * Task-64 hint-metadata + one-line-annotation proof: the proxy must declare this as
+   * `@export_range(0, 100, 1)`, and the deliberately one-line annotated declaration exercises
+   * the initializer parser (the annotation arguments contain `=` before the real initializer).
+   * Overridden in main.tscn to 47 — never the default 5.
+   */
+  @Export(hint = PropertyHint.RANGE, hintString = "0,100,1") var probeRangeValue: Long = 5
 
   private lateinit var spinner: Node3D
   private var angle = 0.0
@@ -295,6 +313,22 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
         "\"genericMs\":$genericMs,\"typedMs\":$typedMs" +
         "}"
     )
+  }
+
+  /**
+   * Task-64 property-push probe (driver method #7): bit 1 = the scene-exported NodePath value
+   * (`NodePath("Spinner")`, never the default) was pushed into Kotlin, bit 2 = the scene value
+   * 47 of the RANGE-hinted one-line-annotated export arrived (proving the initializer parser
+   * and the hint path end to end), bit 4 = the pushed NodePath resolves a live node through the
+   * NodePath accessor overload. A healthy run returns exactly 7.
+   */
+  @RegisterFunction("property_probe")
+  fun propertyProbe(value: Long): Long {
+    var mask = 0L
+    if (spinnerPath.path == "Spinner") mask = mask or 1L
+    if (probeRangeValue == 47L) mask = mask or 2L
+    if (self.getAsOrNull(spinnerPath, ::Node3D) != null) mask = mask or 4L
+    return mask
   }
 
   private companion object {


### PR DESCRIPTION
Task 64 emitter parcel. Four things land together: the initializer-parser fix, Web NodePath properties, hint-metadata emission, and fail-loud property guards — plus the Vector3 declaration completion, `AnimationPlayer.getCurrentAnimation()` for the platformer convergence, and an end-to-end web3dSmoke proof. `PROTOCOL_VERSION` stays 16 and `SCRIPT_MODEL_SCHEMA_VERSION` stays 6 (no new serialized field, no new extern — NodePath rides the existing string property channels).

**DRAFT until kanama-demos#31 merges**: the expression-default guard requires the demos literal-spelling prep, so `DEMOS_REF` points at kanama-demos#31's branch head (`d02fa5472d...`). Update it to the MERGE commit of #31 before undrafting (precedent: #133/#147).

## What changed

1. **Parser fix (shipped bug)**: `extractPropertyInitializer` took the FIRST `=` in the collected declaration, so a one-line annotated declaration (`@Export(hint = PropertyHint.RANGE, hintString = "0,100,1") var numberOfJumps: Long = 2`) parsed annotation-argument garbage, normalized to a null `defaultLiteral`, and the Web proxy declared **and hydrated** the type default — the shipped fps Web build runs with `number_of_jumps = 0` and `Weapon.max_distance = 0`. The parser now finds the `=` after the `var`/`val <name>` keyword.
2. **Web NodePath**: `net.multigesture.kanama.types.NodePath` mirrored into web-runtime commonMain (same fq-name; `value class` over the path string), `getAsOrNull`/`requireAs` NodePath member overloads on the web `Node`, and the full emitter arm set — `@export var view: NodePath = NodePath("../View")` declaration + literal default, push via the string channel (`String(view)`), pull (`NodePath(packed)`), registry setter (`NodePath(value)`) / getter / packed getter (`.path`).
3. **Hint metadata**: a RANGE hint reaches the .gd as `@export_range(min, max[, step][, "flag"...])`. Structural resource/node/typed-array hints are already carried by the typed GDScript declaration (Godot re-derives them; byte-identical corpus). **Every other nonzero hint is a build error** naming the property — nothing is silently dropped.
4. **Vector3 completion**: was `@export var x: Variant = null` followed by a `.x` dereference in the push (a runtime error whenever the scene leaves it unset); now a typed `Vector3` declaration whose default honors the normalized Kotlin literal. Vector2/Vector2i defaults now honor the literal too — corpus-neutral (every existing corpus default is ZERO), and it closes the same silent-clobber class for non-zero vector defaults. VECTOR3I and all other armless types route to the guard.
5. **Fail-loud guards** (mirroring `undispatchedVirtualErrors`): on the Web target, (a) a `@ScriptProperty` type without the full web arm set, (b) a null `defaultLiteral` on a literal-driven type (true expression initializer), and (c) an inexpressible hint are all KSP errors naming script + property + fix.
6. **`AnimationPlayer.getCurrentAnimation(): String`** — no typed opcode carries this string read, so it rides the task-76 generic `callv` tier through the engine's `get_current_animation` getter. Route: commonMain wrappers cannot see wasmJsMain, so a `internal expect fun webGenericImmediateStringCall(target, method)` in commonMain actualizes onto `WebExperimentalGenericCall.callImmediate(...).asString()` — no new extern, and the `genericWebGameplayFallback("AnimationPlayer.get_current_animation")` marker keeps the coverage report's slow-path bucket honest (`WebPlatformerApi.kt` added to the coverage sources).
7. **web3dSmoke end-to-end proof**: `Main` gains a scene-bound `spinnerPath: NodePath` (scene sets `NodePath("Spinner")`, never the default) and a deliberately one-line-annotated `@Export(hint = RANGE, "0,100,1") var probeRangeValue: Long = 5` (scene sets 47). The new `property_probe` (driver method #7) masks: NodePath pushed (bit 1), RANGE/one-liner value pushed (bit 2), NodePath resolves a live node through the new accessor overload (bit 4); three new driver checks require 7.
8. **Docs**: `docs/exporting/web.md` §Web-Compatible Project Scripts — NodePath + hint metadata portable; expression defaults must be spelled as literals (loud build failure).

## Parser-fix consumer audit (who consumed the garbage null defaultLiteral)

| Consumer | Use | Shipped effect |
| --- | --- | --- |
| WebScriptCodeEmitter `gdDefault` | proxy .gd default AND the hydration push | **The live bug**: fps `number_of_jumps`/`max_distance`/`damage`/`spread`/`shot_count`/`knockback` (and every corpus one-liner with annotation arguments) hydrated the type default over the Kotlin initializer on Web |
| Desktop JVM emitter (`default<Name>` + `default<Name>Available`, KanamaProcessor ~:3391) | inspector default / revert-dot via `hasPropertyDefault` | Editor-metadata only: "no default available". Runtime unaffected (the Kotlin field initializer is authoritative). After the fix, affected desktop registrars gain real defaults on their next regeneration — including thirdperson `BeetlebotSkin._force_loop` (`emptyList()`), whose available-flag flips false->true (inspector-only; enumerated, not regenerated here) |
| iOS emitter | none — grep-verified zero `defaultLiteral` consumers | No iOS effect (iOS keeps the Kotlin default at runtime) |
| `ScriptModelJson` | serializes the field | Diagnostic/persistence content only |

The failure mode was always a NULL literal, never a wrong value: every normalizer is a whole-string match, so garbage could not slip through as a plausible literal.

## Gates

### (a) Test suite / format / local CI

- `./gradlew :processor:test`: 19 tests, 0 failures (includes the new NodePath/RANGE/Vector3 emission fixtures, the guard-error fixtures, the range-hint-string parser, and the one-line-annotation initializer parsing test).
- `./gradlew ktfmtFormat` run before commit; `ktfmtCheck` re-verified inside local CI.
- `./scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot`: **exit 0** on this branch (all stages incl. registrar/count/generated-code checks, wrapper drift gates, runtime/tool/hot-reload smokes). `example_project`'s pinned property counts untouched.

### (b) 12-demo proxy regeneration at the B1 pin (kanama-demos d02fa547), raw diff base=origin/main vs after=this branch

Ran `:web-runtime:kspKotlinWasmJs` per demo at origin/main and at this branch (demos checkout at kanama-demos#31 head `d02fa547`), snapshotted `generated/proxies/*.gd`, raw `diff -ru`.

**The guard corpus proof**: all 12 guarded (after) generations SUCCEEDED — the new property guards fire on nothing in the corpus at the B1 pin (that is what kanama-demos#31 was for).

**Byte-identical (7/12)**: match3, bunnymark, dodge, platformer, squash, charactercontroller, citybuilder.

**Differing, every hunk mechanism-named**:

- **fps `Player.gd`**: `@export var number_of_jumps: int = 0` -> `@export_range(0, 100, 1) var number_of_jumps: int = 2` (the headline shipped-bug fix: parser + hint emission).
- **fps `Weapon.gd`**: the five one-line RANGE exports gain their real defaults + `@export_range` (`max_distance` 0->10, `damage` 0.0->25.0, `spread` +range, `shot_count` 0->1, `knockback` 0->20); multi-line-annotated `cooldown` keeps default 0.1 and gains `@export_range(0.1, 1)` (hint emission — the hint was always in the model via KSP, only the .gd never carried it); `position`/`rotation`/`muzzle_position` `Variant = null` -> `Vector3 = Vector3.ZERO` (Vector3 completion); `min_knockback`/`max_knockback` `Vector2.ZERO` -> `Vector2(0.001, 0.001)` / `Vector2(0.0025, 0.002)` (vector defaults honor the Kotlin literal — previously any weapon whose `.tres` did not pin these hydrated ZERO knockback on Web; only `blaster.tres` pins them).
- **thirdperson `Bullet.gd` / `GrenadeLauncher.gd`**: `velocity`, `from_look_position`, `throw_direction` `Variant = null` -> `Vector3 = Vector3.ZERO` (Vector3 completion; also removes the latent `null.x` dereference in the hydration push when a scene leaves them unset).
- **tpsdemo (4 files)**: `Part.gd` `lifetime_random` 0->3.0, `disappearing_time` 0->0.5 and `RedRobot.gd` `aim_preparing` 0->0.5 (one-line-annotation parser repair; `aim_preparing`/`current_animation` literals from B1), `Player.gd` `current_animation` 0->3, `shoot_target`/`target_position` `Variant = null` -> `Vector3 = Vector3.ZERO` (Vector3 completion).
- **web3d `Main.gd`**: the new fixture — `@export var spinner_path: NodePath = NodePath("")`, `@export_range(0, 100, 1) var probe_range_value: int = 5`, their push (`String(spinner_path)` over the string channel) and pull (`NodePath(_kanama_packed_2)`) lines, and `property_probe` (method #7).

One self-caught regression during this gate, fixed before commit: the first Vector3/NodePath type completion also retyped **method signatures** (`func damage(impactPoint: Variant, ...)` -> `Vector3`), whose unsupported-method fallback bodies `return null` — a GDScript compile error under a typed return. The completion is now scoped to property declarations only; method signatures keep `Variant` (thirdperson collapsed from 8 differing files to 2, racing from 2 to 0).

### (c) Wrapper PASS lines (chrome + firefox)

Exports built from this branch + the demos B1 pin; envelope schema enforces every check true, startup.loaded, zero console errors, liveAfterTeardown === 0.

```
web_export_smoke: PASS -- web3d on chrome    (payload 40.5MB, startup 1520ms, 0.89 crossings/tick)
web_export_smoke: PASS -- web3d on firefox   (payload 40.5MB, startup 18312ms, 0.77 crossings/tick)
web_export_smoke: PASS -- fps on chrome      (payload 50.1MB, startup 1839ms, 1.21 crossings/tick)
web_export_smoke: PASS -- fps on firefox     (payload 50.1MB, startup 18718ms, 1.07 crossings/tick)
web_export_smoke: PASS -- match3 on chrome   (payload 41.2MB, startup 3336ms)
web_export_smoke: PASS -- match3 on firefox
web_export_smoke: PASS -- dodge on chrome    (payload 42.2MB, startup 1363ms, 0.2 crossings/tick)
web_export_smoke: PASS -- dodge on firefox
```

- web3d's three NEW checks (`nodePathPropertyPushed`, `rangeHintPropertyPushed`, `nodePathResolvesNode`) are present and TRUE in both envelopes (24 checks total, all true) — the scene-exported `NodePath("Spinner")` and the RANGE one-liner's 47 demonstrably arrive in the Kotlin instance.
- fps note (MEASURED): `number_of_jumps` now hydrates 2 instead of 0, so double-jump exists on Web for the first time; the driver's checks and both budgets stayed green (1.21 / 1.07 crossings/tick, within budget), no metric fell outside its envelope.
- Firefox environment note: the workstation currently has a staged Firefox self-update plus a running user Firefox; headless launches funnel into the Mozilla updater and the BiDi port never comes up. Smokes here ran with `MOZ_UPDATE_ROOT` pointed at an empty scratch dir (affects only the launched browser, no user state touched). Same workaround as documented on kanama-demos#31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
