### PR TITLE
Task 80 slice 3: fill the mixed-channel shapes, then make an undispatchable member a build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,18 @@ versioning once public releases begin.
     `connectVector2/connectVector2i/connectVector3` overloads receive it, and a
     zero-argument `connect` lambda still runs and ignores it as before.
 
-  Two shapes are deliberately still unfilled and stay declared in the build's
-  dispatch census with their reason: `(String, Object)` and `(Int, Object)`.
   The fps Web smoke now shoots an enemy dead, so the player→enemy damage path is
   gated on Chrome and Firefox instead of untested.
+
+  The last two shapes — `(String, Object)` and `(Int, Object?)`, which mix the
+  string and object-handle channels — now dispatch too, packed into one string
+  over the existing crossing (no protocol change). **An argument shape the Web
+  backend cannot dispatch is now a build error** naming the script, the member,
+  the shape and the shapes that *are* supported, instead of a stub that throws
+  when the engine happens to call it; the same gate covers `@ScriptSignal`
+  payloads a Kotlin lambda could not receive. Floats deliberately may not ride
+  the mixed-argument crossing (its decimal text would round them), so a float
+  mixed with text or an object is one of the shapes the build now rejects.
 - `GD.isInstanceValid`, `GD.typeOf` and `GD.hash` now encode their argument as a
   real Variant on desktop/Android (task 78). `GD.encodeVariant` handled six
   scalar types and stringified everything else, so a wrapper object arrived as a

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -65,7 +65,7 @@ Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently **16**); startup rejects a mismatch
+`KANAMA_WEB_PROTOCOL_VERSION` (currently **17**); startup rejects a mismatch
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 
@@ -210,52 +210,73 @@ and `WebPropertyArm` in `WebScriptCodeEmitter.kt` are the arm tables themselves,
 the GDScript emitter switches on them, and the manifest reports whichever arm was
 taken. Admitting a new shape means adding an arm and its emitter branch — the
 manifest cannot drift from what the proxy actually does, because there is only one
-table. The same tables feed a non-fatal per-build report on the KSP warn channel:
+table. The same tables feed a per-build census line on the KSP warn channel:
 
 ```
-[kanama:web-dispatch] 1 of 37 declared member(s) across 8 script(s) do not dispatch typed (method 1, signal 0, property 0, virtual 0)
-[kanama:web-dispatch]   Tile.set_tile_type (method): no arm for the registered-method shape (STRING, OBJECT) -> void; the proxy emits a stub that throws
+[kanama:web-dispatch] 0 of 37 declared member(s) across 6 script(s) do not dispatch typed (method 0, signal 0, property 0, virtual 0)
 ```
 
-Read it as a statement about **emission, not about a broken demo**: an
-`unsupported` stub only throws if Godot actually invokes that registered function
-(Kotlin-to-Kotlin calls never reach the proxy), and an `argument-dropped` signal
-payload still arrives intact when the signal is connected to a **named**
-registered method rather than to a Kotlin lambda — that named path rides the
-method's own arm. Properties and virtuals additionally have hard build-time
-guards (`unsupportedWebPropertyErrors`, `undispatchedVirtualErrors`), so a
-non-`typed` entry in either of those sections means one of those guards has a
-hole.
+**A non-`typed` member fails the build.** `undispatchedMemberErrors` turns every
+entry the census would report into a KSP **error** naming the script, the member,
+the shape and the reason, plus the shapes that *are* dispatched:
+
+```
+e: [ksp] .../Main.kt:49: [kanama:web-dispatch] Main.gate_proof (registered function): no arm
+   for the registered-method shape (FLOAT) -> INT; the proxy emits a stub that throws. Declare a
+   shape the Web backend dispatches — no arguments; any all-numeric argument list up to 6 scalar
+   slots; a single String or object argument; a mixed list of String/NodePath/Long/Boolean/object
+   arguments; or a zero-argument value return — or add the arm for this shape to WebMethodArm and
+   its emitter branch.
+```
+
+This is the repo-wide rule 66a (`undispatchedVirtualErrors`, kanama#114) and
+#148's property guards already applied to virtuals and properties, now
+generalized to registered functions and signals: **a generator may not emit a
+stub that throws at runtime, or quietly drop a declared payload — it either
+dispatches, or it fails the build.** There is deliberately **no allowlist**:
+every shape the corpus declares has an arm, so an exemption list would only be a
+place for the next degradation to hide. Widening a shape means adding an arm, not
+adding an entry. A non-`typed` property or virtual additionally means one of the
+older guards has a hole, and the error says so.
 
 The manifest's own `schemaVersion` versions this file's shape and is independent
 of `protocolVersion`, which versions the runtime bridge contract; adding these
 fields moved the former only.
 
-**What the census then bought.** Reading it across the twelve-demo corpus turned
+**What the census bought.** Reading it across the twelve-demo corpus turned
 "add a `callDouble` arm" into a measured parcel — 52 degraded members over 19
-distinct missing shapes — and two arms plus one signal change closed 50 of them
-at protocol 17:
+distinct missing shapes — and three arms plus one signal change closed all of
+them, at protocol 17 and with **no new bridge entry point after slice 2**:
 
 | Arm | Covers |
 |---|---|
 | `NUMERIC_VOID` | Any all-numeric argument list, flattened into the six-slot `callDoubles` crossing (six slots is exactly one `(VECTOR3, VECTOR3)` pair). |
 | `PACKED_RETURN` | Every zero-argument value-returning method. The value crosses packed into one string with the same encoding `getPackedProperty` uses, so one entry point serves STRING/NODE_PATH/INT/FLOAT/BOOL/VECTOR2/VECTOR2I/VECTOR3/QUATERNION/BASIS. |
+| `PACKED_ARGS` | A **mixed-channel** argument list — text, whole numbers, booleans and object handles together — packed into one string over the *existing* `callString` crossing. Object arguments ride as their handle id (a Kanama-scripted object as its own script handle, anything else as a transient handle released right after the call), which is what reaches shapes the string and object arms cannot: `(STRING, OBJECT)` (match3 `Tile.set_tile_type`) and `(INT, OBJECT?)` (tps-demo `add_player`). |
 | `_kanama_web_signal_dispatch1` | One emitted scalar, packed the same way, delivered by the typed `GodotSignal.connect*` overloads. A zero-argument lambda still runs and ignores it. |
 
-Two shapes remain `unsupported` on purpose, because they mix the string and
-object-handle channels: `(STRING, OBJECT) -> void` (match3 `Tile.set_tile_type`)
-and `(INT, OBJECT) -> void` (tps-demo `add_player`). They stay in the census with
-their reasons rather than being quietly dropped, which is also why the build
-report is still non-fatal.
+`PACKED_ARGS` deliberately refuses **floats** (and the float-backed vectors). The
+packed list is decimal text produced by GDScript's `str()`, which rounds a double
+to 14 significant digits, so a float carried there would arrive slightly *wrong* —
+the silent-wrong-VALUE class this whole gate exists to kill. An all-numeric shape
+has the exact `callDoubles` crossing anyway; what is left over is a float *mixed*
+with text or an object, and that shape has no arm and fails the build rather than
+losing precision in silence. Text arguments are `%`-escaped with the same
+spelling the generic-call transport uses (`%` → `%25`, unit separator → `%1F`), so
+a payload can never split the list.
 
 **Each admitted shape is exercised, not just emitted.** The in-repo `web3d`
 fixture declares one registered function per shape and drives each through the
 real crossing — Kotlin asks Godot to call it BY NAME, Godot dispatches to the
 generated proxy, the proxy takes the arm — then compares the value that came
 back against the value that went out (`Main.dispatch_probe`, driver method #16,
-must return the full mask). A shape that only the emitter tests cover is a shape
-nothing has ever actually run, and the manifest cannot see a shape that
-dispatches but delivers the WRONG VALUE.
+must return the full mask — 127). A shape that only the emitter tests cover is a
+shape nothing has ever actually run, and the manifest cannot see a shape that
+dispatches but delivers the WRONG VALUE. The mixed-channel bit carries a
+deliberately hostile label (real unit separators, percent-escape look-alikes, a
+quote and a backslash) plus a live object handle, and a second call passes a
+`null` object so the nullable lane is proven to deliver `null` rather than a
+wrapper around handle 0.
 
 ## Validation Fixtures
 

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -121,6 +121,12 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
       for (message in WebScriptCodeEmitter.unsupportedWebPropertyErrors(model, env.options)) {
         env.logger.error("[kanama:ksp] $message", symbol)
       }
