### PR TITLE
Audit CLAIMS against reality: fail when a documented blocker is lifted (task 85)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,14 @@ generated wrappers and focused policy fixes over ad hoc hand wrappers.
   Adding a field to the serialized script model (`ScriptModelJson`) means bumping
   `SCRIPT_MODEL_SCHEMA_VERSION`. Before finishing, grep the repo for the old
   value of any pinned constant you touched.
+- Claims drift the same way constants do, and nothing notices. **When you close
+  a task that removes a limitation, grep for the comments citing it** and delete
+  the ones that are now false. Task 30 gave iOS full wrapper breadth and nobody
+  grepped for "missing iOS wrapper types"; that line steered decisions for six
+  more weeks. Where the limitation is machine-checkable, write it as a
+  `KANAMA-BLOCKED` marker instead — `scripts/audit_stale_blockers.py` fails
+  the build when the blocker is lifted. See "Documented Limitations" in
+  `CONTRIBUTING.md`.
 - Do not widen ABI-sensitive types to make wrappers generate. Add exact helper
   shapes and audits first.
 - Prefer generated wrappers and focused policy fixes over ad hoc hand wrappers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,52 @@ Known constraints:
 See `docs/exporting/android.md` and `docs/contributing/android-internals.md`
 for the current Android workflow and limitations.
 
+## Documented Limitations
+
+A comment that says "blocked on X" is true when written and can be a lie by the
+next release: the change that removes X has no reason to grep for the comment.
+Such a claim then keeps steering decisions, because it reads as authoritative.
+This has happened here — one "missing iOS wrapper types" line outlived its cause
+by six weeks and nearly cost a working demo.
+
+**When you land a change that removes a limitation, grep for the comments citing
+it** (`rg -i "<the thing you just added>"`), and delete the ones that are now
+false. This is the counterpart to the pinned-constant rule in `AGENTS.md`.
+
+When the limitation is machine-checkable, do not rely on the grep habit — write
+the claim so `scripts/audit_stale_blockers.py` can re-check it every run:
+
+```
+KANAMA-BLOCKED(since:2026-07-13, symbol:DirAccessHandle@ios): iOS carries no DirAccessHandle
+```
+
+The audit is inverted on purpose: it **fails when the blocker no longer holds**,
+so the build goes red at the moment the comment becomes false, not whenever
+someone next happens to read it. Fixing a failure means deleting the marker and
+the claim it guards.
+
+- `since:YYYY-MM-DD` is required. An undated claim rots invisibly.
+- Every other token asserts an **absence** — the gap the claim depends on:
+  - `symbol:<Name>@<tree>` — no Kotlin declaration or `<Name>.kt` in that tree
+    (`desktop`, `ios`, `web`, `processor`, `example`, `repo`).
+  - `file:<repo-relative-path-or-glob>` — nothing matches.
+  - `webcall:<Class>.<godot_method_name>` — the Web backend contract dispatches
+    no such call. Validated against `extension_api.json`, so a typo cannot pass.
+  - `task:<id>` — the `kanama-tasks` spec is still open (not in `archive/`).
+    That repo is separate, so these tokens are **skipped with a note** when it is
+    absent, including in PR CI. Run the audit locally, or pass `--require-tasks`,
+    to check them.
+- An unresolvable token — unknown kind, unknown tree, a `file:` glob whose
+  anchor directory has moved, a Godot method that does not exist — is a loud
+  failure, never a silent pass. A marker that can never fire is worse than no
+  marker at all.
+- Only convert claims that are actually machine-checkable. Do not invent a
+  marker that guesses at a symbol name a future fix *might* use: it will fail
+  open and go stale exactly like the prose it replaced.
+
+Run it directly with `python3 scripts/audit_stale_blockers.py --list`; it is a
+`local_ci.sh` stage.
+
 ## Design Rules
 
 - Kotlin public APIs use lower-camel names. Do not add PascalCase aliases.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -24,6 +24,12 @@ you are changing:
 - [Web Internals](web-internals.md) before changing the in-development
   Kotlin/Wasm Web backend, its generated proxy, or the versioned JS bridge.
 
+Landing a change that **removes** a limitation is its own kind of change: the
+comments asserting that limitation are now false and nothing else will notice.
+Grep for them, and see "Documented Limitations" in the root `CONTRIBUTING.md`
+for the `KANAMA-BLOCKED` marker that makes the machine-checkable ones fail the
+build the day they go stale.
+
 Use the narrowest useful check while iterating, then run the broader local gate
 before release-facing changes:
 

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -213,9 +213,9 @@ in `scripts/check_wrapper_generator.py`:
 
 - **Explicit uncompilable classes.** `IOS_UNSUPPORTED_CLASSES` lists the classes whose
   generated draft cannot compile on iOS, each with its reason: `DirAccess` (its draft
-  references the hand-authored `DirAccessHandle` desktop policy class iOS does not carry)
-  and `MethodTweener` (its generated fluent methods clash
-  with the hand-written iOS `Tweener` glue). `--ios-emit-class <that class>` logs an
+  references the hand-authored `DirAccessHandle` desktop policy class iOS does not
+  carry) and `MethodTweener` (its generated fluent methods clash with the
+  hand-written iOS `Tweener` glue). `--ios-emit-class <that class>` logs an
   `unsupported:` line and skips it. Together with the collision registry these are the only
   by-design exceptions to iOS class-set parity with desktop (task 30); retire an entry by
   porting the desktop policy surface it depends on.

