### PR TITLE
Prewarm every native call adapter before the first Godot->JVM upcall (task 83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,23 @@ versioning once public releases begin.
   dereference the object, so it is the safe check to keep across a `free()`.
   Source-breaking only for callers that passed a non-`GodotObject` value, which
   could not have been working.
+- **Desktop/Android: every native call adapter is now generated during bootstrap,
+  before Godot can call back into the JVM** (task 83). Linking a Panama downcall
+  handle for a `FunctionDescriptor` the process has not seen makes the JVM
+  generate native code; doing that while execution is already inside a
+  Godot→JVM upcall puts code generation inside a thread-local
+  executable-memory transition. `KanamaBinding.init` now calls
+  `NativeCallSurface.prewarm()` before installing the lifecycle upcall stubs, so
+  an upcall only ever *executes* adapters that already exist. Measured on the
+  example project: 16 of the 18 adapter shapes used to be generated inside an
+  upcall, between 0.118 s and 0.544 s after launch; the prewarm moves all of
+  them to 0.001–0.064 s and costs about 30 ms before Godot's first callback.
+  `KANAMA_TRACE_NATIVE_ADAPTERS=1` prints each adapter with its timestamp and
+  the first-upcall boundary; the runtime, tool, and hot-reload smokes assert no
+  adapter is created after it, and
+  `scripts/check_native_call_surface.py` (a `local_ci.sh` stage) fails the build
+  if a source change adds a call shape that is not prewarmed. No ABI change.
+  This is a hardening change with no known user-visible symptom.
 
 ## 0.4.0 - 2026-07-24
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -148,6 +148,27 @@ Key points:
 - **Class registration happens during the `initialize` upcall**, not during
   `bootstrap.c`. Godot calls us back when it's ready for us to register —
   we don't push.
+- **Every native call adapter is generated before the upcall stubs are
+  installed.** Linking a downcall handle for a `FunctionDescriptor` the process
+  has not seen makes the JVM generate native code (a downcall stub blob plus a
+  specialized binding class). Doing that while execution is already inside a
+  Godot→JVM upcall puts code generation inside a thread-local
+  executable-memory transition, so `KanamaBinding.init` calls
+  `NativeCallSurface.prewarm()` first and an upcall only ever *executes*
+  adapters that already exist.
+
+  `Linker` caches per descriptor, not per symbol, so the whole backend collapses
+  onto 18 shapes — binding an engine function pointer to an already-linked shape
+  generates nothing. `scripts/check_native_call_surface.py` fails the build if a
+  source change introduces a shape that is not prewarmed, and
+  `KANAMA_TRACE_NATIVE_ADAPTERS=1` prints each adapter with a timestamp plus the
+  first-upcall boundary (the runtime, tool, and hot-reload smokes assert no
+  adapter appears after it).
+
+  Upcall stubs are the deliberate exception: each stub is its own native blob,
+  and stubs for `@RegisterClass` / `@ScriptClass` members can only be built once
+  those classes are known, which is inside the `initialize` upcall. The engine
+  offers no earlier registration point.
 
 ## Runtime crossings
 

--- a/scripts/check_native_call_surface.py
+++ b/scripts/check_native_call_surface.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Gate: every native downcall adapter shape is prewarmed before the first upcall.
+
+`java.lang.foreign.Linker` generates a native adapter once per `FunctionDescriptor`
+(`AbstractLinker` keys its downcall cache on the descriptor plus the linker options; the
+symbol-bound overload is `downcallHandle(descriptor).bindTo(symbol)`). The unit of native
+code generation is therefore the *shape*, not the call site.
+
+Kanama prewarms every shape during JNI bootstrap, before any Godot->JVM lifecycle upcall
+exists, so an upcall only ever executes adapters that already exist (task 83). This script
+keeps that true as code changes: it extracts every downcall shape reachable from the
+desktop/Android backend sources and asserts each one is declared in
+`src/main/kotlin/ffi/NativeCallSurface.kt`.
+
+It also enforces the funnel that makes the shapes findable in the first place: outside
+`GodotFFI.kt`, nothing may call `linker.downcallHandle` / `linker.upcallStub` directly.
+
+Usage:
+    python3 scripts/check_native_call_surface.py            # gate
+    python3 scripts/check_native_call_surface.py --list     # print the inventory
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Backend sources that can link a native adapter. `processor/` emits Kotlin as string
+# literals, so it is scanned through the string-literal reconstruction below.
+SCAN_ROOTS = (
+    Path("src/main/kotlin"),
+    Path("processor/src/main/kotlin"),
+)
+
+REGISTRY_FILE = Path("src/main/kotlin/ffi/NativeCallSurface.kt")
+FUNNEL_FILE = Path("src/main/kotlin/ffi/GodotFFI.kt")
+
+# Call sites that link a downcall adapter, and which positional argument carries the
+# descriptor.
+DOWNCALL_SITES = {
+    "GodotFFI.lookup": 1,
+    "GodotFFI.downcallHandle": 1,
+    "GodotFFI.prelinkDowncall": 0,
+    "linker.downcallHandle": 1,
+}
+
+# Reported, not gated -- see NativeCallSurface.kt for why upcall stubs are a different
+# problem (each stub is a distinct native blob, and script classes are only known inside
+# the initialize upcall).
+UPCALL_SITES = {
+    "GodotFFI.upcallStub": 1,
+    "Upcalls.stub": 3,
+    "linker.upcallStub": 1,
+}
+
+RAW_LINKER_CALL = re.compile(r"\blinker\s*\.\s*(downcallHandle|upcallStub)\s*\(")
+
+STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def source_text(path: Path) -> str:
+    """Kotlin to scan for a file.
+
+    For the KSP processor the interesting Kotlin is inside string literals it appends to a
+    StringBuilder, so reconstruct the emitted text by concatenating the literals.
+    """
+    text = path.read_text(encoding="utf-8")
+    if "processor/src/main/kotlin" in path.as_posix():
+        parts = [
+            m.group(1).replace('\\"', '"').replace("\\$", "$").replace("\\n", "\n")
+            for m in STRING_LITERAL.finditer(text)
+        ]
+        return "\n".join(parts)
+    return text
+
+
+def balanced(text: str, open_paren_index: int) -> tuple[str, int]:
+    """Return the text between the parens starting at `open_paren_index`, and the index after."""
+    depth = 0
+    i = open_paren_index
+    while i < len(text):
+        c = text[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_paren_index + 1 : i], i + 1
+        i += 1
+    raise ValueError(f"unbalanced parentheses at offset {open_paren_index}")
+
+
+def split_top_level(args: str) -> list[str]:
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for c in args:
+        if c in "(<[":
+            depth += 1
+        elif c in ")>]":
+            depth -= 1
+        if c == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += c
+    if current.strip():
+        parts.append(current)
+    return [p.strip() for p in parts]
+
+
+def canonical_shape(expr: str) -> str | None:
+    """Normalize a `FunctionDescriptor.of[Void](...)` expression to a comparable string."""
+    expr = expr.strip()
+    match = re.match(r"^FunctionDescriptor\s*\.\s*(of|ofVoid)\s*\(", expr)
+    if not match:
+        return None
+    args, _ = balanced(expr, expr.index("(", match.start(1)))
+    layouts = [a for a in split_top_level(args) if a]
+    layouts = [re.sub(r"^(java\.lang\.foreign\.)?ValueLayout\.", "", a) for a in layouts]
+    return f"{match.group(1)}({','.join(layouts)})"
+
+
+def descriptor_aliases(text: str) -> dict[str, str]:
+    """Map local `val someDesc = FunctionDescriptor...` names to canonical shapes."""
+    aliases: dict[str, str] = {}
+    for match in re.finditer(
+        r"\bval\s+(\w+)\s*(?::\s*FunctionDescriptor\s*)?=\s*(FunctionDescriptor\s*\.)", text
+    ):
+        shape = canonical_shape(text[match.start(2) :])
+        if shape:
+            aliases[match.group(1)] = shape
+    return aliases
+
+
+def resolve(arg: str, aliases: dict[str, str]) -> str | None:
+    shape = canonical_shape(arg)
+    if shape:
+        return shape
+    return aliases.get(arg.strip())
+
+
+def scan_sites(text: str, sites: dict[str, int]) -> list[tuple[str | None, str, int]]:
+    """Return (shape, callee, line) per matching call site; shape is None when unresolvable."""
+    aliases = descriptor_aliases(text)
+    found: list[tuple[str | None, str, int]] = []
+    for callee, position in sites.items():
+        pattern = re.compile(re.escape(callee) + r"\s*\(")
+        for match in pattern.finditer(text):
+            try:
+                args, _ = balanced(text, text.index("(", match.end() - 1))
+            except ValueError:
+                continue
+            parts = split_top_level(args)
+            shape = resolve(parts[position], aliases) if position < len(parts) else None
+            found.append((shape, callee, text.count("\n", 0, match.start()) + 1))
+    return found
+
+
+def kotlin_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        files.extend(sorted((ROOT / root).rglob("*.kt")))
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="print the inventory and exit 0")
+    args = parser.parse_args()
+
+    registry_text = (ROOT / REGISTRY_FILE).read_text(encoding="utf-8")
+    registry: set[str] = set()
+    for match in re.finditer(r"FunctionDescriptor\s*\.\s*of", registry_text):
+        shape = canonical_shape(registry_text[match.start() :])
+        if shape:
+            registry.add(shape)
+    if not registry:
+        print(f"[native-call-surface] no shapes declared in {REGISTRY_FILE}", file=sys.stderr)
+        return 1
+
+    downcalls: dict[str, list[str]] = {}
+    upcalls: dict[str, list[str]] = {}
+    raw_linker: list[str] = []
+    unresolved: list[str] = []
+
+    # GodotFFI.kt is the funnel: its own calls take the descriptor as a parameter, so they
+    # have no shape of their own. NativeCallSurface.kt is the registry being checked against.
+    skip_sites = {FUNNEL_FILE.as_posix(), REGISTRY_FILE.as_posix()}
+
+    for path in kotlin_files():
+        rel = path.relative_to(ROOT).as_posix()
+        text = source_text(path)
+        if rel != FUNNEL_FILE.as_posix():
+            for match in RAW_LINKER_CALL.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                raw_linker.append(f"{rel}:{line}: linker.{match.group(1)}")
+        if rel in skip_sites:
+            continue
+        for shape, callee, line in scan_sites(text, DOWNCALL_SITES):
+            if shape is None:
+                unresolved.append(f"{rel}:{line} ({callee})")
+            else:
+                downcalls.setdefault(shape, []).append(f"{rel}:{line} ({callee})")
+        for shape, callee, line in scan_sites(text, UPCALL_SITES):
+            # Upcalls are reported, not gated; sites that pass the descriptor through a
+            # local helper (ScriptBridge's info3 table) resolve to None and are skipped.
+            if shape is not None:
+                upcalls.setdefault(shape, []).append(f"{rel}:{line} ({callee})")
+
+    if args.list:
+        print(f"downcall shapes reached from the backend ({len(downcalls)}):")
+        for shape in sorted(downcalls):
+            mark = "  " if shape in registry else "!!"
+            print(f"{mark}{shape}")
+            for site in downcalls[shape]:
+                print(f"      {site}")
+        if unresolved:
+            print()
+            print("downcall sites whose descriptor could not be resolved statically:")
+            for site in unresolved:
+                print(f"  {site}")
+        print()
+        print(f"upcall shapes, reported only ({len(upcalls)}):")
+        for shape in sorted(upcalls):
+            print(f"  {shape}  ({len(upcalls[shape])} site(s))")
+        unused = registry - set(downcalls)
+        if unused:
+            print()
+            print("declared but not reached from any scanned site:")
+            for shape in sorted(unused):
+                print(f"  {shape}")
+        return 0
+
+    failures: list[str] = []
+    for shape in sorted(downcalls):
+        if shape not in registry:
+            failures.append(
+                f"downcall shape {shape} is linked but not prewarmed by {REGISTRY_FILE}:\n    "
+                + "\n    ".join(downcalls[shape])
+            )
+    for site in unresolved:
+        failures.append(
+            f"{site} links a downcall adapter with a descriptor this gate cannot resolve; "
+            "pass a FunctionDescriptor literal or a local val holding one"
+        )
+    for entry in raw_linker:
+        failures.append(
+            f"{entry} bypasses the GodotFFI funnel; use GodotFFI.downcallHandle / "
+            "GodotFFI.upcallStub so the adapter is traceable and prewarmable"
+        )
+
+    if failures:
+        print("[native-call-surface] FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "\nAdd the shape to NativeCallSurface.prewarm() (and say which call family "
+            "needs it), or route the call through an existing shape.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[native-call-surface] OK: {len(downcalls)} downcall shape(s) reached, "
+        f"all prewarmed before the first lifecycle upcall"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hot_reload_in_process_smoke.sh
+++ b/scripts/hot_reload_in_process_smoke.sh
@@ -87,9 +87,17 @@ check_absent() {
   fi
 }
 
+check() {
+  local pattern="$1"
+  if ! grep -Eq -- "$pattern" "$LOG_FILE"; then
+    smoke_fail "missing pattern" "$pattern"
+  fi
+}
+
 set_marker "A"
 "$ROOT_DIR/gradlew" -p "$ROOT_DIR" syncExampleAddonJar >/dev/null
 
+KANAMA_TRACE_NATIVE_ADAPTERS=1 \
 KANAMA_IN_PROCESS_HOT_RELOAD_SMOKE=1 \
 KANAMA_IN_PROCESS_HOT_RELOAD_SIGNAL="$SIGNAL_FILE" \
 KANAMA_IN_PROCESS_HOT_RELOAD_STAGE="$STAGE_FILE" \
@@ -117,5 +125,10 @@ check_absent "placeholder=true"
 check_absent "Cannot ptrcall nil constructor"
 check_absent "Orphan StringName"
 check_absent "unclaimed string names"
+# task 83 -- no native call adapter may be generated inside a Godot->JVM upcall.
+# Assert the trace is present first, so a dropped KANAMA_TRACE_NATIVE_ADAPTERS
+# fails loudly instead of making the absence check pass vacuously.
+check "\\[kanama:adapter\\] boundary first-lifecycle-upcall-install"
+check_absent "\\[kanama:adapter\\] downcall .* phase=post-boundary"
 
 echo "[hot_reload_in_process_smoke] PASS"

--- a/scripts/hot_reload_smoke.sh
+++ b/scripts/hot_reload_smoke.sh
@@ -92,17 +92,22 @@ check_common_invariants() {
   check_absent "Cannot ptrcall nil constructor" "$log_file"
   check_absent "Orphan StringName" "$log_file"
   check_absent "unclaimed string names" "$log_file"
+  # task 83 -- no native call adapter may be generated inside a Godot->JVM upcall.
+  # Assert the trace is present first, so a dropped KANAMA_TRACE_NATIVE_ADAPTERS
+  # fails loudly instead of making the absence check pass vacuously.
+  check "\\[kanama:adapter\\] boundary first-lifecycle-upcall-install" "$log_file"
+  check_absent "\\[kanama:adapter\\] downcall .* phase=post-boundary" "$log_file"
 }
 
 set_marker "A"
 "$ROOT_DIR/gradlew" -p "$ROOT_DIR" syncExampleAddonJar >/dev/null
-KANAMA_TRACE_INSTANCES=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" >"$LOG1" 2>&1
+KANAMA_TRACE_INSTANCES=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" >"$LOG1" 2>&1
 check_marker "A" "$LOG1"
 check_common_invariants "$LOG1"
 
 set_marker "B"
 "$ROOT_DIR/gradlew" -p "$ROOT_DIR" syncExampleAddonJar >/dev/null
-KANAMA_TRACE_INSTANCES=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" >"$LOG2" 2>&1
+KANAMA_TRACE_INSTANCES=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" >"$LOG2" 2>&1
 check_marker "B" "$LOG2"
 check_common_invariants "$LOG2"
 

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -233,6 +233,9 @@ python3 "$ROOT_DIR/scripts/check_godot_version_pin.py"
 stage "GDExtension modernization + backend convergence"
 python3 "$ROOT_DIR/scripts/check_gdextension_modernization.py"
 
+stage "native call surface prewarm audit"
+python3 "$ROOT_DIR/scripts/check_native_call_surface.py"
+
 stage "vararg ptrcall audit"
 python3 "$ROOT_DIR/scripts/audit_vararg_ptrcalls.py"
 

--- a/scripts/runtime_smoke.sh
+++ b/scripts/runtime_smoke.sh
@@ -33,7 +33,7 @@ esac
 GLOBAL_CLASS_CACHE="$PROJECT_DIR/.godot/global_script_class_cache.cfg"
 rm -f "$GLOBAL_CLASS_CACHE"
 
-KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" --verbose >"$IMPORT_LOG_FILE" 2>&1
+KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --editor --quit-after 120 --path "$PROJECT_DIR_FOR_GODOT" --verbose >"$IMPORT_LOG_FILE" 2>&1
 
 if ! grep -q '"class": &"SmokeResource"' "$GLOBAL_CLASS_CACHE" ||
    ! grep -q '"base": &"Resource"' "$GLOBAL_CLASS_CACHE"; then
@@ -41,9 +41,9 @@ if ! grep -q '"class": &"SmokeResource"' "$GLOBAL_CLASS_CACHE" ||
   cat "$GLOBAL_CLASS_CACHE" 2>/dev/null || true
   exit 1
 fi
-KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" --quit --verbose >"$LOG_FILE" 2>&1
-KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" res://resource_owner_smoke.tscn --quit --verbose >>"$LOG_FILE" 2>&1
-KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" res://self_smoke.tscn --quit --verbose >>"$LOG_FILE" 2>&1
+KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" --quit --verbose >"$LOG_FILE" 2>&1
+KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" res://resource_owner_smoke.tscn --quit --verbose >>"$LOG_FILE" 2>&1
+KANAMA_TRACE_SCRIPT_PROPERTY_CLEANUP=1 KANAMA_TRACE_NATIVE_ADAPTERS=1 "$GODOT_BIN" --headless --path "$PROJECT_DIR_FOR_GODOT" res://self_smoke.tscn --quit --verbose >>"$LOG_FILE" 2>&1
 
 # Report a failed assertion. The log tail is verbose Godot output, so the reason is
 # restated *after* it -- otherwise the one line that matters ends up ~120 lines above the
@@ -314,5 +314,22 @@ check_absent "local RPC smoke failed"
 check_absent "Leaked instance: FileAccess"
 check_absent "Leaked instance: DirAccess"
 check_absent "Resource still in use: .*Resource_smoke"
+
+# task 83 -- no native call adapter may be generated inside a Godot->JVM upcall.
+# The trace (KANAMA_TRACE_NATIVE_ADAPTERS=1, set above) timestamps every adapter and
+# the moment the first lifecycle upcall is installed. Assert the boundary line is
+# present FIRST, so a dropped env var fails loudly instead of making the absence
+# check pass vacuously.
+for adapter_log in "$LOG_FILE" "$IMPORT_LOG_FILE"; do
+  if ! grep -Eq -- "\[kanama:adapter\] boundary first-lifecycle-upcall-install" "$adapter_log"; then
+    echo "[runtime_smoke] FAIL -- adapter trace missing from $adapter_log" >&2
+    exit 1
+  fi
+  if grep -Eq -- "\[kanama:adapter\] downcall .* phase=post-boundary" "$adapter_log"; then
+    echo "[runtime_smoke] FAIL -- native adapter generated after the first upcall:" >&2
+    grep -E -- "\[kanama:adapter\] downcall .* phase=post-boundary" "$adapter_log" >&2
+    exit 1
+  fi
+done
 
 echo "[runtime_smoke] PASS"

--- a/scripts/tool_smoke.sh
+++ b/scripts/tool_smoke.sh
@@ -23,6 +23,7 @@ case "$(uname -s)" in
 esac
 
 "$ROOT_DIR/gradlew" -p "$ROOT_DIR" syncExampleAddonJar >/dev/null
+export KANAMA_TRACE_NATIVE_ADAPTERS=1
 if [[ "${KANAMA_TOOL_SMOKE_TRACE_INSTANCES:-0}" == "1" ]]; then
   KANAMA_TRACE_INSTANCES=1 "$GODOT_BIN" --headless --editor --quit --path "$PROJECT_DIR_FOR_GODOT" >"$LOG_FILE" 2>&1
 else
@@ -86,5 +87,13 @@ check_absent "ResourceForgeSmoke create_failed"
 # inner owner still gets an editor placeholder. Pre-fix (thread-wide flag) the marker fired.
 check "ReentrantForgeProbe reentered=true"
 check_absent "ReentrantPlaceholderProbe CONSTRUCTED"
+
+# task 83 -- no native call adapter may be generated inside a Godot->JVM upcall.
+# The trace (KANAMA_TRACE_NATIVE_ADAPTERS=1, set above) timestamps every adapter and
+# the moment the first lifecycle upcall is installed. Assert the boundary line is
+# present FIRST, so a dropped env var fails loudly instead of making the absence
+# check pass vacuously.
+check "\[kanama:adapter\] boundary first-lifecycle-upcall-install"
+check_absent "\[kanama:adapter\] downcall .* phase=post-boundary"
 
 echo "[tool_smoke] PASS"

--- a/src/main/kotlin/KanamaBinding.kt
+++ b/src/main/kotlin/KanamaBinding.kt
@@ -18,6 +18,7 @@ import net.multigesture.kanama.binding.runtime.ClassDB
 import net.multigesture.kanama.binding.runtime.GodotStrings
 import net.multigesture.kanama.binding.runtime.installCommonGodotBackend
 import net.multigesture.kanama.ffi.GodotFFI
+import net.multigesture.kanama.ffi.NativeCallSurface
 
 /**
  * Entry point for the Kotlin side of Kanama.
@@ -39,6 +40,9 @@ object KanamaBinding {
 
     this.library = MemorySegment.ofAddress(library)
     GodotFFI.bootstrap(procAddr)
+    // Generate every native call adapter while we are still on the JNI bootstrap thread, before
+    // any Godot→JVM upcall exists (task 83). Must stay ahead of installInitCallbacks.
+    NativeCallSurface.prewarm()
     installCommonGodotBackend()
     val version = fetchGodotVersion()
     System.err.println(
@@ -130,10 +134,18 @@ object KanamaBinding {
     val deinitializeHandle =
       lookup.findStatic(KanamaBinding::class.java, "deinitializeCallback", methodType)
 
+    // Past this line Godot can re-enter the JVM, so every native downcall adapter the backend
+    // will ever need must already exist (task 83).
+    GodotFFI.markLifecycleUpcallsInstalled()
+
     val initializeStub =
-      GodotFFI.linker.upcallStub(initializeHandle, lifecycleDescriptor, GodotFFI.arena)
+      GodotFFI.upcallStub(initializeHandle, lifecycleDescriptor, "KanamaBinding.initializeCallback")
     val deinitializeStub =
-      GodotFFI.linker.upcallStub(deinitializeHandle, lifecycleDescriptor, GodotFFI.arena)
+      GodotFFI.upcallStub(
+        deinitializeHandle,
+        lifecycleDescriptor,
+        "KanamaBinding.deinitializeCallback",
+      )
 
     val initStruct = MemorySegment.ofAddress(initPtr).reinterpret(32)
     initStruct.set(ADDRESS, 16, initializeStub)

--- a/src/main/kotlin/binding/ScriptBridge.kt
+++ b/src/main/kotlin/binding/ScriptBridge.kt
@@ -119,10 +119,10 @@ object ScriptBridge {
     val lookup = MethodHandles.lookup()
 
     fun stub(name: String, type: MethodType, desc: FunctionDescriptor): MemorySegment =
-      GodotFFI.linker.upcallStub(
+      GodotFFI.upcallStub(
         lookup.findStatic(ScriptBridge::class.java, name, type),
         desc,
-        GodotFFI.arena,
+        "ScriptBridge.$name",
       )
 
     // Shared MethodType / FunctionDescriptor constants.
@@ -646,7 +646,11 @@ object ScriptBridge {
     if (si.propertyCount == 0 || si.propertyListPtr == MemorySegment.NULL) return
     if (addFunc.address() == 0L) return
 
-    val callAdd = GodotFFI.linker.downcallHandle(addFunc, addFuncDesc)
+    // This binds a fresh engine-supplied function pointer from inside an upcall, so it is the
+    // one downcall in the backend that *cannot* be hoisted to bootstrap. It is safe only
+    // because [addFuncDesc]'s adapter is prewarmed by NativeCallSurface: binding a symbol to
+    // an already-linked shape is pure MethodHandle work and generates no native code (task 83).
+    val callAdd = GodotFFI.downcallHandle(addFunc, addFuncDesc, "script_instance_state_add")
     val list = si.propertyListPtr.reinterpret(propInfoSize * si.propertyCount)
 
     Arena.ofConfined().use { a ->

--- a/src/main/kotlin/binding/runtime/BuiltinTypes.kt
+++ b/src/main/kotlin/binding/runtime/BuiltinTypes.kt
@@ -166,7 +166,11 @@ object BuiltinTypes {
       check(fn.address() != 0L) {
         "variant_get_ptr_constructor(${type.name}, $constructorIndex) returned NULL"
       }
-      GodotFFI.linker.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS))
+      GodotFFI.downcallHandle(
+        fn,
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS),
+        "variant_ptr_constructor",
+      )
     }
 
   private fun ptrBuiltinMethod(type: VariantType, method: String, hash: Long): MethodHandle =
@@ -177,9 +181,10 @@ object BuiltinTypes {
       check(fn.address() != 0L) {
         "variant_get_ptr_builtin_method(${type.name}, $method, $hash) returned NULL"
       }
-      GodotFFI.linker.downcallHandle(
+      GodotFFI.downcallHandle(
         fn,
         FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, JAVA_INT),
+        "variant_ptr_builtin_method",
       )
     }
 
@@ -187,14 +192,18 @@ object BuiltinTypes {
     keyedSetters.getOrPut(type.id) {
       val fn = getPtrKeyedSetter.invoke(type.id) as MemorySegment
       check(fn.address() != 0L) { "variant_get_ptr_keyed_setter(${type.name}) returned NULL" }
-      GodotFFI.linker.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS))
+      GodotFFI.downcallHandle(
+        fn,
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS),
+        "variant_ptr_keyed_setter",
+      )
     }
 
   private fun ptrDestructor(type: VariantType): MethodHandle =
     destructors.getOrPut(type.id) {
       val fn = getPtrDestructor.invoke(type.id) as MemorySegment
       check(fn.address() != 0L) { "variant_get_ptr_destructor(${type.name}) returned NULL" }
-      GodotFFI.linker.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS))
+      GodotFFI.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS), "variant_ptr_destructor")
     }
 
   /** Destroy an initialized builtin-typed value in-place. */

--- a/src/main/kotlin/binding/runtime/GodotStrings.kt
+++ b/src/main/kotlin/binding/runtime/GodotStrings.kt
@@ -91,13 +91,13 @@ object GodotStrings {
   private val stringDestructor: MethodHandle by lazy {
     val fn = getPtrDestructor.invoke(VariantType.STRING.id) as MemorySegment
     check(fn.address() != 0L) { "variant_get_ptr_destructor(STRING) returned NULL" }
-    GodotFFI.linker.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS))
+    GodotFFI.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS), "string_destructor")
   }
 
   private val stringNameDestructor: MethodHandle by lazy {
     val fn = getPtrDestructor.invoke(VariantType.STRING_NAME.id) as MemorySegment
     check(fn.address() != 0L) { "variant_get_ptr_destructor(STRING_NAME) returned NULL" }
-    GodotFFI.linker.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS))
+    GodotFFI.downcallHandle(fn, FunctionDescriptor.ofVoid(ADDRESS), "string_name_destructor")
   }
 
   /**

--- a/src/main/kotlin/binding/runtime/Upcalls.kt
+++ b/src/main/kotlin/binding/runtime/Upcalls.kt
@@ -24,6 +24,6 @@ object Upcalls {
     descriptor: FunctionDescriptor,
   ): MemorySegment {
     val handle = MethodHandles.lookup().findStatic(targetClass, methodName, methodType)
-    return GodotFFI.linker.upcallStub(handle, descriptor, GodotFFI.arena)
+    return GodotFFI.upcallStub(handle, descriptor, "${targetClass.simpleName}.$methodName")
   }
 }

--- a/src/main/kotlin/binding/runtime/VariantConverters.kt
+++ b/src/main/kotlin/binding/runtime/VariantConverters.kt
@@ -42,7 +42,11 @@ object VariantConverters {
       check(addr.address() != 0L) {
         "get_variant_from_type_constructor(${type.name}) returned NULL"
       }
-      GodotFFI.linker.downcallHandle(addr, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS))
+      GodotFFI.downcallHandle(
+        addr,
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS),
+        "variant_from_type_constructor",
+      )
     }
 
   /** `(GDExtensionTypePtr, GDExtensionVariantPtr) -> void` — unwraps variant into typed. */