+      // Task 80 slice 3: any declared member that would not dispatch typed on Web is a build
+      // error, not a runtime surprise. Slice 1 reported the same population non-fatally and
+      // slice 2 filled it; this is the gate that keeps it filled.
+      for (message in WebScriptCodeEmitter.undispatchedMemberErrors(model, env.options)) {
+        env.logger.error("[kanama:web-dispatch] $message", symbol)
+      }
       symbol.containingFile?.let {
         aggregatorSources += it
         scriptAggregatorSources += it

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -72,6 +72,13 @@ internal enum class WebMethodArm(val dispatch: WebDispatch) {
    * and the proxy parses it per the declared return type (task 80 slice 2).
    */
   PACKED_RETURN(WebDispatch(WebDispatchStatus.TYPED)),
+  /**
+   * A MIXED-channel argument list, packed into one string over the existing `callString` crossing
+   * (task 80 slice 3): `(STRING, OBJECT)`, `(INT, OBJECT)`, `(STRING, INT)`, … — anything whose
+   * arguments are text, whole numbers, booleans, or object handles. Object arguments ride as their
+   * handle id, which is why this arm reaches shapes [NUMERIC_VOID] and [STRING_VOID] cannot.
+   */
+  PACKED_ARGS(WebDispatch(WebDispatchStatus.TYPED)),
   /** No arm matches: the proxy emits a stub that throws through `unsupportedGameplayMethod`. */
   NONE(WebDispatch(WebDispatchStatus.UNSUPPORTED));
 
@@ -194,6 +201,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         method.returnType == null && numericArgSlots(method.args) != null ->
           WebMethodArm.NUMERIC_VOID
         method.args.isEmpty() && isPackedReturn(method.returnType) -> WebMethodArm.PACKED_RETURN
+        method.returnType == null && isPackedArgList(method.args) -> WebMethodArm.PACKED_ARGS
         else -> WebMethodArm.NONE
       }
 
@@ -320,6 +328,87 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "\"\${it.x.x},\${it.x.y},\${it.x.z},\${it.y.x},\${it.y.y},\${it.y.z}," +
             "\${it.z.x},\${it.z.y},\${it.z.z}\" }"
         else -> error("no packed return encoding for ${type.name}")
+      }
+
+    // ---- Task 80 slice 3: the mixed-channel packed argument list ----
+
+    /** The GDScript helper that %-escapes one text argument for the packed list. */
+    internal const val PACKED_ARG_PACK_TEXT = "_kanama_web_pack_text"
+    /** The GDScript helper that turns one object argument into a bridge handle id. */
+    internal const val PACKED_ARG_PACK_OBJECT = "_kanama_web_pack_object"
+    /** The proxy-local array of handles the call allocated, released right after the crossing. */
+    private const val PACKED_ARG_TRANSIENT = "_kanama_packed_transient"
+    /** The proxy-local packed parts being assembled. */
+    private const val PACKED_ARG_PARTS = "_kanama_packed_args"
+    /** The generated-Kotlin name for the decoded parts of the packed argument list. */
+    private const val PACKED_ARG_KOTLIN_PARTS = "packedArgs"
+
+    /**
+     * Whether [arg] can ride the packed argument list.
+     *
+     * Deliberately NOT floats or float-backed vectors: the packed list is decimal TEXT produced by
+     * GDScript's `str()`, which rounds a double to 14 significant digits, so a float carried here
+     * would arrive slightly wrong — the silent-wrong-VALUE class this whole task exists to kill.
+     * Whole numbers, booleans, text, and object handle ids all round-trip exactly. An all-numeric
+     * shape has the exact [WebMethodArm.NUMERIC_VOID] crossing anyway; what is left over is a float
+     * MIXED with text or an object, and that shape has no arm and fails the build rather than
+     * losing precision in silence.
+     */
+    private fun isPackedArgType(arg: ArgModel): Boolean =
+      when (arg.type) {
+        TypeMapping.STRING,
+        TypeMapping.NODE_PATH,
+        TypeMapping.INT,
+        TypeMapping.BOOL -> true
+        TypeMapping.OBJECT -> arg.objectWrapperFqName != null
+        else -> false
+      }
+
+    /** Whether this whole argument list rides the packed crossing. */
+    fun isPackedArgList(args: List<ArgModel>): Boolean =
+      args.isNotEmpty() && args.all(::isPackedArgType)
+
+    /**
+     * The GDScript expression for one packed part, in argument order. Objects resolve to a handle
+     * id — a Kanama-scripted object's own script handle when it has one (so the Kotlin side can
+     * reach its script instance), otherwise a transient handle appended to [PACKED_ARG_TRANSIENT]
+     * and released after the crossing.
+     */
+    fun packedArgGdExpressions(args: List<ArgModel>): List<String> =
+      args.map { arg ->
+        when (arg.type) {
+          TypeMapping.STRING -> "$PACKED_ARG_PACK_TEXT(${arg.name})"
+          TypeMapping.NODE_PATH -> "$PACKED_ARG_PACK_TEXT(String(${arg.name}))"
+          TypeMapping.INT -> "str(${arg.name})"
+          TypeMapping.BOOL -> "(\"1\" if ${arg.name} else \"0\")"
+          TypeMapping.OBJECT -> "str($PACKED_ARG_PACK_OBJECT(${arg.name}, $PACKED_ARG_TRANSIENT))"
+          else -> error("no packed argument encoding for ${arg.type.name}")
+        }
+      }
+
+    /**
+     * The Kotlin expression rebuilding each declared argument from the packed parts. Mirror of
+     * [packedArgGdExpressions] — the two walk the same argument list in the same order, so a part
+     * can never be read as a different argument than it was written.
+     */
+    fun packedArgKotlinExpressions(args: List<ArgModel>): List<String> =
+      args.mapIndexed { index, arg ->
+        val part = "$PACKED_ARG_KOTLIN_PARTS[$index]"
+        val text = "$part.replace(\"%1F\", \"\\u001F\").replace(\"%25\", \"%\")"
+        when (arg.type) {
+          TypeMapping.STRING -> text
+          TypeMapping.NODE_PATH -> "net.multigesture.kanama.types.NodePath($text)"
+          TypeMapping.INT -> "$part.toLong()"
+          TypeMapping.BOOL -> "($part == \"1\")"
+          TypeMapping.OBJECT -> {
+            val wrapper =
+              checkNotNull(arg.objectWrapperFqName) { "packed object argument needs a wrapper" }
+            val handle = "$part.toInt().takeIf { it != 0 }?.let { WebObjectId(it) }"
+            if (arg.nullable) "$handle?.let { $wrapper(it) }"
+            else "$wrapper(checkNotNull($handle) { \"Argument ${arg.name} is not nullable\" })"
+          }
+          else -> error("no packed argument decoding for ${arg.type.name}")
+        }
       }
 
     /** `(FLOAT, INT) -> void` — the shape spelling used in degradation reasons. */
