### PR TITLE
Task 80 slice 2: fill the missing Web dispatch shapes and gate FPS combat (protocol 17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ versioning once public releases begin.
 
 ### Fixed
 
+- **Web: `@RegisterFunction` shapes that used to throw at runtime now dispatch**
+  (Web protocol 16 → 17). The Web emitter models a hand-maintained set of
+  supported method shapes; everything else took an `else` arm that emitted a
+  stub throwing `Kanama Web gameplay method is not implemented`. That is why FPS
+  enemies were immortal on Web — `Enemy.damage(amount: Double)` had no arm.
+  Filled in one protocol bump:
+  - every all-numeric argument list, through one six-slot crossing:
+    `(Float)`, `(Boolean)`, `(Vector2)`, `(Vector3)`, `(Vector3, Vector3)`,
+    `(Vector2, Boolean)`, `(Int, Float)`;
+  - the whole value-returning category, which previously had no arm at all —
+    `String`, `NodePath`, `Int`, `Float`, `Boolean`, `Vector2`, `Vector2i`,
+    `Vector3`, `Quaternion` and `Basis` returns from a zero-argument
+    `@RegisterFunction`;
+  - scalar `@ScriptSignal` payloads reaching Kotlin lambdas. The one-argument
+    delivery helper used to discard the emitted value; new typed
+    `GodotSignal.connectLong/connectDouble/connectBoolean/connectString/`
+    `connectVector2/connectVector2i/connectVector3` overloads receive it, and a
+    zero-argument `connect` lambda still runs and ignores it as before.
+
+  Two shapes are deliberately still unfilled and stay declared in the build's
+  dispatch census with their reason: `(String, Object)` and `(Int, Object)`.
+  The fps Web smoke now shoots an enemy dead, so the player→enemy damage path is
+  gated on Chrome and Firefox instead of untested.
 - iOS now mirrors the object-typed export `class_name` fix (task 64 follow-up):
   the script property descriptor bridge gained a
   `kanama_ios_runtime_script_resource_property_class_name` entry (same

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -213,8 +213,8 @@ manifest cannot drift from what the proxy actually does, because there is only o
 table. The same tables feed a non-fatal per-build report on the KSP warn channel:
 
 ```
-[kanama:web-dispatch] 4 of 49 declared member(s) across 10 script(s) do not dispatch typed (method 2, signal 2, property 0, virtual 0)
-[kanama:web-dispatch]   Enemy.damage (method): no arm for the registered-method shape (FLOAT) -> void; the proxy emits a stub that throws
+[kanama:web-dispatch] 1 of 37 declared member(s) across 8 script(s) do not dispatch typed (method 1, signal 0, property 0, virtual 0)
+[kanama:web-dispatch]   Tile.set_tile_type (method): no arm for the registered-method shape (STRING, OBJECT) -> void; the proxy emits a stub that throws
 ```
 
 Read it as a statement about **emission, not about a broken demo**: an
@@ -230,6 +230,23 @@ hole.
 The manifest's own `schemaVersion` versions this file's shape and is independent
 of `protocolVersion`, which versions the runtime bridge contract; adding these
 fields moved the former only.
+
+**What the census then bought.** Reading it across the twelve-demo corpus turned
+"add a `callDouble` arm" into a measured parcel — 52 degraded members over 19
+distinct missing shapes — and two arms plus one signal change closed 50 of them
+at protocol 17:
+
+| Arm | Covers |
+|---|---|
+| `NUMERIC_VOID` | Any all-numeric argument list, flattened into the six-slot `callDoubles` crossing (six slots is exactly one `(VECTOR3, VECTOR3)` pair). |
+| `PACKED_RETURN` | Every zero-argument value-returning method. The value crosses packed into one string with the same encoding `getPackedProperty` uses, so one entry point serves STRING/NODE_PATH/INT/FLOAT/BOOL/VECTOR2/VECTOR2I/VECTOR3/QUATERNION/BASIS. |
+| `_kanama_web_signal_dispatch1` | One emitted scalar, packed the same way, delivered by the typed `GodotSignal.connect*` overloads. A zero-argument lambda still runs and ignores it. |
+
+Two shapes remain `unsupported` on purpose, because they mix the string and
+object-handle channels: `(STRING, OBJECT) -> void` (match3 `Tile.set_tile_type`)
+and `(INT, OBJECT) -> void` (tps-demo `add_player`). They stay in the census with
+their reasons rather than being quietly dropped, which is also why the build
+report is still non-fatal.
 
 ## Validation Fixtures
 

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -248,6 +248,15 @@ and `(INT, OBJECT) -> void` (tps-demo `add_player`). They stay in the census wit
 their reasons rather than being quietly dropped, which is also why the build
 report is still non-fatal.
 
+**Each admitted shape is exercised, not just emitted.** The in-repo `web3d`
+fixture declares one registered function per shape and drives each through the
+real crossing — Kotlin asks Godot to call it BY NAME, Godot dispatches to the
+generated proxy, the proxy takes the arm — then compares the value that came
+back against the value that went out (`Main.dispatch_probe`, driver method #16,
+must return the full mask). A shape that only the emitter tests cover is a shape
+nothing has ever actually run, and the manifest cannot see a shape that
+dispatches but delivers the WRONG VALUE.
+
 ## Validation Fixtures
 
 The current fixtures are per-demo driver scripts

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 16). It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 17). It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -61,6 +61,17 @@ internal enum class WebMethodArm(val dispatch: WebDispatch) {
   OBJECT_VOID(WebDispatch(WebDispatchStatus.TYPED)),
   /** `(OBJECT, OBJECT, INT) -> void`: `callObjectObjectLong`. */
   OBJECT_OBJECT_INT_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /**
+   * Any all-numeric argument list flattened into the `callDoubles` slots (task 80 slice 2):
+   * `(FLOAT)`, `(BOOL)`, `(VECTOR2)`, `(VECTOR3)`, `(VECTOR3, VECTOR3)`, `(VECTOR2, BOOL)`, `(INT,
+   * FLOAT)`, … — one crossing for every shape whose arguments are scalar components.
+   */
+  NUMERIC_VOID(WebDispatch(WebDispatchStatus.TYPED)),
+  /**
+   * A zero-argument value-returning method: `callPacked` returns the value packed into one string
+   * and the proxy parses it per the declared return type (task 80 slice 2).
+   */
+  PACKED_RETURN(WebDispatch(WebDispatchStatus.TYPED)),
   /** No arm matches: the proxy emits a stub that throws through `unsupportedGameplayMethod`. */
   NONE(WebDispatch(WebDispatchStatus.UNSUPPORTED));
 
@@ -109,7 +120,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 16
+    const val PROTOCOL_VERSION = 17
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -145,6 +156,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     internal const val SIGNAL_DISPATCH_ZERO = "_kanama_web_signal_dispatch0"
     internal const val SIGNAL_DISPATCH_ONE = "_kanama_web_signal_dispatch1"
     internal const val SIGNAL_DISPATCH_OBJECT = "_kanama_web_signal_dispatch_object"
+    /** Packs one emitted scalar payload for [SIGNAL_DISPATCH_ONE] (task 80 slice 2). */
+    internal const val SIGNAL_PACK_ARG = "_kanama_web_pack_signal_arg"
 
     /**
      * The dispatch arm the proxy emits for a registered `@ScriptFunction`. The emitter's method
@@ -178,7 +191,135 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           method.args[0].type == TypeMapping.OBJECT &&
           method.args[1].type == TypeMapping.OBJECT &&
           method.args[2].type == TypeMapping.INT -> WebMethodArm.OBJECT_OBJECT_INT_VOID
+        method.returnType == null && numericArgSlots(method.args) != null ->
+          WebMethodArm.NUMERIC_VOID
+        method.args.isEmpty() && isPackedReturn(method.returnType) -> WebMethodArm.PACKED_RETURN
         else -> WebMethodArm.NONE
+      }
+
+    /**
+     * Numeric slots the `callDoubles` crossing carries.
+     *
+     * Six is exactly one `(VECTOR3, VECTOR3)` pair, the widest all-numeric registered-method shape
+     * in the corpus. A wider one has no arm and says so in the census instead of degrading in
+     * silence — which is the whole point of the arm table.
+     */
+    const val NUMERIC_ARG_SLOTS = 6
+
+    /**
+     * Scalar component count for a type the numeric crossing carries, or null for a type that has
+     * to ride a different channel (strings, objects, arrays).
+     */
+    private fun numericComponents(type: TypeMapping): Int? =
+      when (type) {
+        TypeMapping.FLOAT,
+        TypeMapping.INT,
+        TypeMapping.BOOL -> 1
+        TypeMapping.VECTOR2,
+        TypeMapping.VECTOR2I -> 2
+        TypeMapping.VECTOR3 -> 3
+        else -> null
+      }
+
+    /**
+     * Total numeric slots this argument list occupies, or null when it cannot ride the numeric
+     * crossing (a non-numeric argument, no arguments at all, or more than [NUMERIC_ARG_SLOTS]).
+     */
+    fun numericArgSlots(args: List<ArgModel>): Int? {
+      if (args.isEmpty()) return null
+      var total = 0
+      args.forEach { arg -> total += numericComponents(arg.type) ?: return null }
+      return if (total <= NUMERIC_ARG_SLOTS) total else null
+    }
+
+    /**
+     * Return types the packed-string return channel encodes. Same spelling as the property packer
+     * (`getPackedProperty`), so the proxy parses a returned value exactly the way it already parses
+     * a pulled property — one transport, one encoding, no second table.
+     */
+    fun isPackedReturn(type: TypeMapping?): Boolean =
+      when (type) {
+        TypeMapping.STRING,
+        TypeMapping.NODE_PATH,
+        TypeMapping.INT,
+        TypeMapping.FLOAT,
+        TypeMapping.BOOL,
+        TypeMapping.VECTOR2,
+        TypeMapping.VECTOR2I,
+        TypeMapping.VECTOR3,
+        TypeMapping.QUATERNION,
+        TypeMapping.BASIS -> true
+        else -> false
+      }
+
+    /**
+     * The GDScript expression per numeric slot, in slot order. `float(...)` normalizes bools and
+     * ints so the crossing sees one numeric type regardless of the declared parameter type.
+     */
+    fun numericArgSlotExpressions(args: List<ArgModel>): List<String> = buildList {
+      args.forEach { arg ->
+        when (arg.type) {
+          TypeMapping.FLOAT -> add(arg.name)
+          TypeMapping.INT,
+          TypeMapping.BOOL -> add("float(${arg.name})")
+          TypeMapping.VECTOR2,
+          TypeMapping.VECTOR2I -> {
+            add("float(${arg.name}.x)")
+            add("float(${arg.name}.y)")
+          }
+          TypeMapping.VECTOR3 -> {
+            add(arg.name + ".x")
+            add(arg.name + ".y")
+            add(arg.name + ".z")
+          }
+          else -> error("no numeric slot layout for ${arg.type.name}")
+        }
+      }
+    }
+
+    /**
+     * The Kotlin expression rebuilding each declared argument from the numeric slot parameters
+     * `a0`..`a5`. Mirror of [numericArgSlotExpressions] — the two walk the same argument list in
+     * the same order, so a slot can never be read as a different component than it was written.
+     */
+    fun numericArgKotlinExpressions(args: List<ArgModel>): List<String> = buildList {
+      var slot = 0
+      fun next(): String = "a${slot++}"
+      args.forEach { arg ->
+        when (arg.type) {
+          TypeMapping.FLOAT -> add(next())
+          TypeMapping.INT -> add("${next()}.toLong()")
+          TypeMapping.BOOL -> add("${next()} != 0.0")
+          TypeMapping.VECTOR2 -> add("net.multigesture.kanama.types.Vector2(${next()}, ${next()})")
+          TypeMapping.VECTOR2I -> add("Vector2i(${next()}.toInt(), ${next()}.toInt())")
+          TypeMapping.VECTOR3 ->
+            add("net.multigesture.kanama.types.Vector3(${next()}, ${next()}, ${next()})")
+          else -> error("no numeric slot layout for ${arg.type.name}")
+        }
+      }
+    }
+
+    /**
+     * The Kotlin expression packing a returned value of [type] into the transport string. Same
+     * encoding as `getPackedProperty`; QUATERNION adds `w` and BASIS packs its three COLUMNS in
+     * x/y/z order, which is exactly the argument order of GDScript's `Basis(x, y, z)`.
+     */
+    fun packedReturnExpression(access: String, type: TypeMapping): String =
+      when (type) {
+        TypeMapping.STRING -> access
+        TypeMapping.NODE_PATH -> "$access.path"
+        TypeMapping.INT,
+        TypeMapping.FLOAT -> "$access.toString()"
+        TypeMapping.BOOL -> "if ($access) \"1\" else \"0\""
+        TypeMapping.VECTOR2,
+        TypeMapping.VECTOR2I -> "$access.let { \"\${it.x},\${it.y}\" }"
+        TypeMapping.VECTOR3 -> "$access.let { \"\${it.x},\${it.y},\${it.z}\" }"
+        TypeMapping.QUATERNION -> "$access.let { \"\${it.x},\${it.y},\${it.z},\${it.w}\" }"
+        TypeMapping.BASIS ->
+          "$access.let { " +
+            "\"\${it.x.x},\${it.x.y},\${it.x.z},\${it.y.x},\${it.y.y},\${it.y.z}," +
+            "\${it.z.x},\${it.z.y},\${it.z.z}\" }"
+        else -> error("no packed return encoding for ${type.name}")
       }
 
     /** `(FLOAT, INT) -> void` — the shape spelling used in degradation reasons. */
@@ -197,12 +338,30 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
 
     /**
+     * Scalar signal payload types [SIGNAL_DISPATCH_ONE] packs and delivers to a Kotlin lambda (task
+     * 80 slice 2). Same packing as the property/return channel: one string, parsed by the typed
+     * `GodotSignal.connect*` overload the consumer chose.
+     */
+    fun isScalarSignalPayload(type: TypeMapping): Boolean =
+      when (type) {
+        TypeMapping.STRING,
+        TypeMapping.INT,
+        TypeMapping.FLOAT,
+        TypeMapping.BOOL,
+        TypeMapping.VECTOR2,
+        TypeMapping.VECTOR2I,
+        TypeMapping.VECTOR3 -> true
+        else -> false
+      }
+
+    /**
      * How a declared `@ScriptSignal` payload reaches a Kotlin callback.
      *
      * A proxy emits three delivery helpers ([SIGNAL_DISPATCH_ZERO], [SIGNAL_DISPATCH_ONE],
      * [SIGNAL_DISPATCH_OBJECT]) and `GodotSignal.connect`/`connectObject` pick between them: zero
-     * arguments, or exactly one argument carried as an object handle. Anything else rides
-     * [SIGNAL_DISPATCH_ONE], whose emitted body discards the argument.
+     * arguments, one scalar carried packed by [SIGNAL_DISPATCH_ONE], or one object handle. Two or
+     * more emitted arguments, and single payloads outside [isScalarSignalPayload], still ride
+     * [SIGNAL_DISPATCH_ONE] with the payload dropped.
      *
      * A payload the lambda path drops can still be delivered by connecting the signal to a
      * **named** registered method (`connect(target, "method")`), where it rides that method's own
@@ -214,8 +373,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       if (args.size == 1 && args.single().type == TypeMapping.OBJECT) {
         return WebDispatch(WebDispatchStatus.TYPED)
       }
+      if (args.size == 1 && isScalarSignalPayload(args.single().type)) {
+        return WebDispatch(WebDispatchStatus.TYPED)
+      }
       val limit =
-        if (args.size == 1) "Kotlin lambda callbacks take 0 arguments or 1 object handle"
+        if (args.size == 1)
+          "Kotlin lambda callbacks take 0 arguments, 1 packed scalar, or 1 object handle"
         else "Kotlin lambda callbacks accept at most 1 emitted argument"
       return WebDispatch(
         WebDispatchStatus.ARGUMENT_DROPPED,
@@ -759,6 +922,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendVector2iMethodDispatcher()
     appendObjectMethodDispatcher()
     appendObjectObjectLongMethodDispatcher()
+    appendNumericMethodDispatcher()
+    appendPackedReturnMethodDispatcher()
     appendLine("  private fun unknown(kind: String, id: Int): Nothing =")
     appendLine("    error(\"Unknown Kanama Web \$kind id=\$id\")")
     appendLine("}")
@@ -1165,6 +1330,57 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("      else -> unknown(\"script\", scriptId)")
     appendLine("    }")
     appendLine("  }")
+    appendLine()
+  }
+
+  /**
+   * Task 80 slice 2: every [WebMethodArm.NUMERIC_VOID] method, reached through one six-slot
+   * crossing. The arm table decides membership — this dispatcher never re-reads the shapes.
+   */
+  private fun StringBuilder.appendNumericMethodDispatcher() {
+    val slots = (0 until NUMERIC_ARG_SLOTS).joinToString(", ") { "a$it: Double" }
+    appendLine("  fun callDoubles(scriptId: Int, methodId: Int, script: KanamaWebScript, $slots) {")
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (methodId) {")
+      input.model.methods.forEachIndexed { methodIndex, method ->
+        if (methodArm(method) == WebMethodArm.NUMERIC_VOID) {
+          val arguments = numericArgKotlinExpressions(method.args).joinToString(", ")
+          appendLine(
+            "        ${methodIndex + 1} -> (script as ${input.model.simpleName}).${method.kotlinName}($arguments)"
+          )
+        }
+      }
+      appendLine("        else -> unknown(\"method\", methodId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
+    appendLine("  }")
+    appendLine()
+  }
+
+  /**
+   * Task 80 slice 2: every [WebMethodArm.PACKED_RETURN] method. The returned value is packed with
+   * the same encoding `getPackedProperty` uses and parsed by the proxy per its declared type.
+   */
+  private fun StringBuilder.appendPackedReturnMethodDispatcher() {
+    appendLine("  fun callPacked(scriptId: Int, methodId: Int, script: KanamaWebScript): String =")
+    appendLine("    when (scriptId) {")
+    scripts.forEachIndexed { scriptIndex, input ->
+      appendLine("      ${scriptIndex + 1} -> when (methodId) {")
+      input.model.methods.forEachIndexed { methodIndex, method ->
+        if (methodArm(method) == WebMethodArm.PACKED_RETURN) {
+          val access = "(script as ${input.model.simpleName}).${method.kotlinName}()"
+          val returnType = checkNotNull(method.returnType) { "PACKED_RETURN needs a return type" }
+          appendLine("        ${methodIndex + 1} -> ${packedReturnExpression(access, returnType)}")
+        }
+      }
+      appendLine("        else -> unknown(\"method\", methodId)")
+      appendLine("      }")
+    }
+    appendLine("      else -> unknown(\"script\", scriptId)")
+    appendLine("    }")
     appendLine()
   }
 
@@ -3110,9 +3326,29 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("func $SIGNAL_DISPATCH_ZERO(callback_id: int) -> void:")
     appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
     appendLine()
-    appendLine("func $SIGNAL_DISPATCH_ONE(_arg: Variant, callback_id: int) -> void:")
-    appendLine("\t# One emitted argument, dropped by the Kotlin callback: rides the zero-arg path.")
-    appendLine("\t_kanama_bridge.dispatchSignal0(_kanama_handle, callback_id)")
+    appendLine("func $SIGNAL_DISPATCH_ONE(arg: Variant, callback_id: int) -> void:")
+    appendLine(
+      "\t# Task 80 slice 2: the emitted scalar crosses PACKED, so a typed GodotSignal.connect*"
+    )
+    appendLine(
+      "\t# overload receives it. A zero-argument Kotlin lambda ignores the payload as before."
+    )
+    appendLine(
+      "\t_kanama_bridge.dispatchSignal1(_kanama_handle, callback_id, $SIGNAL_PACK_ARG(arg))"
+    )
+    appendLine()
+    appendLine("func $SIGNAL_PACK_ARG(arg: Variant) -> String:")
+    appendLine("\tmatch typeof(arg):")
+    appendLine("\t\tTYPE_NIL:")
+    appendLine("\t\t\treturn \"\"")
+    appendLine("\t\tTYPE_BOOL:")
+    appendLine("\t\t\treturn \"1\" if arg else \"0\"")
+    appendLine("\t\tTYPE_VECTOR2, TYPE_VECTOR2I:")
+    appendLine("\t\t\treturn \"%s,%s\" % [arg.x, arg.y]")
+    appendLine("\t\tTYPE_VECTOR3, TYPE_VECTOR3I:")
+    appendLine("\t\t\treturn \"%s,%s,%s\" % [arg.x, arg.y, arg.z]")
+    appendLine("\t\t_:")
+    appendLine("\t\t\treturn str(arg)")
     appendLine()
     appendLine("func $SIGNAL_DISPATCH_OBJECT(arg: Variant, callback_id: int) -> void:")
     appendLine("\tvar script_arg_handle := 0")
@@ -3928,6 +4164,24 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           appendLine("\t_kanama_bridge.releaseTransientObjectHandle(first_handle)")
           appendLine("\t_kanama_bridge.releaseTransientObjectHandle(second_handle)")
         }
+        WebMethodArm.NUMERIC_VOID -> {
+          // Task 80 slice 2: every all-numeric argument list flattens into the same six-slot
+          // crossing. Unused slots carry 0.0 so the bridge entry point keeps one fixed arity.
+          val slots = numericArgSlotExpressions(method.args)
+          val padded = slots + List(NUMERIC_ARG_SLOTS - slots.size) { "0.0" }
+          appendLine(
+            "\t_kanama_bridge.callDoubles(_kanama_handle, ${index + 1}, ${padded.joinToString(", ")})"
+          )
+        }
+        WebMethodArm.PACKED_RETURN -> {
+          // Task 80 slice 2: the return value crosses packed into one string with the same
+          // encoding getPackedProperty uses, and is parsed here per the declared return type.
+          val returnType = checkNotNull(method.returnType) { "PACKED_RETURN needs a return type" }
+          appendLine(
+            "\tvar _kanama_packed := String(_kanama_bridge.callPacked(_kanama_handle, ${index + 1}))"
+          )
+          appendPackedReturnParse(returnType)
+        }
         // Task 80: this stub throws at runtime, and the manifest + build report now say so.
         WebMethodArm.NONE -> {
           appendLine(
@@ -3936,6 +4190,49 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           method.returnType?.let { appendLine("\treturn ${gdDefault(it)}") }
         }
       }
+    }
+  }
+
+  /**
+   * Parses the `callPacked` transport string into the declared return type and returns it. Mirror
+   * of [packedReturnExpression] and of the property pull parser — one encoding, parsed the same way
+   * on both channels.
+   */
+  private fun StringBuilder.appendPackedReturnParse(type: TypeMapping) {
+    when (type) {
+      TypeMapping.STRING -> appendLine("\treturn _kanama_packed")
+      TypeMapping.NODE_PATH -> appendLine("\treturn NodePath(_kanama_packed)")
+      TypeMapping.INT -> appendLine("\treturn int(_kanama_packed)")
+      TypeMapping.FLOAT -> appendLine("\treturn float(_kanama_packed)")
+      TypeMapping.BOOL -> appendLine("\treturn _kanama_packed == \"1\"")
+      TypeMapping.VECTOR2 -> {
+        appendLine("\tvar _kanama_parts := _kanama_packed.split_floats(\",\")")
+        appendLine("\treturn Vector2(_kanama_parts[0], _kanama_parts[1])")
+      }
+      TypeMapping.VECTOR2I -> {
+        appendLine("\tvar _kanama_parts := _kanama_packed.split(\",\")")
+        appendLine("\treturn Vector2i(int(_kanama_parts[0]), int(_kanama_parts[1]))")
+      }
+      TypeMapping.VECTOR3 -> {
+        appendLine("\tvar _kanama_parts := _kanama_packed.split_floats(\",\")")
+        appendLine("\treturn Vector3(_kanama_parts[0], _kanama_parts[1], _kanama_parts[2])")
+      }
+      TypeMapping.QUATERNION -> {
+        appendLine("\tvar _kanama_parts := _kanama_packed.split_floats(\",\")")
+        appendLine(
+          "\treturn Quaternion(_kanama_parts[0], _kanama_parts[1], _kanama_parts[2], _kanama_parts[3])"
+        )
+      }
+      TypeMapping.BASIS -> {
+        appendLine("\tvar _kanama_parts := _kanama_packed.split_floats(\",\")")
+        appendLine("\t# Packed as the three basis COLUMNS, which is Basis(x_axis, y_axis, z_axis).")
+        appendLine(
+          "\treturn Basis(Vector3(_kanama_parts[0], _kanama_parts[1], _kanama_parts[2]), " +
+            "Vector3(_kanama_parts[3], _kanama_parts[4], _kanama_parts[5]), " +
+            "Vector3(_kanama_parts[6], _kanama_parts[7], _kanama_parts[8]))"
+        )
+      }
+      else -> error("no packed return parse for ${type.name}")
     }
   }
 

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 16"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 17"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -420,7 +420,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 16"))
+    assertTrue(protocol.contains("\"protocolVersion\": 17"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -431,7 +431,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=16\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=17\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -775,12 +775,16 @@ class WebScriptCodeEmitterTest {
     assertTrue(WebScriptCodeEmitter.unsupportedWebPropertyErrors(unknownHint, emptyMap()).isEmpty())
   }
 
-  // ---------- Task 80 slice 1: the generator declares its own degradations ----------
+  // ---------- Task 80: the generator declares its own degradations, and fills them ----------
 
   /**
-   * The degradation fixture: one method per interesting arm plus the two signal shapes. `damage` is
-   * fps's real hole (task 79) — a single Double argument has no arm, so the proxy emits a stub that
-   * throws.
+   * The dispatch fixture: one method per interesting arm plus the three signal shapes.
+   *
+   * `damage(Double)` is fps's real hole (task 79) and `knockback(Vector3, Vector3)` third-person's;
+   * both ride the slice-2 numeric crossing now. `aim_target`/`current_health` are the whole
+   * value-returning category, which had no arm at all. `retarget(String, Object)` is match3's shape
+   * and is deliberately NOT filled by slice 2 — it stays in the census with its reason, so the
+   * fixture keeps proving that an unfilled shape is still declared rather than hidden.
    */
   private fun task80Model() =
     ScriptModel(
@@ -817,33 +821,85 @@ class WebScriptCodeEmitterTest {
             args = emptyList(),
             kind = MethodKind.REGULAR,
           ),
+          MethodModel(
+            kotlinName = "knockback",
+            godotName = "knockback",
+            returnType = null,
+            args =
+              listOf(
+                ArgModel("impactPoint", TypeMapping.VECTOR3),
+                ArgModel("force", TypeMapping.VECTOR3),
+              ),
+            kind = MethodKind.REGULAR,
+          ),
+          MethodModel(
+            kotlinName = "setStunned",
+            godotName = "set_stunned",
+            returnType = null,
+            args = listOf(ArgModel("stunned", TypeMapping.BOOL)),
+            kind = MethodKind.REGULAR,
+          ),
+          MethodModel(
+            kotlinName = "aimTarget",
+            godotName = "aim_target",
+            returnType = TypeMapping.VECTOR3,
+            args = emptyList(),
+            kind = MethodKind.REGULAR,
+          ),
+          MethodModel(
+            kotlinName = "currentHealth",
+            godotName = "current_health",
+            returnType = TypeMapping.FLOAT,
+            args = emptyList(),
+            kind = MethodKind.REGULAR,
+          ),
+          MethodModel(
+            kotlinName = "retarget",
+            godotName = "retarget",
+            returnType = null,
+            args =
+              listOf(
+                ArgModel("tag", TypeMapping.STRING),
+                ArgModel("node", TypeMapping.OBJECT, "net.multigesture.kanama.api.GodotObject"),
+              ),
+            kind = MethodKind.REGULAR,
+          ),
         ),
       signals =
         listOf(
           SignalModel("died", emptyList()),
           SignalModel("hurt", listOf(ArgModel("amount", TypeMapping.FLOAT))),
+          SignalModel(
+            "scored",
+            listOf(ArgModel("points", TypeMapping.INT), ArgModel("combo", TypeMapping.INT)),
+          ),
         ),
     )
 
+  private fun task80Proxy(): String =
+    WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
+      .proxySources()
+      .single { it.sourceResourcePath.isNotEmpty() }
+      .source
+
   @Test
   fun declaresUnsupportedDispatchForAMethodArgumentWithNoArm() {
-    val method = task80Model().methods.single { it.godotName == "damage" }
+    // Slice 2 deliberately did not fill (STRING, OBJECT) -> void: it mixes the string and the
+    // object-handle channels, and the census keeps declaring it rather than dropping it.
+    val method = task80Model().methods.single { it.godotName == "retarget" }
     val dispatch = WebScriptCodeEmitter.methodDispatch(method)
 
     assertEquals(WebMethodArm.NONE, WebScriptCodeEmitter.methodArm(method))
     assertEquals(WebDispatchStatus.UNSUPPORTED, dispatch.status)
     assertEquals("unsupported", dispatch.status.json)
     // The reason must name the shape that has no arm, not just say "unsupported".
-    assertTrue(dispatch.reason!!.contains("(FLOAT) -> void"), dispatch.reason!!)
+    assertTrue(dispatch.reason!!.contains("(STRING, OBJECT) -> void"), dispatch.reason!!)
     assertTrue(dispatch.reason!!.contains("throws"), dispatch.reason!!)
 
     // The claim behind the status: this is exactly the arm that emits the throwing stub.
-    val proxy =
-      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
-        .proxySources()
-        .single { it.sourceResourcePath.isNotEmpty() }
-        .source
-    assertTrue(proxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 1, \"damage\")"))
+    assertTrue(
+      task80Proxy().contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 7, \"retarget\")")
+    )
   }
 
   @Test
