### PR TITLE
Bump DEMOS_REF to the thirdperson slice-1 convergence (kanama-demos#33)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,8 +50,8 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  # Task 64: single-source platformer convergence (kanama-demos#32 merge).
-  DEMOS_REF: 340fe829226946b664515448419cf6cf8af38a01
+  # Task 64: thirdperson single-source slice 1 (kanama-demos#33 merge).
+  DEMOS_REF: 58d8f0511292ff68dbdc7405998e0eac98772dff
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
One-line pin bump: the Web matrix now runs against kanama-demos#33 (merge `58d8f051`) — thirdperson single-source slice 1, 13 files converged (overrides 30 → 17), unlocked by #150's member parcel.

Validated before merging #33: thirdperson `web_export_smoke: PASS` on chrome (104s) and firefox (340s) at protocol 16, exported against **merged main** (3e131eb5, i.e. including both #150 and #151) rather than the unmerged branch #33 was originally gated on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)