@@ -482,6 +571,68 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       val bounds = parts.takeWhile { RANGE_HINT_NUMBER.matches(it) }
       if (bounds.size < 2) return null
       return bounds + parts.drop(bounds.size).map { "\"$it\"" }
+    }
+
+    /**
+     * Errors for every declared member a Web build would degrade (task 80 slice 3).
+     *
+     * The repo-wide rule, adopted from 66a (`undispatchedVirtualErrors`, kanama#114) and #148's
+     * property guards and now generalized to registered functions and signals: **a generator may
+     * not emit a stub that throws at runtime, or quietly drop a declared payload — it either
+     * dispatches, or it fails the build.** Slice 1 made the population visible (the census), slice
+     * 2 filled it, and this turns the report fatal, so the next hole in the hand-maintained shape
+     * table announces itself as a compile error instead of as a bug someone finds by playing the
+     * game.
+     *
+     * There is deliberately **no allowlist**: every shape the corpus declares has an arm, so an
+     * exemption mechanism would only be a place for the next degradation to hide. Reached through
+     * the same [methodDispatch] / [signalDispatch] / [propertyDispatch] / [virtualDispatch] tables
+     * the manifest and the census read, so the build cannot fail for a reason the manifest denies —
+     * or pass while the manifest declares a degradation. Empty on every non-Web target.
+     */
+    fun undispatchedMemberErrors(model: ScriptModel, options: Map<String, String>): List<String> {
+      if (!isWebTarget(options)) return emptyList()
+      val errors = mutableListOf<String>()
+      model.methods.forEach { method ->
+        val dispatch = methodDispatch(method)
+        if (dispatch.isTyped) return@forEach
+        errors +=
+          "${model.simpleName}.${method.godotName} (registered function): " +
+            "${dispatch.reason ?: dispatch.status.json}. Declare a shape the Web backend " +
+            "dispatches — no arguments; any all-numeric argument list up to $NUMERIC_ARG_SLOTS " +
+            "scalar slots; a single String or object argument; a mixed list of String/NodePath/" +
+            "Long/Boolean/object arguments; or a zero-argument value return — or add the arm for " +
+            "this shape to WebMethodArm and its emitter branch."
+      }
+      model.signals.forEach { signal ->
+        val dispatch = signalDispatch(signal)
+        if (dispatch.isTyped) return@forEach
+        errors +=
+          "${model.simpleName}.${signal.godotName} (signal): " +
+            "${dispatch.reason ?: dispatch.status.json}. Declare a payload the Web backend " +
+            "delivers — no arguments, one packed scalar (String/Long/Double/Boolean/Vector2/" +
+            "Vector2i/Vector3), or one object — or add the wider delivery to the signal dispatch " +
+            "helpers."
+      }
+      // Properties and virtuals already have their own guards; a non-typed entry here means one of
+      // those has a hole, so say exactly that instead of repeating their advice.
+      model.properties.forEach { property ->
+        val dispatch = propertyDispatch(property)
+        if (dispatch.isTyped) return@forEach
+        errors +=
+          "${model.simpleName}.${property.godotName} (property): " +
+            "${dispatch.reason ?: dispatch.status.json} (unsupportedWebPropertyErrors has a hole " +
+            "for this declaration)."
+      }
+      model.virtuals.forEach { virtual ->
+        val dispatch = virtualDispatch(virtual)
+        if (dispatch.isTyped) return@forEach
+        errors +=
+          "${model.simpleName}.${virtual.kotlinMethodName} (virtual): " +
+            "${dispatch.reason ?: dispatch.status.json} (undispatchedVirtualErrors has a hole for " +
+            "this declaration)."
+      }
+      return errors
     }
 
     /**
@@ -743,11 +894,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
 
   /**
-   * The non-fatal build-time degradation report (task 80 slice 1), as lines to log.
+   * The build-time degradation census (task 80 slice 1), as lines to log.
    *
-   * Deliberately NOT a build failure: the corpus trips it today (fps `Enemy.damage(Double)` has no
-   * single-FLOAT arm), so slice 1 only makes the population visible. Turning this into a hard gate
-   * is slice 3, and it cannot land until slice 2 fills the holes this report finds.
+   * Slice 1 made this visible and slice 2 emptied it; since slice 3 the same population is a BUILD
+   * ERROR ([undispatchedMemberErrors]), so on a build that gets this far the detail lines are
+   * always empty and the summary reads `0 of N`. It stays because the count is the census — the
+   * number that turned "add a callDouble arm" into a measured parcel.
    */
   fun degradationReport(): List<String> = buildList {
     val degradations = degradations()
@@ -763,8 +915,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     degradations.forEach { add("[kanama:web-dispatch]   $it") }
     if (degradations.isNotEmpty()) {
       add(
-        "[kanama:web-dispatch] non-fatal (task 80 slice 1): these are declared in " +
-          "KanamaWebProtocol.generated.json as dispatch != \"typed\""
+        "[kanama:web-dispatch] these are declared in KanamaWebProtocol.generated.json as " +
+          "dispatch != \"typed\" and FAIL the build (task 80 slice 3)"
       )
     }
   }
@@ -1191,6 +1343,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine()
   }
 