@@ -50,7 +54,11 @@ object VariantConverters {
     toType.getOrPut(type.id) {
       val addr = getToTypeCtor.invoke(type.id) as MemorySegment
       check(addr.address() != 0L) { "get_variant_to_type_constructor(${type.name}) returned NULL" }
-      GodotFFI.linker.downcallHandle(addr, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS))
+      GodotFFI.downcallHandle(
+        addr,
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS),
+        "variant_to_type_constructor",
+      )
     }
 
   fun variantTypeOf(variant: MemorySegment): VariantType? {

--- a/src/main/kotlin/ffi/GodotFFI.kt
+++ b/src/main/kotlin/ffi/GodotFFI.kt
@@ -6,6 +6,7 @@ import java.lang.foreign.Linker
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.ValueLayout.ADDRESS
 import java.lang.invoke.MethodHandle
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Low-level Panama FFI cache for Kanama.
@@ -16,6 +17,11 @@ import java.lang.invoke.MethodHandle
  *
  * This is the *only* place in the project that calls `MemorySegment.ofAddress` with a raw `long`.
  * All other code should receive real [MemorySegment]s or [MethodHandle]s from here.
+ *
+ * It is also the **single funnel for native adapter creation** (task 83): every downcall handle and
+ * every upcall stub in the desktop/Android backend is linked through [downcallHandle],
+ * [prelinkDowncall] or [upcallStub], never through [linker] directly. See [NativeCallSurface] for
+ * why that matters and `scripts/check_native_call_surface.py` for the gate that keeps it true.
  */
 object GodotFFI {
 
@@ -35,6 +41,72 @@ object GodotFFI {
 
   private var getProcAddress: MethodHandle? = null
 
+  // ---- Native adapter accounting (task 83) ----
+
+  /**
+   * `java.lang.foreign.Linker` generates a native adapter (a downcall stub blob plus a specialized
+   * binding class) **once per `FunctionDescriptor`**, not once per symbol: `AbstractLinker` keys
+   * its `DOWNCALL_CACHE` on the descriptor and the linker options, and the symbol-bound overload is
+   * just `downcallHandle(descriptor).bindTo(symbol)`. So the unit of native code generation — the
+   * thing that must not first happen inside a Godot→JVM upcall — is the *shape*, not the call site.
+   *
+   * These sets track which shapes this process has already linked, so the trace can distinguish
+   * "new adapter generated here" from "existing adapter reused here".
+   */
+  private val linkedDowncallShapes = ConcurrentHashMap.newKeySet<FunctionDescriptor>()
+
+  private val linkedUpcallShapes = ConcurrentHashMap.newKeySet<FunctionDescriptor>()
+
+  private val startNanos = System.nanoTime()
+
+  @Volatile private var lifecycleUpcallsInstalled = false
+
+  /**
+   * Opt-in adapter trace. Off in release: with the variable unset every hook below is a volatile
+   * read plus a set membership test, and nothing is printed.
+   */
+  private val traceAdapters = System.getenv("KANAMA_TRACE_NATIVE_ADAPTERS") == "1"
+
+  private fun elapsedSeconds(): String =
+    String.format("%.3f", (System.nanoTime() - startNanos) / 1_000_000_000.0)
+
+  private fun phase(): String = if (lifecycleUpcallsInstalled) "post-boundary" else "bootstrap"
+
+  private fun noteDowncallShape(descriptor: FunctionDescriptor, label: String) {
+    // Only a *first* sighting of a shape generates native code; repeats hit the JDK's cache.
+    if (!linkedDowncallShapes.add(descriptor)) return
+    if (!traceAdapters) return
+    val violation = if (lifecycleUpcallsInstalled) " VIOLATION" else ""
+    System.err.println(
+      "[kanama:adapter] downcall shape=$descriptor label=$label " +
+        "t=${elapsedSeconds()}s phase=${phase()}$violation"
+    )
+  }
+
+  private fun noteUpcallShape(descriptor: FunctionDescriptor, label: String) {
+    if (!linkedUpcallShapes.add(descriptor)) return
+    if (!traceAdapters) return
+    System.err.println(
+      "[kanama:adapter] upcall shape=$descriptor label=$label t=${elapsedSeconds()}s phase=${phase()}"
+    )
+  }
+
+  /**
+   * Marks the point at which Godot gains the ability to call back into the JVM — everything after
+   * this runs, or can run, inside a Godot→JVM upcall.
+   *
+   * Called once from `KanamaBinding.installInitCallbacks`.
+   */
+  fun markLifecycleUpcallsInstalled() {
+    if (lifecycleUpcallsInstalled) return
+    lifecycleUpcallsInstalled = true
+    if (!traceAdapters) return
+    System.err.println(
+      "[kanama:adapter] boundary first-lifecycle-upcall-install t=${elapsedSeconds()}s " +
+        "downcall-shapes=${linkedDowncallShapes.size} upcall-shapes=${linkedUpcallShapes.size}"
+    )
+  }
+
   /**
    * Wrap the raw proc-address pointer as a Panama [MethodHandle]. Must be called exactly once, as
    * the first thing Kanama does after `KanamaBinding.init` is entered.
@@ -43,7 +115,7 @@ object GodotFFI {
     check(getProcAddress == null) { "GodotFFI.bootstrap called twice" }
     require(procAddrRaw != 0L) { "procAddr is null" }
     val segment = MemorySegment.ofAddress(procAddrRaw).reinterpret(Long.MAX_VALUE)
-    getProcAddress = linker.downcallHandle(segment, getProcAddressDescriptor)
+    getProcAddress = downcallHandle(segment, getProcAddressDescriptor, "get_proc_address")
   }
 
   /**
@@ -57,6 +129,47 @@ object GodotFFI {
     require(fnAddr.address() != 0L) {
       "GDExtension function '$name' not found (get_proc_address returned NULL)"
     }
-    return linker.downcallHandle(fnAddr, descriptor)
+    return downcallHandle(fnAddr, descriptor, name)
+  }
+
+  /**
+   * Bind [symbol] with [descriptor]. [label] names the call family for the adapter trace and is not
+   * used for anything else.
+   *
+   * Use this instead of `GodotFFI.linker.downcallHandle` so that every adapter in the backend is
+   * visible to the trace and to `scripts/check_native_call_surface.py`.
+   */
+  fun downcallHandle(
+    symbol: MemorySegment,
+    descriptor: FunctionDescriptor,
+    label: String,
+  ): MethodHandle {
+    noteDowncallShape(descriptor, label)
+    return linker.downcallHandle(symbol, descriptor)
+  }
+
+  /**
+   * Link the native adapter for [descriptor] without binding a symbol, so that a later
+   * [downcallHandle] for the same shape is a cache hit and generates no code.
+   *
+   * This is how [NativeCallSurface] prewarms; it is intentionally symbol-free, because prewarming
+   * must not depend on which engine entry points happen to exist.
+   */
+  fun prelinkDowncall(descriptor: FunctionDescriptor, label: String) {
+    noteDowncallShape(descriptor, label)
+    linker.downcallHandle(descriptor)
+  }
+
+  /**
+   * Build an upcall stub for [target] in the process-long [arena]. [label] names the callback for
+   * the adapter trace.
+   */
+  fun upcallStub(
+    target: MethodHandle,
+    descriptor: FunctionDescriptor,
+    label: String,
+  ): MemorySegment {
+    noteUpcallShape(descriptor, label)
+    return linker.upcallStub(target, descriptor, arena)
   }
 }

--- a/src/main/kotlin/ffi/NativeCallSurface.kt
+++ b/src/main/kotlin/ffi/NativeCallSurface.kt
@@ -1,0 +1,114 @@
+package net.multigesture.kanama.ffi
+
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.foreign.ValueLayout.JAVA_INT
+import java.lang.foreign.ValueLayout.JAVA_LONG
+
+/**
+ * Every native downcall adapter shape the desktop/Android backend can ever link.
+ *
+ * ## Why this exists
+ *
+ * Kanama reaches Godot through Panama downcall handles. Creating one for a shape the process has
+ * not seen before makes the JVM **generate native code**: `AbstractLinker.downcallHandle` misses
+ * its cache, `DowncallLinker` builds a `NativeEntryPoint` (a downcall stub blob in the code cache)
+ * and `BindingSpecializer` spins a hidden class for the argument marshalling.
+ *
+ * Doing that while execution is already inside a Godot→JVM upcall puts native code generation
+ * inside a thread-local executable-memory transition — on macOS/AArch64 in particular. That is a
+ * bad shape regardless of whether it has ever misbehaved, and it is entirely avoidable: [prewarm]
+ * links every shape during JNI bootstrap, before Kanama installs its lifecycle upcalls, so an
+ * upcall only ever *executes* adapters that already exist.
+ *
+ * ## Why prewarming shapes is enough
+ *
+ * The linker caches on the descriptor, not on the symbol: `downcallHandle(symbol, descriptor)` is
+ * `downcallHandle(descriptor).bindTo(symbol)`. Binding a symbol to an already-linked shape is pure
+ * `MethodHandle` work and generates nothing. That is what makes this tractable — the backend binds
+ * thousands of engine function pointers (one per builtin method, per variant constructor, per
+ * utility function) but they collapse onto the handful of shapes listed below. It is also why
+ * [prewarm] links each shape *unbound*: prewarming must not depend on which engine entry points
+ * happen to exist in a given Godot build.
+ *
+ * ## Adding a call family
+ *
+ * If a new backend call needs a descriptor that is not in this list, add it here with the family
+ * that needs it. `scripts/check_native_call_surface.py` fails the build otherwise, so introducing a
+ * lazily-linked adapter is a visible choice rather than an invisible default.
+ *
+ * ## What this does not cover
+ *
+ * Upcall stubs. The linker caches the per-shape *arrangement*, but `UpcallLinker.makeUpcallStub` is
+ * still called for every individual stub, so each one allocates a fresh native blob. Kanama's stubs
+ * for `@RegisterClass` / `@ScriptClass` members can only be built once those classes are known,
+ * which is inside the `initialize` upcall (and, for hot reload, later still) — the engine offers no
+ * earlier registration point. "No upcall stub creation inside an upcall" is therefore not
+ * achievable, and is deliberately out of scope here; the trace reports upcall shapes so the
+ * residual stays visible.
+ */
+object NativeCallSurface {
+
+  /**
+   * Shape list, in prewarm order: return-by-value shapes first (grouped by arity), then void shapes
+   * (grouped by arity). The order is arbitrary but fixed, so the adapter trace is stable run to
+   * run.
+   *
+   * Labels name the call family, not a single symbol — most shapes are shared.
+   */
+  private val shapes: List<Pair<String, FunctionDescriptor>> =
+    listOf(
+      // get_proc_address, global_get_singleton, classdb_construct_object3
+      "interface_lookup" to FunctionDescriptor.of(ADDRESS, ADDRESS),
+      // script_instance_create3
+      "script_instance_create" to FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS),
+      // variant_get_ptr_utility_function, packed_*_array_operator_index[_const]
+      "utility_lookup" to FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG),
+      // classdb_get_method_bind
+      "method_bind_lookup" to FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_LONG),
+      // variant_get_ptr_destructor, variant_get_ptr_keyed_setter,
+      // get_variant_{from,to}_type_constructor
+      "variant_type_lookup" to FunctionDescriptor.of(ADDRESS, JAVA_INT),
+      // variant_get_ptr_constructor
+      "variant_constructor_lookup" to FunctionDescriptor.of(ADDRESS, JAVA_INT, JAVA_INT),
+      // variant_get_ptr_builtin_method
+      "builtin_method_lookup" to FunctionDescriptor.of(ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG),
+      // variant_get_type
+      "variant_get_type" to FunctionDescriptor.of(JAVA_INT, ADDRESS),
+      // string_to_utf8_chars
+      "string_to_utf8" to FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS, JAVA_LONG),
+      // get_godot_version2, object_destroy, variant_destroy, variant_new_nil, and every
+      // builtin/String/StringName ptr destructor
+      "one_pointer_void" to FunctionDescriptor.ofVoid(ADDRESS),
+      // variant_new_copy, string[_name]_new_with_utf8_chars, classdb_unregister_extension_class,
+      // every variant from/to-type constructor and every builtin ptr constructor
+      "two_pointer_void" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS),
+      // object_set_instance, classdb_register_extension_class_method, builtin keyed setters,
+      // and the engine-supplied add-callback in get_property_state_func
+      "three_pointer_void" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS),
+      // object_method_bind_ptrcall, classdb_register_extension_class6
+      "ptrcall" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS),
+      // classdb_register_extension_class_property
+      "register_property" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS),
+      // classdb_register_extension_class_signal
+      "register_signal" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, JAVA_LONG),
+      // object_method_bind_call -- the generic varcall path behind GodotObject.call and
+      // Object::emit_signal
+      "varcall" to
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS),
+      // builtin ptr methods (Array/Dictionary/StringName/... member calls)
+      "builtin_ptr_call" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, JAVA_INT),
+      // utility-function ptr calls (GD.*)
+      "utility_ptr_call" to FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_INT),
+    )
+
+  /**
+   * Link every adapter in [shapes].
+   *
+   * Called from `KanamaBinding.init` after `GodotFFI.bootstrap` and **before**
+   * `installInitCallbacks`, which is the moment Godot gains the ability to re-enter the JVM.
+   */
+  fun prewarm() {
+    shapes.forEach { (label, descriptor) -> GodotFFI.prelinkDowncall(descriptor, label) }
+  }
+}