@@ -856,18 +912,183 @@ class WebScriptCodeEmitterTest {
     assertEquals(null, dispatch.reason, "a typed entry carries no dispatchReason")
   }
 
+  // ---------- Task 80 slice 2: the numeric crossing ----------
+
   @Test
-  fun declaresArgumentDroppedForAScalarSignalPayload() {
-    // A Kotlin lambda connect binds _kanama_web_signal_dispatch1, whose emitted body discards the
-    // argument, so a scalar payload never reaches the callback.
-    val dropped =
+  fun dispatchesASingleFloatArgumentThroughTheNumericCrossing() {
+    // Task 79's exact bug: fps Enemy.damage(amount: Double) used to emit a throwing stub.
+    val method = task80Model().methods.single { it.godotName == "damage" }
+    assertEquals(WebMethodArm.NUMERIC_VOID, WebScriptCodeEmitter.methodArm(method))
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(method).status)
+    assertEquals(null, WebScriptCodeEmitter.methodDispatch(method).reason)
+
+    val proxy = task80Proxy()
+    assertTrue(proxy.contains("func damage(amount: float) -> void:"), proxy)
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.callDoubles(_kanama_handle, 1, amount, 0.0, 0.0, 0.0, 0.0, 0.0)"
+      ),
+      proxy,
+    )
+    assertFalse(proxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 1,"), proxy)
+
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt"))).registrySource()
+    assertTrue(
+      registry.contains(
+        "fun callDoubles(scriptId: Int, methodId: Int, script: KanamaWebScript, " +
+          "a0: Double, a1: Double, a2: Double, a3: Double, a4: Double, a5: Double)"
+      ),
+      registry,
+    )
+    assertTrue(registry.contains("1 -> (script as Enemy).damage(a0)"), registry)
+  }
+
+  @Test
+  fun dispatchesAVector3PairAndABooleanThroughTheNumericCrossing() {
+    // third-person's body.call("damage", impactPoint, force) shape, and the (BOOL) bucket.
+    val pair = task80Model().methods.single { it.godotName == "knockback" }
+    val flag = task80Model().methods.single { it.godotName == "set_stunned" }
+    assertEquals(WebMethodArm.NUMERIC_VOID, WebScriptCodeEmitter.methodArm(pair))
+    assertEquals(WebMethodArm.NUMERIC_VOID, WebScriptCodeEmitter.methodArm(flag))
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(pair).status)
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(flag).status)
+
+    val proxy = task80Proxy()
+    // Six slots is exactly one Vector3 pair -- nothing is padded away.
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.callDoubles(_kanama_handle, 3, impactPoint.x, impactPoint.y, " +
+          "impactPoint.z, force.x, force.y, force.z)"
+      ),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.callDoubles(_kanama_handle, 4, float(stunned), 0.0, 0.0, 0.0, 0.0, 0.0)"
+      ),
+      proxy,
+    )
+
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt"))).registrySource()
+    assertTrue(
+      registry.contains(
+        "3 -> (script as Enemy).knockback(net.multigesture.kanama.types.Vector3(a0, a1, a2), " +
+          "net.multigesture.kanama.types.Vector3(a3, a4, a5))"
+      ),
+      registry,
+    )
+    assertTrue(registry.contains("4 -> (script as Enemy).setStunned(a0 != 0.0)"), registry)
+  }
+
+  @Test
+  fun rejectsAnArgumentListWiderThanTheNumericSlots() {
+    // Seven components is one past the six-slot crossing: no arm, and the census says why.
+    val wide =
+      MethodModel(
+        kotlinName = "wide",
+        godotName = "wide",
+        returnType = null,
+        args =
+          listOf(
+            ArgModel("a", TypeMapping.VECTOR3),
+            ArgModel("b", TypeMapping.VECTOR3),
+            ArgModel("c", TypeMapping.FLOAT),
+          ),
+        kind = MethodKind.REGULAR,
+      )
+    assertEquals(null, WebScriptCodeEmitter.numericArgSlots(wide.args))
+    assertEquals(WebMethodArm.NONE, WebScriptCodeEmitter.methodArm(wide))
+    assertTrue(
+      WebScriptCodeEmitter.methodDispatch(wide)
+        .reason!!
+        .contains("(VECTOR3, VECTOR3, FLOAT) -> void")
+    )
+  }
+
+  // ---------- Task 80 slice 2: value-returning methods ----------
+
+  @Test
+  fun dispatchesValueReturningMethodsThroughThePackedCrossing() {
+    val vector = task80Model().methods.single { it.godotName == "aim_target" }
+    val scalar = task80Model().methods.single { it.godotName == "current_health" }
+    assertEquals(WebMethodArm.PACKED_RETURN, WebScriptCodeEmitter.methodArm(vector))
+    assertEquals(WebMethodArm.PACKED_RETURN, WebScriptCodeEmitter.methodArm(scalar))
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(vector).status)
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(scalar).status)
+
+    val proxy = task80Proxy()
+    assertTrue(
+      proxy.contains("var _kanama_packed := String(_kanama_bridge.callPacked(_kanama_handle, 5))"),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains("return Vector3(_kanama_parts[0], _kanama_parts[1], _kanama_parts[2])"),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains("var _kanama_packed := String(_kanama_bridge.callPacked(_kanama_handle, 6))"),
+      proxy,
+    )
+    assertTrue(proxy.contains("return float(_kanama_packed)"), proxy)
+
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt"))).registrySource()
+    assertTrue(
+      registry.contains(
+        "fun callPacked(scriptId: Int, methodId: Int, script: KanamaWebScript): String ="
+      ),
+      registry,
+    )
+    assertTrue(
+      registry.contains(
+        "5 -> (script as Enemy).aimTarget().let { \"\${it.x},\${it.y},\${it.z}\" }"
+      ),
+      registry,
+    )
+    assertTrue(registry.contains("6 -> (script as Enemy).currentHealth().toString()"), registry)
+  }
+
+  @Test
+  fun packsEveryValueReturnTypeTheCrossingClaims() {
+    // The packed channel is only honest if every type it claims has both an encode and a parse.
+    fun armFor(type: TypeMapping) =
+      WebScriptCodeEmitter.methodArm(
+        MethodModel("probe", "probe", type, emptyList(), MethodKind.REGULAR)
+      )
+    listOf(
+        TypeMapping.STRING,
+        TypeMapping.NODE_PATH,
+        TypeMapping.INT,
+        TypeMapping.FLOAT,
+        TypeMapping.BOOL,
+        TypeMapping.VECTOR2,
+        TypeMapping.VECTOR2I,
+        TypeMapping.VECTOR3,
+        TypeMapping.QUATERNION,
+        TypeMapping.BASIS,
+      )
+      .forEach { type ->
+        assertTrue(WebScriptCodeEmitter.isPackedReturn(type), type.name)
+        assertEquals(WebMethodArm.PACKED_RETURN, armFor(type), type.name)
+      }
+    // An object return still needs handle bookkeeping: no arm, declared in the census.
+    assertFalse(WebScriptCodeEmitter.isPackedReturn(TypeMapping.OBJECT))
+    assertEquals(WebMethodArm.NONE, armFor(TypeMapping.OBJECT))
+  }
+
+  // ---------- Task 80 slice 2: signal payload delivery ----------
+
+  @Test
+  fun deliversScalarSignalPayloadsAndStillDropsMultiArgumentOnes() {
+    // Slice 2: one emitted scalar now crosses PACKED, so the declared payload does reach Kotlin.
+    val scalar =
       WebScriptCodeEmitter.signalDispatch(
         SignalModel("hurt", listOf(ArgModel("amount", TypeMapping.FLOAT)))
       )
-    assertEquals(WebDispatchStatus.ARGUMENT_DROPPED, dropped.status)
-    assertEquals("argument-dropped", dropped.status.json)
-    assertTrue(dropped.reason!!.contains("signal payload dropped"), dropped.reason!!)
-    assertTrue(dropped.reason!!.contains("(FLOAT)"), dropped.reason!!)
+    assertEquals(WebDispatchStatus.TYPED, scalar.status)
+    assertEquals(null, scalar.reason)
 
     // Zero-argument signals ride dispatch0 intact; a lone object argument rides
     // dispatch_object as a handle. Neither is a degradation.
@@ -896,7 +1117,39 @@ class WebScriptCodeEmitterTest {
         )
       )
     assertEquals(WebDispatchStatus.ARGUMENT_DROPPED, multi.status)