+  /**
+   * The string crossing: one declared STRING argument ([WebMethodArm.STRING_VOID]), or a whole
+   * MIXED argument list packed into that same string ([WebMethodArm.PACKED_ARGS], task 80 slice 3).
+   * The arm table decides which — this dispatcher never re-reads the shapes — so the two encodings
+   * can share one entry point without the protocol growing an extra crossing.
+   */
   private fun StringBuilder.appendStringMethodDispatcher() {
     appendLine(
       "  fun callString(scriptId: Int, methodId: Int, script: KanamaWebScript, value: String) {"
@@ -1199,14 +1357,17 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     scripts.forEachIndexed { scriptIndex, input ->
       appendLine("      ${scriptIndex + 1} -> when (methodId) {")
       input.model.methods.forEachIndexed { methodIndex, method ->
-        if (
-          method.returnType == null &&
-            method.args.size == 1 &&
-            method.args.single().type == TypeMapping.STRING
-        ) {
-          appendLine(
-            "        ${methodIndex + 1} -> (script as ${input.model.simpleName}).${method.kotlinName}(value)"
-          )
+        val target = "(script as ${input.model.simpleName}).${method.kotlinName}"
+        when (methodArm(method)) {
+          WebMethodArm.STRING_VOID -> appendLine("        ${methodIndex + 1} -> $target(value)")
+          WebMethodArm.PACKED_ARGS -> {
+            val arguments = packedArgKotlinExpressions(method.args).joinToString(", ")
+            appendLine("        ${methodIndex + 1} -> {")
+            appendLine("          val packedArgs = value.split('\\u001F')")
+            appendLine("          $target($arguments)")
+            appendLine("        }")
+          }
+          else -> Unit
         }
       }
       appendLine("        else -> unknown(\"method\", methodId)")
@@ -3350,6 +3511,30 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t_:")
     appendLine("\t\t\treturn str(arg)")
     appendLine()
+    appendLine("func $PACKED_ARG_PACK_TEXT(value: String) -> String:")
+    appendLine(
+      "\t# Task 80 slice 3: %-escape a text argument so its payload cannot split the packed"
+    )
+    appendLine("\t# argument list. Same escaping as the generic-call transport: % first.")
+    appendLine("\treturn value.replace(\"%\", \"%25\").replace(\"\\u001f\", \"%1F\")")
+    appendLine()
+    appendLine("func $PACKED_ARG_PACK_OBJECT(value: Object, transient_handles: Array[int]) -> int:")
+    appendLine("\t# Task 80 slice 3: one object argument as a bridge handle id. A Kanama-scripted")
+    appendLine("\t# object crosses as its SCRIPT handle (so Kotlin can resolve its instance);")
+    appendLine("\t# anything else rides a transient handle the caller releases after the call.")
+    appendLine("\tif value == null:")
+    appendLine("\t\treturn 0")
+    appendLine("\tif value.has_method(\"_kanama_ensure_created\"):")
+    appendLine("\t\tvar script_handle := int(value.call(\"_kanama_ensure_created\"))")
+    appendLine("\t\tif script_handle != 0:")
+    appendLine("\t\t\treturn script_handle")
+    appendLine(
+      "\tvar packed_handle := int(_kanama_bridge.allocateTransientObjectHandle(_kanama_handle))"
+    )
+    appendLine("\t_kanama_object_handles[packed_handle] = value")
+    appendLine("\ttransient_handles.append(packed_handle)")
+    appendLine("\treturn packed_handle")
+    appendLine()
     appendLine("func $SIGNAL_DISPATCH_OBJECT(arg: Variant, callback_id: int) -> void:")
     appendLine("\tvar script_arg_handle := 0")
     appendLine("\tif arg != null and arg.has_method(\"_kanama_ensure_created\"):")
@@ -4181,6 +4366,23 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "\tvar _kanama_packed := String(_kanama_bridge.callPacked(_kanama_handle, ${index + 1}))"
           )
           appendPackedReturnParse(returnType)
+        }
+        WebMethodArm.PACKED_ARGS -> {
+          // Task 80 slice 3: a MIXED argument list (text/int/bool/object handle) packed into one
+          // string over the EXISTING string crossing -- object arguments ride as their handle id,
+          // which is what lets one arm carry a shape the string and object arms cannot.
+          appendLine("\tvar $PACKED_ARG_TRANSIENT: Array[int] = []")
+          appendLine("\tvar $PACKED_ARG_PARTS: PackedStringArray = PackedStringArray()")
+          packedArgGdExpressions(method.args).forEach {
+            appendLine("\t$PACKED_ARG_PARTS.append($it)")
+          }
+          appendLine(
+            "\t_kanama_bridge.callString(_kanama_handle, ${index + 1}, " +
+              "\"\\u001f\".join($PACKED_ARG_PARTS))"
+          )
+          appendLine("\tfor _kanama_packed_handle in $PACKED_ARG_TRANSIENT:")
+          appendLine("\t\t_kanama_object_handles.erase(_kanama_packed_handle)")
+          appendLine("\t\t_kanama_bridge.releaseTransientObjectHandle(_kanama_packed_handle)")
         }
         // Task 80: this stub throws at runtime, and the manifest + build report now say so.
         WebMethodArm.NONE -> {

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -410,8 +410,20 @@ class WebScriptCodeEmitterTest {
         "callObjectObjectLong(_kanama_handle, 2, first_handle, second_handle, shapeIdx)"
       )
     )
-    assertTrue(
+    // Task 80 slice 3: match3's (STRING, OBJECT) shape used to emit a throwing stub here; it now
+    // rides the packed argument list over the existing string crossing.
+    assertFalse(
       tileProxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 1, \"set_tile_type\")")
+    )
+    assertTrue(
+      tileProxy.contains("callString(_kanama_handle, 1, \"\\u001f\".join(_kanama_packed_args))"),
+      tileProxy,
+    )
+    assertTrue(
+      tileProxy.contains(
+        "_kanama_packed_args.append(str(_kanama_web_pack_object(texture, _kanama_packed_transient)))"
+      ),
+      tileProxy,
     )
 
     // Neither match3 script declares _enter_tree, so neither proxy may emit the crossing:
@@ -864,6 +876,34 @@ class WebScriptCodeEmitterTest {
               ),
             kind = MethodKind.REGULAR,
           ),
+          // tps-demo's add_player(id, spawnPoint: Marker3D?) shape: the object is nullable and
+          // rides the same packed list as the (STRING, OBJECT) one above.
+          MethodModel(
+            kotlinName = "addPlayer",
+            godotName = "add_player",
+            returnType = null,
+            args =
+              listOf(
+                ArgModel("id", TypeMapping.INT),
+                ArgModel(
+                  "spawnPoint",
+                  TypeMapping.OBJECT,
+                  "net.multigesture.kanama.api.GodotObject",
+                  nullable = true,
+                ),
+              ),
+            kind = MethodKind.REGULAR,
+          ),
+          // A shape no arm covers: a FLOAT argument WITH a value return. The numeric crossing is
+          // void-only, the packed return takes no arguments, and the packed argument list refuses
+          // floats (they do not round-trip through GDScript's decimal text).
+          MethodModel(
+            kotlinName = "reload",
+            godotName = "reload",
+            returnType = TypeMapping.INT,
+            args = listOf(ArgModel("seconds", TypeMapping.FLOAT)),
+            kind = MethodKind.REGULAR,
+          ),
         ),
       signals =
         listOf(
@@ -876,6 +916,14 @@ class WebScriptCodeEmitterTest {
         ),
     )
 
+  /** [task80Model] with its two deliberately degraded members removed: the gate must pass. */
+  private fun task80TypedModel() =
+    task80Model()
+      .copy(
+        methods = task80Model().methods.filter { it.godotName != "reload" },
+        signals = task80Model().signals.filter { it.godotName != "scored" },
+      )
+
   private fun task80Proxy(): String =
     WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
       .proxySources()
@@ -884,21 +932,21 @@ class WebScriptCodeEmitterTest {
 
   @Test
   fun declaresUnsupportedDispatchForAMethodArgumentWithNoArm() {
-    // Slice 2 deliberately did not fill (STRING, OBJECT) -> void: it mixes the string and the
-    // object-handle channels, and the census keeps declaring it rather than dropping it.
-    val method = task80Model().methods.single { it.godotName == "retarget" }
+    // `(FLOAT) -> INT` falls between every arm: the numeric crossing is void-only, the packed
+    // return takes no arguments, and the packed argument list refuses floats on purpose.
+    val method = task80Model().methods.single { it.godotName == "reload" }
     val dispatch = WebScriptCodeEmitter.methodDispatch(method)
 
     assertEquals(WebMethodArm.NONE, WebScriptCodeEmitter.methodArm(method))
     assertEquals(WebDispatchStatus.UNSUPPORTED, dispatch.status)
     assertEquals("unsupported", dispatch.status.json)
     // The reason must name the shape that has no arm, not just say "unsupported".
-    assertTrue(dispatch.reason!!.contains("(STRING, OBJECT) -> void"), dispatch.reason!!)
+    assertTrue(dispatch.reason!!.contains("(FLOAT) -> INT"), dispatch.reason!!)
     assertTrue(dispatch.reason!!.contains("throws"), dispatch.reason!!)
 
     // The claim behind the status: this is exactly the arm that emits the throwing stub.
     assertTrue(
-      task80Proxy().contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 7, \"retarget\")")
+      task80Proxy().contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 9, \"reload\")")
     )
   }
 