--- a/src/main/kotlin/ffi/NativeCallSurface.kt
+++ b/src/main/kotlin/ffi/NativeCallSurface.kt
@@ -54,14 +54,17 @@ object NativeCallSurface {
    * (grouped by arity). The order is arbitrary but fixed, so the adapter trace is stable run to
    * run.
    *
-   * Labels name the call family, not a single symbol — most shapes are shared.
+   * Labels name the call family, not a single symbol — most shapes are shared. Keep them distinct
+   * from real GDExtension function names: `check_gdextension_modernization.py` reads every quoted
+   * lowercase string under `src/main` as evidence that a backend binds that entry point, so a label
+   * spelled `script_instance_create` would look like a deprecated bind.
    */
   private val shapes: List<Pair<String, FunctionDescriptor>> =
     listOf(
       // get_proc_address, global_get_singleton, classdb_construct_object3
       "interface_lookup" to FunctionDescriptor.of(ADDRESS, ADDRESS),
       // script_instance_create3
-      "script_instance_create" to FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS),
+      "script_instance_ctor" to FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS),
       // variant_get_ptr_utility_function, packed_*_array_operator_index[_const]
       "utility_lookup" to FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG),
       // classdb_get_method_bind
@@ -74,7 +77,7 @@ object NativeCallSurface {
       // variant_get_ptr_builtin_method
       "builtin_method_lookup" to FunctionDescriptor.of(ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG),
       // variant_get_type
-      "variant_get_type" to FunctionDescriptor.of(JAVA_INT, ADDRESS),
+      "variant_type_probe" to FunctionDescriptor.of(JAVA_INT, ADDRESS),
       // string_to_utf8_chars
       "string_to_utf8" to FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS, JAVA_LONG),
       // get_godot_version2, object_destroy, variant_destroy, variant_new_nil, and every