+    assertEquals("argument-dropped", multi.status.json)
     assertTrue(multi.reason!!.contains("at most 1 emitted argument"), multi.reason!!)
+
+    // A single payload outside the scalar set still drops, and says which type.
+    val array =
+      WebScriptCodeEmitter.signalDispatch(
+        SignalModel("loaded", listOf(ArgModel("items", TypeMapping.ARRAY)))
+      )
+    assertEquals(WebDispatchStatus.ARGUMENT_DROPPED, array.status)
+    assertTrue(array.reason!!.contains("(ARRAY)"), array.reason!!)
+  }
+
+  @Test
+  fun emitsAPackingSignalDeliveryHelper() {
+    val proxy = task80Proxy()
+    // The one-argument helper carries the payload instead of discarding it.
+    assertTrue(
+      proxy.contains("func _kanama_web_signal_dispatch1(arg: Variant, callback_id: int) -> void:"),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.dispatchSignal1(_kanama_handle, callback_id, " +
+          "_kanama_web_pack_signal_arg(arg))"
+      ),
+      proxy,
+    )
+    assertFalse(proxy.contains("dropped by the Kotlin callback"), proxy)
+    // The packer must agree with the property/return encoding for every scalar it claims.
+    assertTrue(proxy.contains("func _kanama_web_pack_signal_arg(arg: Variant) -> String:"), proxy)
+    assertTrue(proxy.contains("\t\t\treturn \"1\" if arg else \"0\""), proxy)
+    assertTrue(proxy.contains("\t\t\treturn \"%s,%s\" % [arg.x, arg.y]"), proxy)
+    assertTrue(proxy.contains("\t\t\treturn \"%s,%s,%s\" % [arg.x, arg.y, arg.z]"), proxy)
   }
 
   @Test