@@ -1152,6 +1200,211 @@ class WebScriptCodeEmitterTest {
     assertTrue(proxy.contains("\t\t\treturn \"%s,%s,%s\" % [arg.x, arg.y, arg.z]"), proxy)
   }
 
+  // ---------- Task 80 slice 3: the mixed-channel packed argument list ----------
+
+  @Test
+  fun dispatchesMixedArgumentShapesThroughThePackedArgumentCrossing() {
+    // The two shapes slice 2 left unfilled, both of which mix the string and object-handle
+    // channels: match3 Tile.set_tile_type(String, Texture2D) and tps Level.add_player(id,
+    // Marker3D?).
+    val text = task80Model().methods.single { it.godotName == "retarget" }
+    val nullableObject = task80Model().methods.single { it.godotName == "add_player" }
+    assertEquals(WebMethodArm.PACKED_ARGS, WebScriptCodeEmitter.methodArm(text))
+    assertEquals(WebMethodArm.PACKED_ARGS, WebScriptCodeEmitter.methodArm(nullableObject))
+    assertEquals(WebDispatchStatus.TYPED, WebScriptCodeEmitter.methodDispatch(text).status)
+    assertEquals(null, WebScriptCodeEmitter.methodDispatch(nullableObject).reason)
+
+    val proxy = task80Proxy()
+    // The text argument is %-escaped, the object argument becomes a handle id, and the whole
+    // list rides the EXISTING string crossing -- no new bridge entry point, no protocol bump.
+    assertTrue(proxy.contains("_kanama_packed_args.append(_kanama_web_pack_text(tag))"), proxy)
+    assertTrue(
+      proxy.contains(
+        "_kanama_packed_args.append(str(_kanama_web_pack_object(node, _kanama_packed_transient)))"
+      ),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.callString(_kanama_handle, 7, \"\\u001f\".join(_kanama_packed_args))"
+      ),
+      proxy,
+    )
+    assertTrue(proxy.contains("_kanama_packed_args.append(str(id))"), proxy)
+    assertFalse(proxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 7,"), proxy)
+    assertFalse(proxy.contains("unsupportedGameplayMethod(_KANAMA_SCRIPT_ID, 8,"), proxy)
+
+    // Every transient handle the call minted is erased and released after the crossing.
+    assertTrue(proxy.contains("for _kanama_packed_handle in _kanama_packed_transient:"), proxy)
+    assertTrue(
+      proxy.contains("\t\t_kanama_bridge.releaseTransientObjectHandle(_kanama_packed_handle)"),
+      proxy,
+    )
+
+    // The helpers: the escape must be the SAME spelling the generic-call transport uses, and a
+    // Kanama-scripted argument must cross as its script handle so Kotlin can resolve it.
+    assertTrue(proxy.contains("func _kanama_web_pack_text(value: String) -> String:"), proxy)
+    assertTrue(
+      proxy.contains("\treturn value.replace(\"%\", \"%25\").replace(\"\\u001f\", \"%1F\")"),
+      proxy,
+    )
+    assertTrue(
+      proxy.contains(
+        "func _kanama_web_pack_object(value: Object, transient_handles: Array[int]) -> int:"
+      ),
+      proxy,
+    )
+    assertTrue(proxy.contains("\tif value.has_method(\"_kanama_ensure_created\"):"), proxy)
+
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt"))).registrySource()
+    // The Kotlin side splits the same list and unescapes with the mirror of the GDScript packer.
+    assertTrue(registry.contains("val packedArgs = value.split('\\u001F')"), registry)
+    assertTrue(
+      registry.contains(
+        "(script as Enemy).retarget(packedArgs[0].replace(\"%1F\", \"\\u001F\")" +
+          ".replace(\"%25\", \"%\"), net.multigesture.kanama.api.GodotObject(checkNotNull(" +
+          "packedArgs[1].toInt().takeIf { it != 0 }?.let { WebObjectId(it) }) " +
+          "{ \"Argument node is not nullable\" }))"
+      ),
+      registry,
+    )
+    // A nullable object argument delivers null for the 0 handle instead of throwing.
+    assertTrue(
+      registry.contains(
+        "(script as Enemy).addPlayer(packedArgs[0].toLong(), packedArgs[1].toInt()" +
+          ".takeIf { it != 0 }?.let { WebObjectId(it) }?.let " +
+          "{ net.multigesture.kanama.api.GodotObject(it) })"
+      ),
+      registry,
+    )
+  }
+
+  @Test
+  fun refusesFloatArgumentsOnThePackedArgumentCrossing() {
+    // The boundary that keeps the packed list honest: GDScript's str() rounds a double to 14
+    // significant digits, so a float here would arrive slightly WRONG. It has no arm and says so.
+    fun armFor(vararg args: ArgModel) =
+      WebScriptCodeEmitter.methodArm(
+        MethodModel("probe", "probe", null, args.toList(), MethodKind.REGULAR)
+      )
+    val objectArg = ArgModel("node", TypeMapping.OBJECT, "net.multigesture.kanama.api.GodotObject")
+
+    // Exactly-representable argument types ride the crossing...
+    assertEquals(WebMethodArm.PACKED_ARGS, armFor(ArgModel("tag", TypeMapping.STRING), objectArg))
+    assertEquals(WebMethodArm.PACKED_ARGS, armFor(ArgModel("id", TypeMapping.INT), objectArg))
+    assertEquals(WebMethodArm.PACKED_ARGS, armFor(ArgModel("on", TypeMapping.BOOL), objectArg))
+    assertEquals(
+      WebMethodArm.PACKED_ARGS,
+      armFor(ArgModel("path", TypeMapping.NODE_PATH), ArgModel("tag", TypeMapping.STRING)),
+    )
+    // ... a float mixed with them does not, and neither does an unwrapped object.
+    val lossy =
+      MethodModel(
+        "probe",
+        "probe",
+        null,
+        listOf(ArgModel("tag", TypeMapping.STRING), ArgModel("amount", TypeMapping.FLOAT)),
+        MethodKind.REGULAR,
+      )
+    assertEquals(WebMethodArm.NONE, WebScriptCodeEmitter.methodArm(lossy))
+    assertTrue(
+      WebScriptCodeEmitter.methodDispatch(lossy).reason!!.contains("(STRING, FLOAT) -> void"),
+      WebScriptCodeEmitter.methodDispatch(lossy).reason!!,
+    )
+    assertEquals(
+      WebMethodArm.NONE,
+      armFor(ArgModel("tag", TypeMapping.STRING), ArgModel("v", TypeMapping.VECTOR3)),
+    )
+    assertEquals(
+      WebMethodArm.NONE,
+      armFor(ArgModel("tag", TypeMapping.STRING), ArgModel("node", TypeMapping.OBJECT)),
+    )
+    // An all-numeric list keeps its own exact crossing rather than falling through to this one.
+    assertEquals(
+      WebMethodArm.NUMERIC_VOID,
+      armFor(ArgModel("id", TypeMapping.INT), ArgModel("amount", TypeMapping.FLOAT)),
+    )
+    assertFalse(WebScriptCodeEmitter.isPackedArgList(emptyList()))
+  }
+
+  // ---------- Task 80 slice 3: the gate ----------
+
+  @Test
+  fun failsTheBuildForAnyMemberThatDoesNotDispatchTyped() {
+    val errors = WebScriptCodeEmitter.undispatchedMemberErrors(task80Model(), webOptions)
+
+    // Exactly the census population -- no more (a typed member must never fail a build) and no
+    // fewer (an allowlist would just be a place for the next degradation to hide).
+    assertEquals(2, errors.size, errors.toString())
+    val method = errors.single { it.contains("(registered function)") }
+    assertTrue(method.startsWith("Enemy.reload (registered function):"), method)
+    assertTrue(method.contains("(FLOAT) -> INT"), method)
+    assertTrue(method.contains("the proxy emits a stub that throws"), method)
+    // Naming the fix is the difference between a gate and a wall.
+    assertTrue(method.contains("all-numeric argument list up to 6 scalar slots"), method)
+
+    val signal = errors.single { it.contains("(signal)") }
+    assertTrue(signal.startsWith("Enemy.scored (signal):"), signal)
+    assertTrue(signal.contains("at most 1 emitted argument"), signal)
+
+    // The gate is Web-only: the same declarations dispatch normally everywhere else.
+    assertTrue(WebScriptCodeEmitter.undispatchedMemberErrors(task80Model(), emptyMap()).isEmpty())
+    assertTrue(
+      WebScriptCodeEmitter.undispatchedMemberErrors(
+          task80Model(),
+          mapOf("kanamaRuntimeTarget" to "ios"),
+        )
+        .isEmpty()
+    )
+  }
+
+  @Test
+  fun passesTheGateForAFullyTypedScript() {
+    val typed = task80TypedModel()
+    assertEquals(emptyList(), WebScriptCodeEmitter.undispatchedMemberErrors(typed, webOptions))
+    assertEquals(
+      emptyList(),
+      WebScriptCodeEmitter(listOf(WebScriptInput(typed, "res://Enemy.kt"))).degradations(),
+    )
+  }
+
+  @Test
+  fun failsTheBuildWhenAPropertyOrVirtualGuardHasAHole() {
+    // Properties and virtuals have their own guards; the gate re-checks their manifest verdict so
+    // a hole in either one cannot ship as a silently non-typed manifest entry.
+    val holed =
+      task80TypedModel()
+        .copy(
+          properties =
+            listOf(
+              ScriptPropertyModel(
+                kotlinName = "config",
+                godotName = "config",
+                type = TypeMapping.DICTIONARY,
+                isMutable = true,
+              )
+            ),
+          virtuals = listOf(VirtualModel("_notification", "callNotification", "notification")),
+        )
+    val errors = WebScriptCodeEmitter.undispatchedMemberErrors(holed, webOptions)
+    assertEquals(2, errors.size, errors.toString())
+    assertTrue(
+      errors.any {
+        it.startsWith("Enemy.config (property)") &&
+          it.contains("unsupportedWebPropertyErrors has a hole")
+      },
+      errors.toString(),
+    )
+    assertTrue(
+      errors.any {
+        it.startsWith("Enemy.notification (virtual)") &&
+          it.contains("undispatchedVirtualErrors has a hole")
+      },
+      errors.toString(),
+    )
+  }
+
   @Test
   fun writesDispatchVerdictsIntoTheProtocolManifest() {
     val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(task80Model(), "res://Enemy.kt")))