--- a/src/main/kotlin/net/multigesture/kanama/api/GD.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GD.kt
@@ -58,9 +58,10 @@ object GD {
             check(fn.address() != 0L) {
                 "variant_get_ptr_utility_function($name, $hash) returned NULL"
             }
-            GodotFFI.linker.downcallHandle(
+            GodotFFI.downcallHandle(
                 fn,
                 FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_INT),
+                "variant_ptr_utility_function",
             )
         }
 


### PR DESCRIPTION
Task 83. Hardening only — no behaviour change, no ABI change, no known
user-visible symptom.

## The hazard

Linking a Panama downcall handle for a `FunctionDescriptor` the process has not
seen before makes the JVM **generate native code**: `AbstractLinker.downcallHandle`
misses its cache, `DowncallLinker` builds a `NativeEntryPoint` (a downcall stub
blob in the code cache), and `BindingSpecializer` spins a hidden class for the
argument marshalling. Doing that while execution is already inside a Godot→JVM
upcall puts native code generation inside a thread-local executable-memory
transition — on macOS/AArch64 in particular.

That is a bad shape regardless of whether it has ever misbehaved, and it is
entirely avoidable. The safe pattern is to create every adapter during bootstrap,
before any lifecycle upcall is installed, so an upcall only ever *executes*
adapters that already exist.

