### PR TITLE
Encode GD utility arguments as real Variants; GD.isInstanceValid(node) was always false (task 78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ versioning once public releases begin.
 
 ### Fixed
 
+- `GD.isInstanceValid`, `GD.typeOf` and `GD.hash` now encode their argument as a
+  real Variant on desktop/Android (task 78). `GD.encodeVariant` handled six
+  scalar types and stringified everything else, so a wrapper object arrived as a
+  STRING variant: `GD.isInstanceValid(node)` asked Godot whether a *string* was a
+  live instance and returned false for every live object, and `GD.typeOf(node)`
+  reported `TYPE_STRING` (the same collapse hit value types such as `Vector3`).
+  The encoder now delegates to the shared `BuiltinTypes.initVariantFromAny` used
+  by the ptrcall and `Object.call` paths, and fails with a named error instead of
+  silently stringifying an unencodable value; the `print`/`str` family keeps its
+  `toString()` rendering, now scoped to those text utilities alone. The runtime
+  smoke asserts `typeof(node) == TYPE_OBJECT` and `is_instance_valid` true for a
+  live node / false after it is freed.
 - iOS now mirrors the object-typed export `class_name` fix (task 64 follow-up):
   the script property descriptor bridge gained a
   `kanama_ios_runtime_script_resource_property_class_name` entry (same
@@ -47,6 +59,17 @@ versioning once public releases begin.
   `Array[CustomResource]` also match. Runtime smoke now pins the reported
   shape: typed member + typed local assignment, `is` check, load identity, and
   a property round-trip.
+
+### Changed
+
+- `GD.isInstanceValid` now takes `GodotObject?` instead of `Any?`, matching the
+  Web backend (task 78). Godot answers false for every non-object Variant, so
+  the old signature let an instance id or a string compile and then always
+  return false; a wrong argument is now a compile error. New
+  `GD.isInstanceIdValid(id: Long)` covers the id spelling — it does not
+  dereference the object, so it is the safe check to keep across a `free()`.
+  Source-breaking only for callers that passed a non-`GodotObject` value, which
+  could not have been working.
 
 ## 0.4.0 - 2026-07-24
 

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -1009,6 +1009,30 @@ class HelloScript(godotObject: GodotHandle) :
           "closed_rc=$closedRc usable=$usable scalar_main_thread=$scalarMainThread"
       )
     }
+    // task 78 — the GD utilities that take a Variant must encode a wrapper object as a
+    // real TYPE_OBJECT variant. The old encoder stringified anything outside six scalar
+    // types, so is_instance_valid was handed a STRING and answered false for every live
+    // object (type_of_node reported TYPE_STRING = 4, valid_live = false). type_of_node=24
+    // and valid_live=true are the assertions that fail if that fallback comes back;
+    // valid_freed/id_valid_freed prove the check still reports a dead instance.
+    run {
+      val probeNode = ClassDB.instantiate("Node") as? GodotObject
+      val probeInstanceId = probeNode?.getInstanceId() ?: 0L
+      val probeTypeOf = probeNode?.let { GD.typeOf(it) } ?: -1L
+      val probeHash = probeNode?.let { GD.hash(it) } ?: 0L
+      val probeValidLive = probeNode != null && GD.isInstanceValid(probeNode)
+      val probeIdValidLive = GD.isInstanceIdValid(probeInstanceId)
+      probeNode?.call("free")
+      val probeValidFreed = probeNode != null && GD.isInstanceValid(probeNode)
+      val probeIdValidFreed = GD.isInstanceIdValid(probeInstanceId)
+      System.err.println(
+        "[kanama:kt] GD variant utilities type_of_node=$probeTypeOf hash_nonzero=${probeHash != 0L} " +
+          "valid_live=$probeValidLive valid_freed=$probeValidFreed " +
+          "id_valid_live=$probeIdValidLive id_valid_freed=$probeIdValidFreed " +
+          "valid_null=${GD.isInstanceValid(null)} type_of_string=${GD.typeOf("kanama")} " +
+          "type_of_int=${GD.typeOf(7L)} type_of_vector3=${GD.typeOf(Vector3(1f, 2f, 3f))}"
+      )
+    }
     val tweenAwaitTweener = tween?.tweenAwait(selfNode.signal("renamed"))?.setTimeout(30.0)
     val tweenValidBefore = tween?.isValid() ?: false
     val processedTweensBeforeKill = SceneTree.getProcessedTweens().size

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -163,6 +163,13 @@ check "kt script classdb_parity kanama_can=true kanama_instantiate_null=true gds
 # member read (`var m: SmokeResource = hs.smoke_resource` on a typed HelloScript var).
 check "kt script typed_global_class same_load=true member_null=true typed=true is_check=true roundtrip=true member_matches=true instance_class_name=true script_class_name=true"
 check "Mathf lerp=2\\.5 clamp=10 wrap=1 approx=true round=3 lerpf=2\\.5 clampf=10\\.0 sinf=0\\.0 sqrtf=3\\.0"
