### PR TITLE
Task 80 slice 1: make the Web generator declare its own degradations

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -189,6 +189,48 @@ bridge does **not** silently GC handles behind your back, so *the same
 leaks the same way (until the owning script tears down and its whole object table
 is released).
 
+### Declared dispatch degradations (the protocol manifest)
+
+The Web backend supports a **hand-maintained set of member shapes**. Anything
+outside it degrades, and the generator has always known when it was degrading —
+it just never said so. `KanamaWebProtocol.generated.json` therefore carries a
+`dispatch` field on every `properties` / `virtuals` / `methods` / `signals`
+entry, plus a short `dispatchReason` whenever that value is not `typed`
+(a typed entry carries no reason, so the absence of one means "no degradation"):
+
+| `dispatch` | Meaning |
+|---|---|
+| `typed` | Dispatches with its declared payload intact. |
+| `unsupported` | Emitted, but the proxy stub throws if the engine ever calls it. |
+| `argument-dropped` | Dispatches, but part of the declared payload never reaches Kotlin. |
+| `not-emitted` | No crossing is emitted at all, so the member can never run. |
+
+The value is **not** a second reading of the member's signature: `WebMethodArm`
+and `WebPropertyArm` in `WebScriptCodeEmitter.kt` are the arm tables themselves,
+the GDScript emitter switches on them, and the manifest reports whichever arm was
+taken. Admitting a new shape means adding an arm and its emitter branch — the
+manifest cannot drift from what the proxy actually does, because there is only one
+table. The same tables feed a non-fatal per-build report on the KSP warn channel:
+
+```
+[kanama:web-dispatch] 4 of 49 declared member(s) across 10 script(s) do not dispatch typed (method 2, signal 2, property 0, virtual 0)
+[kanama:web-dispatch]   Enemy.damage (method): no arm for the registered-method shape (FLOAT) -> void; the proxy emits a stub that throws
+```
+
+Read it as a statement about **emission, not about a broken demo**: an
+`unsupported` stub only throws if Godot actually invokes that registered function
+(Kotlin-to-Kotlin calls never reach the proxy), and an `argument-dropped` signal
+payload still arrives intact when the signal is connected to a **named**
+registered method rather than to a Kotlin lambda — that named path rides the
+method's own arm. Properties and virtuals additionally have hard build-time
+guards (`unsupportedWebPropertyErrors`, `undispatchedVirtualErrors`), so a
+non-`typed` entry in either of those sections means one of those guards has a
+hole.
+
+The manifest's own `schemaVersion` versions this file's shape and is independent
+of `protocolVersion`, which versions the runtime bridge contract; adding these
+fields moved the former only.
+
 ## Validation Fixtures
 
 The current fixtures are per-demo driver scripts

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -1175,6 +1175,10 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
     env.logger.warn(
       "[kanama:ksp] generated Web @ScriptClass registry for ${webScripts.size} script(s)"
     )
