### PR TITLE
Make the real _process the Web bridge's frame fallthrough; the spike benchmark becomes opt-in (task 84)

### DIFF
--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "updated": "2026-07-30",
-  "note": "Web performance budgets (Task 60f). Every number was MEASURED; each demo records the runs it came from. WHAT IS GATED CHANGED after the first Firefox baseline (see `gatingPolicy`): payload and crossings-per-tick are gated, startup is recorded but NOT gated. Firefox's higher crossings-per-tick on _process-heavy demos is a SETTLED headless-environment artifact, not an engine defect (task 74, 2026-08-03): nothing paces requestAnimationFrame in headless Firefox, so render-frame-driven command emission multiplies while physics-driven work tracks the wall-capped physics step; a display-paced Firefox sits near Chrome. Per-engine budgets bound regressions within each environment's own baseline.",
+  "updated": "2026-08-10",
+  "note": "Web performance budgets (Task 60f). Every number was MEASURED; each demo records the runs it came from. WHAT IS GATED CHANGED after the first Firefox baseline (see `gatingPolicy`): payload and crossings-per-tick are gated, startup is recorded but NOT gated. Firefox's higher crossings-per-tick on _process-heavy demos is a SETTLED headless-environment artifact, not an engine defect (task 74, 2026-08-03): nothing paces requestAnimationFrame in headless Firefox, so render-frame-driven command emission multiplies while physics-driven work tracks the wall-capped physics step; a display-paced Firefox sits near Chrome. Per-engine budgets bound regressions within each environment's own baseline. TASK 84 (2026-08-10) re-measured charactercontroller, thirdperson and racing: those three had no `mode` branch in the JS bridge's frame dispatch and so took its SPIKE BENCHMARK fallthrough, which appended a synthetic scalar mutation per dispatch and never counted a _process tick. Their old numbers graded the benchmark, not the game -- every one of them moved DOWN on re-measurement and every ceiling tightened. Each carries a `supersedes` string with what it replaced; nothing here was loosened.",
   "headroom": "payload +15% (asset growth, not a texture reimport); startup 3x with an 8s floor; crossings/tick 2x with a 2.0 floor -- the ratio is diluted by tick count, so 2x absorbs host variation while a real regression (per-frame work reaching the cross-module path) multiplies it several times over.",
   "knownExceptions": {
     "tpsdemo": "638 MB served payload, 570 MB of it upstream demo assets in index.pck. It RUNS, but nobody would download it: this is far outside any sane web budget, and the number below records reality rather than blessing it. Fixing it is asset work in the demo (texture compression, trimming), which 60f explicitly puts out of scope -- budgets are not met by editing gameplay or scene content."
@@ -50,36 +50,35 @@
     },
     "charactercontroller": {
       "maxPayloadBytes": 97000000,
-      "maxCrossingsPerTick": 9.0,
+      "maxCrossingsPerTick": 3.8,
       "minTicksForVerdict": 30,
-      "measuredOn": "2026-07-30, macOS arm64, Chrome 150 headless, protocol 15",
+      "measuredOn": "2026-08-10, macOS arm64, Chrome 151 headless, protocol 18 (task 84)",
+      "supersedes": "2026-07-30 protocol 15: chrome 4.50 (max 9.0), firefox 19.58 / CI 12.13 (max 39.2). Those runs took bridge.frame()'s SPIKE BENCHMARK fallthrough (task 84): the synthetic per-dispatch scalar mutation was counted as real crossings and processTicks was 0, so the denominator was physics ticks alone. Both halves of the ratio were wrong; the numbers above are re-measured on the real _process path and are NOT comparable to the old ones.",
       "measured": {
         "payloadBytes": 83998154,
-        "startupMs": 2670,
-        "crossingsPerTick": 4.5,
-        "ticksObserved": 211
+        "startupMs": 2704,
+        "crossingsPerTick": 1.86,
+        "ticksObserved": 1543
       },
       "engines": {
         "chrome": {
-          "maxCrossingsPerTick": 9.0,
+          "maxCrossingsPerTick": 3.8,
           "measured": {
-            "crossingsPerTick": 4.5,
-            "ticksObserved": 211,
-            "startupMs": 2670,
-            "on": "macOS arm64, Chrome 150 headless"
+            "crossingsPerTick": 1.86,
+            "ticksObserved": 1543,
+            "startupMs": 2704,
+            "on": "macOS arm64, Chrome 151 headless, protocol 18"
           }
         },
         "firefox": {
-          "maxCrossingsPerTick": 39.2,
+          "maxCrossingsPerTick": 3.8,
           "measured": {
-            "crossingsPerTick": 19.58,
-            "ticksObserved": 295,
-            "startupMs": 37082,
-            "on": "macOS arm64, Firefox 153 headless"
+            "crossingsPerTick": 0.23,
+            "ticksObserved": 9031,
+            "startupMs": 37101,
+            "on": "macOS arm64, Firefox 153 headless, protocol 18 (0.22-0.23 over 4 runs)"
           },
-          "measuredOnCi": {
-            "crossingsPerTick": 12.13
-          }
+          "budgetFrom": "Chrome's number, NOT 2x Firefox's own 0.23. Before task 84 Firefox sat far ABOVE Chrome here (19.58 vs 4.50) because the benchmark transport emitted one synthetic command per dispatch and headless Firefox's unpaced rAF dispatches several times more often. With that gone, the residual crossings are physics-driven (wall-capped) while unpaced rAF only inflates processTicks, so Firefox's ratio now sits BELOW Chrome's and Chrome is the conservative bound for both. The pre-84 CI Firefox figure (12.13) measured the benchmark and is not carried forward; the next full-corpus CI run re-measures it."
         }
       }
     },
