### PR TITLE
Pump the Web coroutine frame scheduler once per frame in every demo (task 82)

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -155,6 +155,15 @@ dispatch of that iteration observes the same tick), with a repeat-handle fallbac
 — Godot dispatches a node's `_process` at most once per iteration, so seeing the
 same handle twice proves a new iteration began.
 
+Because it rides `_process`, the pump advances while *something* is processing.
+Every proxy emits `func _process` unconditionally, so any live Kanama script node
+drives it, and a scene with no live Kanama script has no coroutine owner either —
+owners are script handles, and freeing one drains its queue. The consequence
+worth knowing: while `get_tree().set_paused(true)` holds (or if every Kanama node
+in the scene has explicitly called `set_process(false)`), no `_process` runs, so
+coroutine delays freeze with the rest of the game and resume on unpause. That is
+the intended reading of "paused", not a stall.
+
 Each continuation runs under **its own** owner on both sides of the boundary: the
 Kotlin active script handle and the bridge's active owner are switched to the
 task's owner, not to whichever script's `_process` drove the pump. Billing a

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -137,6 +137,37 @@ mirrors crossings:
 - **Handle generations** — handles are opaque IDs across the bridge, not live
   pointers, so stale generations are detected and rejected explicitly.
 
+### Coroutine frame scheduler (one advance per engine frame, no demo opt-in)
+
+`kanamaScope.launch { … delaySeconds(…) … }` queues its continuation on one
+global scheduler. Nothing runs a queued continuation except the per-frame pump,
+so a demo whose pump never fires never resumes a delay — and nothing throws,
+because nothing failed: the work simply never runs.
+
+The pump is therefore **unconditional and demo-blind**. The bridge calls the
+ownerless `kanamaWebPumpFrameScheduler(delta)` crossing from the `_process`
+dispatch that *every* generated proxy emits, before any per-mode branch, so a new
+demo cannot be brought up without it. Exactly one advance per engine frame: the
+pump also advances the scheduler's frame counter and elapsed clock, so a second
+call in the same frame would run time at N× speed. Frame identity is the rAF tick
+(one engine iteration runs synchronously inside one animation frame, so every
+dispatch of that iteration observes the same tick), with a repeat-handle fallback
+— Godot dispatches a node's `_process` at most once per iteration, so seeing the
+same handle twice proves a new iteration began.
+
+Each continuation runs under **its own** owner on both sides of the boundary: the
+Kotlin active script handle and the bridge's active owner are switched to the
+task's owner, not to whichever script's `_process` drove the pump. Billing a
+resumed coroutine's allocations to the pumping script is the task-72 leak shape —
+the handles outlive the script that made them.
+
+Before protocol 18 this ran through a per-script `kanamaWebFrame(objectId, delta)`
+crossing that the bridge invoked for four hardcoded "Main" handles. The other
+eight demos in the corpus never pumped, so every coroutine delay in them hung
+forever (task 82). The conformance probe that closes it lives in the in-repo
+`web3d` fixture: a coroutine that awaits `delaySeconds` and publishes a mask
+proving it *resumed*, asserted by the browser driver.
+
 ### Lifecycle ownership
 
 Handles, callbacks, connections, tweens/tweeners, scheduler continuations, audio
@@ -246,7 +277,8 @@ fields moved the former only.
 **What the census bought.** Reading it across the twelve-demo corpus turned
 "add a `callDouble` arm" into a measured parcel — 52 degraded members over 19
 distinct missing shapes — and three arms plus one signal change closed all of
-them, at protocol 17 and with **no new bridge entry point after slice 2**:
+them, at protocol 17 (the version current when task 80 landed) and with **no new
+bridge entry point after slice 2**:
 
 | Arm | Covers |
 |---|---|

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 17). It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 18). It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1898,6 +1898,19 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\tif _kanama_handle == 0:")
     appendLine("\t\tpush_error(\"Kanama Web script construction failed\")")
     appendLine("\t\treturn 0")
+    // Publish this script's own handle in the SHARED dictionary, completing the invariant the
+    // node-lookup path below already states: a handle any proxy hands out must resolve in every
+    // proxy. Without it a Kanama script handle resolved ONLY through `self if handle ==
+    // _kanama_handle`, i.e. only inside its own proxy — so a foreign proxy asked to emit a signal
+    // whose payload is another script (charactercontroller's kill plane emits
+    // `kill_plane_touched` with the PLAYER's handle, through the Events autoload's proxy) had no
+    // way to turn that handle back into an Object and pushed "Unknown Kanama Web signal argument
+    // handle". `_exit_tree` already erased this entry; only the insert was missing.
+    //
+    // Nodes only: the erase lives in `_exit_tree`, which a Resource-attached script never gets,
+    // and a RefCounted stored in a static Dictionary would be pinned alive forever.
+    appendLine("\tif self is Node:")
+    appendLine("\t\t_kanama_object_handles[_kanama_handle] = self")
     appendLine(
       "\t_kanama_apply_callback = JavaScriptBridge.create_callback(_kanama_apply_commands)"
     )

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -127,7 +127,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
   private val scripts = inputs.sortedWith(compareBy({ it.resourcePath }, { it.model.fqName }))
 
   companion object {
-    const val PROTOCOL_VERSION = 17
+    /**
+     * Runtime bridge contract version. 18 (task 82) replaces the per-script `kanamaWebFrame`
+     * crossing with the ownerless `kanamaWebPumpFrameScheduler(delta)`, which the bridge drives
+     * from the `_process` dispatch every proxy emits — so the coroutine frame scheduler advances
+     * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
+     * happened to name.
+     */
+    const val PROTOCOL_VERSION = 18
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1909,8 +1909,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     //
     // Nodes only: the erase lives in `_exit_tree`, which a Resource-attached script never gets,
     // and a RefCounted stored in a static Dictionary would be pinned alive forever.
-    appendLine("\tif self is Node:")
-    appendLine("\t\t_kanama_object_handles[_kanama_handle] = self")
+    //
+    // The `Object` local is load-bearing, not ceremony: GDScript's parser rejects `self is Node`
+    // outright in a proxy that `extends Resource` ("Expression is of type Weapon so it can't be
+    // of type Node") and the whole script fails to compile. Widening to the static type the check
+    // is legal for keeps one spelling for every attachment.
+    appendLine("\tvar _kanama_self_object: Object = self")
+    appendLine("\tif _kanama_self_object is Node:")
+    appendLine("\t\t_kanama_object_handles[_kanama_handle] = _kanama_self_object")
     appendLine(
       "\t_kanama_apply_callback = JavaScriptBridge.create_callback(_kanama_apply_commands)"
     )

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -103,6 +103,46 @@ class WebScriptCodeEmitterTest {
     )
   }
 
