### PR TITLE
Bump DEMOS_REF to the platformer convergence (kanama-demos#32)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,9 +50,8 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  # Task 64: literal property defaults (kanama-demos#31 merge) — required by the
-  # expression-default guard this branch introduces.
-  DEMOS_REF: 0a354360078fbde394e445deda11eeb7bf65a90a
+  # Task 64: single-source platformer convergence (kanama-demos#32 merge).
+  DEMOS_REF: 340fe829226946b664515448419cf6cf8af38a01
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
One-line pin bump: the Web matrix now runs against kanama-demos#32 (merge 340fe829) — the task-64 platformer convergence (View/Player/PlatformFalling single-sourced, unlocked by #148's NodePath + hint-metadata emitter parcel). The cc convergence is deferred on the unexplained Firefox module-behavior defect and stays at its #31 override state (fully green).

Sequence context: kanama-demos#31 → kanama#148 → kanama-demos#32 → this pin. The pushed pin was validated end-to-end by #32's gates (platformer wrapper PASS chrome+firefox against #148's content; cc proxies byte-identical to the #31-validated state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)