@@ -246,33 +245,35 @@
     },
     "racing": {
       "maxPayloadBytes": 49000000,
-      "maxCrossingsPerTick": 5.0,
+      "maxCrossingsPerTick": 4.2,
       "minTicksForVerdict": 30,
-      "measuredOn": "2026-07-30, macOS arm64, Chrome 150 headless, protocol 15",
+      "measuredOn": "2026-08-10, macOS arm64, Chrome 151 headless, protocol 18 (task 84)",
+      "supersedes": "2026-07-30 protocol 15: chrome 2.51 (max 5.0), firefox 4.93 (max 9.9). Those runs took bridge.frame()'s SPIKE BENCHMARK fallthrough (task 84) -- synthetic per-dispatch crossings in the numerator, processTicks 0 in the denominator -- so they are not comparable to the numbers above.",
       "measured": {
         "payloadBytes": 42091193,
-        "startupMs": 1582,
-        "crossingsPerTick": 2.51,
-        "ticksObserved": 474
+        "startupMs": 1611,
+        "crossingsPerTick": 2.09,
+        "ticksObserved": 548
       },
       "engines": {
         "chrome": {
-          "maxCrossingsPerTick": 5.0,
+          "maxCrossingsPerTick": 4.2,
           "measured": {
-            "crossingsPerTick": 2.51,
-            "ticksObserved": 474,
-            "startupMs": 1582,
-            "on": "macOS arm64, Chrome 150 headless"
+            "crossingsPerTick": 2.09,
+            "ticksObserved": 548,
+            "startupMs": 1611,
+            "on": "macOS arm64, Chrome 151 headless, protocol 18"
           }
         },
         "firefox": {
-          "maxCrossingsPerTick": 9.9,
+          "maxCrossingsPerTick": 4.2,
           "measured": {
-            "crossingsPerTick": 4.93,
-            "ticksObserved": 570,
-            "startupMs": 14132,
-            "on": "macOS arm64, Firefox 153 headless"
-          }
+            "crossingsPerTick": 0.68,
+            "ticksObserved": 2095,
+            "startupMs": 14371,
+            "on": "macOS arm64, Firefox 153 headless, protocol 18"
+          },
+          "budgetFrom": "Chrome's number, NOT 2x Firefox's own 0.68 -- see charactercontroller.firefox.budgetFrom for why Chrome bounds both engines after task 84."
         }
       }
     },