## Why prewarming shapes (not call sites) is the whole fix

`Linker` caches on the descriptor, not the symbol: `downcallHandle(symbol, desc)`
is `downcallHandle(desc).bindTo(symbol)`. Binding a symbol to an already-linked
shape is pure `MethodHandle` work and generates nothing. So the backend's
thousands of engine function-pointer bindings — one per builtin method, per
variant constructor, per utility function — collapse onto **18 descriptor
shapes**, and `NativeCallSurface.prewarm()` links all 18 unbound (no symbol
needed, so prewarming does not depend on which engine entry points a given Godot
build exposes).

`PanamaPort`'s `_AbstractAndroidLinker` mirrors the JDK here (same
`DOWNCALL_CACHE` keyed on `LinkRequest(descriptor, options)`), so the same
property holds on Android.

## What changed

- `NativeCallSurface.prewarm()` — the 18 shapes, in a fixed order, each labelled
  with the call families that use it. Called from `KanamaBinding.init` right
  after `GodotFFI.bootstrap` and before `installInitCallbacks`.
- `GodotFFI` is now the single funnel: `downcallHandle` / `prelinkDowncall` /
  `upcallStub`. Nothing outside it touches `linker` directly, which is what makes
  the surface enumerable.
- `KANAMA_TRACE_NATIVE_ADAPTERS=1` prints every newly-linked adapter with a
  timestamp and identity, plus the moment the first lifecycle upcall is
  installed. Off in release.
