### PR TITLE
Bump DEMOS_REF to the thirdperson slice-2 convergence (kanama-demos#34)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -50,8 +50,8 @@ env:
   # unpinned demos checkout means an unrelated demo-repo commit can redden every
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
-  # Task 64: thirdperson single-source slice 1 (kanama-demos#33 merge).
-  DEMOS_REF: 58d8f0511292ff68dbdc7405998e0eac98772dff
+  # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
+  DEMOS_REF: 5e0b606aeab5f41591371b1b4c663bd2fc582841
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
One-line pin bump: the Web matrix now runs against kanama-demos#34 (merge `5e0b606`) — thirdperson single-source slice 2 (Grenade, PlayerIdentity, CoinsContainer; overrides 17 → 14), unlocked by #150 (members), #153 (task 78 `GD.isInstanceValid`) and #154 (protocol 17 dispatch shapes).

Validated before merging #34: desktop 3-leg stash-compare (registrars byte-identical, 58 files each side; a jar cross-check proved KSP genuinely re-ran rather than passing vacuously), web proxies byte-identical (33 files each side, live KSP path printed not guessed), and `web_export_smoke: PASS` for thirdperson on chrome + firefox plus fps on chrome.

Note `PlayerIdentity` adds an `isInstanceValid` guard to a desktop path — safe only because #153 fixed that function *and* added a runtime-smoke assertion proving `valid_live=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)