### PR TITLE
Web API: the thirdperson helper tier becomes members (task 64 option A, thirdperson unlock parcel)

### DIFF
--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFpsApi.kt
@@ -6,6 +6,7 @@ import net.multigesture.kanama.backend.AnimatedSprite3DBackendContractProbe
 import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
 import net.multigesture.kanama.backend.GodotVector3
+import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InputEventMouseMotionBackendContractProbe
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 import net.multigesture.kanama.backend.NodeBackendContractProbe
@@ -59,6 +60,14 @@ class RayCast3D(godotObject: GodotHandle) : Node3D(godotObject) {
     RayCast3DBackendContractProbe(backendHandle).getCollisionNormal().let {
       Vector3(it.x, it.y, it.z)
     }
+
+  /**
+   * Adds a collision exception so the ray does not report collisions with [node] — desktop's
+   * CollisionObject3D parameter (web's CollisionObject3D is the aliased PhysicsBody3D tier).
+   */
+  fun addException(node: CollisionObject3D) {
+    GodotBackendCalls.invokeObjectArg(D.RAYCAST3D_ADD_EXCEPTION, backendHandle, node.backendHandle)
+  }
 }
 
 /** 3D billboard sprite (FPS muzzle flashes and impact decals). */

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -135,8 +135,8 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
   fun getNodeOrNull(path: String): GodotObject? =
     NodeLookupBackendContractProbe(backendHandle).getNodeOrNull(path)?.let(::GodotObject)
 
-  fun getParent(): GodotObject? =
-    NodeBackendContractProbe(backendHandle).getParent()?.let(::GodotObject)
+  /** This node's parent, or null at the tree root — desktop's `Node?` return type (task 64). */
+  fun getParent(): Node? = NodeBackendContractProbe(backendHandle).getParent()?.let(::Node)
 
   fun <T : GodotObject> getAsOrNull(path: String, ctor: (GodotHandle) -> T): T? =
     getNodeOrNull(path)?.let { ctor(it.handle) }
@@ -237,6 +237,12 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
 }
 
 open class CanvasItem internal constructor(backendHandle: BackendGodotHandle) : Node(backendHandle) {
+  /**
+   * Public handle constructor, the web wrapper convention ([Node]'s shape) — desktop's CanvasItem
+   * is publicly constructible from a handle, so shared sources can re-type one (task 64).
+   */
+  constructor(godotObject: GodotHandle) : this(godotObject.toBackendHandle())
+
   var modulate: Color
     get() =
       CanvasItemBackendContractProbe(backendHandle).modulate.let { value ->

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -291,7 +291,65 @@ class Camera3D(godotObject: GodotHandle) : Node3D(godotObject) {
 }
 
 /** 3D physics body base (Task 60d). */
-open class PhysicsBody3D(godotObject: GodotHandle) : Node3D(godotObject)
+open class PhysicsBody3D(godotObject: GodotHandle) : Node3D(godotObject) {
+  /**
+   * First collision of a motion sweep; close it when done (KinematicCollision3D rule). Web
+   * supports only Godot's defaults for the trailing arguments — the admitted family carries
+   * just the motion — so non-default values fail loud instead of being silently ignored.
+   */
+  fun moveAndCollide(
+    motion: Vector3,
+    testOnly: Boolean = false,
+    safeMargin: Double = 0.001,
+    recoveryAsCollision: Boolean = false,
+    maxCollisions: Int = 1,
+  ): KinematicCollision3D? {
+    require(!testOnly) { "Web move_and_collide supports only test_only=false" }
+    require(safeMargin == 0.001) { "Web move_and_collide supports only the default safe_margin" }
+    require(!recoveryAsCollision) { "Web move_and_collide supports only recovery_as_collision=false" }
+    require(maxCollisions == 1) { "Web move_and_collide supports only max_collisions=1" }
+    return GodotBackendCalls.invokeVector3RetHandle(
+        D.PHYSICSBODY3D_MOVE_AND_COLLIDE,
+        backendHandle,
+        GodotVector3(motion.x.toFloat(), motion.y.toFloat(), motion.z.toFloat()),
+      )
+      ?.let { KinematicCollision3D(it) }
+  }
+
+  /** Adds a body to the list of bodies this body can't collide with. */
+  fun addCollisionExceptionWith(body: Node) {
+    GodotBackendCalls.invokeObjectArg(
+      D.PHYSICSBODY3D_ADD_COLLISION_EXCEPTION_WITH,
+      backendHandle,
+      body.backendHandle,
+    )
+  }
+
+  /** Locks or unlocks the given PhysicsServer3D.BodyAxis (see the BODY_AXIS_* constants). */
+  fun setAxisLock(axis: Long, lock: Boolean) {
+    GodotBackendCalls.invokeLongBoolArg(D.PHYSICSBODY3D_SET_AXIS_LOCK, backendHandle, axis, lock)
+  }
+
+  /**
+   * Enables or disables the given 1-based layer in `collision_layer` — desktop declares this on
+   * CollisionObject3D; web's CollisionObject3D tier is aliased to this class.
+   */
+  fun setCollisionLayerValue(layerNumber: Int, value: Boolean) {
+    GodotBackendCalls.invokeLongBoolArg(
+      D.COLLISIONOBJECT3D_SET_COLLISION_LAYER_VALUE,
+      backendHandle,
+      layerNumber.toLong(),
+      value,
+    )
+  }
+
+  companion object {
+    /** PhysicsServer3D.BodyAxis constants (set_axis_lock), matching desktop's PhysicsBody3D. */
+    const val BODY_AXIS_ANGULAR_X: Long = 8L
+    const val BODY_AXIS_ANGULAR_Y: Long = 16L
+    const val BODY_AXIS_ANGULAR_Z: Long = 32L
+  }
+}
 
 open class StaticBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject)
 
@@ -333,6 +391,14 @@ open class Area3D(godotObject: GodotHandle) : Node3D(godotObject) {
     const val bodyEntered: String = "body_entered"
     const val bodyExited: String = "body_exited"
   }
+
+  /**
+   * Overlapping scripted bodies as [Node3D] handles, desktop's return type (bodies without
+   * Kanama scripts are omitted by contract).
+   */
+  fun getOverlappingBodies(): List<Node3D> =
+    GodotBackendCalls.invokeNoArgsRetHandleList(D.AREA3D_GET_OVERLAPPING_BODIES, backendHandle)
+      .map { Node3D(WebObjectId(it.backendToken().toInt())) }
 }
 
 open class VisualInstance3D(godotObject: GodotHandle) : Node3D(godotObject)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebThirdPersonApi.kt