+# task 78 — GD's Variant-taking utilities must encode arguments as real Variants. The old
+# encoder knew six scalar types and stringified everything else, so is_instance_valid was
+# handed a STRING and returned false for every LIVE object (and typeof reported TYPE_STRING
+# for objects and value types alike). type_of_node=24 (TYPE_OBJECT), type_of_vector3=9
+# (TYPE_VECTOR3) and valid_live=true all fail if the toString() fallback returns; the
+# _freed=false pair proves the check still reports a dead instance.
+check "GD variant utilities type_of_node=24 hash_nonzero=true valid_live=true valid_freed=false id_valid_live=true id_valid_freed=false valid_null=false type_of_string=4 type_of_int=2 type_of_vector3=9"
 check "Generated name constants ok=true"
 check "ProjectSettings string_list=alpha\\|beta"
 check "ProjectSettings dictionary name=kanama enabled=true count=2 scale=1\\.5"

--- a/src/main/kotlin/net/multigesture/kanama/api/GD.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GD.kt
@@ -1,8 +1,7 @@
 package net.multigesture.kanama.api
 
+import net.multigesture.kanama.binding.runtime.BuiltinTypes
 import net.multigesture.kanama.binding.runtime.GodotStrings
-import net.multigesture.kanama.binding.runtime.VariantConverters
-import net.multigesture.kanama.binding.runtime.VariantType
 import net.multigesture.kanama.ffi.GodotFFI
 import java.lang.foreign.Arena
 import java.lang.foreign.FunctionDescriptor