- `scripts/check_native_call_surface.py` (new `local_ci.sh` stage) extracts the
  descriptor shapes the sources actually link — including the ones the KSP
  processor emits as string literals — and fails if one is missing from
  `NativeCallSurface`, or if anything bypasses the funnel.
- The four desktop smokes run with the trace on and assert the boundary line is
  present **and** that no downcall adapter is logged after it. The
  boundary-present check is deliberate: without it a dropped env var would make
  the absence check pass vacuously.

## Evidence

### Positive — zero adapters after the boundary

All four smokes, macOS arm64, Godot 4.7 stable. Representative (`tool_smoke`):

```
[kanama:adapter] downcall shape=(a8)a8 label=get_proc_address t=0.001s phase=bootstrap
[kanama:adapter] downcall shape=(a8a8)a8 label=script_instance_ctor t=0.037s phase=bootstrap
... 16 more, all phase=bootstrap ...
[kanama:adapter] downcall shape=(a8a8i4)v label=utility_ptr_call t=0.064s phase=bootstrap
[kanama:adapter] boundary first-lifecycle-upcall-install t=0.078s downcall-shapes=18 upcall-shapes=0
[kanama:adapter] upcall shape=(a8i4)v label=KanamaBinding.initializeCallback t=0.078s phase=post-boundary
```