@@ -63,42 +63,33 @@ private fun Vector3.toGodot(): GodotVector3 = GodotVector3(x.toFloat(), y.toFloa
 
 private fun GodotVector3.toApi(): Vector3 = Vector3(x, y, z)
 
-/** First collision of a motion sweep; close it when done (KinematicCollision3D rule). */
-fun PhysicsBody3D.moveAndCollide(motion: Vector3): KinematicCollision3D? =
-  GodotBackendCalls.invokeVector3RetHandle(
-      D.PHYSICSBODY3D_MOVE_AND_COLLIDE,
-      backendHandle,
-      motion.toGodot(),
-    )
-    ?.let { KinematicCollision3D(it) }
+/** Import-compat alias for shared demo sources; delegates to the [PhysicsBody3D] member (task 64). */
+fun PhysicsBody3D.moveAndCollide(motion: Vector3): KinematicCollision3D? = moveAndCollide(motion)
 
-fun PhysicsBody3D.addCollisionExceptionWith(body: GodotObject) {
-  GodotBackendCalls.invokeObjectArg(
-    D.PHYSICSBODY3D_ADD_COLLISION_EXCEPTION_WITH,
-    backendHandle,
-    body.backendHandle,
-  )
-}
+/**
+ * Import-compat alias for shared demo sources; widens desktop's Node parameter for the ported
+ * corpus and delegates to the [PhysicsBody3D] member (task 64).
+ */
+fun PhysicsBody3D.addCollisionExceptionWith(body: GodotObject) =
+  addCollisionExceptionWith(Node(body.handle))
 
-fun PhysicsBody3D.setAxisLock(axis: Long, lock: Boolean) {
-  GodotBackendCalls.invokeLongBoolArg(D.PHYSICSBODY3D_SET_AXIS_LOCK, backendHandle, axis, lock)
-}
+/** Import-compat alias for shared demo sources; delegates to the [PhysicsBody3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun PhysicsBody3D.setAxisLock(axis: Long, lock: Boolean) = setAxisLock(axis, lock)
 
-/** PhysicsServer3D.BodyAxis constants (PhysicsBody3D.set_axis_lock). */
+/** Import-compat alias for shared demo sources; mirrors the [PhysicsBody3D] companion (task 64). */
 object BodyAxis {
-  const val ANGULAR_X: Long = 8L
-  const val ANGULAR_Y: Long = 16L
-  const val ANGULAR_Z: Long = 32L
+  const val ANGULAR_X: Long = PhysicsBody3D.BODY_AXIS_ANGULAR_X
+  const val ANGULAR_Y: Long = PhysicsBody3D.BODY_AXIS_ANGULAR_Y
+  const val ANGULAR_Z: Long = PhysicsBody3D.BODY_AXIS_ANGULAR_Z
 }
 
-fun CollisionObject3D.setCollisionLayerValue(layer: Long, value: Boolean) {
-  GodotBackendCalls.invokeLongBoolArg(
-    D.COLLISIONOBJECT3D_SET_COLLISION_LAYER_VALUE,
-    backendHandle,
-    layer,
-    value,
-  )
-}
+/**
+ * Import-compat alias for shared demo sources; keeps the ported corpus's Long layer parameter and
+ * delegates to the [PhysicsBody3D] member, which takes desktop's Int layerNumber (task 64).
+ */
+fun CollisionObject3D.setCollisionLayerValue(layer: Long, value: Boolean) =
+  setCollisionLayerValue(layer.toInt(), value)
 
 /** CollisionObject3D alias tier for the third-person port (layer/mask + exceptions). */
 typealias CollisionObject3D = PhysicsBody3D
@@ -168,9 +159,11 @@ class SpringArm3D(godotObject: GodotHandle) : Node3D(godotObject) {
   }
 }
 