@@ -34,6 +33,7 @@ object GD {
     private const val TYPEOF_HASH: Long = 326422594L
     private const val HASH_HASH: Long = 326422594L
     private const val IS_INSTANCE_VALID_HASH: Long = 996128841L
+    private const val IS_INSTANCE_ID_VALID_HASH: Long = 2232439758L
     private const val ONE_FLOAT_HASH: Long = 2140049587L
     private const val TWO_FLOAT_HASH: Long = 92296394L
     private const val THREE_FLOAT_HASH: Long = 998901048L
@@ -48,11 +48,6 @@ object GD {
     private val getPtrUtilityFunction = GodotFFI.lookup(
         "variant_get_ptr_utility_function",
         FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG),
-    )
-
-    private val variantDestroy = GodotFFI.lookup(
-        "variant_destroy",
-        FunctionDescriptor.ofVoid(ADDRESS),
     )
 
     private val utilityCalls = ConcurrentHashMap<Pair<String, Long>, MethodHandle>()
@@ -74,62 +69,45 @@ object GD {
         val release: () -> Unit,
     )
 
+    /**
+     * Encodes [value] as a real Variant for the utility-call ABI.
+     *
+     * Delegates to [BuiltinTypes.initVariantFromAny] — the same encoder the ptrcall and
+     * `Object.call` paths use — so a [GodotObject] arrives as a `TYPE_OBJECT` variant and
+     * every value type keeps its own Variant type instead of collapsing to one of six
+     * scalars.
+     *
+     * There is deliberately no `toString()` fallback here (task 78): encoding an
+     * unsupported value as a STRING variant made `isInstanceValid(node)` ask Godot
+     * whether a *string* was a live instance, so it answered false for every live
+     * object, and `typeOf(node)` reported `TYPE_STRING`. Unsupported types now fail with
+     * `Unsupported Variant value type: <class>` instead of silently lying. The
+     * text-rendering utilities keep their conversion in [displayArgument].
+     */
     private fun encodeVariant(arena: Arena, value: Any?): VariantScratch {
-        val variant = arena.allocate(24L, 8L)
-        return when (value) {
-            null -> VariantScratch(variant) { variantDestroy.invoke(variant) }
-            is String -> {
-                val typed = arena.allocate(8L, 8L)
-                GodotStrings.initString(typed, value)
-                VariantConverters.variantFromType(VariantType.STRING).invoke(variant, typed)
-                VariantScratch(variant) {
-                    variantDestroy.invoke(variant)
-                    GodotStrings.destroyString(typed)
-                }
-            }
-
-            is Boolean -> {
-                val typed = arena.allocate(JAVA_BYTE)
-                typed.set(JAVA_BYTE, 0, if (value) 1.toByte() else 0.toByte())
-                VariantConverters.variantFromType(VariantType.BOOL).invoke(variant, typed)
-                VariantScratch(variant) { variantDestroy.invoke(variant) }
-            }
-
-            is Int -> {
-                val typed = arena.allocate(JAVA_LONG)
-                typed.set(JAVA_LONG, 0, value.toLong())
-                VariantConverters.variantFromType(VariantType.INT).invoke(variant, typed)
-                VariantScratch(variant) { variantDestroy.invoke(variant) }
-            }
-
-            is Long -> {
-                val typed = arena.allocate(JAVA_LONG)
-                typed.set(JAVA_LONG, 0, value)
-                VariantConverters.variantFromType(VariantType.INT).invoke(variant, typed)
-                VariantScratch(variant) { variantDestroy.invoke(variant) }
-            }
-
-            is Float -> {
-                val typed = arena.allocate(JAVA_DOUBLE)
-                typed.set(JAVA_DOUBLE, 0, value.toDouble())
-                VariantConverters.variantFromType(VariantType.FLOAT).invoke(variant, typed)
-                VariantScratch(variant) { variantDestroy.invoke(variant) }
-            }
-
-            is Double -> {
-                val typed = arena.allocate(JAVA_DOUBLE)
-                typed.set(JAVA_DOUBLE, 0, value)
-                VariantConverters.variantFromType(VariantType.FLOAT).invoke(variant, typed)
-                VariantScratch(variant) { variantDestroy.invoke(variant) }
-            }
-
-            else -> encodeVariant(arena, value.toString())
-        }
+        val variant = arena.allocate(BuiltinTypes.VARIANT_SIZE, 8L)
+        BuiltinTypes.initVariantFromAny(variant, value, arena)
+        return VariantScratch(variant) { BuiltinTypes.destroyVariant(variant) }
     }
+
+    /**
+     * Argument conversion for the `print`/`str` family only.
+     *
+     * Those utilities exist to render text, so a value Godot has no Variant for is
+     * rendered with Kotlin's `toString()` rather than aborting the call. That is the
+     * pre-task-78 behaviour, kept here — confined to the text-rendering family — instead
+     * of living inside the encoder that every utility shares. The scalar set below is
+     * passed through untouched so Godot keeps formatting numbers and booleans itself.
+     */
+    private fun displayArgument(value: Any?): Any? =
+        when (value) {
+            null, is String, is Boolean, is Int, is Long, is Float, is Double -> value
+            else -> value.toString()
+        }
 
     private fun callVoidVarargUtility(name: String, hash: Long, values: Array<out Any?>) {
         Arena.ofConfined().use { arena ->
-            val encoded = values.map { encodeVariant(arena, it) }
+            val encoded = values.map { encodeVariant(arena, displayArgument(it)) }
             try {
                 val args = if (encoded.isEmpty()) {
                     MemorySegment.NULL
@@ -163,7 +141,7 @@ object GD {
 
     private fun callStringVarargUtility(name: String, hash: Long, values: Array<out Any?>): String {
         Arena.ofConfined().use { arena ->
-            val encoded = values.map { encodeVariant(arena, it) }
+            val encoded = values.map { encodeVariant(arena, displayArgument(it)) }
             val ret = arena.allocate(8L, 8L)
             GodotStrings.initString(ret, "")
             try {
@@ -424,6 +402,18 @@ object GD {
         }
     }
 
+    private fun callBoolOneLongUtility(name: String, hash: Long, value: Long): Boolean {
+        Arena.ofConfined().use { arena ->
+            val arg0 = arena.allocate(JAVA_LONG)
+            arg0.set(JAVA_LONG, 0, value)
+            val args = arena.allocate(ADDRESS, 1)
+            args.setAtIndex(ADDRESS, 0, arg0)
+            val ret = arena.allocate(JAVA_BYTE)
+            utilityCall(name, hash).invoke(ret, args, 1)
+            return ret.get(JAVA_BYTE, 0).toInt() != 0
+        }
+    }
+
     private fun callLongOneVariantUtility(name: String, hash: Long, value: Any?): Long {
         Arena.ofConfined().use { arena ->
             val encoded = encodeVariant(arena, value)
@@ -562,15 +552,37 @@ object GD {
     @JvmStatic
     fun seed(value: Long) = callVoidOneLongUtility("seed", SEED_HASH, value)
 
+    /**
+     * Returns the `Variant.Type` of [value] (`TYPE_OBJECT` = 24 for a wrapper,
+     * `TYPE_STRING` = 4 for a `String`, and so on).
+     */
     @JvmStatic
     fun typeOf(value: Any?): Long = callLongOneVariantUtility("typeof", TYPEOF_HASH, value)
 
+    /** Returns Godot's Variant hash of [value]. */
     @JvmStatic
     fun hash(value: Any?): Long = callLongOneVariantUtility("hash", HASH_HASH, value)
 
+    /**
+     * Returns true when [instance] still refers to a live Godot object.
+     *
+     * The parameter is a typed wrapper rather than `Any?` on purpose: Godot answers
+     * false for every non-object Variant, so an id or a string would compile and then
+     * always return false (task 78). Use [isInstanceIdValid] to check a raw instance id.
+     */
     @JvmStatic
-    fun isInstanceValid(value: Any?): Boolean =
-        callBoolOneVariantUtility("is_instance_valid", IS_INSTANCE_VALID_HASH, value)
+    fun isInstanceValid(instance: GodotObject?): Boolean =
+        callBoolOneVariantUtility("is_instance_valid", IS_INSTANCE_VALID_HASH, instance)
+
+    /**
+     * Returns true when [id] — an id from `GodotObject.getInstanceId()` — still resolves
+     * to a live Godot object. This is the id-shaped counterpart of [isInstanceValid];
+     * unlike that call it does not dereference the object, so it stays valid to ask
+     * after the object has been freed.
+     */
+    @JvmStatic
+    fun isInstanceIdValid(id: Long): Boolean =
+        callBoolOneLongUtility("is_instance_id_valid", IS_INSTANCE_ID_VALID_HASH, id)
 
     @JvmStatic
     fun degToRad(value: Double): Double = callDoubleOneArgUtility("deg_to_rad", ONE_FLOAT_HASH, value)

--- a/src/main/kotlin/net/multigesture/kanama/api/GD.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GD.kt
@@ -569,6 +569,12 @@ object GD {
      * The parameter is a typed wrapper rather than `Any?` on purpose: Godot answers
      * false for every non-object Variant, so an id or a string would compile and then
      * always return false (task 78). Use [isInstanceIdValid] to check a raw instance id.
+     *
+     * Note that building the OBJECT variant reads the object's header, so this asks the
+     * question through the wrapper's raw pointer. GDScript's `is_instance_valid` reads
+     * the instance id its Variant already cached instead. If you are holding a wrapper
+     * across a `free()` you can capture `getInstanceId()` while it is alive and use
+     * [isInstanceIdValid], which never touches the object.
      */
     @JvmStatic
     fun isInstanceValid(instance: GodotObject?): Boolean =


### PR DESCRIPTION
Fixes task 78: `GD.encodeVariant` handled exactly six Kotlin scalar types and ended with
`else -> encodeVariant(arena, value.toString())`, so **every wrapper object passed to a
one-variant utility became a STRING variant**. `GD.isInstanceValid(node)` asked Godot
whether a *string* was a live instance and therefore returned `false` for every live
object; `GD.typeOf(node)` reported `TYPE_STRING`. The same collapse hit value types —
`GD.typeOf(Vector3(...))` also reported `TYPE_STRING`.

Shipped impact: `godot-4-3d-third-person-controller/kotlin-src/CameraController.kt:177`
uses this pattern, so `get_aim_collider_instance_id` returns `0` unconditionally on
desktop today.

## What changed

**1. The encoder builds real Variants.** `GD.encodeVariant` now delegates to
`BuiltinTypes.initVariantFromAny` — the same encoder the ptrcall and `Object.call` paths
already use — instead of carrying its own six-type copy. Objects encode as `TYPE_OBJECT`,
value types keep their own Variant type, and unsupported types fail with the shared
`Unsupported Variant value type: <class>` error rather than silently stringifying.

**2. The lossy fallback is gone from the shared path.** The `print`/`str` family keeps its
`toString()` rendering — those utilities exist to produce text — but it now lives in
`displayArgument`, applied only by `callVoidVarargUtility` / `callStringVarargUtility`.
Behaviour for `print`/`printerr`/`prints`/`str`/… is byte-identical to before.

*Caller audit for the old `else` branch:* the only entry points reaching `encodeVariant`
are the print/str vararg family (9 + 1 functions) and `typeOf` / `hash` /
`isInstanceValid`. In this repo every `GD.print` call site passes a single interpolated
`String` (`example_project/`, `templates/starter/`, docs); the KSP processor emits no `GD.*`
calls; in `kanama-demos` all 45 `GD.print` sites pass a single interpolated `String`, and
`GD.str`/`typeOf`/`hash` are unused. Nothing relied on the stringifying `else` — it is kept
in the text family purely to preserve the "print anything" contract.

**3. `isInstanceValid` is narrowed to `GodotObject?`** (matching
`web-runtime/.../WebGodotApi.kt`). Godot answers false for every non-object Variant, so
`Any?` let an instance id or a string compile and then always return false. No in-repo
caller passes anything else, and the one demo caller already holds a `GodotObject?`.
`typeOf`/`hash` keep `Any?` and rely on (1).

Added `GD.isInstanceIdValid(id: Long)` so the id spelling stays available and honest — it
is also the *safe* check across a `free()`, since it never dereferences the object
(building an OBJECT variant reads the object header; GDScript avoids that only because its
Variant already carries the cached instance id). Documented on both functions.

**4. Regression coverage.** `example_project/HelloScript.kt` instantiates a `Node`, checks
`typeOf`/`hash`/`isInstanceValid` on it, frees it and re-checks; `scripts/runtime_smoke.sh`
pins the whole line. No exported-property set changed, so the pinned `properties size = 25`
/ `propertyCount` invariants are untouched.

## Gates

| Gate | Ran | Expected | Measured |
|---|---|---|---|
| `./gradlew ktfmtFormat` / `ktfmtCheck` | yes | green | exit 0 (GD.kt is in the ktfmt-excluded `api/**` set; edits keep its 4-space style) |
| `./gradlew jar` | yes | green | exit 0 |
| `./scripts/local_ci.sh <Godot 4.7 stable>` | yes | PASS | exit 0 — `[runtime_smoke] PASS`, `[tool_smoke] PASS`, `[hot_reload_smoke] PASS`, `[hot_reload_in_process_smoke] PASS`, `[local_ci] PASS`; all static stages (drift gate, property coverage, ABI/Variant-marshalling audits, GDExtension modernization) PASS |
| New smoke assertion | yes | PASS | `GD variant utilities type_of_node=24 hash_nonzero=true valid_live=true valid_freed=false id_valid_live=true id_valid_freed=false valid_null=false type_of_string=4 type_of_int=2 type_of_vector3=9` |

### Deliberate revert proof

The assertion was observed failing. Reverting only the encoder (re-applying the
stringifying fallback inside `encodeVariant`) produces:

```
GD variant utilities type_of_node=4 hash_nonzero=true valid_live=false valid_freed=false
  id_valid_live=true id_valid_freed=false valid_null=false type_of_string=4 type_of_int=2
  type_of_vector3=4

[runtime_smoke] FAIL -- missing pattern: GD variant utilities type_of_node=24 ... valid_live=true ... type_of_vector3=9
exit=1
```

`type_of_node` 24 → 4, `type_of_vector3` 9 → 4, `valid_live` true → false. Restored, and
the smoke is back to `[runtime_smoke] PASS`.

Worth recording: the *first* revert run did not even reach the assertion — Godot aborted
(`Abort trap: 6`, exit 134) during the editor import pass, because the pre-fix encoder
reaches `value.toString()`, and `GodotObject.toString()` ptrcalls `to_string()` on the
freed probe node. So the old fallback was not merely lossy on freed handles, it was a
use-after-free. The clean assertion-failure output above was captured with that one
freed-handle line temporarily stubbed out; both temporary edits were reverted.

## Follow-ups (out of scope here)

- Converge thirdperson `PlayerIdentity.kt` — its `GD.isInstanceValid` dead-handle guard is
  now portable to desktop.
- Fix `godot-4-3d-third-person-controller/kotlin-src/CameraController.kt:177`
  (`get_aim_collider_instance_id` is unconditionally `0` on desktop until the demos repo
  picks this up).

Both are kanama-demos changes.

## Noted while auditing (not changed)

- `BuiltinTypes.initVariantFromAny` has `is GodotObject ->` before `is Resource ->`, and
  `Resource : RefCounted : GodotObject`, so the `is Resource` branch is unreachable. Its
  `requireOpenHandle()` closed-handle check therefore never runs; a closed `Resource`
  encodes its stale handle instead of throwing. Pre-existing and unrelated to this fix —
  flagging rather than touching a hot marshalling path in a bug-fix PR.
- The iOS backend keeps `isInstanceValid(value: Any?)`
  (`ios-runtime/.../IosGodotApi.kt:943`). It is a documented approximation — iOS has no
  utility-function call path, so it answers "non-null, and for an engine object a non-zero
  handle", and `else -> true` for anything else. That is a different bug shape from the
  desktop one this PR fixes, and narrowing it is a separate change against a backend whose
  gates are local device runs; flagging it rather than folding it in. Desktop and Web now
  agree on `GodotObject?`.
- There is no natural unit-test home for this: the only JVM test source is
  `src/test/kotlin/.../CompositeApproxTest.kt` (pure Kotlin), and `object GD` initialises
  FFI lookups eagerly, so touching it outside a Godot process fails. Coverage is the
  runtime smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