@@ -904,17 +1157,36 @@ class WebScriptCodeEmitterTest {
     val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
     val protocol = emitter.protocolManifest()
 
-    // The manifest shape changed, so its own schemaVersion moved -- but the bridge contract did
-    // not, so the protocol version must not.
+    // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
+    // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 16"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 17"), protocol)
 
+    // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(
       protocol.contains(
         "\"name\": \"damage\", \"arguments\": [{\"name\": \"amount\", " +
           "\"type\": \"Double\", \"nullable\": false, \"hasDefault\": false}], " +
-          "\"returnType\": null, \"dispatch\": \"unsupported\", \"dispatchReason\": \"no arm " +
-          "for the registered-method shape (FLOAT) -> void; the proxy emits a stub that throws\""
+          "\"returnType\": null, \"dispatch\": \"typed\"}"
+      ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains("\"name\": \"knockback\"") &&
+        protocol.contains("\"returnType\": null, \"dispatch\": \"typed\"}"),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains(
+        "\"name\": \"aim_target\", \"arguments\": [], " +
+          "\"returnType\": \"net.multigesture.kanama.types.Vector3\", \"dispatch\": \"typed\"}"
+      ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains(
+        "\"name\": \"current_health\", \"arguments\": [], \"returnType\": \"Double\", " +
+          "\"dispatch\": \"typed\"}"
       ),
       protocol,
     )
@@ -928,9 +1200,26 @@ class WebScriptCodeEmitterTest {
       protocol.contains("\"name\": \"died\", \"arguments\": [], \"dispatch\": \"typed\"}"),
       protocol,
     )
+    // The scalar signal payload is delivered now; only the two-argument one still drops.
     assertTrue(
       protocol.contains("\"name\": \"hurt\"") &&
+        protocol.contains(
+          "{\"name\": \"amount\", \"type\": \"Double\", \"nullable\": false, " +
+            "\"hasDefault\": false}], \"dispatch\": \"typed\"}"
+        ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains("\"name\": \"scored\"") &&
         protocol.contains("\"dispatch\": \"argument-dropped\", \"dispatchReason\": \"signal "),
+      protocol,
+    )
+    // The shape slice 2 deliberately left unfilled is still declared, with its reason.
+    assertTrue(
+      protocol.contains(
+        "\"dispatch\": \"unsupported\", \"dispatchReason\": \"no arm for the registered-method " +
+          "shape (STRING, OBJECT) -> void; the proxy emits a stub that throws\""
+      ),
       protocol,
     )
     // Properties and dispatched virtuals are guarded elsewhere (#148 / 66a) and must read typed.
@@ -944,7 +1233,7 @@ class WebScriptCodeEmitterTest {
     assertEquals(
       2,
       Regex("\"dispatchReason\"").findAll(protocol).count(),
-      "only the two degraded entries may carry a reason",
+      "only the two remaining degraded entries may carry a reason",
     )
   }
 
@@ -955,25 +1244,25 @@ class WebScriptCodeEmitterTest {
     val degradations = emitter.degradations()
     assertEquals(2, degradations.size, degradations.toString())
     assertEquals(
-      listOf("Enemy.damage (method)", "Enemy.hurt (signal)"),
+      listOf("Enemy.retarget (method)", "Enemy.scored (signal)"),
       degradations.map { "${it.scriptName}.${it.memberName} (${it.kind})" },
     )
-    // 1 property + 1 virtual + 2 methods + 2 signals.
-    assertEquals(6, emitter.memberCount())
+    // 1 property + 1 virtual + 7 methods + 3 signals.
+    assertEquals(12, emitter.memberCount())
 
     val report = emitter.degradationReport()
     assertTrue(
-      report.first().contains("2 of 6 declared member(s) across 1 script(s)"),
+      report.first().contains("2 of 12 declared member(s) across 1 script(s)"),
       report.first(),
     )
     assertTrue(report.first().contains("method 1, signal 1, property 0, virtual 0"), report.first())
-    assertTrue(report.any { it.contains("Enemy.damage (method): no arm for") }, report.toString())
+    assertTrue(report.any { it.contains("Enemy.retarget (method): no arm for") }, report.toString())
     assertTrue(
-      report.any { it.contains("Enemy.hurt (signal): signal payload dropped") },
+      report.any { it.contains("Enemy.scored (signal): signal payload dropped") },
       report.toString(),
     )
 
-    // Slice 1 is non-fatal on purpose: a degradation must never become a build error here.
+    // Still non-fatal: the hard gate is slice 3, and it cannot land while any shape is unfilled.
     assertTrue(
       WebScriptCodeEmitter.unsupportedWebPropertyErrors(task80Model(), webOptions).isEmpty()
     )
@@ -985,8 +1274,8 @@ class WebScriptCodeEmitterTest {
     val typed =
       task80Model()
         .copy(
-          methods = task80Model().methods.filter { it.godotName == "die" },
-          signals = task80Model().signals.filter { it.godotName == "died" },
+          methods = task80Model().methods.filter { it.godotName != "retarget" },
+          signals = task80Model().signals.filter { it.godotName != "scored" },
         )
     val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(typed, "res://Enemy.kt")))
 

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -178,7 +178,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -254,7 +254,7 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeCitybuilder: ready.mode === "citybuilder",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
     // Injected build placed a structure on the grid at the mouse-ray cell.

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -262,7 +262,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -137,7 +137,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -4,9 +4,10 @@
 // the weapon-swap tween chain from _process (change_weapon hydrates the Weapon resources,
 // instantiates the weapon model, and sets the crosshair texture), enemies bob in _process
 // and return fire at the Player through their RayCast3D on a timer, and the Kanama-scripted
-// Audio autoload pumps its pooled players. This driver OBSERVES the first scene generation
-// (no input, so no reload path), then triggers Smoke.smoke_teardown — which frees the Audio
-// autoload and the scene root — and polls live handles to zero.
+// Audio autoload pumps its pooled players. This driver OBSERVES the first scene generation,
+// then FIGHTS (tasks 79 / 80 slice 2: it shoots an enemy dead, which is the only automated
+// coverage the player->enemy damage path has ever had), then triggers Smoke.smoke_teardown —
+// which frees the Audio autoload and the scene root — and polls live handles to zero.
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
@@ -24,6 +25,10 @@ async function snapshot(evaluate) {
         const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
         return entry?.[1] ?? 0;
       };
+      const liveCount = (suffix) => {
+        const entry = Object.entries(bridge.liveScriptsByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
       return {
         mode: bridge.mode,
         protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
@@ -35,6 +40,10 @@ async function snapshot(evaluate) {
         hudReady: classCount(".Hud"),
         audioReady: classCount(".Audio"),
         enemyReady: classCount(".Enemy"),
+        // LIVE, not cumulative: liveScriptsByClass decrements on the _exit_tree free, which is
+        // what lets the combat gate below see an enemy actually die.
+        enemyLive: liveCount(".Enemy"),
+        doubleArgCalls: bridge.doubleArgCalls ?? 0,
         weaponInstantiations: bridge.match3PackedSceneInstantiations,
         processCalls: bridge.processCalls,
         appliedCommands: bridge.appliedCommands,
@@ -124,6 +133,77 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const atPeak = gameplay.last ?? ready;
   trace(`gameplay: process=${peak.processCalls} weapons=${peak.weaponInstantiations} live=${atPeak.liveHandles}`);
 
+  // --- Combat: shoot an enemy dead (tasks 79 / 80 slice 2) --------------------------
+  //
+  // This is the assertion the whole parcel exists for. The damage path is
+  //   Player.actionShoot -> collider.call("damage", weapon.damage)  (Kotlin)
+  //     -> the enemy's GDScript proxy `func damage(amount: float)`
+  //       -> _kanama_bridge.callDoubles -> Kotlin Enemy.damage
+  // and the middle step used to emit `unsupportedGameplayMethod`, which threw. FPS enemies
+  // were therefore immortal on Web, and no gate noticed because this driver never fired a shot.
+  //
+  // Everything below is ENGINE-LEVEL injection, the same transport racing/thirdperson/tpsdemo
+  // already use, because browser key synthesis stalls headless Firefox and SafariDriver has no
+  // `keys` transport at all:
+  //   * ops 142/143 set the Player's global_position and global_rotation, which carry the
+  //     Head/Camera/RayCast with them. `shoot` is bound to mouse button 1 and mouse LOOK is a
+  //     motion event no injected ACTION can express, so the stance is set rather than steered.
+  //   * ops 86/87 press and release the `shoot` action Player.kt reads through
+  //     Input.isActionPressed("shoot").
+  // The SHOT is entirely real: real RayCast3D, real collider, real call("damage", float), real
+  // Kotlin Enemy.damage, real queue_free. Only the stance is placed.
+  //
+  // The stance must be re-issued every poll, and that is not tidiness -- the blaster's knockback
+  // is 40 and `movementVelocity += Vector3(0, 0, knockback)` throws the Player backwards several
+  // metres per volley, off the level and into Player.process's `position.y < -10` scene reload.
+  // Pinning the stance each poll is what makes the burst repeatable instead of a slingshot.
+  //
+  // Stance: `Enemies/enemy-flying` in scenes/main.tscn sits at (-3.5, 2.5, -6) and its
+  // CollisionShape3D sphere (r = 0.75) centres 0.25 higher. The Player's camera rides one metre
+  // above its root (Head at local y=1), so a root at (-3.5, 1.75, -3) with zero rotation puts the
+  // camera exactly 3 m from that sphere centre along -Z. The blaster's spread cone is +/-1.0 at
+  // the 10 m ray end, i.e. +/-0.3 m at 3 m -- inside the sphere, so every one of the three shots
+  // per 0.25 s volley connects for 25 damage and the 100-health enemy dies in two volleys.
+  const STANCE_POSITION = [-3.5, 1.75, -3];
+  const objectQuery = (opcode, payload) =>
+    evaluate(
+      `globalThis.KanamaWebBridge.immediateObjectQuery(${opcode}, globalThis.KanamaWebBridge.fpsPlayerHandle, ${payload}); true`,
+    );
+  const takeStance = async () => {
+    await objectQuery(142, `[${STANCE_POSITION.join(", ")}].join(String.fromCharCode(31))`);
+    await objectQuery(143, "[0, 0, 0].join(String.fromCharCode(31))");
+  };
+  const shootAction = (opcode) => objectQuery(opcode, '"shoot"');
+
+  const enemiesBefore = atPeak.enemyLive;
+  trace(`combat: taking stance, enemiesBefore=${enemiesBefore}`);
+  await takeStance();
+  await shootAction(86);
+  const combatDeadline = Math.min(deadline, Date.now() + 25_000);
+  let enemiesAfter = enemiesBefore;
+  let combatSnap = atPeak;
+  while (Date.now() < combatDeadline) {
+    await takeStance();
+    await delay(80);
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      combatSnap = snap;
+      enemiesAfter = snap.enemyLive;
+      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+      trace(
+        `combat: enemies=${snap.enemyLive} damageCalls=${snap.doubleArgCalls} ` +
+          `ready=${snap.readyCount} impacts=${snap.weaponInstantiations} errs=${snap.callbackErrors}`,
+      );
+      if (snap.enemyLive < enemiesBefore) break;
+    }
+  }
+  await shootAction(87);
+  trace(`combat: enemiesBefore=${enemiesBefore} enemiesAfter=${enemiesAfter}`);
+  peak.maxLiveHandles = Math.max(peak.maxLiveHandles, combatSnap.maxLiveHandles ?? 0);
+  peak.crossings = Math.max(peak.crossings, combatSnap.crossings ?? 0);
+  peak.processCalls = Math.max(peak.processCalls, combatSnap.processCalls ?? 0);
+  peak.appliedCommands = Math.max(peak.appliedCommands, combatSnap.appliedCommands ?? 0);
+
   // Full teardown: Smoke.smoke_teardown (method#1 on the scene root's script) frees the
   // Audio autoload and the scene root, draining every live handle to zero.
   trace("smoke_teardown");
@@ -146,6 +226,10 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
       ready.enemyReady >= 1,
     // change_weapon ran: the hydrated Weapon resource instantiated its model scene.
     weaponModelInstantiated: peak.weaponInstantiations >= 1,
+    // Tasks 79 / 80 slice 2: a shot reached Kotlin's Enemy.damage through the enemy's GDScript
+    // proxy, health fell past zero, and destroy() queue_free'd the enemy. Before slice 2 the
+    // proxy's damage(amount: float) threw and enemies were immortal on Web.
+    enemyKilledByPlayerShot: enemiesBefore >= 1 && enemiesAfter < enemiesBefore,
     processFramesAdvanced: peak.processCalls >= ready.processCalls + 120,
     gameplayCommandsApplied: peak.appliedCommands > ready.appliedCommands,
     crossingsAdvanced: peak.crossings > ready.crossings,
@@ -178,6 +262,11 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
       processCalls: peak.processCalls,
       weaponInstantiations: peak.weaponInstantiations,
       appliedCommands: peak.appliedCommands,
+      enemiesBeforeShooting: enemiesBefore,
+      enemiesAfterShooting: enemiesAfter,
+      // Task 80 slice 2's new numeric crossing, counted: each one is a damage(float) that used
+      // to reach `unsupportedGameplayMethod` and throw.
+      numericMethodCrossings: combatSnap.doubleArgCalls ?? 0,
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -234,7 +234,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol16: firstRun.settled.protocol === 16 && secondRun.settled.protocol === 16,
+    protocol17: firstRun.settled.protocol === 17 && secondRun.settled.protocol === 17,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -192,7 +192,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -185,7 +185,7 @@ export async function runSoak({ url, evaluate, navigate, deadline }) {
 
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol16: ready.protocol === 16,
+    protocol17: ready.protocol === 17,
     // The run really lasted: several full rounds, and enough samples to judge.
     soakCyclesCompleted: cycles >= 2,
     soakSamplesCollected: samples.length >= 8,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -194,7 +194,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -221,7 +221,7 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
   const protocolVersion = menu.protocol;
   const checks = {
     modeTpsdemo: menu.mode === "tpsdemo",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     // The menu boots, and pressing Play streams the whole level in: the AnimationTree-driven
     // player, its input synchronizer, the shake camera, and the four red robots with their
     // detachable death parts.

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -116,6 +116,25 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   );
   trace(`propertyProbe: mask=${propertyProbe}`);
 
+  // Task 80 slice 2 dispatch-shape conformance: Main.dispatch_probe (method#16, Int->Int)
+  // returns a mask. Every bit is a shape slice 2 admitted, exercised through the REAL crossing
+  // (Kotlin asks Godot to call the method by name, Godot dispatches to the generated GDScript
+  // proxy, the proxy takes the new arm) rather than through the emitter tests alone:
+  //   1 = a (FLOAT) registered function received its argument -- task 79's exact hole
+  //   2 = a (BOOL) registered function received its argument
+  //   4 = a (VECTOR3, VECTOR3) registered function received BOTH vectors intact
+  //   8 = a () -> VECTOR3 return survived the packed transport AND the proxy's parse
+  //  16 = the () -> FLOAT / STRING / BOOL / INT returns did too
+  //  32 = a one-int signal payload reached a Kotlin lambda instead of being discarded
+  // A healthy run returns exactly 63. Values, not just dispatch: each bit compares the value
+  // that came back against the value that went out.
+  const dispatchProbe = Number(
+    await evaluate(
+      "globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, 16, 0)",
+    ),
+  );
+  trace(`dispatchProbe: mask=${dispatchProbe}`);
+
   // Observe the render running: the spinner's _process advances processCalls and its
   // Node3D.rotation mutations advance appliedCommands each frame.
   const seed = {
@@ -197,6 +216,8 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
     rangeHintPropertyPushed: (propertyProbe & 2) === 2,
     // Task 64: the pushed NodePath resolves a live node through the NodePath accessor overload.
     nodePathResolvesNode: (propertyProbe & 4) === 4,
+    // Task 80 slice 2: every admitted dispatch shape round-tripped its VALUE, not just its call.
+    dispatchShapesRoundTrip: dispatchProbe === 63,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,
     transformCommandsApplied: peak.appliedCommands >= ready.appliedCommands + 10,

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -184,7 +184,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol16: protocolVersion === 16,
+    protocol17: protocolVersion === 17,
     sceneReady: ready.mainReady >= 1,
     // 66b: the bridge crossing fired and the Kotlin @OnEnterTree body observed it.
     enterTreeDispatched: ready.enterTreeCalls >= 1 && (enterTreeProbe & 1) === 1,

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -34,6 +34,8 @@ import net.multigesture.kanama.backend.TweenBackendContractProbe
 import net.multigesture.kanama.types.Color
 import net.multigesture.kanama.types.Rect2
 import net.multigesture.kanama.types.Vector2
+import net.multigesture.kanama.types.Vector2i
+import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.webScriptInstance
 import net.multigesture.kanama.web.WebObjectId
 
@@ -72,6 +74,11 @@ internal object WebSignalCallbackRegistry {
     val oneShot: Boolean,
     val callback: (() -> Unit)? = null,
     val objectCallback: ((Int) -> Unit)? = null,
+    /**
+     * Task 80 slice 2: receives the emitted scalar payload as the proxy packed it. The typed
+     * `GodotSignal.connect*` overloads parse it back into the declared type.
+     */
+    val scalarCallback: ((String) -> Unit)? = null,
   )
 
   private var nextId = 1
@@ -104,6 +111,19 @@ internal object WebSignalCallbackRegistry {
     return id
   }
 
+  /** Registers a callback that wants the emitted scalar payload (task 80 slice 2). */
+  fun registerScalar(
+    ownerHandle: Int,
+    sourceHandle: Int,
+    oneShot: Boolean,
+    callback: (String) -> Unit,
+  ): Int {
+    check(nextId > 0) { "Kanama Web signal callback registry exhausted" }
+    val id = nextId++
+    entries[id] = Entry(ownerHandle, sourceHandle, oneShot, scalarCallback = callback)
+    return id
+  }
+
   fun unregister(id: Int) {
     entries.remove(id)
   }
@@ -122,6 +142,24 @@ internal object WebSignalCallbackRegistry {
       entry.callback ?: error("Kanama Web signal callback id=$id expects an emitted object")
     if (entry.oneShot) entries.remove(id)
     callback()
+  }
+
+  /**
+   * Delivers one emitted scalar payload (task 80 slice 2).
+   *
+   * A callback registered without a payload type still runs and simply ignores [packed] — that is
+   * what keeps `connect(target, argumentCount = 1) { ... }` and `await(target, 1)` working after
+   * the one-argument delivery helper started carrying the payload.
+   */
+  fun dispatchScalar(ownerHandle: Int, id: Int, packed: String) {
+    val entry = requireEntry(ownerHandle, id)
+    val scalar = entry.scalarCallback
+    val plain = entry.callback
+    if (scalar == null && plain == null) {
+      error("Kanama Web signal callback id=$id expects an emitted object")
+    }
+    if (entry.oneShot) entries.remove(id)
+    if (scalar != null) scalar(packed) else plain!!()
   }
 
   fun dispatchObject(ownerHandle: Int, id: Int, argHandle: Int) {
@@ -222,6 +260,89 @@ class GodotSignal internal constructor(private val owner: GodotObject, private v
     if (result != 0L) WebSignalCallbackRegistry.unregister(callbackId)
     return result
   }
+
+  /**
+   * Connects a one-argument scalar signal and DELIVERS the payload (task 80 slice 2).
+   *
+   * The proxy packs the emitted value into one string with the same encoding the property channel
+   * uses; [parse] turns it back into the declared type. The typed overloads below are the public
+   * surface — this is the shared plumbing.
+   */
+  private fun <T> connectScalar(
+    target: GodotObject,
+    flags: Long,
+    parse: (String) -> T,
+    callback: (T) -> Unit,
+  ): Long {
+    val callbackId =
+      WebSignalCallbackRegistry.registerScalar(
+        target.handle.value,
+        owner.handle.value,
+        oneShot = flags and GodotObject.CONNECT_ONE_SHOT != 0L,
+      ) { packed ->
+        callback(parse(packed))
+      }
+    val result =
+      SignalBackendContractProbe(owner.backendHandle)
+        .connectBound(
+          target.backendHandle,
+          name,
+          "_kanama_web_signal_dispatch1",
+          callbackId.toLong(),
+          flags,
+        )
+    if (result != 0L) WebSignalCallbackRegistry.unregister(callbackId)
+    return result
+  }
+
+  /** Connects a one-`int` signal, delivering the emitted value. */
+  fun connectLong(target: GodotObject, flags: Long = 0L, callback: (Long) -> Unit): Long =
+    connectScalar(target, flags, { it.trim().toLong() }, callback)
+
+  /** Connects a one-`float` signal, delivering the emitted value. */
+  fun connectDouble(target: GodotObject, flags: Long = 0L, callback: (Double) -> Unit): Long =
+    connectScalar(target, flags, { it.trim().toDouble() }, callback)
+
+  /** Connects a one-`bool` signal, delivering the emitted value. */
+  fun connectBoolean(target: GodotObject, flags: Long = 0L, callback: (Boolean) -> Unit): Long =
+    connectScalar(target, flags, { it == "1" }, callback)
+
+  /** Connects a one-`String` signal, delivering the emitted value. */
+  fun connectString(target: GodotObject, flags: Long = 0L, callback: (String) -> Unit): Long =
+    connectScalar(target, flags, { it }, callback)
+
+  /** Connects a one-`Vector2` signal, delivering the emitted value. */
+  fun connectVector2(target: GodotObject, flags: Long = 0L, callback: (Vector2) -> Unit): Long =
+    connectScalar(
+      target,
+      flags,
+      { packed -> packed.split(',').let { Vector2(it[0].toDouble(), it[1].toDouble()) } },
+      callback,
+    )
+
+  /** Connects a one-`Vector2i` signal, delivering the emitted value. */
+  fun connectVector2i(target: GodotObject, flags: Long = 0L, callback: (Vector2i) -> Unit): Long =
+    connectScalar(
+      target,
+      flags,
+      { packed ->
+        packed.split(',').let { Vector2i(it[0].trim().toInt(), it[1].trim().toInt()) }
+      },
+      callback,
+    )
+
+  /** Connects a one-`Vector3` signal, delivering the emitted value. */
+  fun connectVector3(target: GodotObject, flags: Long = 0L, callback: (Vector3) -> Unit): Long =
+    connectScalar(
+      target,
+      flags,
+      { packed ->
+        packed.split(',').let {
+          Vector3(it[0].toDouble(), it[1].toDouble(), it[2].toDouble())
+        }
+      },
+      callback,
+    )
 
   /**
    * Connects a one-argument object signal (e.g. body_entered). The emitted Godot object arrives

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -455,6 +455,51 @@ fun kanamaWebCallObject(objectId: Int, methodId: Int, argHandle: Int): Int {
   }
 }
 
+/**
+ * Task 80 slice 2: every all-numeric registered-method shape, flattened into six slots by the proxy
+ * and rebuilt by the generated dispatcher. Unused slots carry 0.0.
+ */
+@JsExport
+fun kanamaWebCallDoubles(
+  objectId: Int,
+  methodId: Int,
+  a0: Double,
+  a1: Double,
+  a2: Double,
+  a3: Double,
+  a4: Double,
+  a5: Double,
+): Int {
+  return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
+    KanamaWebProjectRegistry.callDoubles(
+      record.scriptId,
+      methodId,
+      record.script,
+      a0,
+      a1,
+      a2,
+      a3,
+      a4,
+      a5,
+    )
+    commands.flush()
+    1
+  }
+}
+
+/**
+ * Task 80 slice 2: a zero-argument value-returning registered method. The value comes back packed
+ * into one string (the `getPackedProperty` encoding) and the proxy parses it per declared type.
+ */
+@JsExport
+fun kanamaWebCallPacked(objectId: Int, methodId: Int): String {
+  return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
+    val packed = KanamaWebProjectRegistry.callPacked(record.scriptId, methodId, record.script)
+    commands.flush()
+    packed
+  }
+}
+
 @JsExport
 fun kanamaWebFree(objectId: Int): Int {
   return webCallbackBoundary(objectId, "_exit_tree") { record ->
@@ -523,6 +568,19 @@ fun kanamaWebMatch3Group6CancellationProbe(objectId: Int): Int {
 fun kanamaWebDispatchSignal0(objectId: Int, callbackId: Int): Int {
   return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch0") {
     WebSignalCallbackRegistry.dispatch(objectId, callbackId)
+    1
+  }
+}
+
+/**
+ * Task 80 slice 2: one emitted scalar signal payload, packed by the proxy. A callback registered
+ * without a payload type still runs — [WebSignalCallbackRegistry.dispatchScalar] falls back to the
+ * zero-argument callback — so this is a strict widening of the old `dispatchSignal0` path.
+ */
+@JsExport
+fun kanamaWebDispatchSignal1(objectId: Int, callbackId: Int, packed: String): Int {
+  return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch1") {
+    WebSignalCallbackRegistry.dispatchScalar(objectId, callbackId, packed)
     1
   }
 }

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -10,6 +10,7 @@ import net.multigesture.kanama.annotations.PropertyHint
 import net.multigesture.kanama.annotations.RegisterFunction
 import net.multigesture.kanama.annotations.ScriptClass
 import net.multigesture.kanama.annotations.ScriptProperty
+import net.multigesture.kanama.annotations.Signal
 import net.multigesture.kanama.api.AudioStreamPlayer
 import net.multigesture.kanama.api.CanvasLayer
 import net.multigesture.kanama.api.DirectionalLight3D
@@ -92,6 +93,7 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     }
 
     spinner = self.requireAs("Spinner", ::Node3D)
+    armSignalPayloadProbe()
   }
 
   @OnProcess
@@ -331,7 +333,127 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     return mask
   }
 
+  // ---------- Task 80 slice 2: dispatch-shape conformance probe ----------
+  //
+  // The shapes slice 2 admitted are exercised HERE, through the real crossing, because a shape
+  // that only the emitter tests cover is a shape nothing has ever actually run. Each probe method
+  // below is reached the way gameplay reaches one: Kotlin asks Godot to call it BY NAME, Godot
+  // dispatches to the generated GDScript proxy, and the proxy takes the new arm.
+  //
+  // This is the miniature of task 80's slice 4 (a backend conformance fixture): it catches what
+  // the manifest cannot, namely a shape that dispatches but delivers the WRONG VALUE.
+
+  @Signal("dispatch_probe_scalar") fun dispatchProbeScalar(value: Long) = Unit
+
+  private var probeFloatArgument = 0.0
+  private var probeBoolArgument = false
+  private var probeImpactSum = Vector3.ZERO
+  private var probeSignalPayload = -1L
+
+  @RegisterFunction("dispatch_probe_float")
+  fun dispatchProbeFloat(amount: Double) {
+    probeFloatArgument = amount
+  }
+
+  @RegisterFunction("dispatch_probe_bool")
+  fun dispatchProbeBool(flag: Boolean) {
+    probeBoolArgument = flag
+  }
+
+  /** The third-person `damage(impactPoint, force)` shape: six numeric slots, the widest one. */
+  @RegisterFunction("dispatch_probe_impact")
+  fun dispatchProbeImpact(impactPoint: Vector3, force: Vector3) {
+    probeImpactSum = impactPoint + force
+  }
+
+  @RegisterFunction("dispatch_probe_vector") fun dispatchProbeVector(): Vector3 = PROBE_VECTOR
+
+  @RegisterFunction("dispatch_probe_number") fun dispatchProbeNumber(): Double = PROBE_NUMBER
+
+  @RegisterFunction("dispatch_probe_text") fun dispatchProbeText(): String = PROBE_TEXT
+
+  @RegisterFunction("dispatch_probe_flag") fun dispatchProbeFlag(): Boolean = true
+
+  @RegisterFunction("dispatch_probe_count") fun dispatchProbeCount(): Long = PROBE_COUNT
+
+  /**
+   * Task-80 dispatch probe (driver method #16). Bits, all of which a healthy run sets (mask 63):
+   *
+   * 1 = a single-FLOAT registered function received its argument (task 79's exact hole),
+   * 2 = a `(BOOL)` registered function received its argument,
+   * 4 = a `(VECTOR3, VECTOR3)` registered function received BOTH vectors intact,
+   * 8 = a `() -> VECTOR3` return survived the packed transport AND the proxy's parse,
+   * 16 = the `() -> FLOAT`, `() -> STRING`, `() -> BOOL` and `() -> INT` returns all did too,
+   * 32 = a one-`int` signal payload reached a Kotlin lambda instead of being discarded.
+   *
+   * Everything except the signal bit rides `callv` through the generic tier, so the values make a
+   * full Kotlin -> GDScript proxy -> Kotlin round trip and the proxy's own parse is under test.
+   */
+  @RegisterFunction("dispatch_probe")
+  fun dispatchProbe(value: Long): Long {
+    val generic = WebExperimentalGenericCall
+    var mask = 0L
+
+    // The two argument shapes exactly as the corpus reaches them: the FPS's typed
+    // call(method, Double) and third-person's typed call(method, Vector3, Vector3). Both are
+    // QUEUED mutations, so the first callImmediate below (which flushes) is what applies them.
+    self.call("dispatch_probe_float", PROBE_NUMBER)
+    self.call("dispatch_probe_impact", PROBE_IMPACT, PROBE_FORCE)
+    // A single BOOL has no typed call family; the generic tier carries it, and callv dispatches
+    // to the same proxy function the engine would.
+    generic.callImmediate(self, "dispatch_probe_bool", listOf(true))
+    if (probeFloatArgument == PROBE_NUMBER) mask = mask or 1L
+    if (probeBoolArgument) mask = mask or 2L
+    if (probeImpactSum == PROBE_IMPACT + PROBE_FORCE) mask = mask or 4L
+
+    // The generic tier tags a Vector3 return "v3" with its three components as the payload.
+    val vector = generic.callImmediate(self, "dispatch_probe_vector")
+    if (
+      vector.tag == "v3" &&
+        vector.payload.size == 3 &&
+        vector.payload[0].toDouble() == PROBE_VECTOR.x &&
+        vector.payload[1].toDouble() == PROBE_VECTOR.y &&
+        vector.payload[2].toDouble() == PROBE_VECTOR.z
+    ) {
+      mask = mask or 8L
+    }
+
+    val number = generic.callImmediate(self, "dispatch_probe_number")
+    val text = generic.callImmediate(self, "dispatch_probe_text")
+    val flag = generic.callImmediate(self, "dispatch_probe_flag")
+    val count = generic.callImmediate(self, "dispatch_probe_count")
+    if (
+      number.asDouble() == PROBE_NUMBER &&
+        text.asString() == PROBE_TEXT &&
+        flag.asBoolean() &&
+        count.asLong() == PROBE_COUNT
+    ) {
+      mask = mask or 16L
+    }
+
+    if (probeSignalPayload == PROBE_COUNT) mask = mask or 32L
+    return mask
+  }
+
+  /**
+   * Connects and fires the scalar-payload signal once. Called from [ready] so the payload has
+   * landed long before the driver reads [dispatchProbe]; the connection is one-shot, so it
+   * unregisters itself and the smoke's callback-drain assertion is unaffected.
+   */
+  private fun armSignalPayloadProbe() {
+    self
+      .signal("dispatch_probe_scalar")
+      .connectLong(self, GodotObject.CONNECT_ONE_SHOT) { payload -> probeSignalPayload = payload }
+    self.emitSignal("dispatch_probe_scalar", PROBE_COUNT)
+  }
+
   private companion object {
     const val ENTER_TREE_EXPORTED = "web3d-enter-tree"
+    const val PROBE_NUMBER = 12.25
+    const val PROBE_TEXT = "kanama-packed-return"
+    const val PROBE_COUNT = 4242L
+    val PROBE_VECTOR = Vector3(1.5, -2.5, 3.5)
+    val PROBE_IMPACT = Vector3(0.25, 0.5, 0.75)
+    val PROBE_FORCE = Vector3(-1.25, 2.5, -3.75)
   }
 }

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 16;
+  const KANAMA_WEB_PROTOCOL_VERSION = 17;
 
   function commandWordCount(opcode) {
     if (
@@ -877,6 +877,32 @@
         `method#${methodId}`,
         () => this.api.kanamaWebCallObject(handle, methodId, objectHandle),
         0,
+      );
+    },
+    // Task 80 slice 2: the one crossing every all-numeric registered-method shape rides. The
+    // proxy flattens each declared argument into these six slots (six is one VECTOR3 pair, the
+    // widest shape in the corpus) and pads the rest with 0.0; the generated Kotlin dispatcher
+    // rebuilds the declared arguments from the same walk. This is what makes the FPS's
+    // damage(amount: float) reach Kotlin instead of throwing (task 79).
+    callDoubles(handle, methodId, a0, a1, a2, a3, a4, a5) {
+      return this.invoke(
+        handle,
+        "registered_function",
+        `method#${methodId}`,
+        () => this.api.kanamaWebCallDoubles(handle, methodId, a0, a1, a2, a3, a4, a5),
+        0,
+      );
+    },
+    // Task 80 slice 2: a zero-argument value-returning registered method. The value crosses
+    // packed into one string with the same encoding getPackedProperty uses, so the whole
+    // value-returning category needs one entry point rather than one per return type.
+    callPacked(handle, methodId) {
+      return this.invoke(
+        handle,
+        "registered_function",
+        `method#${methodId}`,
+        () => this.api.kanamaWebCallPacked(handle, methodId),
+        "",
       );
     },
     bunnymarkMethodId(method) {
@@ -1979,6 +2005,20 @@
         "_kanama_web_signal_dispatch0",
         `callback#${callbackId}`,
         () => this.api.kanamaWebDispatchSignal0(handle, callbackId),
+        0,
+      );
+      if (result === 1 && this.mode === "match3") this.match3LambdaCallbacks += 1;
+      return result;
+    },
+    // Task 80 slice 2: one emitted scalar, packed by the proxy the same way a packed property
+    // is. A zero-argument Kotlin lambda still runs -- the registry ignores the payload for it --
+    // so this replaces dispatchSignal0 on the one-argument helper without changing that path.
+    dispatchSignal1(handle, callbackId, packed) {
+      const result = this.invoke(
+        handle,
+        "_kanama_web_signal_dispatch1",
+        `callback#${callbackId}`,
+        () => this.api.kanamaWebDispatchSignal1(handle, callbackId, String(packed)),
         0,
       );
       if (result === 1 && this.mode === "match3") this.match3LambdaCallbacks += 1;

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -238,6 +238,10 @@
     // is the number that says which.
     simSeconds: 0,
     noArgCalls: 0,
+    // Task 80 slice 2: how often the two new registered-method crossings actually ran. A
+    // driver can otherwise only see the SIDE EFFECT of a dispatched method, never the dispatch.
+    doubleArgCalls: 0,
+    packedReturnCalls: 0,
     addBunnyCalls: 0,
     removeBunnyCalls: 0,
     finishCalls: 0,
@@ -270,6 +274,11 @@
     latestSnapshotY: 0,
     match3Properties: new Map(),
     match3ReadyByClass: {},
+    // Script class name -> how many instances are LIVE right now. match3ReadyByClass only ever
+    // counts up (it is a _ready tally), so a driver cannot use it to see something die. This
+    // decrements on the _exit_tree free, which is what lets the FPS driver assert that a shot
+    // enemy actually queue_free()d instead of merely that enemies once existed.
+    liveScriptsByClass: {},
     match3DeferredReadyByClass: {},
     // handle -> script class name, recorded at ready. Purely diagnostic: a
     // boundary failure otherwise reports a bare handle number, which tells a CI
@@ -885,6 +894,7 @@
     // rebuilds the declared arguments from the same walk. This is what makes the FPS's
     // damage(amount: float) reach Kotlin instead of throwing (task 79).
     callDoubles(handle, methodId, a0, a1, a2, a3, a4, a5) {
+      this.doubleArgCalls += 1;
       return this.invoke(
         handle,
         "registered_function",
@@ -897,6 +907,7 @@
     // packed into one string with the same encoding getPackedProperty uses, so the whole
     // value-returning category needs one entry point rather than one per return type.
     callPacked(handle, methodId) {
+      this.packedReturnCalls += 1;
       return this.invoke(
         handle,
         "registered_function",
@@ -957,6 +968,11 @@
           this.match3TileScriptFrees += 1;
         }
         this.match3ScriptNamesByHandle.delete(handle);
+        const liveScriptName = this.scriptNameByHandle[handle];
+        if (liveScriptName !== undefined) {
+          const remaining = (this.liveScriptsByClass[liveScriptName] ?? 0) - 1;
+          this.liveScriptsByClass[liveScriptName] = remaining > 0 ? remaining : 0;
+        }
         this.releaseBrowserHandlesOwnedBy(handle);
       }
       return result;
@@ -2352,6 +2368,7 @@
       this.readyCount += 1;
       this.scriptNameByHandle[handle] = scriptName;
       this.match3ReadyByClass[scriptName] = (this.match3ReadyByClass[scriptName] ?? 0) + 1;
+      this.liveScriptsByClass[scriptName] = (this.liveScriptsByClass[scriptName] ?? 0) + 1;
       if (this.mode === "dodge" && scriptName.endsWith(".Main")) {
         // The Web smoke drives gameplay from the browser driver (dodge's SmokeQuit
         // gate reads an env var, which Kotlin/Wasm cannot; the driver calls new_game
@@ -2630,6 +2647,8 @@
         readyCount: this.readyCount,
         processCalls: this.processCalls,
         noArgCalls: this.noArgCalls,
+        doubleArgCalls: this.doubleArgCalls,
+        packedReturnCalls: this.packedReturnCalls,
         addBunnyCalls: this.addBunnyCalls,
         removeBunnyCalls: this.removeBunnyCalls,
         finishCalls: this.finishCalls,


### PR DESCRIPTION
Task 80 slice 2: fill the registered-method and signal shapes the slice-1 census
measured, in ONE protocol bump (16 → 17), and prove FPS combat works again.

## What the census said, and what it says now

Slice 1 (#151) made the Web generator declare its own degradations. Reading that
census across all twelve demos — the live KSP manifest, one KSP run per demo — is
what scoped this parcel.

| Demo | before | after | members |
|---|---|---|---|
| match3 | 6 | **1** | 37 |
| bunnymark | 1 | **0** | 13 |
| dodge | 2 | **0** | 30 |
| web3d | 1 | **0** | 25 |
| platformer | 2 | **0** | 36 |
| squash | 1 | **0** | 29 |
| fps | 4 | **0** | 49 |
| charactercontroller | 3 | **0** | 39 |
| thirdperson | 18 | **0** | 131 |
| racing | 3 | **0** | 19 |
| citybuilder | 1 | **0** | 31 |
| tpsdemo | 10 | **1** | 111 |
| **total** | **52 / 19 distinct shapes** | **2 / 2 distinct shapes** | 550 |

(The parcel was scoped from "40 / 18"; measuring the live manifest per demo on
`main` at cdc47e9c gives 52 / 19. Reported as measured.)

## The fix: two arms and one signal helper, not sixteen entry points

Everything goes through the ONE arm table `WebMethodArm`, so the manifest cannot
drift from what the proxy emits.

- **`NUMERIC_VOID`** — any all-numeric argument list flattened into one six-slot
  `callDoubles` crossing. Six slots is exactly one `(VECTOR3, VECTOR3)` pair, the
  widest all-numeric shape in the corpus. Covers `(FLOAT)` ×9 — task 79's bug,
  fps `Enemy.damage`/`Player.damage` — plus `(VECTOR3, VECTOR3)` ×4,
  `(BOOL)` ×3, `(VECTOR2)` ×2, `(VECTOR3)`, `(VECTOR2, BOOL)`, `(INT, FLOAT)`.
- **`PACKED_RETURN`** — the whole value-returning category, which had *no arm at
  all*. **Transport chosen: the existing packed-string channel**, the same
  encoding `getPackedProperty` already uses and the proxy already parses, rather
  than a new extern per return type. One entry point serves STRING, NODE_PATH,
  INT, FLOAT, BOOL, VECTOR2, VECTOR2I, VECTOR3, QUATERNION and BASIS. The
  corpus's value-returning methods are all zero-argument and all cold — the
  thirdperson ones (`get_aim_target`, `get_camera_forward`, …) are called
  Kotlin-to-Kotlin from `Player.kt` and never touch the proxy — so the argument
  side kept a numeric channel and only the return side is stringly.
- **Signal payloads** — `_kanama_web_signal_dispatch1` packs the emitted scalar
  instead of discarding it (its old body literally said "dropped by the Kotlin
  callback"). New typed `GodotSignal.connectLong/connectDouble/connectBoolean/`
  `connectString/connectVector2/connectVector2i/connectVector3` overloads parse
  it. A zero-argument `connect(target, argumentCount = 1) { }` lambda still runs
  and ignores the payload, and `connectObject` is untouched.

**Deliberately not filled, still declared with their reasons:**
`(STRING, OBJECT) -> void` (match3 `Tile.set_tile_type`) and
`(INT, OBJECT) -> void` (tps-demo `add_player`) mix the string and object-handle
channels. They remain `unsupported` in the census — not dropped — which is also
why the build report stays non-fatal and slice 3 still cannot land.

Three new bridge entry points (`callDoubles`, `callPacked`, `dispatchSignal1`)
change the runtime contract, so `PROTOCOL_VERSION` moves 16 → 17 in every pinned
place: emitter, JS bridge constant, twelve demo drivers, emitter tests, docs.

## Proof that combat works

`scripts/web/drivers/demos/fps.mjs` never fired a shot — that is why a
months-old runtime throw was found by a human playing the game. It now takes a
stance in front of `Enemies/enemy-flying` through the existing engine-level
`global_position`/`global_rotation` object queries (ops 142/143), holds `shoot`
(ops 86/87), and asserts the **live** Enemy count drops. The shot is real end to
end: real RayCast3D, real collider, real `call("damage", float)` into the
enemy's GDScript proxy, real Kotlin `Enemy.damage`, real `queue_free`. Only the
stance is placed — mouse LOOK is a motion event no injected action can express,
and the blaster's knockback of 40 throws the Player off the level otherwise.

Two supporting bridge counters, both generally useful: `liveScriptsByClass` (a
LIVE per-class count; `match3ReadyByClass` only ever counts up, so no driver
could see anything die) and `doubleArgCalls`/`packedReturnCalls` (how often the
new crossings actually ran).

Measured: chrome 4 enemies → 3 after 4 damage crossings (4 x 25 = the enemy's
100 health), firefox 4 → 3 after 6. 11/11 checks true on both.

## And every other admitted shape, exercised

A shape that only the emitter tests cover is a shape nothing has ever actually
run. The in-repo `web3d` fixture now declares one registered function per
admitted shape and drives each through the real crossing, comparing the value
that came back against the value that went out (`Main.dispatch_probe`, driver
method #16, must return 63):

| bit | proves |
|---|---|
| 1 | a `(FLOAT)` registered function received its argument — task 79's exact hole |
| 2 | a `(BOOL)` registered function received its argument |
| 4 | a `(VECTOR3, VECTOR3)` registered function received BOTH vectors intact |
| 8 | a `() -> VECTOR3` return survived the packed transport AND the proxy's parse |
| 16 | the `() -> FLOAT` / `STRING` / `BOOL` / `INT` returns did too |
| 32 | a one-`int` signal payload reached a Kotlin lambda instead of being dropped |

This is the miniature of task 80 slice 4: it catches what the manifest cannot,
namely a shape that dispatches but delivers the WRONG VALUE. Measured mask 63
and 25/25 checks on Chrome and Firefox.

## Gates

| gate | result |
|---|---|
| `ktfmtFormat`, `:processor:test` | green — 36 tests, 0 failures (was 30) |
| `scripts/local_ci.sh` | PASS, all 48 stages, run twice (before and after the web3d probe) |
| `scripts/web_ci_matrix.sh --demo-set full --engine chrome --engine firefox` | **PASS — 12 demos x 2 engines, 24/24, every cell protocol 17** |
| fps combat on chrome + firefox | PASS, `enemyKilledByPlayerShot` true on both |
| web3d conformance on chrome + firefox | PASS, mask 63 on both |

The full-matrix run predates the web3d probe commit; the probe touches only the
web3d fixture and its driver, and both web3d cells were re-run green afterwards.
tpsdemo ran locally (it is a local-only tier — its Wasm compile OOMs a hosted
runner); Safari was not run (local-only tier, and out of this parcel's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