-fun RayCast3D.addException(body: GodotObject) {
-  GodotBackendCalls.invokeObjectArg(D.RAYCAST3D_ADD_EXCEPTION, backendHandle, body.backendHandle)
-}
+/**
+ * Import-compat alias for shared demo sources; widens desktop's CollisionObject3D parameter for
+ * the ported corpus and delegates to the [RayCast3D] member (task 64).
+ */
+fun RayCast3D.addException(body: GodotObject) = addException(CollisionObject3D(body.handle))
 
 /** Position marker (grenade launch point) — pure transform surface. */
 class Marker3D(godotObject: GodotHandle) : Node3D(godotObject)
@@ -189,11 +182,13 @@ class Animation internal constructor(godotObject: GodotHandle) : GodotObject(god
   }
 }
 
-/** Overlapping scripted bodies (bodies without Kanama scripts are omitted by contract). */
-fun Area3D.getOverlappingBodies(): List<GodotObject> =
-  GodotBackendCalls.invokeNoArgsRetHandleList(D.AREA3D_GET_OVERLAPPING_BODIES, backendHandle).map {
-    GodotObject(WebObjectId(it.backendToken().toInt()))
-  }
+/**
+ * Import-compat alias for shared demo sources; delegates to the [Area3D] member and keeps the
+ * ported corpus's List<GodotObject> return type, covariant over the member's List<Node3D>
+ * (task 64).
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Area3D.getOverlappingBodies(): List<GodotObject> = getOverlappingBodies()
 
 /** Import-compat alias for shared demo sources; delegates to the [GodotObject] member (task 64). */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")