--- a/docs/contributing/wrapper-maintenance.md
+++ b/docs/contributing/wrapper-maintenance.md
@@ -208,11 +208,13 @@ in `scripts/check_wrapper_generator.py`:
   `collision:` line and skips it, instead of writing a `<Class>.kt` that duplicate-declares
   the class and breaks the compile. When a class graduates to a real generated wrapper
   (as `Time`/`InputMap`/`PhysicsServer3D` did), delete its entry so generation is allowed.
+  `FileAccess` lives here: iOS hosts it as a hand-written static facade plus its own
+  `FileAccessHandle` in `ios-runtime/.../api/FileAccess.kt`.
 
 - **Explicit uncompilable classes.** `IOS_UNSUPPORTED_CLASSES` lists the classes whose
-  generated draft cannot compile on iOS, each with its reason: `DirAccess`/`FileAccess`
-  (their drafts reference the hand-authored `DirAccessHandle`/`FileAccessHandle` desktop
-  policy classes iOS does not carry) and `MethodTweener` (its generated fluent methods clash
+  generated draft cannot compile on iOS, each with its reason: `DirAccess` (its draft
+  references the hand-authored `DirAccessHandle` desktop policy class iOS does not carry)
+  and `MethodTweener` (its generated fluent methods clash
   with the hand-written iOS `Tweener` glue). `--ios-emit-class <that class>` logs an
   `unsupported:` line and skips it. Together with the collision registry these are the only
   by-design exceptions to iOS class-set parity with desktop (task 30); retire an entry by

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -390,6 +390,7 @@ A quarantined cell that **passes** is reported just as loudly, with an explicit
 "lift the quarantine" line, because a stale quarantine is worse than none.
 Lifting one is a one-line deletion.
 
+<!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the quarantined cells below -->
 Currently quarantined: `dodge:firefox`, `squash:chrome` and `squash:firefox` —
 task 71, spawned mobs never free on a Linux host. Both demos pass on macOS, and
 `dodge:chrome` passes on Linux, so it is neither a browser nor a demo property.
@@ -501,6 +502,7 @@ commits, per-demo checksums, payload sizes, protocol version and driver results.
   Kotlin/JS production path.
 - A packaged/addon install path (exporting without the Kanama checkout) is not
   yet available; the current workflow is a source-checkout export.
+<!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the unexplained-defect entry below -->
 - **One defect is unexplained, not solved (task 71).** On one Linux CI host,
   spawned mobs in two demos travel far off screen yet
   `VisibleOnScreenNotifier2D.screen_exited` never fires, so they are never

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -170,6 +170,7 @@ above — mobile WebKit stays outside the validated claim.
 - No Web editor, no hot reload, no threads, no Kotlin/JS path.
 - Safari has **no headless mode**, so the Safari gate is a local GUI gate rather
   than a CI cell; iOS/iPadOS WebKit is hand-checked only, not gated.
+<!-- KANAMA-BLOCKED(since:2026-07-28, task:71): Linux-host mobs never free; matrix cells quarantined -->
 - One defect is tracked openly rather than solved: on one Linux CI host,
   spawned mobs never receive `VisibleOnScreenNotifier2D.screen_exited` and are
   never freed (task 71; the affected matrix cells are quarantined, not hidden).

--- a/scripts/audit_stale_blockers.py
+++ b/scripts/audit_stale_blockers.py
@@ -191,7 +191,9 @@ def scan_markers(root: Path) -> tuple[list[Marker], list[str]]:
                 continue
             raw_tokens = [part.strip() for part in match.group(1).split(",")]
             raw_tokens = [part for part in raw_tokens if part]
-            reason = match.group(2).strip()
+            # A marker in a .md file is written as an HTML comment so it stays out of
+            # the rendered page; drop the comment terminator from the reason.
+            reason = re.sub(r"(?:-->|\*/)\s*$", "", match.group(2)).strip()
             since = ""
             tokens: list[str] = []
             for token in raw_tokens:

--- a/scripts/audit_stale_blockers.py
+++ b/scripts/audit_stale_blockers.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Audit KANAMA-BLOCKED markers: fail when a documented blocker no longer holds.
+
+Every other `scripts/audit_*` compares code to code. This one compares a CLAIM
+to reality, and it is deliberately inverted:
+
+    the audit goes RED exactly when the limitation is LIFTED.
+
+That is the failure mode nothing else in this repo notices. A comment that says
+"blocked: missing iOS wrapper types (AnimatedSprite3D, RayCast3D)" was true when
+written; the task that shipped those wrappers had no reason to grep for it, so
+the comment outlived its cause by six weeks and kept steering decisions while
+reading as authoritative.
+
+Marker grammar (one line, anywhere a comment can live):
+
+    KANAMA-BLOCKED(since:2026-06-23, symbol:RayCast3D@ios): FPS needs this wrapper
+
+* `since:` is REQUIRED. An undated claim rots invisibly; a dated one at least
+  tells a reader how much to trust it.
+* Every other token asserts an ABSENCE -- the gap the claim depends on. The
+  audit resolves each one and FAILS if the gap has been closed.
+* An unresolvable token (unknown kind, unknown tree, a path whose anchor
+  directory no longer exists, a Godot method that does not exist) is a LOUD
+  error, never a silent pass. A marker that can never fire is worse than no
+  marker at all: it is the exact defect this audit exists to kill.
+
+Token kinds:
+
+    symbol:<Name>@<tree>   no Kotlin declaration (or <Name>.kt file) named
+                           <Name> exists in the named source tree.
+    file:<path-or-glob>    no repo-relative path matches (globs allowed).
+    webcall:<Class>.<m>    the Web backend contract
+                           (scripts/platform_backend_calls.json) dispatches no
+                           <Class>.<m>. <Class>.<m> is validated against
+                           extension_api.json, so a typo cannot pass.
+    task:<id>              the kanama-tasks spec <id>-*.md is still OPEN (lives
+                           at the tasks-repo root, not in archive/). kanama-tasks
+                           is a SEPARATE repo: when it is absent these tokens are
+                           SKIPPED with a note, never a hard failure. Pass
+                           --require-tasks to make an absent tasks repo fatal.
+
+Exit codes: 0 = every blocker still holds, 1 = a blocker was lifted or a token
+could not be resolved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "scripts/platform_backend_calls.json"
+EXTENSION_API_PATH = ROOT / "extension_api.json"
+
+# Named Kotlin source trees a `symbol:` token may be scoped to. A symbol token
+# MUST name one: an unscoped "does this exist anywhere" question is not the
+# question any real blocker asks, and answering it repo-wide would make the
+# audit fire on unrelated trees.
+SYMBOL_TREES = {
+    "desktop": "src/main/kotlin",
+    "ios": "ios-runtime/src",
+    "web": "web-runtime/src",
+    "processor": "processor/src/main/kotlin",
+    "example": "example_project",
+    "repo": ".",
+}
+
+MARKER_RE = re.compile(r"KANAMA-BLOCKED\(([^)]*)\)\s*:\s*(.*)$")
+# A marker is the word followed IMMEDIATELY by `(` or `:`. Prose that merely mentions
+# the convention ("the KANAMA-BLOCKED marker below") is not a claim, while a botched
+# marker (`KANAMA-BLOCKED: reason`) still gets caught as malformed rather than dropped.
+CANDIDATE_RE = re.compile(r"KANAMA-BLOCKED[(:]")
+DECL_KEYWORDS = ("class", "interface", "object", "fun", "val", "var", "typealias")
+SINCE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+SYMBOL_TOKEN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)@([a-z]+)$")
+WEBCALL_TOKEN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\.([a-z_][a-z0-9_]*)$")
+TASK_TOKEN_RE = re.compile(r"^[0-9]+[a-z]?$")
+
+# Files whose KANAMA-BLOCKED text is grammar, not a claim. This audit spells the
+# marker out; nothing else may be exempted, and the count is printed on PASS so
+# the exemption cannot grow quietly.
+EXEMPT_PATHS = {"scripts/audit_stale_blockers.py"}
+
+BINARY_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp", ".svg",
+    ".zip", ".jar", ".so", ".dylib", ".dll", ".a", ".o",
+    ".ttf", ".otf", ".woff", ".woff2", ".wasm", ".pck", ".res",
+    ".ogg", ".wav", ".mp3", ".import", ".pdf",
+}
+
+
+@dataclass
+class Marker:
+    path: str
+    line_no: int
+    since: str
+    tokens: list[str]
+    reason: str
+
+
+@dataclass
+class Result:
+    lifted: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    resolved: int = 0
+    skipped: int = 0
+
+
+def default_tasks_dir() -> Path:
+    """Best guess at the sibling kanama-tasks checkout.
+
+    Resolved beside the MAIN worktree, not beside ROOT: audits are routinely run
+    from `.claude/worktrees/<name>`, where ROOT.parent is `worktrees`.
+    """
+    env = os.environ.get("KANAMA_TASKS_DIR")
+    if env:
+        return Path(env).expanduser()
+    candidates = [ROOT.parent / "kanama-tasks"]
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if common:
+            candidates.append(Path(common).parent.parent / "kanama-tasks")
+    except (subprocess.CalledProcessError, OSError):
+        pass
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[0]
+
+
+def tracked_files(root: Path) -> list[str]:
+    """Enumerate tracked text files. git keeps build output and vendored trees out."""
+    out = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [
+        name
+        for name in out.split("\0")
+        if name and Path(name).suffix.lower() not in BINARY_SUFFIXES
+    ]
+
+
+def scan_markers(root: Path) -> tuple[list[Marker], list[str]]:
+    markers: list[Marker] = []
+    errors: list[str] = []
+    for name in tracked_files(root):
+        if name in EXEMPT_PATHS:
+            continue
+        path = root / name
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        if not CANDIDATE_RE.search(text):
+            continue
+        in_fence = False
+        is_markdown = path.suffix.lower() in {".md", ".markdown"}
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if is_markdown and line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if not CANDIDATE_RE.search(line):
+                continue
+            # A marker inside a markdown code fence is documentation of the
+            # grammar, not a claim about this repo.
+            if in_fence:
+                continue
+            match = MARKER_RE.search(line)
+            if not match:
+                errors.append(
+                    f"{name}:{line_no}: malformed KANAMA-BLOCKED marker; expected "
+                    f"KANAMA-BLOCKED(since:YYYY-MM-DD, <token>, ...): <reason>"
+                )
+                continue
+            raw_tokens = [part.strip() for part in match.group(1).split(",")]
+            raw_tokens = [part for part in raw_tokens if part]
+            reason = match.group(2).strip()
+            since = ""
+            tokens: list[str] = []
+            for token in raw_tokens:
+                if token.startswith("since:"):
+                    since = token[len("since:"):].strip()
+                else:
+                    tokens.append(token)
+            if not SINCE_RE.match(since):
+                errors.append(
+                    f"{name}:{line_no}: KANAMA-BLOCKED needs a since:YYYY-MM-DD token "
+                    f"(got {since!r}); undated claims rot invisibly"
+                )
+                continue
+            if not tokens:
+                errors.append(
+                    f"{name}:{line_no}: KANAMA-BLOCKED has no checkable token; "
+                    f"a marker with nothing to resolve is prose, not a claim"
+                )
+                continue
+            if not reason:
+                errors.append(f"{name}:{line_no}: KANAMA-BLOCKED has an empty reason")
+                continue
+            markers.append(Marker(name, line_no, since, tokens, reason))
+    return markers, errors
+
+
+def kotlin_symbol_hits(tree: Path, name: str) -> list[str]:
+    hits: list[str] = []
+    decl_re = re.compile(rf"\b(?:{'|'.join(DECL_KEYWORDS)})\s+{re.escape(name)}\b")
+    for path in sorted(tree.rglob("*.kt")):
+        if path.stem == name:
+            hits.append(str(path.relative_to(ROOT)))
+            continue
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        if name not in text:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if decl_re.search(line):
+                hits.append(f"{path.relative_to(ROOT)}:{line_no}")
+                break
+    return hits
+
+
+def glob_anchor(pattern: str) -> Path:
+    """Deepest wildcard-free directory of a glob.
+
+    A `file:` token whose whole subtree was renamed would otherwise match
+    nothing forever and pass forever. Requiring the anchor to exist turns that
+    silent pass into a loud error.
+    """
+    anchor = ROOT
+    for part in Path(pattern).parent.parts:
+        if any(ch in part for ch in "*?["):
+            break
+        anchor = anchor / part
+    return anchor
+
+
+def load_contract_calls() -> set[str]:
+    data = json.loads(CONTRACT_PATH.read_text())
+    return {
+        f"{call.get('className')}.{call.get('methodName')}"
+        for call in data.get("calls", [])
+    }
+
+
+def load_godot_methods() -> dict[str, set[str]]:
+    data = json.loads(EXTENSION_API_PATH.read_text())
+    methods: dict[str, set[str]] = {}
+    for klass in data.get("classes", []):
+        methods[klass["name"]] = {m["name"] for m in klass.get("methods", []) or []}
+    return methods
+
+
+def task_files(tasks_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
+    open_tasks: dict[str, str] = {}
+    closed_tasks: dict[str, str] = {}
+    id_re = re.compile(r"^(\d+[a-z]?)-")
+    for path in sorted(tasks_dir.glob("*.md")):
+        match = id_re.match(path.name)
+        if match:
+            open_tasks[match.group(1)] = path.name
+    archive = tasks_dir / "archive"
+    if archive.is_dir():
+        for path in sorted(archive.rglob("*.md")):
+            match = id_re.match(path.name)
+            if match:
+                closed_tasks[match.group(1)] = f"archive/{path.name}"
+    return open_tasks, closed_tasks
+
+
+def resolve(
+    marker: Marker,
+    token: str,
+    result: Result,
+    contract: set[str],
+    godot_methods: dict[str, set[str]],
+    tasks: tuple[dict[str, str], dict[str, str]] | None,
+) -> None:
+    where = f"{marker.path}:{marker.line_no}"
+    if ":" not in token:
+        result.errors.append(
+            f"{where}: token {token!r} has no kind; expected "
+            f"symbol:/file:/webcall:/task:"
+        )
+        return
+    kind, _, value = token.partition(":")
+    kind = kind.strip()
+    value = value.strip()
+    if not value:
+        result.errors.append(f"{where}: token {token!r} has an empty value")
+        return
+
+    if kind == "symbol":
+        match = SYMBOL_TOKEN_RE.match(value)
+        if not match:
+            result.errors.append(
+                f"{where}: symbol token must be symbol:<Name>@<tree> (got {value!r}); "
+                f"trees: {', '.join(sorted(SYMBOL_TREES))}"
+            )
+            return
+        name, tree_name = match.groups()
+        if tree_name not in SYMBOL_TREES:
+            result.errors.append(
+                f"{where}: unknown symbol tree {tree_name!r}; "
+                f"known: {', '.join(sorted(SYMBOL_TREES))}"
+            )
+            return
+        tree = ROOT / SYMBOL_TREES[tree_name]
+        if not tree.is_dir():
+            result.errors.append(
+                f"{where}: symbol tree {tree_name!r} -> {SYMBOL_TREES[tree_name]} "
+                f"does not exist; the tree moved and this token can never fire"
+            )
+            return
+        hits = kotlin_symbol_hits(tree, name)
+        result.resolved += 1
+        if hits:
+            result.lifted.append(
+                f"{where}: BLOCKER LIFTED -- {name} now exists in the {tree_name} tree "
+                f"({', '.join(hits[:3])}{', ...' if len(hits) > 3 else ''}). "
+                f"Claim: {marker.reason}"
+            )
+        return
+
+    if kind == "file":
+        anchor = glob_anchor(value)
+        if not anchor.exists():
+            result.errors.append(
+                f"{where}: file token anchor {anchor.relative_to(ROOT)} does not exist; "
+                f"the path moved and this token can never fire"
+            )
+            return
+        hits = sorted(str(p.relative_to(ROOT)) for p in ROOT.glob(value))
+        result.resolved += 1
+        if hits:
+            result.lifted.append(
+                f"{where}: BLOCKER LIFTED -- {value} now matches "
+                f"{', '.join(hits[:3])}{', ...' if len(hits) > 3 else ''}. "
+                f"Claim: {marker.reason}"
+            )
+        return
+
+    if kind == "webcall":
+        match = WEBCALL_TOKEN_RE.match(value)
+        if not match:
+            result.errors.append(
+                f"{where}: webcall token must be webcall:<Class>.<godot_method_name> "
+                f"(got {value!r})"
+            )
+            return
+        class_name, method_name = match.groups()
+        if class_name not in godot_methods:
+            result.errors.append(
+                f"{where}: webcall token names class {class_name!r}, which is not in "
+                f"extension_api.json; this token can never fire"
+            )
+            return
+        if method_name not in godot_methods[class_name]:
+            result.errors.append(
+                f"{where}: webcall token names {class_name}.{method_name}, which Godot "
+                f"does not declare; this token can never fire"
+            )
+            return
+        result.resolved += 1
+        if value in contract:
+            result.lifted.append(
+                f"{where}: BLOCKER LIFTED -- the Web backend contract now dispatches "
+                f"{value}. Claim: {marker.reason}"
+            )
+        return
+
+    if kind == "task":
+        if not TASK_TOKEN_RE.match(value):
+            result.errors.append(
+                f"{where}: task token must be a task id like task:71 (got {value!r})"
+            )
+            return
+        if tasks is None:
+            result.skipped += 1
+            return
+        open_tasks, closed_tasks = tasks
+        if value in open_tasks:
+            result.resolved += 1
+            return
+        if value in closed_tasks:
+            result.resolved += 1
+            result.lifted.append(
+                f"{where}: BLOCKER LIFTED -- task {value} is closed "
+                f"({closed_tasks[value]}). Claim: {marker.reason}"
+            )
+            return
+        result.errors.append(
+            f"{where}: task {value} exists neither open nor archived in the "
+            f"kanama-tasks checkout; this token can never fire"
+        )
+        return
+
+    result.errors.append(
+        f"{where}: unknown token kind {kind!r}; expected symbol:/file:/webcall:/task:"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=None,
+        help="kanama-tasks checkout (default: $KANAMA_TASKS_DIR, else the sibling of the main worktree)",
+    )
+    parser.add_argument(
+        "--require-tasks",
+        action="store_true",
+        help="fail instead of skipping when the kanama-tasks checkout is absent",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print every marker with its age",
+    )
+    args = parser.parse_args()
+
+    markers, errors = scan_markers(ROOT)
+    result = Result(errors=list(errors))
+
+    tasks_dir = args.tasks_dir if args.tasks_dir is not None else default_tasks_dir()
+    tasks: tuple[dict[str, str], dict[str, str]] | None = None
+    tasks_note = ""
+    if tasks_dir.is_dir():
+        tasks = task_files(tasks_dir)
+    elif args.require_tasks:
+        result.errors.append(
+            f"--require-tasks was passed but {tasks_dir} is not a directory"
+        )
+    else:
+        tasks_note = f" task-tokens-skipped (no checkout at {tasks_dir})"
+
+    contract = load_contract_calls()
+    godot_methods = load_godot_methods()
+
+    for marker in markers:
+        for token in marker.tokens:
+            resolve(marker, token, result, contract, godot_methods, tasks)
+
+    if args.list:
+        today = _datetime.date.today()
+        for marker in sorted(markers, key=lambda m: (m.since, m.path, m.line_no)):
+            try:
+                age = (today - _datetime.date.fromisoformat(marker.since)).days
+            except ValueError:
+                age = -1
+            print(
+                f"  {marker.path}:{marker.line_no}  since {marker.since} ({age}d)  "
+                f"{' '.join(marker.tokens)}  -- {marker.reason}"
+            )
+
+    if result.lifted or result.errors:
+        print("[stale_blockers] FAIL", file=sys.stderr)
+        for line in result.lifted:
+            print(f"  - {line}", file=sys.stderr)
+        for line in result.errors:
+            print(f"  - UNRESOLVABLE {line}", file=sys.stderr)
+        if result.lifted:
+            print(
+                "\n  A lifted blocker is not a bug in this audit: the comment above is "
+                "now a lie.\n  Delete the marker and the claim it guards, then re-run.",
+                file=sys.stderr,
+            )
+        return 1
+
+    oldest = min((m.since for m in markers), default="-")
+    print(
+        f"[stale_blockers] PASS markers={len(markers)} tokens={result.resolved} "
+        f"skipped={result.skipped} oldest={oldest} exempt={len(EXEMPT_PATHS)}"
+        f"{tasks_note}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_stale_blockers.py
+++ b/scripts/audit_stale_blockers.py
@@ -220,12 +220,23 @@ def scan_markers(root: Path) -> tuple[list[Marker], list[str]]:
     return markers, errors
 
 
-def kotlin_symbol_hits(tree: Path, name: str) -> list[str]:
+def kotlin_symbol_hits(tree_prefix: str, name: str, kotlin_files: list[str]) -> list[str]:
+    """Search TRACKED .kt files under a tree prefix.
+
+    Tracked-only on purpose: an rglob would also walk `build/` and any nested
+    worktree, so a symbol token could fire on stale generated output and report a
+    blocker as lifted when nothing in the source tree had changed.
+    """
     hits: list[str] = []
     decl_re = re.compile(rf"\b(?:{'|'.join(DECL_KEYWORDS)})\s+{re.escape(name)}\b")
-    for path in sorted(tree.rglob("*.kt")):
+    scoped = [
+        n for n in kotlin_files
+        if tree_prefix == "." or n == tree_prefix or n.startswith(tree_prefix + "/")
+    ]
+    for rel in scoped:
+        path = ROOT / rel
         if path.stem == name:
-            hits.append(str(path.relative_to(ROOT)))
+            hits.append(rel)
             continue
         try:
             text = path.read_text()
@@ -235,7 +246,7 @@ def kotlin_symbol_hits(tree: Path, name: str) -> list[str]:
             continue
         for line_no, line in enumerate(text.splitlines(), start=1):
             if decl_re.search(line):
-                hits.append(f"{path.relative_to(ROOT)}:{line_no}")
+                hits.append(f"{rel}:{line_no}")
                 break
     return hits
 
@@ -295,6 +306,7 @@ def resolve(
     contract: set[str],
     godot_methods: dict[str, set[str]],
     tasks: tuple[dict[str, str], dict[str, str]] | None,
+    kotlin_files: list[str],
 ) -> None:
     where = f"{marker.path}:{marker.line_no}"
     if ":" not in token:
@@ -325,14 +337,14 @@ def resolve(
                 f"known: {', '.join(sorted(SYMBOL_TREES))}"
             )
             return
-        tree = ROOT / SYMBOL_TREES[tree_name]
-        if not tree.is_dir():
+        tree_prefix = SYMBOL_TREES[tree_name]
+        if not (ROOT / tree_prefix).is_dir():
             result.errors.append(
-                f"{where}: symbol tree {tree_name!r} -> {SYMBOL_TREES[tree_name]} "
+                f"{where}: symbol tree {tree_name!r} -> {tree_prefix} "
                 f"does not exist; the tree moved and this token can never fire"
             )
             return
-        hits = kotlin_symbol_hits(tree, name)
+        hits = kotlin_symbol_hits(tree_prefix, name, kotlin_files)
         result.resolved += 1
         if hits:
             result.lifted.append(
@@ -457,10 +469,11 @@ def main() -> int:
 
     contract = load_contract_calls()
     godot_methods = load_godot_methods()
+    kotlin_files = [n for n in tracked_files(ROOT) if n.endswith(".kt")]
 
     for marker in markers:
         for token in marker.tokens:
-            resolve(marker, token, result, contract, godot_methods, tasks)
+            resolve(marker, token, result, contract, godot_methods, tasks, kotlin_files)
 
     if args.list:
         today = _datetime.date.today()

--- a/scripts/generate_api_wrapper.py
+++ b/scripts/generate_api_wrapper.py
@@ -205,6 +205,10 @@ IOS_EMIT_CLASSES: set[str] | None = None
 # anywhere on iOS — requesting one logs an `unsupported:` line and skips it, so a bulk regen
 # stays fail-loud instead of writing a file that breaks compileKotlinIosArm64. Retire an entry
 # by porting the desktop policy surface it depends on.
+# FileAccess sat in this same list until iOS grew its own FileAccessHandle (2026-07-13), and the
+# docs still described it as uncompilable four weeks later. The marker below makes
+# scripts/audit_stale_blockers.py go red the day DirAccess gets the same treatment.
+# KANAMA-BLOCKED(since:2026-07-13, symbol:DirAccessHandle@ios): iOS carries no DirAccessHandle policy class
 IOS_UNSUPPORTED_CLASSES = {
     "DirAccess": "desktop hosts DirAccess as a hand-shaped static facade; the generated draft "
                  "references the hand-authored DirAccessHandle alias class iOS does not carry",

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -269,6 +269,9 @@ python3 "$ROOT_DIR/scripts/audit_replicated_script_properties.py" "$ROOT_DIR/exa
 stage "value-type builtin parity audit"
 python3 "$ROOT_DIR/scripts/audit_value_type_wrappers.py" --strict
 
+stage "stale blocker claim audit"
+python3 "$ROOT_DIR/scripts/audit_stale_blockers.py"
+
 stage "JDWP bootstrap/project-setting guard"
 if ! rg -q 'debug/jdwp_port' "$ROOT_DIR/bootstrap/bootstrap.c" "$ROOT_DIR/example_project/addons/kanama_tools/plugin.gd" "$ROOT_DIR/templates/starter/addons/kanama_tools/plugin.gd"; then
   echo "[local_ci] JDWP project setting is not wired through bootstrap and editor tools" >&2

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -134,9 +134,12 @@ kanama_web_demo_local_only_reason() {
 # because nobody was looking. A quarantined cell that PASSES is reported just as
 # loudly, because a stale quarantine is worse than none.
 #
-# Lifting one is a one-line deletion here.
+# Lifting one is a one-line deletion here -- and scripts/audit_stale_blockers.py makes the
+# deletion mandatory: the KANAMA-BLOCKED marker below fails the build the moment its task is
+# archived, so a quarantine cannot outlive the defect it cites.
 kanama_web_quarantine_reason() {
   case "$1" in
+    # KANAMA-BLOCKED(since:2026-07-28, task:71): dodge/squash mobs never free on a Linux host
     dodge:firefox|squash:chrome|squash:firefox)
       echo "task 71 — spawned mobs never free on a Linux host; both demos pass on macOS"
       ;;

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
@@ -800,6 +800,7 @@ class MultiplayerSynchronizer(godotObject: GodotHandle) : Node(godotObject.toBac
 }
 
 object IP {
+  // KANAMA-BLOCKED(since:2026-07-27, webcall:IP.get_local_addresses): Web dispatches no IP call
   /** No socket surface on Web; the lobby falls back to its "this device" copy. */
   fun getLocalAddresses(): List<String> = emptyList()
 }


### PR DESCRIPTION
Task 85 slice 1. Kanama has twelve `scripts/audit_*` and **every one compares code to code**. None compares a *claim* to reality, which is why eight stale claims surfaced in a single session — one of them (`# Blocked: missing iOS wrapper types (AnimatedSprite3D, RayCast3D, OS)`) outlived its cause by six weeks and nearly cost a working demo.

`scripts/audit_stale_blockers.py` closes that gap, and it is **inverted on purpose**:

> it goes RED exactly when the limitation is LIFTED — the moment the comment becomes a lie and nothing currently notices.

## Marker grammar

```
KANAMA-BLOCKED(since:2026-07-13, symbol:DirAccessHandle@ios): iOS carries no DirAccessHandle
```

- `since:` is **required** (spec item 3: undated claims rot invisibly). It is reported, never a failure — a time-bomb gate would be worse than the problem.
- Every other token asserts an **absence** — the gap the claim rests on. One uniform direction, so "the audit fails when a gap closes" needs no per-token reasoning.
  - `symbol:<Name>@<tree>` — no Kotlin declaration or `<Name>.kt` in that tree (`desktop`/`ios`/`web`/`processor`/`example`/`repo`). The tree is **mandatory**: an unscoped "does it exist anywhere" is not the question a blocker asks.
  - `file:<path-or-glob>` — nothing matches.
  - `webcall:<Class>.<godot_method>` — the Web backend contract dispatches no such call, validated against `extension_api.json`. (Named `webcall:` rather than the spec's `opcode:` because the opcode *number* is not stable identity; the class/method pair is.)
  - `task:<id>` — the `kanama-tasks` spec is still open (not in `archive/`). Separate repo, so these **skip with a note** when it is absent, including in PR CI.
- **An unresolvable token is a loud failure, never a silent pass** — that fail-open mode is the exact defect this task exists to kill. Covered: unknown kind, unknown tree, unscoped symbol, a `file:` glob whose anchor directory has moved, a Godot class/method that does not exist, a task id in neither root nor `archive/`, a missing `since:`, an empty token list, and a malformed marker.

## Six markers converted

| Site | Token | Effect when lifted |
|---|---|---|
| `scripts/generate_api_wrapper.py` `IOS_UNSUPPORTED_CLASSES` | `symbol:DirAccessHandle@ios` | red the day iOS gains the policy class |
| `web-runtime/.../WebTpsApi.kt` `IP.getLocalAddresses` | `webcall:IP.get_local_addresses` | red when Web dispatches an IP call |
| `scripts/web/demos.sh` quarantine | `task:71` | all four fire together, so closing task 71 |
| `docs/reference/version-support.md` | `task:71` | cannot leave a stale quarantine or a stale |
| `docs/exporting/web.md` (x2) | `task:71` | docs paragraph behind |

Markdown markers are HTML comments, so they do not render.

## One already-stale claim found and fixed

`docs/contributing/wrapper-maintenance.md` filed **`FileAccess`** under `IOS_UNSUPPORTED_CLASSES` — "their drafts reference the hand-authored `DirAccessHandle`/`FileAccessHandle` desktop policy classes **iOS does not carry**". iOS grew its own `FileAccessHandle` in `ios-runtime/.../api/FileAccess.kt:72` on **2026-07-13**, three days after that doc line was written (2026-07-10), and it sits in `IOS_HANDWRITTEN_COLLISION_CLASSES`, not the unsupported list. Four weeks stale. Corrected here.

That symbol doubles as the negative proof below: the audit names the exact file and line where the gap closed.

## Both-ways proof

Positive, repo as-is:

```
[stale_blockers] PASS markers=6 tokens=6 skipped=0 oldest=2026-07-13 exempt=1
exit=0
```

Negative — add `symbol:FileAccessHandle@ios`, a symbol that demonstrably exists:

```
[stale_blockers] FAIL
  - scripts/generate_api_wrapper.py:211: BLOCKER LIFTED -- FileAccessHandle now exists in the ios tree (ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FileAccess.kt:72). Claim: iOS carries no DirAccessHandle policy class

  A lifted blocker is not a bug in this audit: the comment above is now a lie.
  Delete the marker and the claim it guards, then re-run.
exit=1
```

Negative — simulate closing task 71 by pointing `--tasks-dir` at a checkout where `71-*.md` sits in `archive/`:

```
[stale_blockers] FAIL
  - docs/exporting/web.md:393: BLOCKER LIFTED -- task 71 is closed (archive/71-web-linux-mobs-never-free.md). Claim: the quarantined cells below
  - docs/exporting/web.md:505: BLOCKER LIFTED -- task 71 is closed (archive/71-web-linux-mobs-never-free.md). Claim: the unexplained-defect entry below
  - docs/reference/version-support.md:173: BLOCKER LIFTED -- task 71 is closed (archive/71-web-linux-mobs-never-free.md). Claim: Linux-host mobs never free; matrix cells quarantined
  - scripts/web/demos.sh:142: BLOCKER LIFTED -- task 71 is closed (archive/71-web-linux-mobs-never-free.md). Claim: dodge/squash mobs never free on a Linux host
exit=1
```

A throwaway probe file exercised every path; all thirteen fired (ten unresolvable-token errors plus three lifted blockers), and the tree is clean afterwards. Line 13 of that probe replays the actual motivating case:

```
  - scripts/_probe_markers.txt:13: BLOCKER LIFTED -- RayCast3D now exists in the ios tree (ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/RayCast3D.kt). Claim: the real 2026-06-23 FPS claim, replayed
```

## Sweep

The full `blocked|not supported|unsupported|missing .* wrapper|does not exist|no .* support` sweep over `scripts/ src/ ios/ ios-runtime/ web-runtime/ processor/ docs/` returned 313 hits; after excluding Godot-synced KDoc and generated files, 170 were triaged by hand. One already-stale claim (above). All 37 `unsupportedWebGameplayFamily("Class.method")` assertions were machine-checked against the Web contract — **none** is stale. Six of those 37 use approximate labels (`Node3D.get_visible`, `Light3D.get_shadow`, …) that no Godot class declares, so they can never be cross-checked; flagged, not changed, since `generate_web_gameplay_coverage.py` may key off the exact strings.

Verified-still-true and deliberately left as prose (no safe token): `newScriptInstance` deferred on iOS (the symbol *exists* as a throwing stub, so an absence token is the wrong shape — `check_ios_no_silent_stubs.py` already guards it), typed-Dictionary deferred on iOS (`IosScriptCodeEmitter.kt:771` warn-skip), "no separate committed Android wrapper tree", "no packaged Web install path", "no mobile hot reload", and the iOS utility-function call path. Marking those would have meant guessing a symbol name a future fix might use — a token that fails open, which is the defect this audit exists to kill.

## Convention

`CONTRIBUTING.md` gains a **Documented Limitations** section (grammar + the "grep for comments citing a limitation you just removed" habit), `AGENTS.md` gains the task-closing bullet beside the pinned-constant rule, and `docs/contributing/index.md` points at both.

## Scope

Out: the `kanama-demos` FPS repair (separate repo, needs a device run) and cross-source checks against `kanama-tasks`. Only machine-checkable claims were converted — several verified-true claims were deliberately **not** marked because the only available token would have guessed at a symbol name a future fix might use, and would fail open exactly like the prose it replaced.

`scripts/local_ci.sh` gains one stage (`stale blocker claim audit`), kept to a single added line for a trivial rebase against the parallel task-83 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