@@ -1214,11 +1467,30 @@ class WebScriptCodeEmitterTest {
         protocol.contains("\"dispatch\": \"argument-dropped\", \"dispatchReason\": \"signal "),
       protocol,
     )
-    // The shape slice 2 deliberately left unfilled is still declared, with its reason.
+    // Slice 3 filled the two mixed-channel shapes; both now read typed IN THE MANIFEST.
+    assertTrue(
+      protocol.contains("\"name\": \"retarget\"") &&
+        protocol.contains(
+          "{\"name\": \"node\", \"type\": \"net.multigesture.kanama.api.GodotObject\", " +
+            "\"nullable\": false, \"hasDefault\": false}], \"returnType\": null, " +
+            "\"dispatch\": \"typed\"}"
+        ),
+      protocol,
+    )
+    assertTrue(
+      protocol.contains("\"name\": \"add_player\"") &&
+        protocol.contains(
+          "{\"name\": \"spawnPoint\", \"type\": \"net.multigesture.kanama.api.GodotObject\", " +
+            "\"nullable\": true, \"hasDefault\": false}], \"returnType\": null, " +
+            "\"dispatch\": \"typed\"}"
+        ),
+      protocol,
+    )
+    // A shape with no arm is still declared, with its reason.
     assertTrue(
       protocol.contains(
         "\"dispatch\": \"unsupported\", \"dispatchReason\": \"no arm for the registered-method " +
-          "shape (STRING, OBJECT) -> void; the proxy emits a stub that throws\""
+          "shape (FLOAT) -> INT; the proxy emits a stub that throws\""
       ),
       protocol,
     )
@@ -1244,25 +1516,35 @@ class WebScriptCodeEmitterTest {
     val degradations = emitter.degradations()
     assertEquals(2, degradations.size, degradations.toString())
     assertEquals(
-      listOf("Enemy.retarget (method)", "Enemy.scored (signal)"),
+      listOf("Enemy.reload (method)", "Enemy.scored (signal)"),
       degradations.map { "${it.scriptName}.${it.memberName} (${it.kind})" },
     )
-    // 1 property + 1 virtual + 7 methods + 3 signals.
-    assertEquals(12, emitter.memberCount())
+    // 1 property + 1 virtual + 9 methods + 3 signals.
+    assertEquals(14, emitter.memberCount())
 
     val report = emitter.degradationReport()
     assertTrue(
-      report.first().contains("2 of 12 declared member(s) across 1 script(s)"),
+      report.first().contains("2 of 14 declared member(s) across 1 script(s)"),
       report.first(),
     )
     assertTrue(report.first().contains("method 1, signal 1, property 0, virtual 0"), report.first())
-    assertTrue(report.any { it.contains("Enemy.retarget (method): no arm for") }, report.toString())
+    assertTrue(report.any { it.contains("Enemy.reload (method): no arm for") }, report.toString())
     assertTrue(
       report.any { it.contains("Enemy.scored (signal): signal payload dropped") },
       report.toString(),
     )
+    // Since slice 3 the census population is fatal, and the report says so.
+    assertTrue(report.any { it.contains("FAIL the build (task 80 slice 3)") }, report.toString())
 
-    // Still non-fatal: the hard gate is slice 3, and it cannot land while any shape is unfilled.
+    // The census and the gate read one table: the same two members, no more and no fewer.
+    assertEquals(
+      degradations.map { "${it.scriptName}.${it.memberName}" },
+      WebScriptCodeEmitter.undispatchedMemberErrors(task80Model(), webOptions).map {
+        it.substringBefore(" (")
+      },
+    )
+    // The older per-kind guards stay quiet here: this script's degradations are a method and a
+    // signal, which is exactly the population they never covered.
     assertTrue(
       WebScriptCodeEmitter.unsupportedWebPropertyErrors(task80Model(), webOptions).isEmpty()
     )
@@ -1271,13 +1553,7 @@ class WebScriptCodeEmitterTest {
 
   @Test
   fun reportsNothingForAFullyTypedScript() {
-    val typed =
-      task80Model()
-        .copy(
-          methods = task80Model().methods.filter { it.godotName != "retarget" },
-          signals = task80Model().signals.filter { it.godotName != "scored" },
-        )
-    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(typed, "res://Enemy.kt")))
+    val emitter = WebScriptCodeEmitter(listOf(WebScriptInput(task80TypedModel(), "res://Enemy.kt")))
 
     assertEquals(emptyList(), emitter.degradations())
     assertEquals(1, emitter.degradationReport().size, "a clean script reports only the summary")

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -116,8 +116,8 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   );
   trace(`propertyProbe: mask=${propertyProbe}`);
 