### PR DESCRIPTION
The thirdperson helper tier becomes members on the web wrapper classes — the same shape as option-A parcel 1 (#146), scoped to the six helpers the 2026-08-05 thirdperson re-audit named as its top unlock, plus two typing/visibility items. **Wrapper layer only**: no processor, contract, emitter, protocol, driver or demo changes.

Per the re-audit this unlocks 15 of thirdperson's 30 files for mechanical convergence (13 that already converge + Box on `getParent()` typing + Coin on the collision helpers). The convergence itself is a separate demos PR.

## Members added (each matching the desktop signature)

| # | Web member | Desktop reference | Compat alias kept |
|---|---|---|---|
| 1 | `PhysicsBody3D.moveAndCollide(motion, testOnly=false, safeMargin=0.001, recoveryAsCollision=false, maxCollisions=1): KinematicCollision3D?` | `PhysicsBody3D.kt:28` — identical | yes (1-arg) |
| 2 | `PhysicsBody3D.addCollisionExceptionWith(body: Node)` | `PhysicsBody3D.kt:93` — identical | yes (widened `GodotObject`) |
| 3 | `PhysicsBody3D.setAxisLock(axis: Long, lock: Boolean)` | `PhysicsBody3D.kt:66` — identical | yes (shadowed) |
| 3b | `PhysicsBody3D.BODY_AXIS_ANGULAR_X/Y/Z = 8/16/32` | `PhysicsBody3D.kt:110-112` via `PhysicsServer3D.kt:165-167` — same values | `BodyAxis` object now delegates |
| 4 | `PhysicsBody3D.setCollisionLayerValue(layerNumber: Int, value: Boolean)` | `CollisionObject3D.kt:109` — identical | yes (`Long` layer) |
| 5 | `RayCast3D.addException(node: CollisionObject3D)` | `RayCast3D.kt:214` — identical | yes (widened `GodotObject`) |
| 6 | `Area3D.getOverlappingBodies(): List<Node3D>` | `Area3D.kt:479` — identical | yes (`List<GodotObject>`, shadowed) |
| 7 | `Node.getParent(): Node?` (was `GodotObject?`) | `Node.kt:373` — identical | n/a (return narrowed) |
| 8 | `CanvasItem` public `GodotHandle` constructor | `CanvasItem.kt:17` is publicly handle-constructible | n/a |

Note on 3b: web's `BodyAxis` object keeps its existing values and now reads them from the new companion constants, so the two spellings cannot drift.

`CollisionObject3D` is a typealias for `PhysicsBody3D` on web, so items 2/3/4 land on one class — no collision in practice (distinct names), and the shadow warnings below prove the resolution.

## Resolution proof (the #146 pattern)

Two aliases have signatures identical to their new members and therefore carry `@Suppress("EXTENSION_SHADOWED_BY_MEMBER")`. Removing both suppressions and recompiling makes the compiler name the shadowing members explicitly:

```
w: WebThirdPersonApi.kt:77:19 This extension is shadowed by a member:
   'fun setAxisLock(axis: Long, lock: Boolean): Unit' defined in 'net.multigesture.kanama.api.PhysicsBody3D'.
w: WebThirdPersonApi.kt:189:12 This extension is shadowed by a member:
   'fun getOverlappingBodies(): List<Node3D>' defined in 'net.multigesture.kanama.api.Area3D'.
```

That is the guarantee the self-named delegations (`fun PhysicsBody3D.setAxisLock(...) = setAxisLock(...)`) resolve to the **member** rather than recursing: Kotlin resolves members before extensions. The four aliases with converted parameter types delegate across a real signature difference and need no suppression.

## Gates

| Gate | Ran | Expected | Measured |
|---|---|---|---|
| (a) format + processor | `ktfmtCheck`, `:processor:test` | green, processor untouched | **exit 0** |
| (b) corpus web compile | `:web-runtime:compileKotlinWasmJs` for all 12 demo keys at `DEMOS_REF` 340fe829 | 12/12 compile | **12/12 COMPILE OK** |
| (b2) shadow proof | suppressions removed, recompiled thirdperson | both warnings name the members | **both fired, verbatim above**; file restored, tree clean |
| (c) smokes | `web_ci_matrix.sh --demo thirdperson --demo fps --engine chrome --engine firefox` | 4/4 PASS, budgets unmoved | **4/4 PASS** (see lines below); fps 1.06 crossings/tick, "within budget"; protocol 16 on every cell |
| (d) proxy byte-identity | `kspKotlinWasmJs` for thirdperson + fps in this branch and in a detached `origin/main` worktree; raw `diff -ru` of the KSP proxy output | byte-identical (a wrapper-layer change cannot reach KSP output) | **BYTE-IDENTICAL**: thirdperson 31/31 proxies, fps 11/11 |
| (e) PR CI | GitHub Actions | green | *(pending — Actions outage at time of opening)* |

```
web_export_smoke: PASS -- thirdperson on chrome    (Chrome 150.0.0.0, 30s, protocol 16)
web_export_smoke: PASS -- thirdperson on firefox   (Firefox 153.0, 93s, protocol 16)
web_export_smoke: PASS -- fps on chrome            (Chrome 150.0.0.0, 7s, protocol 16)
web_export_smoke: PASS -- fps on firefox           (Firefox 153.0, 22s, protocol 16)
```

thirdperson is the load-bearing cell: its web overrides call every one of the six delegated helpers each physics frame, so a delegation that resolved to itself would exhaust the stack on the first frame rather than passing.

Method note on gate (d): the first attempt diffed `build/web-scripts/generated`, which KSP does not write — both sides were empty and the comparison reported "identical" vacuously. Corrected to the real KSP output directory with an explicit non-empty assertion; the numbers above are from the corrected run.

## Behavior notes

- The new `moveAndCollide` member adds `require(...)` guards on the trailing arguments Web cannot honor, so a non-default value fails loud instead of being silently ignored. No existing caller passes them, so no behavior changes.
- `getOverlappingBodies` callers now receive `List<Node3D>` instead of `List<GodotObject>` — a covariant narrowing, source-compatible for every corpus call site (proven by the 12/12 compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