Every `phase=post-boundary` line in every smoke log is an *upcall* stub. Counts
of `downcall … phase=post-boundary`, all zero:

| smoke | Godot launches | downcall shapes linked | post-boundary downcalls |
|---|---|---|---|
| `runtime_smoke` (+ import pass) | 4 | 18 each | 0 |
| `tool_smoke` | 1 | 18 | 0 |
| `hot_reload_smoke` | 2 | 18 each | 0 |
| `hot_reload_in_process_smoke` | 1 (reload in place) | 18 | 0 |

### Negative — the gate is falsifiable

Dropping the `varcall` shape from `NativeCallSurface` and re-running:

```
$ scripts/runtime_smoke.sh /Applications/Godot.app/Contents/MacOS/Godot
[runtime_smoke] FAIL -- native adapter generated after the first upcall:
[kanama:adapter] downcall shape=(a8a8a8j8a8a8)v label=object_method_bind_call t=0.560s phase=post-boundary VIOLATION
```

boundary in that run: `t=0.074s downcall-shapes=17`. The static gate fails on the
same change, before anything runs:

```
$ python3 scripts/check_native_call_surface.py
[native-call-surface] FAIL
  - downcall shape ofVoid(ADDRESS,ADDRESS,ADDRESS,JAVA_LONG,ADDRESS,ADDRESS) is linked but not prewarmed by src/main/kotlin/ffi/NativeCallSurface.kt:
    src/main/kotlin/binding/runtime/ObjectCalls.kt:157 (GodotFFI.lookup)
    src/main/kotlin/binding/runtime/Signals.kt:40 (GodotFFI.lookup)
```