-  // Task 80 slice 2 dispatch-shape conformance: Main.dispatch_probe (method#16, Int->Int)
-  // returns a mask. Every bit is a shape slice 2 admitted, exercised through the REAL crossing
+  // Task 80 dispatch-shape conformance: Main.dispatch_probe (method#16, Int->Int)
+  // returns a mask. Every bit is a shape task 80 admitted, exercised through the REAL crossing
   // (Kotlin asks Godot to call the method by name, Godot dispatches to the generated GDScript
   // proxy, the proxy takes the new arm) rather than through the emitter tests alone:
   //   1 = a (FLOAT) registered function received its argument -- task 79's exact hole
@@ -126,7 +126,9 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   //   8 = a () -> VECTOR3 return survived the packed transport AND the proxy's parse
   //  16 = the () -> FLOAT / STRING / BOOL / INT returns did too
   //  32 = a one-int signal payload reached a Kotlin lambda instead of being discarded
-  // A healthy run returns exactly 63. Values, not just dispatch: each bit compares the value
+  //  64 = the slice-3 MIXED shapes: (STRING, OBJECT) carried a hostile label plus a live object
+  //       handle, and (INT, OBJECT?) carried a number plus a null object
+  // A healthy run returns exactly 127. Values, not just dispatch: each bit compares the value
   // that came back against the value that went out.
   const dispatchProbe = Number(
     await evaluate(
@@ -217,7 +219,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
     // Task 64: the pushed NodePath resolves a live node through the NodePath accessor overload.
     nodePathResolvesNode: (propertyProbe & 4) === 4,
     // Task 80 slice 2: every admitted dispatch shape round-tripped its VALUE, not just its call.
-    dispatchShapesRoundTrip: dispatchProbe === 63,
+    dispatchShapesRoundTrip: dispatchProbe === 127,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.
     renderFramesAdvanced: peak.processCalls >= ready.processCalls + 10,
     transformCommandsApplied: peak.appliedCommands >= ready.appliedCommands + 10,

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -370,28 +370,6 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     probeImpactSum = impactPoint + force
   }
 
-  /**
-   * The match3 `Tile.set_tile_type(String, Texture2D)` shape (task 80 slice 3): text and an object
-   * handle in one packed argument list. The label is deliberately HOSTILE — it carries the packed
-   * transport's own separator and percent-escape look-alikes — so the escaping is under test, not
-   * just the arity.
-   */
-  @RegisterFunction("dispatch_probe_tag")
-  fun dispatchProbeTag(label: String, node: Node3D) {
-    probeTagArgument = label
-    probeTagNodeMatched = node.handle == self.handle
-  }
-
-  /**
-   * The tps `Level.add_player(id, spawnPoint: Marker3D?)` shape: a whole number plus a NULLABLE
-   * object, so the 0 handle must arrive as Kotlin `null` rather than as a wrapper around nothing.
-   */
-  @RegisterFunction("dispatch_probe_join")
-  fun dispatchProbeJoin(id: Long, spawnPoint: Node3D?) {
-    probeJoinId = id
-    probeJoinNodeWasNull = spawnPoint == null
-  }
-
   @RegisterFunction("dispatch_probe_vector") fun dispatchProbeVector(): Vector3 = PROBE_VECTOR
 
   @RegisterFunction("dispatch_probe_number") fun dispatchProbeNumber(): Double = PROBE_NUMBER
@@ -475,6 +453,32 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
       mask = mask or 64L
     }
     return mask
+  }
+
+  // A registered function's method id is its DECLARATION ORDER, and the browser drivers call
+  // several of these by id (dispatch_probe is method#16). Append new ones BELOW this line --
+  // inserting one above shifts every id after it and the driver silently calls the wrong method.
+
+  /**
+   * The match3 `Tile.set_tile_type(String, Texture2D)` shape (task 80 slice 3): text and an object
+   * handle in one packed argument list. The label is deliberately HOSTILE — it carries the packed
+   * transport's own separator and percent-escape look-alikes — so the escaping is under test, not
+   * just the arity.
+   */
+  @RegisterFunction("dispatch_probe_tag")
+  fun dispatchProbeTag(label: String, node: Node3D) {
+    probeTagArgument = label
+    probeTagNodeMatched = node.handle == self.handle
+  }
+
+  /**
+   * The tps `Level.add_player(id, spawnPoint: Marker3D?)` shape: a whole number plus a NULLABLE
+   * object, so the 0 handle must arrive as Kotlin `null` rather than as a wrapper around nothing.
+   */
+  @RegisterFunction("dispatch_probe_join")
+  fun dispatchProbeJoin(id: Long, spawnPoint: Node3D?) {
+    probeJoinId = id
+    probeJoinNodeWasNull = spawnPoint == null
   }
 
   /**

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -349,6 +349,10 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
   private var probeBoolArgument = false
   private var probeImpactSum = Vector3.ZERO
   private var probeSignalPayload = -1L
+  private var probeTagArgument = ""
+  private var probeTagNodeMatched = false
+  private var probeJoinId = -1L
+  private var probeJoinNodeWasNull = false
 
   @RegisterFunction("dispatch_probe_float")
   fun dispatchProbeFloat(amount: Double) {
@@ -366,6 +370,28 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     probeImpactSum = impactPoint + force
   }
 
+  /**
+   * The match3 `Tile.set_tile_type(String, Texture2D)` shape (task 80 slice 3): text and an object
+   * handle in one packed argument list. The label is deliberately HOSTILE — it carries the packed
+   * transport's own separator and percent-escape look-alikes — so the escaping is under test, not
+   * just the arity.
+   */
+  @RegisterFunction("dispatch_probe_tag")
+  fun dispatchProbeTag(label: String, node: Node3D) {
+    probeTagArgument = label
+    probeTagNodeMatched = node.handle == self.handle
+  }
+
+  /**
+   * The tps `Level.add_player(id, spawnPoint: Marker3D?)` shape: a whole number plus a NULLABLE
+   * object, so the 0 handle must arrive as Kotlin `null` rather than as a wrapper around nothing.
+   */
+  @RegisterFunction("dispatch_probe_join")
+  fun dispatchProbeJoin(id: Long, spawnPoint: Node3D?) {
+    probeJoinId = id
+    probeJoinNodeWasNull = spawnPoint == null
+  }
+
   @RegisterFunction("dispatch_probe_vector") fun dispatchProbeVector(): Vector3 = PROBE_VECTOR
 
   @RegisterFunction("dispatch_probe_number") fun dispatchProbeNumber(): Double = PROBE_NUMBER