@@ -310,36 +311,35 @@
     },
     "thirdperson": {
       "maxPayloadBytes": 122000000,
-      "maxCrossingsPerTick": 2.3,
+      "maxCrossingsPerTick": 2.0,
       "minTicksForVerdict": 30,
-      "measuredOn": "2026-07-30, macOS arm64, Chrome 150 headless, protocol 15",
+      "measuredOn": "2026-08-10, macOS arm64, Chrome 151 headless, protocol 18 (task 84)",
+      "supersedes": "2026-07-30 protocol 15: chrome 1.15 (max 2.3), firefox 6.01 / CI 7.08 (max 14.2). Those runs took bridge.frame()'s SPIKE BENCHMARK fallthrough (task 84) -- synthetic per-dispatch crossings in the numerator, processTicks 0 in the denominator -- so they are not comparable to the numbers above. The pre-84 CI Firefox figure (7.08) measured the benchmark and is not carried forward; the next full-corpus CI run re-measures it.",
       "measured": {
         "payloadBytes": 105819088,
-        "startupMs": 4412,
-        "crossingsPerTick": 1.15,
-        "ticksObserved": 657
+        "startupMs": 4444,
+        "crossingsPerTick": 0.29,
+        "ticksObserved": 1738
       },
       "engines": {
         "chrome": {
-          "maxCrossingsPerTick": 2.3,
+          "maxCrossingsPerTick": 2.0,
           "measured": {
-            "crossingsPerTick": 1.15,
-            "ticksObserved": 657,
-            "startupMs": 4412,
-            "on": "macOS arm64, Chrome 150 headless"
+            "crossingsPerTick": 0.29,
+            "ticksObserved": 1738,
+            "startupMs": 4444,
+            "on": "macOS arm64, Chrome 151 headless, protocol 18"
           }
         },
         "firefox": {
-          "maxCrossingsPerTick": 14.2,
+          "maxCrossingsPerTick": 2.0,
           "measured": {
-            "crossingsPerTick": 6.01,
-            "ticksObserved": 1314,
-            "startupMs": 64691,
-            "on": "macOS arm64, Firefox 153 headless"
+            "crossingsPerTick": 0.12,
+            "ticksObserved": 8728,
+            "startupMs": 64977,
+            "on": "macOS arm64, Firefox 153 headless, protocol 18"
           },
-          "measuredOnCi": {
-            "crossingsPerTick": 7.08
-          }
+          "budgetFrom": "Chrome's number, NOT 2x Firefox's own 0.12 -- see charactercontroller.firefox.budgetFrom for why Chrome bounds both engines after task 84. 2.0 is the declared crossings/tick floor from `headroom`, which 2x0.29 falls under."
         }
       }
     },