Removing the prewarm call entirely shows the real size of the problem — **16 of
18 shapes were being generated inside an upcall**, spread across half a second:

```
downcall (a8a8)v      string_name_new_with_utf8_chars              t=0.118s post-boundary VIOLATION
downcall (a8a8a8a8)v  classdb_register_extension_class6            t=0.133s post-boundary VIOLATION
downcall (a8a8a8)v    object_set_instance                          t=0.147s post-boundary VIOLATION
downcall (a8a8j8)a8   classdb_get_method_bind                      t=0.180s post-boundary VIOLATION
downcall (a8a8a8a8a8)v classdb_register_extension_class_property   t=0.205s post-boundary VIOLATION
downcall (a8a8a8a8j8)v classdb_register_extension_class_signal     t=0.209s post-boundary VIOLATION
downcall (i4i4)a8     variant_get_ptr_constructor                  t=0.255s post-boundary VIOLATION
downcall (i4a8j8)a8   variant_get_ptr_builtin_method               t=0.257s post-boundary VIOLATION
downcall (a8a8a8i4)v  variant_ptr_builtin_method                   t=0.258s post-boundary VIOLATION
downcall (i4)a8       variant_get_ptr_destructor                   t=0.260s post-boundary VIOLATION
downcall (a8a8j8)j8   string_to_utf8_chars                         t=0.262s post-boundary VIOLATION
downcall (a8a8)a8     script_instance_create3                      t=0.408s post-boundary VIOLATION
downcall (a8)i4       variant_get_type                             t=0.422s post-boundary VIOLATION
downcall (a8j8)a8     variant_get_ptr_utility_function             t=0.440s post-boundary VIOLATION
downcall (a8a8i4)v    variant_ptr_utility_function                 t=0.442s post-boundary VIOLATION
downcall (a8a8a8j8a8a8)v object_method_bind_call                   t=0.544s post-boundary VIOLATION
```

### Startup cost

Same-process boundary timestamp, 3 runs each, headless `example_project`:

| | boundary | shapes linked by then |
|---|---|---|
| without prewarm | 0.046 / 0.047 / 0.047 s | 2 |
| with prewarm | 0.077 / 0.079 / 0.076 s | 18 |

**+30 ms before Godot's first callback.** Total process wall time did not resolve
above run-to-run noise (baseline 0.85 s and 0.93 s across two 5-run passes;
prewarmed 0.89 s) — the work largely moves rather than adds, since those 16
adapters were being generated later anyway.

## Deliberately out of scope: upcall stubs

`Linker` caches the per-shape upcall *arrangement*, but `makeUpcallStub` still
runs per stub, so each one allocates its own native blob. Kanama's stubs for
`@RegisterClass` / `@ScriptClass` members can only be built once those classes
are known, which is inside the `initialize` upcall (and later still for hot
reload) — the engine offers no earlier registration point. "No upcall stub
creation inside an upcall" is therefore not achievable, and this PR does not
claim it. The trace reports upcall shapes so the residual stays visible.

## Validation

- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot` — **PASS**
  (macOS arm64, JDK 25.0.3, Godot 4.7 stable), including the new
  `native call surface prewarm audit` stage and all four smokes.
- `assembleAndroidPluginAar` — **PASS** locally; `PanamaPort` Core
  `0.1.3-kanama-r8.4` exposes the unbound `downcallHandle(FunctionDescriptor, …)`
  overload the prewarm uses.
- iOS xcframework — not built locally. `ios-runtime` does not add
  `src/main/kotlin` to its source set and no file under `ios/`, `ios-runtime/` or
  `kanama-common-api/` is touched; CI's mobile lane builds it anyway.
- No retry, no sleep, no ABI change.

## Note on task 53

The hazard was noticed while investigating task 53's intermittent hot-reload
crash, and that is the whole of the relationship. That crash is unreproducible
(0/70 on the unfixed baseline) and this PR makes **no claim** to fix it; task 53
stays open. This change stands on its own because, unlike that one, it has an
exit gate that can actually be falsified — see the negative evidence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