@@ -377,14 +403,16 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
   @RegisterFunction("dispatch_probe_count") fun dispatchProbeCount(): Long = PROBE_COUNT
 
   /**
-   * Task-80 dispatch probe (driver method #16). Bits, all of which a healthy run sets (mask 63):
+   * Task-80 dispatch probe (driver method #16). Bits, all of which a healthy run sets (mask 127):
    *
    * 1 = a single-FLOAT registered function received its argument (task 79's exact hole),
    * 2 = a `(BOOL)` registered function received its argument,
    * 4 = a `(VECTOR3, VECTOR3)` registered function received BOTH vectors intact,
    * 8 = a `() -> VECTOR3` return survived the packed transport AND the proxy's parse,
    * 16 = the `() -> FLOAT`, `() -> STRING`, `() -> BOOL` and `() -> INT` returns all did too,
-   * 32 = a one-`int` signal payload reached a Kotlin lambda instead of being discarded.
+   * 32 = a one-`int` signal payload reached a Kotlin lambda instead of being discarded,
+   * 64 = the slice-3 MIXED shapes: `(STRING, OBJECT)` carried a hostile label and a live object
+   * handle, and `(INT, OBJECT?)` carried a number plus a null object.
    *
    * Everything except the signal bit rides `callv` through the generic tier, so the values make a
    * full Kotlin -> GDScript proxy -> Kotlin round trip and the proxy's own parse is under test.
@@ -432,6 +460,20 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     }
 
     if (probeSignalPayload == PROBE_COUNT) mask = mask or 32L
+
+    // Task 80 slice 3: the two MIXED-channel shapes. The generic tier is the only caller that can
+    // pass a string/int AND an object handle, which is exactly the shape the packed argument list
+    // exists for; `null` proves the nullable-object lane delivers null rather than a 0 wrapper.
+    generic.callImmediate(self, "dispatch_probe_tag", listOf(PROBE_HOSTILE_TEXT, self))
+    generic.callImmediate(self, "dispatch_probe_join", listOf(PROBE_COUNT, null))
+    if (
+      probeTagArgument == PROBE_HOSTILE_TEXT &&
+        probeTagNodeMatched &&
+        probeJoinId == PROBE_COUNT &&
+        probeJoinNodeWasNull
+    ) {
+      mask = mask or 64L
+    }
     return mask
   }
 
@@ -451,6 +493,11 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
     const val ENTER_TREE_EXPORTED = "web3d-enter-tree"
     const val PROBE_NUMBER = 12.25
     const val PROBE_TEXT = "kanama-packed-return"
+    /**
+     * Real unit separators, percent-escape look-alikes, a quote and a backslash: the packed
+     * argument list must survive every byte that could split or mis-decode it.
+     */
+    const val PROBE_HOSTILE_TEXT = "a\u001Fb:c%1F\u001Fd\\e\"f%25"
     const val PROBE_COUNT = 4242L
     val PROBE_VECTOR = Vector3(1.5, -2.5, 3.5)
     val PROBE_IMPACT = Vector3(0.25, 0.5, 0.75)


### PR DESCRIPTION
Closes the last two degraded shapes in the corpus, then turns task 80's
degradation census into a **build error**, so this class of bug cannot ship
silently again.

## 1. The mixed-channel arm (`WebMethodArm.PACKED_ARGS`)

The two survivors after slice 2 both mix the string and object-handle channels:

| Shape | Where |
|---|---|
| `(STRING, OBJECT) -> void` | match3 `Tile.set_tile_type` |
| `(INT, OBJECT?) -> void` | tps-demo `Level.add_player` |

**Filled with a real arm, not allowlisted.** A mixed argument list packs into ONE
string over the **existing** `callString` crossing: text is `%`-escaped with the
same spelling the generic-call transport already uses (`%` → `%25`, unit
separator → `%1F`), whole numbers and booleans are their exact decimal text, and
an object rides as its bridge **handle id** — a Kanama-scripted object as its own
script handle (so Kotlin can resolve its script instance), anything else as a
transient handle released right after the call. That is what reaches a shape the
string and object arms cannot. Following the `callObjectObjectLong` grain for the
handle bookkeeping and the slice-2 `callPacked` grain for the encoding.

`packedArgGdExpressions` / `packedArgKotlinExpressions` are mirrors that walk the
same argument list in the same order, so a part can never be read as a different
argument than it was written — the same discipline slice 2's numeric slots use.

**Floats are deliberately excluded.** The packed list is decimal text produced by
GDScript's `str()`, which rounds a double to 14 significant digits; a float
carried here would arrive slightly WRONG, which is exactly the silent-wrong-VALUE
class this task exists to kill. An all-numeric shape has the exact `callDoubles`
crossing anyway, so what is left over is a float *mixed* with text or an object —
and that shape has no arm and now fails the build rather than losing precision in
silence.

**No new bridge entry point, so the protocol stays at 17.** All 12 drivers'
`protocol17:` checks, the JS bridge constant and the emitter constant are
unchanged (grepped).

## 2. The gate

`undispatchedMemberErrors` makes any member whose manifest `dispatch` is not
`typed` a KSP **build error** naming the script, the member, the shape, the reason
and the shapes that *are* dispatched. This generalizes 66a's
`undispatchedVirtualErrors` (#114) and #148's property guards to registered
functions and signals; a non-typed property or virtual additionally reports that
one of the older guards has a hole.

**There is no allowlist.** Every shape the corpus declares has an arm, so an
exemption mechanism would only be a place for the next degradation to hide.

## 3. Evidence

**Census across all 12 corpus demos: 0 degraded of 562 declared members**
(52/19 before slice 2, 2/2 before this PR). Read from a freshly regenerated
`KanamaWebProtocol.generated.json` per demo — the file is deleted before each run
and the reader asserts a non-empty manifest at protocol 17.

**The gate was observed failing.** A temporary `@RegisterFunction fun
gateProof(seconds: Double): Long` in the in-repo web3d fixture:

```
e: [ksp] .../web3dSmoke/web/kotlin-src/Main.kt:49: [kanama:web-dispatch] Main.gate_proof
   (registered function): no arm for the registered-method shape (FLOAT) -> INT; the proxy emits a
   stub that throws. Declare a shape the Web backend dispatches — no arguments; any all-numeric
   argument list up to 6 scalar slots; a single String or object argument; a mixed list of
   String/NodePath/Long/Boolean/object arguments; or a zero-argument value return — or add the arm
   for this shape to WebMethodArm and its emitter branch.
BUILD FAILED
```

Removed, and the same build then reports `0 of 37 declared member(s) ... do not
dispatch typed`.

**The new arm is exercised, not just emitted.** `web3d`'s dispatch probe grows a
seventh bit (mask 63 → 127): both mixed shapes are driven through the REAL
crossing (Kotlin asks Godot to call by name → generated proxy → the new arm →
Kotlin), with a hostile label carrying real unit separators, percent-escape
look-alikes, a quote and a backslash, plus a live object handle; a second call
passes a `null` object so the nullable lane is proven to deliver `null` rather
than a wrapper around handle 0.

**Corpus revalidation** (protocol unchanged, so the PR subset plus the two demos
that carried the most degradations), `web_export_smoke: PASS` on every cell:
match3, web3d, dodge, fps, thirdperson × Chrome + Firefox. fps carries the new
combat gate (`enemyKilledByPlayerShot: true`) on both engines.

## Driver touched

`scripts/web/drivers/demos/web3d.mjs` — the expected dispatch-probe mask only
(63 → 127) plus its comment.

## One thing the run caught

A registered function's method id is its DECLARATION ORDER, and the web3d driver
calls several probes by id. Declaring the two new probes *above* `dispatch_probe`
moved it from method#16 to #18, so the driver called `dispatch_probe_flag` and
web3d failed on both engines with `Unknown Kanama Web method id=16`. Fixed by
appending them below, with a comment on the line that has to hold. Worth knowing:
nothing but a browser run would have caught it.

## Gates

| Gate | Result |
|---|---|
| `ktfmtFormat` + `:processor:test` | green (41 tests) |
| `scripts/local_ci.sh` (Godot 4.7 stable) | `[local_ci] PASS` — every stage, including the web Wasm compile + coverage gate and the four runtime smokes |
| Census, all 12 demos | **0 degraded / 562 members** |
| `web_ci_matrix.sh` match3 · web3d · dodge · fps · thirdperson × chrome + firefox | 10/10 `web_export_smoke: PASS` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