+    // Task 80 slice 1: name every member that does not dispatch typed. Non-fatal by design --
+    // the corpus trips it today -- but printed through the same warn channel as the line above
+    // so it lands in normal Gradle output instead of only under --info.
+    emitter.degradationReport().forEach(env.logger::warn)
   }
 
   companion object {

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -3,6 +3,107 @@ package net.multigesture.kanama.processor
 /** One Web script model paired with its Godot resource path. */
 internal data class WebScriptInput(val model: ScriptModel, val resourcePath: String)
 
+// ---------- Task 80 slice 1: the generator declares its own degradations ----------
+
+/**
+ * How a declared script member actually reaches Kotlin on the Web backend.
+ *
+ * The Web emitter models a hand-maintained set of supported shapes; anything outside it degrades,
+ * historically in silence. Every manifest entry carries one of these so the degradation is a number
+ * in `KanamaWebProtocol.generated.json` and a build-time report line instead of a runtime surprise.
+ */
+internal enum class WebDispatchStatus(val json: String) {
+  /** Dispatches with its declared payload intact. */
+  TYPED("typed"),
+  /** Emitted, but calling it throws at runtime (the `unsupportedGameplayMethod` stub). */
+  UNSUPPORTED("unsupported"),
+  /** Dispatches, but part of the declared payload never reaches Kotlin. */
+  ARGUMENT_DROPPED("argument-dropped"),
+  /** No crossing is emitted at all, so the member can never run on Web. */
+  NOT_EMITTED("not-emitted"),
+}
+
+/** A member's Web dispatch verdict: the status plus a short machine-readable reason. */
+internal data class WebDispatch(val status: WebDispatchStatus, val reason: String? = null) {
+  val isTyped: Boolean
+    get() = status == WebDispatchStatus.TYPED
+}
+
+/**
+ * The proxy dispatch arm a registered `@ScriptFunction` takes, chosen by parameter shape.
+ *
+ * This enum IS the arm choice: [WebScriptCodeEmitter.methodArm] decides it once, the GDScript
+ * emitter switches on it, and the protocol manifest reports it. Adding a bridge entry point means
+ * adding an arm here and an emitter branch for it — the shape table cannot drift from what the
+ * manifest claims, because there is only one table.
+ */
+internal enum class WebMethodArm(val dispatch: WebDispatch) {
+  /** `_draw()` — crossed by the `_draw` virtual dispatcher, not by a per-method function. */
+  DRAW_VIRTUAL(WebDispatch(WebDispatchStatus.TYPED)),
+  /** A `_draw` overload the draw dispatcher does not accept: no crossing is emitted for it. */
+  DRAW_SHAPE_MISMATCH(
+    WebDispatch(
+      WebDispatchStatus.NOT_EMITTED,
+      "the _draw crossing dispatches only the zero-argument void form",
+    )
+  ),
+  /** No arguments, no return: `callNoArgs`. */
+  NO_ARGS(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(INT) -> INT`: `callInt`. */
+  INT_RET_INT(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(VECTOR2I) -> void`: `callVector2i`. */
+  VECTOR2I_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(INT) -> void`: `callLongVoid`. */
+  INT_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(STRING) -> void`: `callString`. */
+  STRING_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(OBJECT) -> void`: `callObject`. */
+  OBJECT_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /** `(OBJECT, OBJECT, INT) -> void`: `callObjectObjectLong`. */
+  OBJECT_OBJECT_INT_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /** No arm matches: the proxy emits a stub that throws through `unsupportedGameplayMethod`. */
+  NONE(WebDispatch(WebDispatchStatus.UNSUPPORTED));
+
+  val isTyped: Boolean
+    get() = dispatch.isTyped
+}
+
+/**
+ * The proxy push arm an `@ScriptProperty` takes at hydration, keyed the same way the emitted
+ * `_kanama_ensure_created` body is. [WebPropertyArm.NONE] is the historical `else -> Unit` silent
+ * drop; task 64's `unsupportedWebPropertyErrors` already fails the build for it, so a NONE entry in
+ * the manifest means that guard has a hole.
+ */
+internal enum class WebPropertyArm(val dispatch: WebDispatch) {
+  STRING(WebDispatch(WebDispatchStatus.TYPED)),
+  NODE_PATH(WebDispatch(WebDispatchStatus.TYPED)),
+  INT(WebDispatch(WebDispatchStatus.TYPED)),
+  FLOAT(WebDispatch(WebDispatchStatus.TYPED)),
+  BOOL(WebDispatch(WebDispatchStatus.TYPED)),
+  VECTOR2(WebDispatch(WebDispatchStatus.TYPED)),
+  VECTOR3(WebDispatch(WebDispatchStatus.TYPED)),
+  VECTOR2I(WebDispatch(WebDispatchStatus.TYPED)),
+  OBJECT(WebDispatch(WebDispatchStatus.TYPED)),
+  STRING_ARRAY(WebDispatch(WebDispatchStatus.TYPED)),
+  OBJECT_ARRAY(WebDispatch(WebDispatchStatus.TYPED)),
+  NONE(WebDispatch(WebDispatchStatus.NOT_EMITTED));
+
+  val isTyped: Boolean
+    get() = dispatch.isTyped
+}
+
+/** One non-`typed` manifest entry, as the build-time report prints it. */
+internal data class WebDegradation(
+  val scriptName: String,
+  val memberName: String,
+  /** `method`, `signal`, `property`, or `virtual` — the manifest section the entry sits in. */
+  val kind: String,
+  val dispatch: WebDispatch,
+) {
+  override fun toString(): String =
+    "$scriptName.$memberName ($kind): ${dispatch.reason ?: dispatch.status.json}"
+}
+
 /** Static Kotlin/Wasm registry, protocol manifest, and Godot proxy emitter for Task 57. */
 internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
@@ -30,6 +131,138 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
 
     /** True when KSP is running for the Web (Kotlin/Wasm) target. */
     fun isWebTarget(options: Map<String, String>): Boolean = options["kanamaRuntimeTarget"] == "web"
+
+    // ---- Task 80: one arm table per member kind, read by the emitter AND the manifest ----
+
+    /** The GDScript names of the three signal-delivery helpers every proxy emits. */
+    internal const val SIGNAL_DISPATCH_ZERO = "_kanama_web_signal_dispatch0"
+    internal const val SIGNAL_DISPATCH_ONE = "_kanama_web_signal_dispatch1"
+    internal const val SIGNAL_DISPATCH_OBJECT = "_kanama_web_signal_dispatch_object"
+
+    /**
+     * The dispatch arm the proxy emits for a registered `@ScriptFunction`. The emitter's method
+     * loop switches on this and nothing else, so the manifest's `dispatch` value is the arm that
+     * was actually taken rather than a second reading of the same shapes.
+     */
+    fun methodArm(method: MethodModel): WebMethodArm =
+      when {
+        method.godotName == "_draw" ->
+          if (method.args.isEmpty() && method.returnType == null) WebMethodArm.DRAW_VIRTUAL
+          else WebMethodArm.DRAW_SHAPE_MISMATCH
+        method.args.isEmpty() && method.returnType == null -> WebMethodArm.NO_ARGS
+        method.returnType == TypeMapping.INT &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.INT -> WebMethodArm.INT_RET_INT
+        method.returnType == null &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.VECTOR2I -> WebMethodArm.VECTOR2I_VOID
+        method.returnType == null &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.INT -> WebMethodArm.INT_VOID
+        method.returnType == null &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.STRING -> WebMethodArm.STRING_VOID
+        method.returnType == null &&
+          method.args.size == 1 &&
+          method.args.single().type == TypeMapping.OBJECT &&
+          method.args.single().objectWrapperFqName != null -> WebMethodArm.OBJECT_VOID
+        method.returnType == null &&
+          method.args.size == 3 &&
+          method.args[0].type == TypeMapping.OBJECT &&
+          method.args[1].type == TypeMapping.OBJECT &&
+          method.args[2].type == TypeMapping.INT -> WebMethodArm.OBJECT_OBJECT_INT_VOID
+        else -> WebMethodArm.NONE
+      }
+
+    /** `(FLOAT, INT) -> void` — the shape spelling used in degradation reasons. */
+    private fun shapeOf(args: List<ArgModel>, returnType: TypeMapping?): String =
+      "(${args.joinToString(", ") { it.type.name }}) -> ${returnType?.name ?: "void"}"
+
+    /** [WebMethodArm.dispatch] with the offending shape spelled into the reason. */
+    fun methodDispatch(method: MethodModel): WebDispatch {
+      val arm = methodArm(method)
+      if (arm != WebMethodArm.NONE) return arm.dispatch
+      return WebDispatch(
+        WebDispatchStatus.UNSUPPORTED,
+        "no arm for the registered-method shape " +
+          "${shapeOf(method.args, method.returnType)}; the proxy emits a stub that throws",
+      )
+    }
+
+    /**
+     * How a declared `@ScriptSignal` payload reaches a Kotlin callback.
+     *
+     * A proxy emits three delivery helpers ([SIGNAL_DISPATCH_ZERO], [SIGNAL_DISPATCH_ONE],
+     * [SIGNAL_DISPATCH_OBJECT]) and `GodotSignal.connect`/`connectObject` pick between them: zero
+     * arguments, or exactly one argument carried as an object handle. Anything else rides
+     * [SIGNAL_DISPATCH_ONE], whose emitted body discards the argument.
+     *
+     * A payload the lambda path drops can still be delivered by connecting the signal to a
+     * **named** registered method (`connect(target, "method")`), where it rides that method's own
+     * arm — so this is `argument-dropped`, never `unsupported`.
+     */
+    fun signalDispatch(signal: SignalModel): WebDispatch {
+      val args = signal.args
+      if (args.isEmpty()) return WebDispatch(WebDispatchStatus.TYPED)
+      if (args.size == 1 && args.single().type == TypeMapping.OBJECT) {
+        return WebDispatch(WebDispatchStatus.TYPED)
+      }
+      val limit =
+        if (args.size == 1) "Kotlin lambda callbacks take 0 arguments or 1 object handle"
+        else "Kotlin lambda callbacks accept at most 1 emitted argument"
+      return WebDispatch(
+        WebDispatchStatus.ARGUMENT_DROPPED,
+        "signal payload dropped: $limit, so the declared " +
+          "(${args.joinToString(", ") { it.type.name }}) payload reaches Kotlin only through a " +
+          "named registered-method connect",
+      )
+    }
+
+    /**
+     * The push arm the proxy emits for an `@ScriptProperty` at hydration. Same contract as
+     * [methodArm]: the emitter switches on this value, and the manifest reports it.
+     */
+    fun propertyArm(property: ScriptPropertyModel): WebPropertyArm =
+      when (property.type) {
+        TypeMapping.STRING -> WebPropertyArm.STRING
+        TypeMapping.NODE_PATH -> WebPropertyArm.NODE_PATH
+        TypeMapping.INT -> WebPropertyArm.INT
+        TypeMapping.FLOAT -> WebPropertyArm.FLOAT
+        TypeMapping.BOOL -> WebPropertyArm.BOOL
+        TypeMapping.VECTOR2 -> WebPropertyArm.VECTOR2
+        TypeMapping.VECTOR3 -> WebPropertyArm.VECTOR3
+        TypeMapping.VECTOR2I -> WebPropertyArm.VECTOR2I
+        TypeMapping.OBJECT -> WebPropertyArm.OBJECT
+        TypeMapping.ARRAY ->
+          if (property.arrayElementString) WebPropertyArm.STRING_ARRAY
+          else WebPropertyArm.OBJECT_ARRAY
+        else -> WebPropertyArm.NONE
+      }
+
+    /** [WebPropertyArm.dispatch] with the offending type spelled into the reason. */
+    fun propertyDispatch(property: ScriptPropertyModel): WebDispatch {
+      val arm = propertyArm(property)
+      if (arm != WebPropertyArm.NONE) return arm.dispatch
+      return WebDispatch(
+        WebDispatchStatus.NOT_EMITTED,
+        "no proxy push arm for property type ${property.type.name}; the exported value would " +
+          "never be hydrated into Kotlin",
+      )
+    }
+
+    /**
+     * Whether the proxy crosses this virtual into Kotlin. [DISPATCHED_VIRTUALS] is the single arm
+     * table; `undispatchedVirtualErrors` already fails a Web build for anything outside it, so a
+     * non-typed virtual in the manifest means that guard has a hole.
+     */
+    fun virtualDispatch(virtual: VirtualModel): WebDispatch =
+      if (virtual.virtualName in DISPATCHED_VIRTUALS) WebDispatch(WebDispatchStatus.TYPED)
+      else
+        WebDispatch(
+          WebDispatchStatus.NOT_EMITTED,
+          "${virtual.virtualName} is not dispatched by the Kanama Web backend, so the body " +
+            "would never run",
+        )
 
     /**
      * Errors for virtuals a Web build would silently drop (task 66).
@@ -535,10 +768,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("    when (scriptId) {")
     scripts.forEachIndexed { index, input ->
       val virtual = input.model.virtuals.firstOrNull { it.virtualName == "_draw" }
-      val method =
-        input.model.methods.firstOrNull {
-          it.godotName == "_draw" && it.args.isEmpty() && it.returnType == null
-        }
+      // WebMethodArm.DRAW_VIRTUAL is exactly "_draw() -> void": one arm table decides which
+      // _draw shapes this dispatcher accepts and which the manifest reports as not-emitted.
+      val method = input.model.methods.firstOrNull { methodArm(it) == WebMethodArm.DRAW_VIRTUAL }
       val body =
         when {
           virtual != null -> "(script as ${input.model.simpleName}).${virtual.kotlinMethodName}()"
@@ -1294,42 +1526,42 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine("\t_kanama_bridge.refreshParticlesSnapshot(_kanama_handle, emitting, lifetime)")
     }
     model.properties.forEachIndexed { index, property ->
-      when (property.type) {
-        TypeMapping.STRING ->
+      when (propertyArm(property)) {
+        WebPropertyArm.STRING ->
           appendLine(
             "\t_kanama_bridge.setStringProperty(_kanama_handle, ${index + 1}, ${property.godotName})"
           )
         // A NodePath is its plain path string on the wire everywhere (protocol unchanged);
         // the Kotlin registry rewraps it into the web NodePath value class.
-        TypeMapping.NODE_PATH ->
+        WebPropertyArm.NODE_PATH ->
           appendLine(
             "\t_kanama_bridge.setStringProperty(_kanama_handle, ${index + 1}, String(${property.godotName}))"
           )
-        TypeMapping.INT ->
+        WebPropertyArm.INT ->
           appendLine(
             "\t_kanama_bridge.setLongProperty(_kanama_handle, ${index + 1}, ${property.godotName})"
           )
-        TypeMapping.FLOAT ->
+        WebPropertyArm.FLOAT ->
           appendLine(
             "\t_kanama_bridge.setDoubleProperty(_kanama_handle, ${index + 1}, ${property.godotName})"
           )
-        TypeMapping.BOOL ->
+        WebPropertyArm.BOOL ->
           appendLine(
             "\t_kanama_bridge.setLongProperty(_kanama_handle, ${index + 1}, 1 if ${property.godotName} else 0)"
           )
-        TypeMapping.VECTOR2 ->
+        WebPropertyArm.VECTOR2 ->
           appendLine(
             "\t_kanama_bridge.setVector2Property(_kanama_handle, ${index + 1}, ${property.godotName}.x, ${property.godotName}.y)"
           )
-        TypeMapping.VECTOR3 ->
+        WebPropertyArm.VECTOR3 ->
           appendLine(
             "\t_kanama_bridge.setVector3Property(_kanama_handle, ${index + 1}, ${property.godotName}.x, ${property.godotName}.y, ${property.godotName}.z)"
           )
-        TypeMapping.VECTOR2I ->
+        WebPropertyArm.VECTOR2I ->
           appendLine(
             "\t_kanama_bridge.setVector2iProperty(_kanama_handle, ${index + 1}, ${property.godotName}.x, ${property.godotName}.y)"
           )
-        TypeMapping.OBJECT -> {
+        WebPropertyArm.OBJECT -> {
           appendLine("\tvar property_handle_${index + 1}: int = 0")
           appendLine("\tif ${property.godotName} != null:")
           appendLine(
@@ -1362,13 +1594,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "\t\t_kanama_bridge.refreshNode3DSnapshot(property_handle_${index + 1}, property_seed_node3d_${index + 1}.position.x, property_seed_node3d_${index + 1}.position.y, property_seed_node3d_${index + 1}.position.z, property_seed_node3d_${index + 1}.rotation.x, property_seed_node3d_${index + 1}.rotation.y, property_seed_node3d_${index + 1}.rotation.z, property_seed_node3d_${index + 1}.scale.x, property_seed_node3d_${index + 1}.scale.y, property_seed_node3d_${index + 1}.scale.z)"
           )
         }
-        TypeMapping.ARRAY -> {
-          if (property.arrayElementString) {
-            appendLine(
-              "\t_kanama_bridge.setStringArrayProperty(_kanama_handle, ${index + 1}, \"\\u001f\".join(${property.godotName}))"
-            )
-            return@forEachIndexed
-          }
+        WebPropertyArm.STRING_ARRAY ->
+          appendLine(
+            "\t_kanama_bridge.setStringArrayProperty(_kanama_handle, ${index + 1}, \"\\u001f\".join(${property.godotName}))"
+          )
+        WebPropertyArm.OBJECT_ARRAY -> {
           appendLine("\tvar property_handles_${index + 1}: String = \"\"")
           appendLine("\tfor property_value in ${property.godotName}:")
           appendLine("\t\tvar property_value_handle := 0")
@@ -1390,7 +1620,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "\t_kanama_bridge.setObjectArrayProperty(_kanama_handle, ${index + 1}, property_handles_${index + 1})"
           )
         }
-        else -> Unit
+        // Task 80: the historical silent drop. unsupportedWebPropertyErrors (task 64) already
+        // fails a Web build here, and the manifest now records it as not-emitted either way.
+        WebPropertyArm.NONE -> Unit
       }
     }
     appendLine("\treturn _kanama_handle")
@@ -1428,9 +1660,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t_kanama_bridge.ready(_kanama_handle)")
     val immediateMethod =
       model.methods.withIndex().firstOrNull { (_, method) ->
-        method.returnType == TypeMapping.INT &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.INT
+        methodArm(method) == WebMethodArm.INT_RET_INT
       }
     if (immediateMethod != null) {
       appendLine(
@@ -2808,14 +3038,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t_kanama_bridge.recordImmediateConnectResult(result)")
     appendLine("\treturn result")
     appendLine()
-    appendLine("func _kanama_web_signal_dispatch0(callback_id: int) -> void:")
+    appendLine("func $SIGNAL_DISPATCH_ZERO(callback_id: int) -> void:")
     appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
     appendLine()
-    appendLine("func _kanama_web_signal_dispatch1(_arg: Variant, callback_id: int) -> void:")
+    appendLine("func $SIGNAL_DISPATCH_ONE(_arg: Variant, callback_id: int) -> void:")
     appendLine("\t# One emitted argument, dropped by the Kotlin callback: rides the zero-arg path.")
     appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
     appendLine()
-    appendLine("func _kanama_web_signal_dispatch_object(arg: Variant, callback_id: int) -> void:")
+    appendLine("func $SIGNAL_DISPATCH_OBJECT(arg: Variant, callback_id: int) -> void:")
     appendLine("\tvar script_arg_handle := 0")
     appendLine("\tif arg != null and arg.has_method(\"_kanama_ensure_created\"):")
     appendLine("\t\tscript_arg_handle = int(arg.call(\"_kanama_ensure_created\"))")
@@ -3544,7 +3774,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\treturn result")
 
     model.methods.forEachIndexed { index, method ->
-      if (method.godotName == "_draw") return@forEachIndexed
+      val arm = methodArm(method)
+      // Both _draw arms skip the per-method function: the zero-arg void form is crossed by the
+      // _draw virtual dispatcher, and any other _draw shape has no crossing at all.
+      if (arm == WebMethodArm.DRAW_VIRTUAL || arm == WebMethodArm.DRAW_SHAPE_MISMATCH) {
+        return@forEachIndexed
+      }
       appendLine()
       val args = method.args.joinToString(", ") { "${it.name}: ${gdType(it)}" }
       val returnType = " -> ${method.returnType?.let(::gdType) ?: "void"}"
@@ -3556,41 +3791,33 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         "\t\t_kanama_bridge.recordDeferredGameplayMethod(${quote(model.fqName)}, ${quote(method.godotName)})"
       )
       appendLine("\t\treturn${method.returnType?.let { " ${gdDefault(it)}" } ?: ""}")
-      when {
-        method.args.isEmpty() && method.returnType == null ->
+      when (arm) {
+        // Handled above: neither _draw arm reaches this point.
+        WebMethodArm.DRAW_VIRTUAL,
+        WebMethodArm.DRAW_SHAPE_MISMATCH -> Unit
+        WebMethodArm.NO_ARGS ->
           appendLine("\t_kanama_bridge.callNoArgs(_kanama_handle, ${index + 1})")
-        method.returnType == TypeMapping.INT &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.INT -> {
+        WebMethodArm.INT_RET_INT -> {
           val arg = method.args.single()
           appendLine(
             "\treturn int(_kanama_bridge.callInt(_kanama_handle, ${index + 1}, ${arg.name}))"
           )
         }
-        method.returnType == null &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.VECTOR2I -> {
+        WebMethodArm.VECTOR2I_VOID -> {
           val arg = method.args.single()
           appendLine(
             "\t_kanama_bridge.callVector2i(_kanama_handle, ${index + 1}, ${arg.name}.x, ${arg.name}.y)"
           )
         }
-        method.returnType == null &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.INT -> {
+        WebMethodArm.INT_VOID -> {
           val arg = method.args.single()
           appendLine("\t_kanama_bridge.callLongVoid(_kanama_handle, ${index + 1}, ${arg.name})")
         }
-        method.returnType == null &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.STRING -> {
+        WebMethodArm.STRING_VOID -> {
           val arg = method.args.single()
           appendLine("\t_kanama_bridge.callString(_kanama_handle, ${index + 1}, ${arg.name})")
         }
-        method.returnType == null &&
-          method.args.size == 1 &&
-          method.args.single().type == TypeMapping.OBJECT &&
-          method.args.single().objectWrapperFqName != null -> {
+        WebMethodArm.OBJECT_VOID -> {
           // Registered function taking a single Godot object (e.g. a body_entered signal
           // handler). A Kanama-scripted node is passed as its SCRIPT handle (mirrors node
           // lookup) so the Kotlin side can resolve kotlinScriptInstance on it; anything else
@@ -3612,11 +3839,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           appendLine("\t\t_kanama_object_handles.erase(arg_handle)")
           appendLine("\t\t_kanama_bridge.releaseTransientObjectHandle(arg_handle)")
         }
-        method.returnType == null &&
-          method.args.size == 3 &&
-          method.args[0].type == TypeMapping.OBJECT &&
-          method.args[1].type == TypeMapping.OBJECT &&
-          method.args[2].type == TypeMapping.INT -> {
+        WebMethodArm.OBJECT_OBJECT_INT_VOID -> {
           val first = method.args[0]
           val second = method.args[1]
           val value = method.args[2]
@@ -3636,7 +3859,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           appendLine("\t_kanama_bridge.releaseTransientObjectHandle(first_handle)")
           appendLine("\t_kanama_bridge.releaseTransientObjectHandle(second_handle)")
         }
-        else -> {
+        // Task 80: this stub throws at runtime, and the manifest + build report now say so.
+        WebMethodArm.NONE -> {
           appendLine(
             "\t_kanama_bridge.unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, ${index + 1}, ${quote(method.godotName)})"
           )

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -110,7 +110,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
 
   companion object {
     const val PROTOCOL_VERSION = 16
-    const val PROTOCOL_SCHEMA_VERSION = 1
+
+    /**
+     * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
+     * [PROTOCOL_VERSION], which versions the runtime bridge contract. 2 adds the per-entry
+     * `dispatch` / `dispatchReason` fields (task 80); no bridge entry point changed, so the
+     * protocol version deliberately did not move.
+     */
+    const val PROTOCOL_SCHEMA_VERSION = 2
 
     /**
      * Godot virtuals the emitted proxy actually crosses into Kotlin. Keep in sync with the
@@ -440,6 +447,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     val name: String,
     val args: List<ArgModel>,
     val returnType: TypeMapping?,
+    val dispatch: WebDispatch,
   )
 
   fun proxySources(): List<ProxySource> =
@@ -505,28 +513,37 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         append("        {\"id\": ${index + 1}, \"name\": ${quote(property.godotName)}, ")
         append("\"type\": ${quote(protocolPropertyType(property))}, ")
         append("\"nullable\": ${property.nullable}, \"hint\": ${property.hint}, ")
-        append("\"hintString\": ${quote(property.hintString)}, \"usage\": ${property.usage}}")
+        append("\"hintString\": ${quote(property.hintString)}, \"usage\": ${property.usage}")
+        appendDispatch(propertyDispatch(property))
+        append("}")
         appendLine(if (index == model.properties.lastIndex) "" else ",")
       }
       appendLine("      ],")
       appendProtocolMethods(
         "virtuals",
         model.virtuals.map { virtual ->
-          ProtocolMethod(virtual.virtualName, virtual.args, virtual.returnType)
+          ProtocolMethod(
+            virtual.virtualName,
+            virtual.args,
+            virtual.returnType,
+            virtualDispatch(virtual),
+          )
         },
       )
       appendLine(",")
       appendProtocolMethods(
         "methods",
         model.methods.map { method ->
-          ProtocolMethod(method.godotName, method.args, method.returnType)
+          ProtocolMethod(method.godotName, method.args, method.returnType, methodDispatch(method))
         },
       )
       appendLine(",")
       appendLine("      \"signals\": [")
       model.signals.forEachIndexed { index, signal ->
         append("        {\"id\": ${index + 1}, \"name\": ${quote(signal.godotName)}, ")
-        append("\"arguments\": ${protocolArgs(signal.args)}}")
+        append("\"arguments\": ${protocolArgs(signal.args)}")
+        appendDispatch(signalDispatch(signal))
+        append("}")
         appendLine(if (index == model.signals.lastIndex) "" else ",")
       }
       appendLine("      ]")
@@ -535,6 +552,58 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
     appendLine("  ]")
     appendLine("}")
+  }
+
+  /**
+   * Every non-`typed` manifest entry, in manifest order (task 80).
+   *
+   * Same arm tables the emitter and [protocolManifest] use, so the build report can never claim a
+   * different population than the manifest it is reporting on.
+   */
+  fun degradations(): List<WebDegradation> = buildList {
+    scripts.forEach { input ->
+      val model = input.model
+      fun record(name: String, kind: String, dispatch: WebDispatch) {
+        if (!dispatch.isTyped) add(WebDegradation(model.simpleName, name, kind, dispatch))
+      }
+      model.properties.forEach { record(it.godotName, "property", propertyDispatch(it)) }
+      model.virtuals.forEach { record(it.virtualName, "virtual", virtualDispatch(it)) }
+      model.methods.forEach { record(it.godotName, "method", methodDispatch(it)) }
+      model.signals.forEach { record(it.godotName, "signal", signalDispatch(it)) }
+    }
+  }
+
+  /** Total manifest entries across every script, i.e. the denominator of [degradations]. */
+  fun memberCount(): Int =
+    scripts.sumOf { (model, _) ->
+      model.properties.size + model.virtuals.size + model.methods.size + model.signals.size
+    }
+
+  /**
+   * The non-fatal build-time degradation report (task 80 slice 1), as lines to log.
+   *
+   * Deliberately NOT a build failure: the corpus trips it today (fps `Enemy.damage(Double)` has no
+   * single-FLOAT arm), so slice 1 only makes the population visible. Turning this into a hard gate
+   * is slice 3, and it cannot land until slice 2 fills the holes this report finds.
+   */
+  fun degradationReport(): List<String> = buildList {
+    val degradations = degradations()
+    val byKind = degradations.groupingBy { it.kind }.eachCount()
+    val counts =
+      listOf("method", "signal", "property", "virtual").joinToString(", ") {
+        "$it ${byKind[it] ?: 0}"
+      }
+    add(
+      "[kanama:web-dispatch] ${degradations.size} of ${memberCount()} declared member(s) across " +
+        "${scripts.size} script(s) do not dispatch typed ($counts)"
+    )
+    degradations.forEach { add("[kanama:web-dispatch]   $it") }
+    if (degradations.isNotEmpty()) {
+      add(
+        "[kanama:web-dispatch] non-fatal (task 80 slice 1): these are declared in " +
+          "KanamaWebProtocol.generated.json as dispatch != \"typed\""
+      )
+    }
   }
 
   fun constantsSource(): String = buildString {
@@ -3876,10 +3945,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       append("        {\"id\": ${index + 1}, \"name\": ${quote(method.name)}, ")
       append("\"arguments\": ${protocolArgs(method.args)}, \"returnType\": ")
       append(method.returnType?.let { quote(it.kotlinType) } ?: "null")
+      appendDispatch(method.dispatch)
       append("}")
       appendLine(if (index == methods.lastIndex) "" else ",")
     }
     append("      ]")
+  }
+
+  /**
+   * Task 80: every manifest entry declares how it actually reaches Kotlin. `dispatchReason` is
+   * present only when the entry is not `typed`, so its absence is exactly "no degradation".
+   */
+  private fun StringBuilder.appendDispatch(dispatch: WebDispatch) {
+    append(", \"dispatch\": ${quote(dispatch.status.json)}")
+    dispatch.reason?.let { append(", \"dispatchReason\": ${quote(it)}") }
   }
 
   private fun protocolArgs(args: List<ArgModel>): String = buildString {

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -775,6 +775,226 @@ class WebScriptCodeEmitterTest {
     assertTrue(WebScriptCodeEmitter.unsupportedWebPropertyErrors(unknownHint, emptyMap()).isEmpty())
   }
 
+  // ---------- Task 80 slice 1: the generator declares its own degradations ----------
+
+  /**
+   * The degradation fixture: one method per interesting arm plus the two signal shapes. `damage` is
+   * fps's real hole (task 79) — a single Double argument has no arm, so the proxy emits a stub that
+   * throws.
+   */
+  private fun task80Model() =
+    ScriptModel(
+      simpleName = "Enemy",
+      fqName = "net.multigesture.kanama.web.Enemy",
+      attachTo = "Node3D",
+      isTool = false,
+      isGlobalClass = false,
+      properties =
+        listOf(
+          ScriptPropertyModel(
+            kotlinName = "health",
+            godotName = "health",
+            type = TypeMapping.FLOAT,
+            isMutable = true,
+            defaultLiteral = "100.0",
+          )
+        ),
+      toolButtons = emptyList(),
+      virtuals = listOf(VirtualModel("_ready", "callReady", "ready")),
+      methods =
+        listOf(
+          MethodModel(
+            kotlinName = "damage",
+            godotName = "damage",
+            returnType = null,
+            args = listOf(ArgModel("amount", TypeMapping.FLOAT)),
+            kind = MethodKind.REGULAR,
+          ),
+          MethodModel(
+            kotlinName = "die",
+            godotName = "die",
+            returnType = null,
+            args = emptyList(),
+            kind = MethodKind.REGULAR,
+          ),
+        ),
+      signals =
+        listOf(
+          SignalModel("died", emptyList()),
+          SignalModel("hurt", listOf(ArgModel("amount", TypeMapping.FLOAT))),
+        ),
+    )
+
+  @Test
+  fun declaresUnsupportedDispatchForAMethodArgumentWithNoArm() {
+    val method = task80Model().methods.single { it.godotName == "damage" }
+    val dispatch = WebScriptCodeEmitter.methodDispatch(method)
+
+    assertEquals(WebMethodArm.NONE, WebScriptCodeEmitter.methodArm(method))
+    assertEquals(WebDispatchStatus.UNSUPPORTED, dispatch.status)
+    assertEquals("unsupported", dispatch.status.json)
+    // The reason must name the shape that has no arm, not just say "unsupported".
+    assertTrue(dispatch.reason!!.contains("(FLOAT) -> void"), dispatch.reason!!)
+    assertTrue(dispatch.reason!!.contains("throws"), dispatch.reason!!)
+
+    // The claim behind the status: this is exactly the arm that emits the throwing stub.
+    val proxy =
+      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+    assertTrue(proxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 1, \"damage\")"))
+  }
+
+  @Test
+  fun declaresTypedDispatchForANoArgumentMethod() {
+    val method = task80Model().methods.single { it.godotName == "die" }
+    val dispatch = WebScriptCodeEmitter.methodDispatch(method)
+
+    assertEquals(WebMethodArm.NO_ARGS, WebScriptCodeEmitter.methodArm(method))
+    assertEquals(WebDispatchStatus.TYPED, dispatch.status)
+    assertEquals(null, dispatch.reason, "a typed entry carries no dispatchReason")
+  }
+
+  @Test
+  fun declaresArgumentDroppedForAScalarSignalPayload() {
+    // A Kotlin lambda connect binds _kanama_web_signal_dispatch1, whose emitted body discards the
+    // argument, so a scalar payload never reaches the callback.
+    val dropped =
+      WebScriptCodeEmitter.signalDispatch(
+        SignalModel("hurt", listOf(ArgModel("amount", TypeMapping.FLOAT)))
+      )
+    assertEquals(WebDispatchStatus.ARGUMENT_DROPPED, dropped.status)
+    assertEquals("argument-dropped", dropped.status.json)
+    assertTrue(dropped.reason!!.contains("signal payload dropped"), dropped.reason!!)
+    assertTrue(dropped.reason!!.contains("(FLOAT)"), dropped.reason!!)
+
+    // Zero-argument signals ride dispatch0 intact; a lone object argument rides
+    // dispatch_object as a handle. Neither is a degradation.
+    assertEquals(
+      WebDispatchStatus.TYPED,
+      WebScriptCodeEmitter.signalDispatch(SignalModel("died", emptyList())).status,
+    )
+    assertEquals(
+      WebDispatchStatus.TYPED,
+      WebScriptCodeEmitter.signalDispatch(
+          SignalModel(
+            "body_entered",
+            listOf(ArgModel("body", TypeMapping.OBJECT, "net.multigesture.kanama.api.GodotObject")),
+          )
+        )
+        .status,
+    )
+
+    // Multi-argument payloads cannot reach a lambda at all (connect requires 0..1), but a named
+    // registered-method connect can still carry them -- so they are dropped, not unsupported.
+    val multi =
+      WebScriptCodeEmitter.signalDispatch(
+        SignalModel(
+          "scored",
+          listOf(ArgModel("points", TypeMapping.INT), ArgModel("combo", TypeMapping.INT)),
+        )
+      )
+    assertEquals(WebDispatchStatus.ARGUMENT_DROPPED, multi.status)
+    assertTrue(multi.reason!!.contains("at most 1 emitted argument"), multi.reason!!)
+  }
+
+  @Test
+  fun writesDispatchVerdictsIntoTheProtocolManifest() {
+    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
+    val protocol = emitter.protocolManifest()
+
+    // The manifest shape changed, so its own schemaVersion moved -- but the bridge contract did
+    // not, so the protocol version must not.
+    assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 16"), protocol)
+
+    assertTrue(
+      protocol.contains(
+        "\"name\": \"damage\", \"arguments\": [{\"name\": \"amount\", " +
+          "\"type\": \"Double\", \"nullable\": false, \"hasDefault\": false}], " +
+          "\"returnType\": null, \"dispatch\": \"unsupported\", \"dispatchReason\": \"no arm " +
+          "for the registered-method shape (FLOAT) -> void; the proxy emits a stub that throws\""
+      ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains(
+        "\"name\": \"die\", \"arguments\": [], \"returnType\": null, \"dispatch\": \"typed\"}"
+      ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains("\"name\": \"died\", \"arguments\": [], \"dispatch\": \"typed\"}"),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains("\"name\": \"hurt\"") &&
+        protocol.contains("\"dispatch\": \"argument-dropped\", \"dispatchReason\": \"signal "),
+      protocol,
+    )
+    // Properties and dispatched virtuals are guarded elsewhere (#148 / 66a) and must read typed.
+    assertTrue(protocol.contains("\"name\": \"health\""), protocol)
+    assertFalse(
+      protocol.contains("\"dispatch\": \"not-emitted\""),
+      "no property or virtual in this fixture may be not-emitted",
+    )
+
+    // A typed entry carries no dispatchReason at all, so its absence means "no degradation".
+    assertEquals(
+      2,
+      Regex("\"dispatchReason\"").findAll(protocol).count(),
+      "only the two degraded entries may carry a reason",
+    )
+  }
+
+  @Test
+  fun reportsEveryNonTypedEntryWithCounts() {
+    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
+
+    val degradations = emitter.degradations()
+    assertEquals(2, degradations.size, degradations.toString())
+    assertEquals(
+      listOf("Enemy.damage (method)", "Enemy.hurt (signal)"),
+      degradations.map { "${it.scriptName}.${it.memberName} (${it.kind})" },
+    )
+    // 1 property + 1 virtual + 2 methods + 2 signals.
+    assertEquals(6, emitter.memberCount())
+
+    val report = emitter.degradationReport()
+    assertTrue(
+      report.first().contains("2 of 6 declared member(s) across 1 script(s)"),
+      report.first(),
+    )
+    assertTrue(report.first().contains("method 1, signal 1, property 0, virtual 0"), report.first())
+    assertTrue(report.any { it.contains("Enemy.damage (method): no arm for") }, report.toString())
+    assertTrue(
+      report.any { it.contains("Enemy.hurt (signal): signal payload dropped") },
+      report.toString(),
+    )
+
+    // Slice 1 is non-fatal on purpose: a degradation must never become a build error here.
+    assertTrue(
+      WebScriptCodeEmitter.unsupportedWebPropertyErrors(task80Model(), webOptions).isEmpty()
+    )
+    assertTrue(WebScriptCodeEmitter.undispatchedVirtualErrors(task80Model(), webOptions).isEmpty())
+  }
+
+  @Test
+  fun reportsNothingForAFullyTypedScript() {
+    val typed =
+      task80Model()
+        .copy(
+          methods = task80Model().methods.filter { it.godotName == "die" },
+          signals = task80Model().signals.filter { it.godotName == "died" },
+        )
+    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(typed, "res://Enemy.kt")))
+
+    assertEquals(emptyList(), emitter.degradations())
+    assertEquals(1, emitter.degradationReport().size, "a clean script reports only the summary")
+    assertFalse(emitter.protocolManifest().contains("dispatchReason"))
+  }
+
   @Test
   fun parsesRangeHintStrings() {
     assertEquals(listOf("0", "100", "1"), WebScriptCodeEmitter.rangeExportArguments("0,100,1"))


### PR DESCRIPTION
Slice 1 of [task 80](https://github.com/falcon4ever/kanama/issues) — make the Web generator **declare its own degradations**. Non-fatal by design.

## Why

Kanama's Web backend supports a hand-maintained set of member shapes. Anything outside it degrades — silently, or by throwing at runtime — and nothing was reported at build time. In every recent bug the generator *knew* it was degrading: task 79's Double-arg method took the `else ->` arm and emitted a throwing stub; the signal helper literally carries the comment *"One emitted argument, dropped by the Kotlin callback"*. A human found the worst one by playing the game.

This PR turns that invisible problem into a number. **It fixes none of the holes** — that is slice 2, deliberately — and it adds **no build-failing gate**, because the corpus itself trips one today (slice 3 cannot land before slice 2).

## What changed

- **`dispatch` on every manifest entry.** Each `properties` / `virtuals` / `methods` / `signals` entry in `KanamaWebProtocol.generated.json` now carries `"typed" | "unsupported" | "argument-dropped" | "not-emitted"`, plus a machine-readable `dispatchReason` whenever it is not `typed`. A typed entry carries **no** reason, so the absence of one means "no degradation".
- **No duplicated shape logic.** `WebMethodArm` / `WebPropertyArm` *are* the arm tables: `methodArm()` decides once, the GDScript emitter switches on the returned arm instead of re-reading the signature, and the manifest reports whichever arm was taken. This also **removed two pre-existing duplicate shape tests** that could already have drifted — the `_draw` dispatcher and the immediate-method probe now read the same table.
- **Non-fatal build report** on the KSP `warn` channel (the same channel as the existing `[kanama:ksp] generated Web ...` line), so it lands in normal Gradle output rather than only under `--info`.
- `PROTOCOL_VERSION` stays **16** — no bridge entry point and no dispatch change. The manifest's own `schemaVersion` moved 1 → 2; the only reader of this file is Gradle's `readProtocolVersion()`, a regex on `protocolVersion`, which is unaffected.

## Corpus census — nobody had ever counted

All 12 demo keys generate successfully. **40 distinct degraded members across 18 distinct missing shapes** (52 counting the same script reused by several demos) — an order of magnitude more than the two known holes.

### Per-demo totals

| demo | scripts | declared members | non-typed | method | signal | property | virtual |
|---|--:|--:|--:|--:|--:|--:|--:|
| match3 | 7 | 37 | **6** | 3 | 3 | 0 | 0 |
| bunnymark | 3 | 13 | **1** | 0 | 1 | 0 | 0 |
| dodge | 7 | 30 | **2** | 1 | 1 | 0 | 0 |
| web3d | 6 | 25 | **1** | 0 | 1 | 0 | 0 |
| platformer | 11 | 36 | **2** | 0 | 2 | 0 | 0 |
| squash | 7 | 29 | **1** | 0 | 1 | 0 | 0 |
| fps | 10 | 49 | **4** | 2 | 2 | 0 | 0 |
| charactercontroller | 11 | 39 | **3** | 2 | 1 | 0 | 0 |
| thirdperson | 30 | 131 | **18** | 16 | 2 | 0 | 0 |
| racing | 6 | 19 | **3** | 2 | 1 | 0 | 0 |
| citybuilder | 9 | 31 | **1** | 0 | 1 | 0 | 0 |
| tpsdemo | 17 | 111 | **10** | 9 | 1 | 0 | 0 |
| **total (with duplicates across demos)** | 124 | 550 | **52** | 35 | 17 | 0 | 0 |

### Every degraded member (deduplicated across demos)

| script.member | kind | dispatch | shape | demos |
|---|---|---|---|---|
| `BeeBot.damage` | method | `unsupported` | `(VECTOR3, VECTOR3) -> void` | thirdperson |
| `BeetleBot.damage` | method | `unsupported` | `(VECTOR3, VECTOR3) -> void` | thirdperson |
| `Box.damage` | method | `unsupported` | `(VECTOR3, VECTOR3) -> void` | thirdperson |
| `CameraController.get_aim_collider_instance_id` | method | `unsupported` | `() -> INT` | thirdperson |
| `CameraController.get_aim_target` | method | `unsupported` | `() -> VECTOR3` | thirdperson |
| `CameraController.get_camera_forward` | method | `unsupported` | `() -> VECTOR3` | thirdperson |
| `CameraController.get_camera_global_position` | method | `unsupported` | `() -> VECTOR3` | thirdperson |
| `CameraNoiseShakeEffect.add_trauma` | method | `unsupported` | `(FLOAT) -> void` | tpsdemo |
| `CharacterSkin.set_moving` | method | `unsupported` | `(BOOL) -> void` | thirdperson |
| `CharacterSkin.set_moving_speed` | method | `unsupported` | `(FLOAT) -> void` | thirdperson |
| `Coin._follow` | method | `unsupported` | `(FLOAT) -> void` | thirdperson |
| `Coin.spawn` | method | `unsupported` | `(FLOAT) -> void` | thirdperson |
| `Enemy.damage` | method | `unsupported` | `(FLOAT) -> void` | fps |
| `Grenade.throw` | method | `unsupported` | `(VECTOR3) -> void` | thirdperson |
| `GrenadeLauncher.throw_grenade` | method | `unsupported` | `() -> BOOL` | thirdperson |
| `Icone.set_state` | method | `unsupported` | `(BOOL) -> void` | thirdperson |
| `Level.add_player` | method | `unsupported` | `(INT, OBJECT) -> void` | tpsdemo |
| `Player.add_camera_shake_trauma` | method | `unsupported` | `(FLOAT) -> void` | tpsdemo |
| `Player.animate` | method | `unsupported` | `(INT, FLOAT) -> void` | tpsdemo |
| `Player.damage` | method | `unsupported` | `(FLOAT) -> void` | fps, thirdperson |
| `Player.get_ground_height` | method | `unsupported` | `() -> FLOAT` | thirdperson |
| `Player.start` | method | `unsupported` | `(VECTOR2) -> void` | dodge |
| `PlayerInputSynchronizer.get_aim_rotation` | method | `unsupported` | `() -> FLOAT` | tpsdemo |
| `PlayerInputSynchronizer.get_camera_base_quaternion` | method | `unsupported` | `() -> QUATERNION` | tpsdemo |
| `PlayerInputSynchronizer.get_camera_rotation_basis` | method | `unsupported` | `() -> BASIS` | tpsdemo |
| `PlayerInputSynchronizer.rotate_camera` | method | `unsupported` | `(VECTOR2) -> void` | tpsdemo |
| `RedRobot._clip_ray` | method | `unsupported` | `(FLOAT) -> void` | tpsdemo |
| `SophiaSkin._set_run_tilt` | method | `unsupported` | `(FLOAT) -> void` | charactercontroller |
| `SophiaSkin.set_blink` | method | `unsupported` | `(BOOL) -> void` | charactercontroller |
| `Tile.get_tile_type` | method | `unsupported` | `() -> STRING` | match3 |
| `Tile.move_to` | method | `unsupported` | `(VECTOR2, BOOL) -> void` | match3 |
| `Tile.set_tile_type` | method | `unsupported` | `(STRING, OBJECT) -> void` | match3 |
| `Vehicle.get_vehicle_position` | method | `unsupported` | `() -> VECTOR3` | racing |
| `VehicleMotorcycle.get_vehicle_position` | method | `unsupported` | `() -> VECTOR3` | racing |
| `Player.coin_collected` | signal | `argument-dropped` | `(INT)` | platformer |
| `Player.health_updated` | signal | `argument-dropped` | `(INT)` | fps |
| `Player.weapon_switched` | signal | `argument-dropped` | `(STRING)` | thirdperson |
| `Tile.tile_pressed` | signal | `argument-dropped` | `(VECTOR2I)` | match3 |
| `Tile.tile_released` | signal | `argument-dropped` | `(VECTOR2I)` | match3 |
| `WebSpikeScript.changed` | signal | `argument-dropped` | `(INT)` | match3, bunnymark, dodge, web3d, platformer, squash, fps, charactercontroller, thirdperson, racing, citybuilder, tpsdemo |

### Grouped by missing shape

| kind | dispatch | shape | distinct members |
|---|---|---|--:|
| method | `unsupported` | `(FLOAT) -> void` | 9 |
| method | `unsupported` | `() -> VECTOR3` | 5 |
| method | `unsupported` | `(BOOL) -> void` | 3 |
| signal | `argument-dropped` | `(INT)` | 3 |
| method | `unsupported` | `(VECTOR3, VECTOR3) -> void` | 3 |
| method | `unsupported` | `() -> FLOAT` | 2 |
| method | `unsupported` | `(VECTOR2) -> void` | 2 |
| signal | `argument-dropped` | `(VECTOR2I)` | 2 |
| method | `unsupported` | `() -> BASIS` | 1 |
| method | `unsupported` | `() -> BOOL` | 1 |
| method | `unsupported` | `() -> INT` | 1 |
| method | `unsupported` | `() -> QUATERNION` | 1 |
| method | `unsupported` | `() -> STRING` | 1 |
| method | `unsupported` | `(INT, FLOAT) -> void` | 1 |
| method | `unsupported` | `(INT, OBJECT) -> void` | 1 |
| signal | `argument-dropped` | `(STRING)` | 1 |
| method | `unsupported` | `(STRING, OBJECT) -> void` | 1 |
| method | `unsupported` | `(VECTOR2, BOOL) -> void` | 1 |
| method | `unsupported` | `(VECTOR3) -> void` | 1 |

**40 distinct degraded members** across 19 distinct missing shapes.

`WebSpikeScript.changed` is the in-repo `web-runtime` fixture, not demo code; it appears in all 12 because it always compiles into the Wasm target.

### How to read this

`dispatch` describes **emission, not a broken demo**. An `unsupported` stub only throws if Godot actually invokes that registered function — Kotlin-to-Kotlin calls never reach the proxy, which is why the corpus is green today. An `argument-dropped` signal payload still arrives intact when the signal is connected to a **named** registered method (it then rides that method's own arm); only the Kotlin *lambda* path discards it. That nuance is spelled out in each reason string rather than flattened into a scarier status.

Findings worth calling out beyond the two known ones:

- **`() -> T` value-returning registered methods have no arm at all** — 11 distinct members (`() -> VECTOR3` ×5, `() -> FLOAT` ×2, plus `INT`, `BOOL`, `STRING`, `QUATERNION`, `BASIS`). This was not on anyone's list.
- **`(BOOL) -> void` has no arm** (×3) even though single-INT and single-STRING do.
- The single-FLOAT hole (task 79) is the **largest single bucket at 9 distinct members**, not the one `fps` case that prompted it.
- A `_draw` overload that is not `_draw() -> void` would be emitted nowhere and dispatched nowhere. The corpus has none, but the manifest would now say `not-emitted` instead of dropping it silently.
- **Zero property and zero virtual degradations** across the whole corpus, which is the expected result: #148 and 66a already fail the build for those. A non-`typed` entry in either section would mean one of those guards has a hole.

## Gates

| Gate | Ran | Expected | Measured |
|---|---|---|---|
| (a) `ktfmtFormat` + `:processor:test` | yes | green | **PASS** — `ktfmtCheck` BUILD SUCCESSFUL; all processor tests pass incl. 6 new ones |
| (b) `./scripts/local_ci.sh <godot>` | yes | green | **PASS** — exit 0, `[local_ci] PASS`, all 48 stages incl. `runtime_smoke`, `tool_smoke`, `hot_reload_smoke`, `hot_reload_in_process_smoke`, `web_backend`, `mkdocs strict` |
| (c) 12-demo census | yes | all 12 generate | **PASS** — 12/12 `BUILD SUCCESSFUL` |
| (d) proxy byte-identity vs `origin/main` | yes | identical, non-zero both sides | **PASS** — thirdperson **31 vs 31** `.gd`, fps **11 vs 11**; raw `/usr/bin/diff -ru` exit 0 with **0 bytes** of output; corroborated by identical sha256 over the concatenated sorted set. Non-vacuous: same run shows the manifest *did* change (8752 → 10435 bytes, 49 `dispatch` fields added) |
| (e) fps wrapper smoke, firefox | yes | PASS | **PASS** — `web_export_smoke: PASS -- fps on firefox (.../smoke/fps-firefox.json)` |
| (e) fps wrapper smoke, chrome | yes | PASS | **FAIL, pre-existing — not from this PR** (see below) |
| (f) PR CI | opened, not awaited | — | **RUNNING** — correction: I was briefed that Actions was down repo-wide, but this PR **did** create runs (`local-ci (linux)`, `docs (mkdocs strict)`, `gdextension-header`, …). They were in progress at time of writing and were not waited on. |

### Chrome: a pre-existing failure, reported as measured

`fps` on Chrome fails one of ten checks, `processFramesAdvanced` (`peak.processCalls >= ready.processCalls + 120`; it reached 76). It **reproduces identically on `origin/main`**: I built the same export from a clean `f8d1e3ea` worktree and ran the same smoke.

| | kotlinToGodotCalls | processCalls | weaponInstantiations | appliedCommands | verdict |
|---|--:|--:|--:|--:|---|
| this branch | 101 | 76 | 1 | 122 | 9/10, `processFramesAdvanced` false |
| `origin/main` (control) | 101 | 76 | 1 | 122 | 9/10, `processFramesAdvanced` false |
| this branch, firefox | 299 | 285 | 1 | 331 | 10/10 PASS |

Byte-for-byte identical crossing counts on branch and baseline — exactly what byte-identical proxies predict. **Unexplained:** why headless Chrome under-runs frames for `fps` on this workstation is not diagnosed here; it is outside this PR's change surface and is not a regression it introduced. I did not weaken or skip the gate — I am reporting it as failing with its control.

## Not in this PR

Task 79's single-FLOAT arm and scalar signal-payload delivery are **slice 2** (one protocol bump, one corpus revalidation). The hard gate is **slice 3**. The census above is the input to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