@@ -425,6 +425,6 @@
   "gatingPolicy": {
     "payloadBytes": "GATED. Bytes are host- and engine-independent by construction.",
     "startupMs": "RECORDED, NOT GATED. It is wall-clock and it does not survive a loaded machine: the same thirdperson build measured 4.4s on an idle Chrome and 64.7s on a Firefox sharing a busy workstation. A gate that red-lights because someone else was compiling is measuring the machine, and the failure it would catch (a demo that stops booting) already shows up as a driver timeout.",
-    "crossingsPerTick": "GATED PER ENGINE. Engine-stable for most of the corpus (bunnymark 2.22/1.97, dodge 0.19/0.20, citybuilder 0.84/0.77, fps 1.10/1.02 for chrome/firefox) but NOT for the input-heavy demos, where Firefox does 5-10x the boundary work: charactercontroller 4.50 -> 19.58, thirdperson 1.15 -> 6.01. A Chrome-derived budget had no business gating a Firefox run, which is exactly how this was found -- the gate reddened main."
+    "crossingsPerTick": "GATED PER ENGINE. Engine-stable for most of the corpus (bunnymark 2.22/1.97, dodge 0.19/0.20, citybuilder 0.84/0.77, fps 1.10/1.02 for chrome/firefox). The per-engine split was introduced because Firefox measured 5-10x Chrome's ratio on the input-heavy demos (charactercontroller 4.50 -> 19.58, thirdperson 1.15 -> 6.01) and a Chrome-derived budget reddened main. Task 84 (2026-08-10) established that for those three demos the asymmetry was an artifact of the spike-benchmark fallthrough: the synthetic per-dispatch command scaled with Firefox's unpaced rAF. On the real _process path the asymmetry INVERTS (charactercontroller 1.86 -> 0.23, thirdperson 0.29 -> 0.12, racing 2.09 -> 0.68), because the residual crossings are physics-driven and wall-capped while unpaced rAF only inflates processTicks. Those three therefore take Chrome's ceiling on both engines as the conservative bound. The structure stays per-engine: it is still the right shape, and the rest of the corpus was never re-measured under it."
   }
 }

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -45,6 +45,12 @@ async function snapshot(evaluate) {
         flagReady: classCount(".Flag3D"),
         killPlaneReady: classCount(".KillPlane3D"),
         physicsCalls: bridge.physicsProcessCalls ?? 0,
+        // Task 84: real _process dispatches. This demo has no mode branch in the
+        // bridge's frame dispatch, and until task 84 the fallthrough there was the
+        // SYNTHETIC SPIKE BENCHMARK -- so this demo reported processTicks: 0 while
+        // quietly appending a benchmark scalar mutation on every dispatch.
+        // (No backticks in here: this whole function body is a template literal.)
+        processCalls: bridge.processCalls ?? 0,
         // Task 82: the coroutine frame scheduler's per-frame advance. cc named no "Main"
         // handle anywhere, which is exactly why it never pumped before protocol 18.
         pumps: bridge.frameSchedulerPumps ?? 0,
@@ -304,8 +310,20 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
     // Headless rAF throttles to ~15 ticks/s; 40 ticks proves sustained physics.
     physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
     // travel(Idle/Move) + particle toggles + blink timers flow as queued commands.
+    // MEASURED 2026-08-10 (macOS arm64, Chrome 151 headless, protocol 18, task 84): the
+    // gameplay window applies ~800 commands over its baseline, so +80 keeps a 10x margin
+    // on the REAL _process path. The threshold is unchanged and was NOT re-derived from
+    // the pre-84 runs, which were inflated by the benchmark's synthetic per-dispatch
+    // scalar mutation -- a lower bound met partly by scaffolding is a lower bound that
+    // proves nothing, so it had to be re-measured even though the number stayed put.
     gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
     crossingsAdvanced: peak.crossings > ready.crossings,
+    // Task 84: this demo runs the engine's REAL `_process`, not the transport benchmark.
+    // MEASURED 829 (Chrome) / 8524 (Firefox) process dispatches; it was exactly 0 on both
+    // before the fix. Asserted as > 0 rather than a magnitude because the count tracks the
+    // host's rAF rate, and the thing worth failing on is the demo silently leaving the
+    // real dispatch path again.
+    realProcessPathDispatched: afterGameplay.processCalls > 0,
     // Task 82: the coroutine frame scheduler is advanced in THIS demo, which names no
     // "Main" handle anywhere -- the pump rides the _process dispatch every proxy emits.
     frameSchedulerPumped: afterGameplay.pumps >= 10,
@@ -348,6 +366,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
       kotlinToGodotCalls: peak.crossings,
       physicsProcessCalls: peak.physicsCalls,
       appliedCommands: peak.appliedCommands,
+      processCalls: afterGameplay.processCalls,
       playerDisplacement: Number(displacement.toFixed(3)),
       frameSchedulerPumps: afterGameplay.pumps,
       frameSchedulerContinuations: afterGameplay.continuations,

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -35,6 +35,12 @@ async function snapshot(evaluate) {
         viewReady: classCount(".View"),
         smokeReady: classCount(".Smoke"),
         physicsCalls: bridge.physicsProcessCalls ?? 0,
+        // Task 84: real _process dispatches. This demo has no mode branch in the
+        // bridge's frame dispatch, and until task 84 the fallthrough there was the
+        // SYNTHETIC SPIKE BENCHMARK -- so this demo reported processTicks: 0 while
+        // quietly appending a benchmark scalar mutation on every dispatch.
+        // (No backticks in here: this whole function body is a template literal.)
+        processCalls: bridge.processCalls ?? 0,
         appliedCommands: bridge.appliedCommands,
         liveHandles: bridge.liveBrowserHandleCount,
         maxLiveHandles: bridge.maxLiveBrowserHandles,
@@ -198,8 +204,20 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
     // Held forward drove the sphere racer; the camera rig followed it.
     playerMovedOnInput: displacement > 1.0,
     physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    // MEASURED 2026-08-10 (macOS arm64, Chrome 151 headless, protocol 18, task 84): the
+    // measured drive applies ~2900 commands over its baseline, so +80 keeps a wide margin
+    // on the REAL _process path. The threshold is unchanged and was NOT re-derived from
+    // the pre-84 runs, which were inflated by the benchmark's synthetic per-dispatch
+    // scalar mutation -- a lower bound met partly by scaffolding proves nothing, so it
+    // had to be re-measured even though the number stayed put.
     gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
     crossingsAdvanced: peak.crossings > baseline.crossings,
+    // Task 84: this demo runs the engine's REAL `_process`, not the transport benchmark.
+    // MEASURED 90 (Chrome) / 1527 (Firefox) process dispatches; it was exactly 0 on both
+    // before the fix. Asserted as > 0 rather than a magnitude because the count tracks the
+    // host's rAF rate, and the thing worth failing on is the demo silently leaving the
+    // real dispatch path again.
+    realProcessPathDispatched: settled.processCalls > 0,
     fullTeardownToZero: settled.liveHandles === 0,
     physicsOrderingDeterministic: (settled.physicsAfterProcess ?? 0) === 0,
     noCallbackFaults:
@@ -227,6 +245,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
       kotlinToGodotCalls: peak.crossings,
       physicsProcessCalls: peak.physicsCalls,
       appliedCommands: peak.appliedCommands,
+      processCalls: settled.processCalls,
       playerDisplacement: Number(displacement.toFixed(3)),
     },
     callbacks: {

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -40,6 +40,12 @@ async function snapshot(evaluate) {
         boxReady: classCount(".Box"),
         smokeQuitReady: classCount(".SmokeQuit"),
         physicsCalls: bridge.physicsProcessCalls ?? 0,
+        // Task 84: real _process dispatches. This demo has no mode branch in the
+        // bridge's frame dispatch, and until task 84 the fallthrough there was the
+        // SYNTHETIC SPIKE BENCHMARK -- so this demo reported processTicks: 0 while
+        // quietly appending a benchmark scalar mutation on every dispatch.
+        // (No backticks in here: this whole function body is a template literal.)
+        processCalls: bridge.processCalls ?? 0,
         appliedCommands: bridge.appliedCommands,
         liveHandles: bridge.liveBrowserHandleCount,
         maxLiveHandles: bridge.maxLiveBrowserHandles,
@@ -208,8 +214,20 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     // Synthetic move_up displaced the player through the camera-relative controller.
     playerMovedOnInput: displacement > 1.0,
     physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    // MEASURED 2026-08-10 (macOS arm64, Chrome 151 headless, protocol 18, task 84): the
+    // gameplay window applies ~680 commands over its baseline, so +80 keeps an 8x margin
+    // on the REAL _process path. The threshold is unchanged and was NOT re-derived from
+    // the pre-84 runs, which were inflated by the benchmark's synthetic per-dispatch
+    // scalar mutation -- a lower bound met partly by scaffolding proves nothing, so it
+    // had to be re-measured even though the number stayed put.
     gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
     crossingsAdvanced: peak.crossings > baseline.crossings,
+    // Task 84: this demo runs the engine's REAL `_process`, not the transport benchmark.
+    // MEASURED 793 (Chrome) / 7405 (Firefox) process dispatches; it was exactly 0 on both
+    // before the fix. Asserted as > 0 rather than a magnitude because the count tracks the
+    // host's rAF rate, and the thing worth failing on is the demo silently leaving the
+    // real dispatch path again.
+    realProcessPathDispatched: settled.processCalls > 0,
     fullTeardownToZero: settled.liveHandles === 0,
     physicsOrderingDeterministic: (settled.physicsAfterProcess ?? 0) === 0,
     noCallbackFaults:
@@ -237,6 +255,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
       kotlinToGodotCalls: peak.crossings,
       physicsProcessCalls: peak.physicsCalls,
       appliedCommands: peak.appliedCommands,
+      processCalls: settled.processCalls,
       playerDisplacement: Number(displacement.toFixed(3)),
     },
     callbacks: {

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -358,6 +358,18 @@ tasks.register("stageWebSpikeGodotProject") {
             into(stagingDir.resolve("kanama-web/generated"))
         }
 
+        // Task 84: the benchmark harness now NAMES itself, exactly like every demo page does.
+        // It used to be the bridge's fallback mode, which meant "the page said nothing" and "the
+        // page asked for the synthetic transport benchmark" were the same state. The bridge's
+        // fallback is a plain game now, so this line is what selects the benchmark.
+        val shell = stagingDir.resolve("kanama-web/shell.html")
+        val originalShell = shell.readText()
+        val pageStart = "globalThis.KanamaWebPageStartedAt = performance.now();"
+        check(originalShell.contains(pageStart)) { "Missing Web shell bootstrap marker" }
+        shell.writeText(
+            originalShell.replace(pageStart, "$pageStart\n      globalThis.KanamaWebMode = \"spike\";")
+        )
+
         val manifest = webProxyResources.get().file("KanamaWebProxyManifest.generated.tsv").asFile
         check(manifest.isFile) { "Missing generated Web proxy manifest: $manifest" }
         val mappings =

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -267,7 +267,16 @@ fun kanamaWebPumpFrameScheduler(delta: Double): Int {
   }
 }
 
-/** Synthetic transport benchmark path; real Web scripts use [kanamaWebProcess]. */
+/**
+ * Synthetic transport benchmark path; real Web scripts use [kanamaWebProcess].
+ *
+ * Runs the script's `_process` and then appends one synthetic scalar mutation per dispatch, so the
+ * harness can measure command-crossing throughput without a game emitting commands of its own. That
+ * appended marker is work no game asked for, which is why the bridge must only reach this when the
+ * page explicitly asks: `globalThis.KanamaWebMode === "spike"`. It was the bridge's `frame()`
+ * fallthrough until task 84, and the three demos with no mode branch (charactercontroller,
+ * thirdperson, racing) silently ran the benchmark instead of their gameplay.
+ */
 @JsExport
 fun kanamaWebSpikeProcess(objectId: Int, delta: Double): Int {
   return webCallbackBoundary(objectId, "_process") { record ->

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -170,7 +170,12 @@
   const bridge = {
     api: null,
     protocolVersion: KANAMA_WEB_PROTOCOL_VERSION,
-    mode: globalThis.KanamaWebMode ?? "spike",
+    // Task 84: the fallback mode is a plain GAME, never the benchmark. Defaulting to "spike" put
+    // the same trap one level up -- a page that forgot its `KanamaWebMode` line took the synthetic
+    // transport AND the single-script benchmark lifecycle below, silently. Every page that wants
+    // the benchmark now says so; every page that forgets gets a game (and its driver's
+    // `mode === "<demo>"` check fails loudly instead of the run quietly measuring the wrong thing).
+    mode: globalThis.KanamaWebMode ?? "game",
     bunnymarkVariant: globalThis.KanamaWebBunnymarkVariant ?? null,
     bunnymarkLanguage: globalThis.KanamaWebBunnymarkLanguage ?? "kanama",
     previewBunnies: requestedPreviewBunnies(),
@@ -560,35 +565,33 @@
       return executed;
     },
 
+    /**
+     * One engine frame's dispatch into one script.
+     *
+     * Task 84: the REAL `_process` is the FALLTHROUGH and the synthetic transport benchmark is an
+     * explicitly named branch. It used to be the other way round -- eight demos were listed here
+     * and the three nobody remembered (charactercontroller, thirdperson, racing) silently ran the
+     * benchmark instead of their game: ~150 dispatches dropped into `kanamaWebEmptyFrame`, then
+     * `kanamaWebSpikeProcess` appending a synthetic scalar mutation on EVERY dispatch forever.
+     * Nothing failed, so nothing noticed; the numbers simply stopped describing the game
+     * (inflated appliedCommands, an extra crossing per script per frame, and `processTicks: 0`
+     * for a demo that never reached `process()` at all).
+     *
+     * The default has to be what a GAME needs; benchmark scaffolding is what you opt INTO. This is
+     * the same accident shape as task 82's mode-gated scheduler pump one layer down: there the
+     * per-frame work was MISSING by default, here it was WRONG by default. A demo that adds no
+     * branch here now gets correct behaviour by construction, so demo thirteen cannot repeat it.
+     */
     frame(handle, delta) {
       this.lastProcessRafTick = this.rafTick;
       // Before any mode branch: the scheduler advance belongs to the engine frame, not to a demo.
       this.pumpFrameScheduler(handle, delta);
-      if (this.mode === "bunnymark") {
-        return this.process(handle, delta);
-      }
-      if (this.mode === "web3d") {
-        // Minimal 3D render smoke: the single Node3D script runs its _process (spins a
-        // child); no benchmark transport.
-        return this.process(handle, delta);
-      }
-      if (this.mode === "squash") {
-        return this.process(handle, delta);
-      }
-      if (this.mode === "fps") {
-        return this.process(handle, delta);
-      }
-      if (this.mode === "tpsdemo") {
-        // Every script runs its plain _process dispatch; nothing here takes the spike
-        // benchmark transport.
-        return this.process(handle, delta);
-      }
-      if (this.mode === "citybuilder") {
-        return this.process(handle, delta);
-      }
-      if (this.mode === "platformer") {
-        return this.process(handle, delta);
-      }
+      // Opt-in only, named by the page: `stageWebSpikeGodotProject` writes
+      // `globalThis.KanamaWebMode = "spike"` into the harness shell, the same way every demo's
+      // staging task names its own mode. The benchmark is legitimate tooling -- it measures
+      // crossing throughput with no gameplay in the way -- so it stays reachable via
+      // `./gradlew :web-runtime:exportWebSpike`, but only when asked for.
+      if (this.mode === "spike") return this.spikeBenchmarkFrame(handle, delta);
       if (this.mode === "match3") {
         if (handle === this.match3AudioHandle) {
           this.match3AudioProcessCalls += 1;
@@ -604,15 +607,19 @@
         // Tween-driven); only Main runs its own _process. The scheduler advance above is
         // unaffected -- it already happened, whichever handle arrived first this frame.
         if (handle !== this.match3MainHandle) return 0;
-        return this.process(handle, delta);
       }
-      if (this.mode === "dodge") {
-        // Real scene demo: every dodge script (Main, Player, spawned Mobs) runs its _process
-        // via process(). Neither path takes the spike benchmark transport below, which appends
-        // a scalar (op100) marker that only the spike main script can apply — that mis-route is
-        // what fataled dodge's per-frame scripts.
-        return this.process(handle, delta);
-      }
+      return this.process(handle, delta);
+    },
+
+    /**
+     * The synthetic transport benchmark (`KanamaWebMode === "spike"`, the webSpikeGodot harness).
+     *
+     * Samples empty crossings first, then batched frames whose `_process` appends one synthetic
+     * scalar mutation (opcode 1000) per dispatch, so throughput can be measured without a game
+     * emitting its own commands. That appended marker is why this must never be a fallthrough: a
+     * real demo taking it reports work no game asked for.
+     */
+    spikeBenchmarkFrame(handle, delta) {
       const started = performance.now();
       let result;
       const emptyLimit = WARMUP_FRAMES + SAMPLE_FRAMES;


### PR DESCRIPTION
# Task 84 — the real `_process` becomes the fallthrough; the benchmark becomes opt-in

`bridge.frame()` in `kanama-web-bridge.js` dispatched per demo `mode`, and its
**fallthrough was the synthetic spike benchmark transport**. Eight demos were
listed; the three nobody remembered — **charactercontroller, thirdperson,
racing** — silently ran `kanamaWebEmptyFrame` and then `kanamaWebSpikeProcess`,
which appends an `OPCODE_SCALAR_MUTATION` on *every* dispatch that the proxy
dutifully applies.

Nothing failed, so nothing noticed. The numbers simply stopped describing the
game: inflated `appliedCommands`, an extra crossing per script per frame, and
`processTicks: 0` for demos that never reached `process()` at all.

This is the same accident shape as #157 (task 82) one layer up: there the
per-frame work was *missing* by default, here it was *wrong* by default.

## The fix: invert the default

The real `_process` path is now the **fallthrough**. The benchmark is an
explicitly named branch:

```js
if (this.mode === "spike") return this.spikeBenchmarkFrame(handle, delta);
```

A demo that adds no branch gets correct behaviour by construction, so demo
thirteen cannot repeat this.

**The benchmark stays reachable and working — it is legitimate throughput
tooling.** It is now selected exactly the way every demo selects its own mode:
`stageWebSpikeGodotProject` writes `globalThis.KanamaWebMode = "spike"` into the
harness shell, so `./gradlew :web-runtime:exportWebSpike` still produces the
benchmark page. The bridge's fallback mode changed from `"spike"` to `"game"` —
otherwise the same trap just moves one level up, and a page that forgot its
`KanamaWebMode` line would take the benchmark *and* the single-script benchmark
lifecycle in `recordReady`. A page that forgets now gets a game, and its
driver's `mode === "<demo>"` check fails loudly.

## Headline evidence — before/after

Same export, same host, same session; only `kanama-web-bridge.js` swapped
between the two runs (`origin/main`'s copy vs this branch's). macOS arm64,
Chrome 151 / Firefox 153 headless, Godot 4.7 stable, protocol 18.

| demo | engine | `processTicks` | `appliedCommands` | crossings | ticks | crossings/tick |
|---|---|---|---|---|---|---|
| charactercontroller | chrome | **0 → 829** | 5607 → 4682 | 3714 → 2867 | 747 → 1543 | **4.97 → 1.86** |
| charactercontroller | firefox | **0 → 8524** | 17679 → 3462 | 15767 → 2039 | 752 → 9031 | **20.97 → 0.23** |
| thirdperson | chrome | **0 → 793** | 1078 → 954 | 755 → 509 | 657 → 1738 | **1.15 → 0.29** |
| thirdperson | firefox | **0 → 7405** | 9003 → 1842 | 7949 → 1016 | 1305 → 8728 | **6.09 → 0.12** |
| racing | chrome | **0 → 90** | 3797 → 3668 | 1189 → 1148 | 474 → 548 | **2.51 → 2.09** |
| racing | firefox | **0 → 1527** | 5997 → 4551 | 2838 → 1425 | 574 → 2095 | **4.94 → 0.68** |

`processTicks` for **charactercontroller is 829 on Chrome** (8524 on Firefox) —
it was exactly 0 on both.

The Firefox collapse is the clearest read on how much of the old number was
scaffolding: 15767 crossings → 2039 for charactercontroller. Headless Firefox's
unpaced rAF dispatched `_process` many times per wall second, and every one of
those dispatches minted a synthetic command.

## Budgets and driver thresholds, re-measured

Both halves of crossings-per-tick were wrong for these three demos (synthetic
commands in the numerator, `processTicks: 0` in the denominator), so every
number is re-measured and **every ceiling tightens**:

| demo | chrome max | firefox max |
|---|---|---|
| charactercontroller | 9.0 → **3.8** | 39.2 → **3.8** |
| thirdperson | 2.3 → **2.0** | 14.2 → **2.0** |
| racing | 5.0 → **4.2** | 9.9 → **4.2** |

Each demo carries a `supersedes` string recording what it replaced and why the
old figure is not comparable. The two pre-84 `measuredOnCi` Firefox figures
(12.13, 7.08) measured the benchmark and are not carried forward; the note says
so, and the next full-corpus CI run re-measures them.

Those three now take **Chrome's** ceiling on both engines rather than 2x their
own Firefox measurement. Before task 84 Firefox sat far *above* Chrome here; on
the real path the asymmetry inverts, because the residual crossings are
physics-driven and wall-capped while unpaced rAF only inflates `processTicks`.
Chrome is the conservative bound for both. The per-engine structure stays — it
is still the right shape and the rest of the corpus was never re-measured.

**No driver threshold was loosened.** `gameplayCommandsApplied` keeps its `+80`
lower bound, re-measured at ~800 / ~680 / ~2900 commands over baseline on the
real path — it now stands on its own evidence instead of partly on benchmark
scaffolding. Each of the three drivers gains
**`realProcessPathDispatched: processCalls > 0`**, the assertion that would have
caught this in the first place.

## Gates

| gate | result |
|---|---|
| `ktfmtFormat`, `:processor:test` | PASS |
| `scripts/local_ci.sh` (all stages incl. web bridge syntax, scaffold self-test, backend dispatch drift, Wasm compile + coverage, runtime/@Tool/hot-reload smokes) | PASS |
| full corpus `--demo-set full --engine chrome --engine firefox` | see comment below |

## Carried, not introduced: task 77

`charactercontroller:firefox` is a coin flip on this macOS workstation. It is
**task 77**, whose documented fingerprint is `playerDisplacement: 0.667` with
exactly `playerMovedOnInput` + `physicsFramesAdvanced` failing. Verified by
running the same export four times on each bridge:

| bridge | runs | passes | failure signature |
|---|---|---|---|
| `origin/main` (before) | 4 | 2 | `0.667`, physics 140/141 |
| this branch (after) | 4 | 1 | `0.667`, physics 139/140/141 |

Identical signature and identical magnitudes on both sides, including on the
**unmodified main bridge**. Not introduced here, not touched here, nothing
weakened for it. Linux CI has never seen it.

## What else decides behaviour by `mode`

Audited every `this.mode` site in the bridge (48 references):

- **`frame()`** — fixed here.
- **`recordReady()` per-demo handle capture** (`charSmokeQuitHandle`,
  `racingVehicleHandle`, …). "Missing by default", but it fails *loudly*: every
  driver's ready-loop requires its handles to be non-zero, so an unwired demo
  cannot reach ready. Safe as-is.
- **`recordReady()` single-script benchmark lifecycle** (`bunnymark`/`spike`):
  correctly opt-in — a scene demo must not treat the 2nd `_ready` as a run
  finish. It was reachable through the old `"spike"` default; it no longer is.
- **`frame()`'s match3 branch** (`handle !== match3MainHandle → return 0`):
  genuinely demo-specific, correctly scoped to a named mode.
- **~20 match3/bunnymark telemetry counters** (`match3TweensCreated`,
  `addBunnyCalls`, …): additive only. The default is "don't count", which is
  the right default for a counter.
- **`shouldDeferReady()` returns `false` unconditionally** — vestigial; its
  partner `recordDeferredReady` still feeds `deferredSubsystemReady` in the
  match3 snapshot. Dead-ish, harmless, reported not fixed (out of scope).

Only `frame()` had an unsafe default. Reported for the record rather than
fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