+  /**
+   * Task 82: a proxy publishes its own script handle in the shared handle dictionary so a FOREIGN
+   * proxy can resolve it (a signal payload that is another Kanama script). The Node test must go
+   * through an `Object`-typed local, because GDScript's parser rejects `self is Node` outright in a
+   * proxy that `extends Resource` — "Expression is of type Weapon so it can't be of type Node" —
+   * and takes the whole script down with it. That is not hypothetical: it red-lighted the FPS demo,
+   * whose `Weapon` is `@ScriptClass(attachTo = "Resource")`, and the export does not type-check
+   * GDScript, so nothing caught it before the browser did.
+   */
+  @Test
+  fun publishesOwnHandleThroughAnObjectWidenedNodeTestForEveryAttachment() {
+    for (attachTo in listOf("Node2D", "Resource")) {
+      val proxy =
+        WebScriptCodeEmitter(
+            listOf(
+              WebScriptInput(
+                model("HandleScript").copy(attachTo = attachTo),
+                "res://HandleScript.kt",
+              )
+            )
+          )
+          .proxySources()
+          .single { it.sourceResourcePath.isNotEmpty() }
+
+      assertTrue(
+        proxy.source.contains("var _kanama_self_object: Object = self"),
+        "attachTo=$attachTo must widen self before the Node test:\n${proxy.source}",
+      )
+      assertTrue(
+        proxy.source.contains(
+          "\tif _kanama_self_object is Node:\n" +
+            "\t\t_kanama_object_handles[_kanama_handle] = _kanama_self_object"
+        ),
+        "attachTo=$attachTo must publish its handle for Nodes only:\n${proxy.source}",
+      )
+      // The spelling GDScript refuses to parse under `extends Resource`.
+      assertFalse(proxy.source.contains("if self is Node:"))
+    }
+  }
+
   @Test
   fun emitsProxyWithLifecycleBatchAndImmediatePaths() {
     val emitter =

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 17"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 18"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -432,7 +432,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 17"))
+    assertTrue(protocol.contains("\"protocolVersion\": 18"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -443,7 +443,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=17\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=18\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1413,7 +1413,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 17"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 18"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -11,6 +11,12 @@
 // handle to zero.
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+// How far below the start height counts as "off the platform and falling". The level's
+// KillPlane sits ~17 units down, so anything past this is unambiguously a fall, not a step.
+const FALL_DEPTH = 5;
+// The kill-plane reset teleports to the position captured in the player's _ready; the driver's
+// baseline is read after a settle, so allow for the gravity snap between the two.
+const RESET_TOLERANCE = 2.0;
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
 const START = Date.now();
 const trace = (msg) => {
@@ -39,6 +45,10 @@ async function snapshot(evaluate) {
         flagReady: classCount(".Flag3D"),
         killPlaneReady: classCount(".KillPlane3D"),
         physicsCalls: bridge.physicsProcessCalls ?? 0,
+        // Task 82: the coroutine frame scheduler's per-frame advance. cc named no "Main"
+        // handle anywhere, which is exactly why it never pumped before protocol 18.
+        pumps: bridge.frameSchedulerPumps ?? 0,
+        continuations: bridge.frameSchedulerContinuations ?? 0,
         appliedCommands: bridge.appliedCommands,
         liveHandles: bridge.liveBrowserHandleCount,
         maxLiveHandles: bridge.maxLiveBrowserHandles,
@@ -107,6 +117,10 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   // fallback otherwise (works headless-Chrome, stalls headless-Firefox rAF).
   const keyDown = keys ? () => keys("down", "w") : () => evaluate(keyExpression("keydown", "KeyW", "w", 87));
   const keyUp = keys ? () => keys("up", "w") : () => evaluate(keyExpression("keyup", "KeyW", "w", 87));
+  // move_down (S). move_up walks the player into the level's boundary wall ~15 units ahead;
+  // the open edge of the starting platform is ~3 units BEHIND the spawn, so S is the way off.
+  const backDown = keys ? () => keys("down", "s") : () => evaluate(keyExpression("keydown", "KeyS", "s", 83));
+  const backUp = keys ? () => keys("up", "s") : () => evaluate(keyExpression("keyup", "KeyS", "s", 83));
   const startupStart = Date.now();
   trace("navigate");
   await navigate(`${url}?charactercontroller=${Date.now()}`);
@@ -165,6 +179,100 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
     : 0;
   trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
 
+  // ---- Task 82 gate (a): the kill plane, the LOSE transition ----
+  //
+  // Keep walking until the player leaves the platform and falls. The level's KillPlane is an
+  // Area3D whose body_entered handler does NOT emit straight away: it defers one frame through
+  // `kanamaScope.launch { delaySeconds(0.0) }` -- the Web spelling of desktop's
+  // MainThread.awaitNextFrame -- because Godot forbids restructuring nodes inside a physics
+  // callback. Only then does it emit kill_plane_touched, which teleports the player back to its
+  // start position with zero velocity.
+  //
+  // That deferral is the entire test. Before protocol 18 the frame scheduler was never pumped in
+  // this demo, so the continuation after delaySeconds(0.0) never ran: body_entered fired, nothing
+  // threw, and the player fell forever. The assertion is therefore the OBSERVED return to the
+  // start position, read through the engine's own global-position channel -- never "no error".
+  trace("kill plane: walking off the platform");
+  await backDown();
+  let lowestY = startPosition.y;
+  const fallDeadline = Math.min(deadline, Date.now() + 40_000);
+  while (Date.now() < fallDeadline) {
+    const here = await playerPosition(evaluate);
+    if (here) {
+      lowestY = Math.min(lowestY, here.y);
+      trace(`kill plane: y=${here.y.toFixed(2)} x=${here.x.toFixed(2)} z=${here.z.toFixed(2)}`);
+      if (here.y < startPosition.y - FALL_DEPTH) break;
+    }
+    await delay(200);
+  }
+  await backUp();
+  trace(`kill plane: lowest y=${lowestY.toFixed(2)} (start y=${startPosition.y.toFixed(2)})`);
+
+  let killPlaneReset = null;
+  const resetDeadline = Math.min(deadline, Date.now() + 30_000);
+  while (Date.now() < resetDeadline) {
+    const here = await playerPosition(evaluate);
+    if (
+      here &&
+      Math.hypot(here.x - startPosition.x, here.z - startPosition.z) < RESET_TOLERANCE &&
+      here.y > startPosition.y - RESET_TOLERANCE
+    ) {
+      killPlaneReset = here;
+      break;
+    }
+    await delay(200);
+  }
+  trace(`kill plane: reset=${JSON.stringify(killPlaneReset)}`);
+
+  // ---- Task 82 gate (b): the flag, the WIN transition ----
+  //
+  // Reaching the flag on foot means crossing the whole platforming course, which no synthetic
+  // key hold can steer, so the win is driven at the signal it actually hangs off: the Events
+  // autoload's `flag_reached`, emitted through Godot itself (the bridge's no-args signal
+  // crossing, the same one Kotlin uses). Everything downstream is the real chain --
+  // FlagReachedScreen's connected Kotlin lambda launches
+  // `kanamaScope.launch { delaySeconds(2.0); play("fade_in"); await(animation_finished);
+  // reloadCurrentScene() }`.
+  //
+  // The observable is the LEVEL RELOAD: every script in the scene is torn down and readied
+  // again, so the player's script handle changes and its ready count goes to two. None of it
+  // happens if the coroutine never resumes past its 2-second delay.
+  const eventsHandle = Number(
+    await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const entry = Object.entries(bridge.scriptNameByHandle ?? {}).find(([, name]) =>
+        String(name).endsWith(".Events"),
+      );
+      return entry ? Number(entry[0]) : 0;
+    })()`),
+  );
+  trace(`flag: eventsHandle=${eventsHandle} playerHandle=${ready.playerHandle}`);
+  let flagReload = null;
+  if (eventsHandle > 0) {
+    await evaluate(
+      `globalThis.KanamaWebBridge.immediateEmitSignalNoArgs(${eventsHandle}, "flag_reached"); true`,
+    );
+    const reloadDeadline = Math.min(deadline, Date.now() + 40_000);
+    while (Date.now() < reloadDeadline) {
+      const snap = await snapshot(evaluate);
+      if (snap && snap.playerReady >= 2 && snap.playerHandle !== ready.playerHandle) {
+        flagReload = snap;
+        break;
+      }
+      await delay(250);
+    }
+  }
+  trace(
+    `flag: reloaded=${flagReload !== null} playerReady=${flagReload?.playerReady} newPlayerHandle=${flagReload?.playerHandle}`,
+  );
+
+  const afterGameplay = (await snapshot(evaluate)) ?? atPeak;
+  peak.maxLiveHandles = Math.max(peak.maxLiveHandles, afterGameplay.maxLiveHandles);
+  peak.crossings = Math.max(peak.crossings, afterGameplay.crossings);
+  peak.appliedCommands = Math.max(peak.appliedCommands, afterGameplay.appliedCommands);
+  peak.callbackErrors = Math.max(peak.callbackErrors, afterGameplay.callbackErrors);
+  trace(`scheduler: pumps=${afterGameplay.pumps} continuations=${afterGameplay.continuations}`);
+
   // Full teardown: SmokeQuit.smoke_teardown (method#1) frees the Events autoload and
   // the scene root; every node exits the tree and releases its handles.
   trace("smoke_teardown");
@@ -194,6 +302,19 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
     // travel(Idle/Move) + particle toggles + blink timers flow as queued commands.
     gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
     crossingsAdvanced: peak.crossings > ready.crossings,
+    // Task 82: the coroutine frame scheduler is advanced in THIS demo, which names no
+    // "Main" handle anywhere -- the pump rides the _process dispatch every proxy emits.
+    frameSchedulerPumped: afterGameplay.pumps >= 10,
+    // The lose transition: the player left the platform (engine-level global position)...
+    playerFellOffLevel: lowestY < startPosition.y - FALL_DEPTH,
+    // ...and the KillPlane's deferred coroutine put it back at the start. Nothing else in
+    // this demo moves the player upward, so the observed return IS the resumed continuation.
+    killPlaneResetPlayer: killPlaneReset !== null,
+    // The win transition: `flag_reached` reached FlagReachedScreen's coroutine, which after a
+    // 2-second delay played the fade and reloaded the level -- every script readied a second
+    // time under a new handle.
+    flagSignalSourceResolved: eventsHandle > 0,
+    flagReachedReloadedLevel: flagReload !== null,
     fullTeardownToZero: settled.liveHandles === 0,
     // Godot runs every physics tick before the idle/_process pass inside one rAF
     // iteration; the bridge counts any same-tick physics-after-process dispatch.
@@ -224,6 +345,10 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
       physicsProcessCalls: peak.physicsCalls,
       appliedCommands: peak.appliedCommands,
       playerDisplacement: Number(displacement.toFixed(3)),
+      frameSchedulerPumps: afterGameplay.pumps,
+      frameSchedulerContinuations: afterGameplay.continuations,
+      // How far the player fell before the kill plane's deferred emit put it back.
+      killPlaneFallDepth: Number(Math.max(0, startPosition.y - lowestY).toFixed(3)),
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -192,37 +192,41 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   // this demo, so the continuation after delaySeconds(0.0) never ran: body_entered fired, nothing
   // threw, and the player fell forever. The assertion is therefore the OBSERVED return to the
   // start position, read through the engine's own global-position channel -- never "no error".
+  //
+  // Fall and reset are watched by ONE tight loop, so the ordering is part of the assertion: the
+  // return to the spawn only counts once a sample has actually seen the player below the
+  // platform. The whole excursion is about a second of free fall, so the poll is fast enough to
+  // land several samples inside it on an engine whose rAF nothing is pacing.
   trace("kill plane: walking off the platform");
   await backDown();
   let lowestY = startPosition.y;
-  const fallDeadline = Math.min(deadline, Date.now() + 40_000);
-  while (Date.now() < fallDeadline) {
+  let killPlaneReset = null;
+  let walkedOff = false;
+  const killPlaneDeadline = Math.min(deadline, Date.now() + 60_000);
+  while (Date.now() < killPlaneDeadline) {
     const here = await playerPosition(evaluate);
     if (here) {
       lowestY = Math.min(lowestY, here.y);
-      trace(`kill plane: y=${here.y.toFixed(2)} x=${here.x.toFixed(2)} z=${here.z.toFixed(2)}`);
-      if (here.y < startPosition.y - FALL_DEPTH) break;
+      if (!walkedOff && lowestY < startPosition.y - FALL_DEPTH) {
+        walkedOff = true;
+        trace(`kill plane: falling at y=${here.y.toFixed(2)} z=${here.z.toFixed(2)}`);
+        await backUp(); // stop walking so the reset lands at the spawn and stays there
+      }
+      if (
+        walkedOff &&
+        Math.hypot(here.x - startPosition.x, here.z - startPosition.z) < RESET_TOLERANCE &&
+        here.y > startPosition.y - RESET_TOLERANCE
+      ) {
+        killPlaneReset = here;
+        break;
+      }
     }
-    await delay(200);
+    await delay(50);
   }
-  await backUp();
-  trace(`kill plane: lowest y=${lowestY.toFixed(2)} (start y=${startPosition.y.toFixed(2)})`);
-
-  let killPlaneReset = null;
-  const resetDeadline = Math.min(deadline, Date.now() + 30_000);
-  while (Date.now() < resetDeadline) {
-    const here = await playerPosition(evaluate);
-    if (
-      here &&
-      Math.hypot(here.x - startPosition.x, here.z - startPosition.z) < RESET_TOLERANCE &&
-      here.y > startPosition.y - RESET_TOLERANCE
-    ) {
-      killPlaneReset = here;
-      break;
-    }
-    await delay(200);
-  }
-  trace(`kill plane: reset=${JSON.stringify(killPlaneReset)}`);
+  if (!walkedOff) await backUp();
+  trace(
+    `kill plane: lowest y=${lowestY.toFixed(2)} (start y=${startPosition.y.toFixed(2)}) reset=${JSON.stringify(killPlaneReset)}`,
+  );
 
   // ---- Task 82 gate (b): the flag, the WIN transition ----
   //

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -178,7 +178,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -254,7 +254,7 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeCitybuilder: ready.mode === "citybuilder",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
     // Injected build placed a structure on the grid at the mouse-ray cell.

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -262,7 +262,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -217,7 +217,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -234,7 +234,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol17: firstRun.settled.protocol === 17 && secondRun.settled.protocol === 17,
+    protocol18: firstRun.settled.protocol === 18 && secondRun.settled.protocol === 18,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -141,7 +141,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -192,7 +192,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -185,7 +185,7 @@ export async function runSoak({ url, evaluate, navigate, deadline }) {
 
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol17: ready.protocol === 17,
+    protocol18: ready.protocol === 18,
     // The run really lasted: several full rounds, and enough samples to judge.
     soakCyclesCompleted: cycles >= 2,
     soakSamplesCollected: samples.length >= 8,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -141,7 +141,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -194,7 +194,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -221,7 +221,7 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
   const protocolVersion = menu.protocol;
   const checks = {
     modeTpsdemo: menu.mode === "tpsdemo",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     // The menu boots, and pressing Play streams the whole level in: the AnimationTree-driven
     // player, its input synchronizer, the shake camera, and the four red robots with their
     // detachable death parts.

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -31,6 +31,9 @@ async function snapshot(evaluate) {
         enterTreeCalls: bridge.enterTreeCalls,
         mainReady: classCount(".Main"),
         processCalls: bridge.processCalls,
+        // Task 82: the coroutine frame scheduler's per-frame advance. Demo-independent.
+        pumps: bridge.frameSchedulerPumps ?? 0,
+        continuations: bridge.frameSchedulerContinuations ?? 0,
         appliedCommands: bridge.appliedCommands,
         liveHandles: bridge.liveBrowserHandleCount,
         maxLiveHandles: bridge.maxLiveBrowserHandles,
@@ -193,6 +196,35 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   );
   trace(`generic: ${JSON.stringify(generic)}`);
 
+  // Task 82 coroutine conformance probe. Main.coroutine_probe (method#19) launches ONE coroutine
+  // on the script's own scope that awaits both delay shapes gameplay uses -- the wait-one-frame
+  // safe point delaySeconds(0.0) and a timed delaySeconds -- then posts to the main thread.
+  // Main.coroutine_probe_mask (method#20, Int->Int) reports how far it got.
+  //
+  // This is the generic version of the bug task 82 fixed: before the fix the frame scheduler was
+  // pumped only for four hardcoded "Main" handles, so in eight of twelve demos a launched
+  // coroutine stopped at its first delay and NOTHING threw. An unpumped scheduler stalls this
+  // mask at 3 forever; a pumped one reaches 31. Asserting "no error" would have passed either way.
+  const readCoroutineMask = () =>
+    evaluate(
+      "globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, 20, 0)",
+    ).then(Number);
+  trace("coroutine_probe");
+  const maskBeforeArm = await readCoroutineMask();
+  await evaluate(
+    "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.web3dMainHandle, 19); true",
+  );
+  let coroutineMask = await readCoroutineMask();
+  const coroutineDeadline = Math.min(deadline, Date.now() + 15_000);
+  while (coroutineMask !== 31 && Date.now() < coroutineDeadline) {
+    await delay(150);
+    coroutineMask = await readCoroutineMask();
+  }
+  const afterCoroutine = (await snapshot(evaluate)) ?? atPeak;
+  trace(
+    `coroutine: mask=${coroutineMask} (was ${maskBeforeArm}) pumps=${afterCoroutine.pumps} continuations=${afterCoroutine.continuations}`,
+  );
+
   // Full teardown: SmokeQuit.smoke_teardown (method#1) frees the scene root, draining handles.
   trace("smoke_teardown");
   await evaluate(
@@ -205,7 +237,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol17: protocolVersion === 17,
+    protocol18: protocolVersion === 18,
     sceneReady: ready.mainReady >= 1,
     // 66b: the bridge crossing fired and the Kotlin @OnEnterTree body observed it.
     enterTreeDispatched: ready.enterTreeCalls >= 1 && (enterTreeProbe & 1) === 1,
@@ -274,6 +306,16 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
       generic.typedHits === 500 &&
       generic.genericMs > 0 &&
       generic.typedMs > 0,
+    // Task 82 (a) the frame scheduler is advanced at all, without this demo naming a "Main"
+    // handle anywhere -- the pump rides the _process dispatch every proxy emits.
+    frameSchedulerPumped: afterCoroutine.pumps >= 10,
+    // ...(b) and a launched coroutine RESUMED past both delay shapes and ran its main-thread
+    // post. Bit 1 armed, 2 body entered, 4 past delaySeconds(0.0), 8 past a timed delay,
+    // 16 MainThread.post ran. An unpumped scheduler stalls at 3 and throws nothing.
+    coroutineDelayResumed: coroutineMask === 31,
+    // The probe had NOT already run before the driver armed it: the mask is a fresh observation,
+    // not a leftover from startup.
+    coroutineProbeArmedByDriver: maskBeforeArm === 0,
     fullTeardownToZero: settled.liveHandles === 0,
     noCallbackFaults: peak.callbackErrors === 0 && settled.callbackErrors === 0 && settled.failure === null,
   };
@@ -298,6 +340,8 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
     crossings: {
       kotlinToGodotCalls: peak.crossings,
       processCalls: peak.processCalls,
+      frameSchedulerPumps: afterCoroutine.pumps,
+      frameSchedulerContinuations: afterCoroutine.continuations,
       appliedCommands: peak.appliedCommands,
       // Task 76 spike cost measurement (schema requires non-negative numbers, so the
       // millisecond totals ride x1000 and the generic/typed ratio rides x100).

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -203,8 +203,9 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   //
   // This is the generic version of the bug task 82 fixed: before the fix the frame scheduler was
   // pumped only for four hardcoded "Main" handles, so in eight of twelve demos a launched
-  // coroutine stopped at its first delay and NOTHING threw. An unpumped scheduler stalls this
-  // mask at 3 forever; a pumped one reaches 31. Asserting "no error" would have passed either way.
+  // coroutine stopped at its first delay and NOTHING threw. A pumped scheduler reaches 31; an
+  // unpumped one never gets past bit 1, because `launch` dispatches even its first continuation
+  // through the same scheduler. Asserting "no error" would have passed either way.
   const readCoroutineMask = () =>
     evaluate(
       "globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, 20, 0)",

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -223,18 +223,47 @@ fun kanamaWebPhysicsProcess(objectId: Int, delta: Double): Int {
   }
 }
 
-/** Match3's single frame pump; the JavaScript bridge invokes it only for the Main script. */
+/**
+ * Advances the shared coroutine frame scheduler by exactly one engine frame.
+ *
+ * Task 82: this is the ONLY scheduler advance, and it deliberately takes **no script handle**. The
+ * pump is global and owner-agnostic — [WebFrameScheduler.pump] selects work by due frame/time and
+ * each queued task carries its own owner — so nothing about advancing it belongs to a particular
+ * script. Its predecessor `kanamaWebFrame(objectId, delta)` pumped *and* ran one script's
+ * `_process`, which is why the JavaScript bridge had to name a "Main" handle per demo; four demos
+ * were named and the other eight silently never resumed a `delaySeconds`.
+ *
+ * The bridge now calls this from the generated `_process` dispatch that EVERY Kanama proxy emits,
+ * once per engine frame. Advancing twice in a frame would double-count `frame`/`elapsedSeconds`, so
+ * the once-per-frame guard lives at that single call site.
+ */
 @JsExport
-fun kanamaWebFrame(objectId: Int, delta: Double): Int {
-  return webCallbackBoundary(objectId, "frame_scheduler") { record ->
+fun kanamaWebPumpFrameScheduler(delta: Double): Int {
+  try {
     commands.clear()
     val executed =
       WebFrameScheduler.pump(delta, instances::isLive) { ownerHandle, action ->
-        withActiveWebScriptHandle(ownerHandle, action)
+        // Both sides of the boundary must see the CONTINUATION's owner rather than whichever
+        // script's _process drove this frame's pump: the Kotlin active handle resolves singleton
+        // calls, and the bridge's active owner is who a browser handle allocated inside the
+        // continuation is billed to. Billing it to the pumping script is task 72's leak class —
+        // the resumed work outlives its own script and its handles never come back.
+        withActiveWebScriptHandle(ownerHandle) {
+          val previousOwner = enterWebBridgeFrameOwner(ownerHandle)
+          try {
+            action()
+          } finally {
+            exitWebBridgeFrameOwner(previousOwner)
+          }
+        }
       }
-    KanamaWebProjectRegistry.process(record.scriptId, record.script, delta)
     commands.flush()
-    executed
+    return executed
+  } catch (error: Throwable) {
+    throw IllegalStateException(
+      "Kanama Web frame scheduler pump failed: cause=${describeCauseChain(error)}",
+      error,
+    )
   }
 }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommandInterop.kt
@@ -319,3 +319,18 @@ private fun stageWebGenericArgs(value: String): Int =
   js("globalThis.KanamaWebBridge.stageGenericArgs(value)")
 
 internal fun webNowMillis(): Double = js("performance.now()")
+
+/**
+ * Task 82: scopes the JS bridge's active owner to a resumed coroutine's OWN script for the length
+ * of that continuation, and returns the previous owner so the caller can restore it.
+ *
+ * The bridge bills every browser handle allocated during a crossing to its active owner. A frame
+ * pump is not a script callback, so without this the whole frame's continuations would be billed to
+ * whichever script's `_process` drove the pump — handles minted by a mob's resumed coroutine
+ * charged to the scene root, which outlives it (task 72's leak shape).
+ */
+internal fun enterWebBridgeFrameOwner(ownerHandle: Int): Int =
+  js("globalThis.KanamaWebBridge?.enterFrameSchedulerOwner(ownerHandle) ?? 0")
+
+internal fun exitWebBridgeFrameOwner(previousOwner: Int): Int =
+  js("globalThis.KanamaWebBridge?.exitFrameSchedulerOwner(previousOwner) ?? 0")

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -525,7 +525,9 @@ class Main(godotObject: GodotHandle) :
    * Task-82 coroutine conformance readback (driver method #20): bit 1 = [coroutineProbe] ran,
    * 2 = the coroutine body started, 4 = it resumed past `delaySeconds(0.0)`, 8 = it resumed past a
    * timed `delaySeconds`, 16 = a `MainThread.post` from inside the coroutine ran. A pumped
-   * scheduler reaches 31; an unpumped one stalls at 3 forever.
+   * scheduler reaches 31. An unpumped one never gets past bit 1: `launch` dispatches even its
+   * FIRST continuation through this same scheduler, so the body does not merely stall mid-way —
+   * it never starts, and still throws nothing.
    */
   @RegisterFunction("coroutine_probe_mask")
   fun coroutineProbeMask(value: Long): Long = coroutineMask

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -17,19 +17,24 @@ import net.multigesture.kanama.api.DirectionalLight3D
 import net.multigesture.kanama.api.GodotHandle
 import net.multigesture.kanama.api.GodotObject
 import net.multigesture.kanama.api.Input
+import net.multigesture.kanama.api.KanamaCoroutineOwner
+import net.multigesture.kanama.api.KanamaScope
 import net.multigesture.kanama.api.KanamaScript
+import net.multigesture.kanama.api.MainThread
 import net.multigesture.kanama.api.ManualGodotLifetimeApi
 import net.multigesture.kanama.api.Node3D
 import net.multigesture.kanama.api.OS
 import net.multigesture.kanama.api.RenderingServer
 import net.multigesture.kanama.api.Resource
 import net.multigesture.kanama.api.ResourceLoader
+import net.multigesture.kanama.api.SceneTree
 import net.multigesture.kanama.api.WorldEnvironment
 import net.multigesture.kanama.api.genericWebGameplayFallback
 import net.multigesture.kanama.api.lookAt
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.web.WebExperimentalGenericCall
+import kotlinx.coroutines.launch
 
 /**
  * Kanama Web 3D rendering-foundation smoke (Task 60c).
@@ -44,9 +49,17 @@ import net.multigesture.kanama.web.WebExperimentalGenericCall
  * `_kanama_ensure_created()`, which constructs the Kotlin instance and applies every export
  * before dispatching — and (c) via [ready], that it ran BEFORE `_ready`. The driver reads the
  * combined mask through [enterTreeProbe] and fails the smoke unless it is exactly 7.
+ *
+ * Task 82 addition: [coroutineProbe] / [coroutineProbeMask] are the coroutine conformance probe —
+ * the generic, demo-independent proof that the Web frame scheduler is actually pumped, so a
+ * `delaySeconds` resumes instead of hanging forever in silence.
  */
 @ScriptClass(attachTo = "Node3D")
-class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3D) {
+class Main(godotObject: GodotHandle) :
+  KanamaScript<Node3D>(godotObject, ::Node3D), KanamaCoroutineOwner {
+  /** Task 82: owns the coroutine conformance probe, so owner teardown cancels it. */
+  override val kanamaScope = KanamaScope()
+
   /** Overridden in main.tscn to [ENTER_TREE_EXPORTED] — never the default — for the 66b proof. */
   @ScriptProperty var enterTreeGreeting: String = "unset"
 
@@ -353,6 +366,7 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
   private var probeTagNodeMatched = false
   private var probeJoinId = -1L
   private var probeJoinNodeWasNull = false
+  private var coroutineMask = 0L
 
   @RegisterFunction("dispatch_probe_float")
   fun dispatchProbeFloat(amount: Double) {
@@ -482,6 +496,41 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
   }
 
   /**
+   * Task-82 coroutine conformance probe (driver method #19), armed by the browser driver.
+   *
+   * The fifteen lines that would have caught task 82 on day one, in every demo: launch a coroutine
+   * on this script's own scope, await the two delay shapes gameplay actually uses — the
+   * wait-one-frame safe point `delaySeconds(0.0)` (desktop's `MainThread.awaitNextFrame`, which
+   * the kill plane and every "restructure after the physics callback unwinds" site depends on) and
+   * a real timed delay — and record that each one RESUMED.
+   *
+   * Nothing here can fail loudly on its own: a scheduler that is never pumped leaves the whole
+   * body unrun and throws nothing at all. That is exactly why the assertion has to be a positive
+   * observation of resumption, read back through [coroutineProbeMask], and never "no error".
+   */
+  @RegisterFunction("coroutine_probe")
+  fun coroutineProbe() {
+    coroutineMask = 1L
+    kanamaScope.launch {
+      coroutineMask = coroutineMask or 2L
+      SceneTree.delaySeconds(0.0)
+      coroutineMask = coroutineMask or 4L
+      self.getTree().delaySeconds(COROUTINE_PROBE_DELAY_SECONDS)
+      coroutineMask = coroutineMask or 8L
+      MainThread.post { coroutineMask = coroutineMask or 16L }
+    }
+  }
+
+  /**
+   * Task-82 coroutine conformance readback (driver method #20): bit 1 = [coroutineProbe] ran,
+   * 2 = the coroutine body started, 4 = it resumed past `delaySeconds(0.0)`, 8 = it resumed past a
+   * timed `delaySeconds`, 16 = a `MainThread.post` from inside the coroutine ran. A pumped
+   * scheduler reaches 31; an unpumped one stalls at 3 forever.
+   */
+  @RegisterFunction("coroutine_probe_mask")
+  fun coroutineProbeMask(value: Long): Long = coroutineMask
+
+  /**
    * Connects and fires the scalar-payload signal once. Called from [ready] so the payload has
    * landed long before the driver reads [dispatchProbe]; the connection is one-shot, so it
    * unregisters itself and the smoke's callback-drain assertion is unaffected.
@@ -503,6 +552,8 @@ class Main(godotObject: GodotHandle) : KanamaScript<Node3D>(godotObject, ::Node3
      */
     const val PROBE_HOSTILE_TEXT = "a\u001Fb:c%1F\u001Fd\\e\"f%25"
     const val PROBE_COUNT = 4242L
+    /** Long enough that a resume proves the timed lane, short enough for a driver poll window. */
+    const val COROUTINE_PROBE_DELAY_SECONDS = 0.25
     val PROBE_VECTOR = Vector3(1.5, -2.5, 3.5)
     val PROBE_IMPACT = Vector3(0.25, 0.5, 0.75)
     val PROBE_FORCE = Vector3(-1.25, 2.5, -3.75)

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 17;
+  const KANAMA_WEB_PROTOCOL_VERSION = 18;
 
   function commandWordCount(opcode) {
     if (
@@ -341,8 +341,16 @@
     lastRafTimestamp: -1,
     lastProcessRafTick: -1,
     physicsAfterProcessSameTick: 0,
-    match3FramePumps: 0,
-    match3FrameContinuations: 0,
+    // Task 82: the coroutine frame scheduler's per-frame advance. These are demo-independent
+    // on purpose -- a demo that never pumps is a demo whose `delaySeconds` never returns, so
+    // every driver can assert on them and none has to be told which script is "Main".
+    frameSchedulerPumps: 0,
+    frameSchedulerContinuations: 0,
+    lastPumpRafTick: -1,
+    // Handles that have taken their _process dispatch since the last pump. Godot dispatches a
+    // node's _process at most once per engine iteration, so a REPEAT proves a new iteration
+    // began -- the fallback that keeps the pump alive if the rAF tick token ever stops moving.
+    pumpDispatchedHandles: new Set(),
     match3ScaleMutations: 0,
     match3ModulateMutations: 0,
     match3TweensCreated: 0,
@@ -497,64 +505,88 @@
         0,
       );
     },
+    // Task 82: scope the bridge's active owner to a resumed coroutine's OWN script. Called from
+    // Kotlin around each continuation the pump runs (see kanamaWebPumpFrameScheduler); mirrors
+    // the ownership rule `invoke` applies for a real script callback.
+    enterFrameSchedulerOwner(handle) {
+      const previous = this.activeOwnerHandle;
+      if (handle > 0) {
+        this.activeOwnerHandle = this.applyCallbacks.has(handle)
+          ? handle
+          : this.ownerForHandle(handle);
+      }
+      return previous;
+    },
+    exitFrameSchedulerOwner(previous) {
+      this.activeOwnerHandle = previous;
+      return 1;
+    },
+
+    /**
+     * Task 82: advance the shared coroutine frame scheduler EXACTLY once per engine frame.
+     *
+     * This is deliberately unconditional and mode-blind. It used to be a per-demo branch below
+     * that named a "Main" handle, and the eight demos nobody remembered to name never resumed a
+     * `delaySeconds` at all -- silently, because nothing failed; the queued work simply never
+     * ran. The pump itself was always global (it selects by due frame/time, and each task carries
+     * its own owner), so the gating was pure accident. Riding the `_process` dispatch that EVERY
+     * generated proxy emits makes it impossible to bring up a demo without it.
+     *
+     * Once per frame, not once per script: the pump advances the scheduler's frame counter and
+     * elapsed clock, so a second call in the same frame would run time at N x speed. Frame
+     * identity is the rAF tick -- one engine iteration runs synchronously inside one animation
+     * frame, so every dispatch of an iteration observes the same tick -- with a repeat-handle
+     * fallback: Godot dispatches a node's `_process` at most once per iteration, so seeing the
+     * same handle twice proves a new iteration even if the tick token ever stops moving.
+     */
+    pumpFrameScheduler(handle, delta) {
+      const tick = this.rafTick;
+      if (tick === this.lastPumpRafTick && !this.pumpDispatchedHandles.has(handle)) {
+        this.pumpDispatchedHandles.add(handle);
+        return 0;
+      }
+      this.lastPumpRafTick = tick;
+      this.pumpDispatchedHandles.clear();
+      this.pumpDispatchedHandles.add(handle);
+      this.frameSchedulerPumps += 1;
+      const executed = this.invoke(
+        0,
+        "frame_scheduler",
+        "frame scheduler",
+        () => this.api.kanamaWebPumpFrameScheduler(delta),
+        0,
+      );
+      this.frameSchedulerContinuations += executed;
+      return executed;
+    },
+
     frame(handle, delta) {
       this.lastProcessRafTick = this.rafTick;
+      // Before any mode branch: the scheduler advance belongs to the engine frame, not to a demo.
+      this.pumpFrameScheduler(handle, delta);
       if (this.mode === "bunnymark") {
         return this.process(handle, delta);
       }
       if (this.mode === "web3d") {
         // Minimal 3D render smoke: the single Node3D script runs its _process (spins a
-        // child); no coroutine frame scheduler and no benchmark transport.
+        // child); no benchmark transport.
         return this.process(handle, delta);
       }
       if (this.mode === "squash") {
-        // squash-the-creeps is physics-driven; no script owns coroutines, so every
-        // script runs its plain _process/_physics_process dispatch.
         return this.process(handle, delta);
       }
       if (this.mode === "fps") {
-        // FPS scripts own no coroutines; every script runs its plain dispatch.
         return this.process(handle, delta);
       }
       if (this.mode === "tpsdemo") {
-        // Main is the persistent scene root (it survives the menu/level swap), so it pumps the
-        // shared coroutine frame scheduler for every coroutine owner in the demo (Level robot
-        // respawns, Part fade timers, Blast/PartDisappear lifetimes). Every other script runs
-        // its plain _process dispatch; nothing here takes the spike benchmark transport.
-        if (handle === this.tpsMainHandle) {
-          const executed = this.invoke(
-            handle,
-            "frame_scheduler",
-            "frame scheduler",
-            () => this.api.kanamaWebFrame(handle, delta),
-            0,
-          );
-          this.processCalls += 1;
-        this.simSeconds += delta;
-          return executed;
-        }
+        // Every script runs its plain _process dispatch; nothing here takes the spike
+        // benchmark transport.
         return this.process(handle, delta);
       }
       if (this.mode === "citybuilder") {
-        // City-Builder scripts (Builder cursor/actions, View camera, Audio pool) own no
-        // coroutines; every script runs its plain _process dispatch.
         return this.process(handle, delta);
       }
       if (this.mode === "platformer") {
-        // The Main scene root pumps the shared coroutine frame scheduler (Brick's delaySeconds);
-        // every other script runs its own _process/_physics_process. No benchmark transport.
-        if (handle === this.platformerMainHandle) {
-          const executed = this.invoke(
-            handle,
-            "frame_scheduler",
-            "frame scheduler",
-            () => this.api.kanamaWebFrame(handle, delta),
-            0,
-          );
-          this.processCalls += 1;
-        this.simSeconds += delta;
-          return executed;
-        }
         return this.process(handle, delta);
       }
       if (this.mode === "match3") {
@@ -568,38 +600,17 @@
             0,
           );
         }
+        // match3's board Tiles deliberately take no per-frame dispatch (their animation is
+        // Tween-driven); only Main runs its own _process. The scheduler advance above is
+        // unaffected -- it already happened, whichever handle arrived first this frame.
         if (handle !== this.match3MainHandle) return 0;
-        this.match3FramePumps += 1;
-        const executed = this.invoke(
-          handle,
-          "frame_scheduler",
-          "frame scheduler",
-          () => this.api.kanamaWebFrame(handle, delta),
-          0,
-        );
-        this.match3FrameContinuations += executed;
-        this.processCalls += 1;
-        this.simSeconds += delta;
-        return executed;
+        return this.process(handle, delta);
       }
       if (this.mode === "dodge") {
-        // Real scene demo: the main script pumps the shared coroutine frame scheduler
-        // (and runs its own _process); every other dodge script (Player, spawned Mobs)
-        // runs its _process via process(). Neither path takes the spike benchmark
-        // transport below, which appends a scalar (op100) marker that only the spike
-        // main script can apply — that mis-route is what fataled dodge's per-frame scripts.
-        if (handle === this.dodgeMainHandle) {
-          const executed = this.invoke(
-            handle,
-            "frame_scheduler",
-            "frame scheduler",
-            () => this.api.kanamaWebFrame(handle, delta),
-            0,
-          );
-          this.processCalls += 1;
-        this.simSeconds += delta;
-          return executed;
-        }
+        // Real scene demo: every dodge script (Main, Player, spawned Mobs) runs its _process
+        // via process(). Neither path takes the spike benchmark transport below, which appends
+        // a scalar (op100) marker that only the spike main script can apply — that mis-route is
+        // what fataled dodge's per-frame scripts.
         return this.process(handle, delta);
       }
       const started = performance.now();


### PR DESCRIPTION
Fixes task 82.

## The bug

`WebFrameScheduler.pump` is the only thing that runs a queued coroutine
continuation, and its only caller was `kanamaWebFrame(objectId, delta)`, which
the JavaScript bridge invoked for **four hardcoded "Main" handles**
(`tpsMainHandle`, `platformerMainHandle`, `match3MainHandle`,
`dodgeMainHandle`). charactercontroller had zero references, and so did squash,
fps, thirdperson, racing, citybuilder, web3d and bunnymark.

In those eight demos **every `kanamaScope.launch { … delaySeconds(…) … }` hung
forever** — silently, because nothing failed. The work simply never ran. In
charactercontroller that meant walking off the level's edge fell forever: the
kill plane's `body_entered` fired, but the continuation after its
`delaySeconds(0.0)` safe point never did, so `kill_plane_touched` was never
emitted and the player was never reset. Reaching the flag was dark for the same
reason one step further along.

The pump itself was always global and owner-agnostic (it selects by due
frame/time, and each queued task carries its own owner), so the gating was pure
accident of match3 being brought up first.

## The fix (protocol 18)

The per-script `kanamaWebFrame` crossing is replaced by the **ownerless**
`kanamaWebPumpFrameScheduler(delta)`, which the bridge calls from the `_process`
dispatch **every** generated proxy emits, before any mode branch. There is no
per-demo code left: bringing up a new demo cannot omit it.

Exactly once per engine frame — the pump advances the scheduler's frame counter
and elapsed clock, so a second call in a frame would run time at N× speed.
Frame identity is the rAF tick (one engine iteration runs synchronously inside
one animation frame, so every dispatch of that iteration observes the same
tick), with a repeat-handle fallback: Godot dispatches a node's `_process` at
most once per iteration, so seeing the same handle twice proves a new iteration
began even if the tick token ever stopped moving.

Each continuation now runs under **its own** owner on both sides of the
boundary, instead of being billed to whichever script's `_process` drove the
pump — billing a resumed coroutine's allocations to the pumping script is task
72's leak shape.

## Second defect, found by running the chain

With the kill plane finally reaching its emit, the next link failed loudly:
`ERROR: Unknown Kanama Web signal argument handle: 65539`. A proxy never
published **its own** script handle in the shared `KanamaWebHandles.handles`
dictionary, so a Kanama script handle resolved only inside its own proxy. A
foreign proxy asked to emit a signal whose payload is another script (the kill
plane emits `kill_plane_touched` carrying the *player*, through the Events
autoload's proxy) had no way to turn that handle back into an Object.
`_exit_tree` already erased the entry; only the insert was missing. Nodes only —
a Resource never gets `_exit_tree`, so registering one would pin it alive.

## Gates

- **Conformance probe (the generic one).** `web3d`'s in-repo fixture launches a
  coroutine that awaits `delaySeconds(0.0)` and a timed delay and publishes a
  mask; the driver asserts it **resumed** (`coroutineDelayResumed`), plus
  `frameSchedulerPumped`. Falsified against the bug: with the pump call removed
  from the exported bridge, both checks go false and the smoke FAILS — the
  fifteen-line test that would have caught this on day one.
- **charactercontroller's two dark transitions** (task 81's ranked gap #6) are
  now gated on observable effects, never "no error": the player is walked off
  the platform and asserted **back at its spawn** through the engine's
  global-position channel, and `flag_reached` is emitted through Godot's own
  signal crossing with the **level reload** asserted (second `_ready`, new
  script handle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
