### PR TITLE
Gate the opt-in spike benchmark: driver, smoke wiring, matrix cell (task 84 follow-up)

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -247,9 +247,11 @@ scripts/web_ci_matrix.sh \
 Every cell runs even after an earlier one fails, so a red run reports the whole
 picture. `--demo-set pr` is the per-PR subset (`match3`, `web3d`, `dodge` — a
 pointer-drag demo, a 3D demo needing no demos checkout, and a full-lifecycle
-demo); `--demo-set full` is the 12-demo corpus. Per-demo budgets live in
-`scripts/web/demos.sh`; scale them for a slower host with `--timeout-scale`
-rather than editing them, so local and CI numbers stay comparable.
+demo); `--demo-set full` is the 12-demo corpus plus the gated spike benchmark
+cell (as is `ci`, minus what a hosted runner cannot build — see the Spike
+Benchmark Cell below). Per-demo budgets live in `scripts/web/demos.sh`; scale
+them for a slower host with `--timeout-scale` rather than editing them, so local
+and CI numbers stay comparable.
 
 **Chrome and Firefox are the CI cells** (`.github/workflows/web.yml`): the PR
 subset on every Web-relevant pull request, the full corpus on push to `main` and
@@ -266,6 +268,7 @@ Which gate runs when, and where. A gate that is not on this list runs nowhere.
 | `ci` corpus × Chrome + Firefox (everything a runner can build) | push to `main`, and nightly | CI |
 | **tps-demo** | before a release tag | local (OOM-killed on a hosted runner) |
 | Soak (10 min, `--demo soak`) | nightly | CI |
+| Spike transport benchmark (`--demo spike`, in the `ci`/`full` sets) | push to `main`, and nightly | CI |
 | Full corpus on **Safari** | before a release tag, and before any promotion decision | local (no headless mode) |
 | Fresh-checkout gate | before a release tag | local |
 | Browser floor re-bisect | when a floor is claimed to move, or a browser major ships that breaks a cell | local |
@@ -297,6 +300,29 @@ registered coroutine jobs must not be higher in the second half than the first
 (plus a few handles of sampling slack), gameplay must still be running at the
 end, and teardown must still drain to zero after a long run rather than only
 after a short one.
+
+### Spike Benchmark Cell
+
+```sh
+scripts/web_ci_matrix.sh --godot /absolute/path/to/godot \
+  --template <web_nothreads_release.zip> --demo spike --engine chrome --engine firefox
+```
+
+The spike is the synthetic transport benchmark (the staged in-repo
+`webSpikeGodot` project — it needs no demos checkout and exports through its own
+`:web-runtime:exportWebSpike` task). It is **opt-in**: the bridge's frame
+fallthrough is the real `_process`, and only a page that stamps
+`globalThis.KanamaWebMode = "spike"` reaches the benchmark transport. This cell
+is what keeps the opt-in path from rotting. Its driver asserts the staging still
+names the mode (an export that loses the mode line falls back to gameplay and
+fails here, loudly), that the benchmark branch's own counters advanced while the
+real `_process` path stayed at exactly zero — the inverse of the demo drivers'
+`realProcessPathDispatched` — folds the page's structural verdict (the
+10000-mutation batch must cross the boundary exactly ONCE) into the envelope,
+and quits the SceneTree to drain live handles to zero. Transport cost is gated
+structurally rather than by a ratio: the spike never takes the
+`_process`/`_physics_process` tick paths, so crossings-per-tick is exempt in
+`scripts/web/budgets.json` with the reason recorded.
 
 ## Performance Budgets
 

--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -420,6 +420,40 @@
         "crossingsPerTick": 0.22,
         "ticksObserved": 94701
       }
+    },
+    "spike": {
+      "maxPayloadBytes": 47000000,
+      "maxCrossingsPerTick": null,
+      "minTicksForVerdict": 0,
+      "measuredOn": "2026-08-11, macOS arm64, Chrome 151 headless, protocol 18",
+      "note": "The gated transport benchmark cell (task 84 follow-up). Its transport cost is NOT gated by a ceiling here but STRUCTURALLY by the driver's page_* checks: the OPERATIONS(10000)-mutation batch must cross the boundary exactly ONCE (page_backendQueuedCrossings), with zero command-buffer growths -- exact equalities, tighter than any measured ceiling could be. The observed run counters are engine-stable because the lifecycle is frame-count-structural, not wall-clocked: 186/305 crossings/spikeFrames on Chrome vs 185/304 on Firefox, appliedCommands 260161 vs 260160.",
+      "tickRatioNotApplicable": "The spike never takes the _process/_physics_process tick paths this ratio counts -- its frames dispatch into kanamaWebEmptyFrame/kanamaWebSpikeProcess, and processTicks === physicsTicks === 0 is itself a driver assertion (realProcessPathNotDispatched, the inverse of the demo drivers' realProcessPathDispatched). A ratio with a structurally zero denominator is not a measurement. Payload is still gated.",
+      "measured": {
+        "payloadBytes": 40255932,
+        "startupMs": 1303,
+        "crossingsPerTick": 0,
+        "ticksObserved": 0
+      },
+      "engines": {
+        "chrome": {
+          "maxCrossingsPerTick": null,
+          "measured": {
+            "crossingsPerTick": 0,
+            "ticksObserved": 0,
+            "startupMs": 1303,
+            "on": "2026-08-11, macOS arm64, Chrome 151 headless: kotlinToGodotCalls 186, spikeFrameDispatches 305, appliedCommands 260161"
+          }
+        },
+        "firefox": {
+          "maxCrossingsPerTick": null,
+          "measured": {
+            "crossingsPerTick": 0,
+            "ticksObserved": 0,
+            "startupMs": 5153,
+            "on": "2026-08-11, macOS arm64, Firefox 153 headless: kotlinToGodotCalls 185, spikeFrameDispatches 304, appliedCommands 260160"
+          }
+        }
+      }
     }
   },
   "gatingPolicy": {

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -28,12 +28,39 @@ KANAMA_WEB_PR_DEMOS=(match3 web3d dodge)
 # DODGE export for a long window and asserts no slow leak. It is deliberately
 # absent from both lists above -- it is opt-in (`--demo soak`), because it costs
 # ten minutes, and it must never silently pad a "corpus is green" claim.
-#
+
+# The gated transport benchmark (task 84 follow-up). Like soak it is a harness
+# cell rather than a thirteenth game demo, but unlike soak the CI matrix DOES
+# fold it into the full and ci sets: task 84 made the benchmark opt-in, and
+# opt-in with no gate is exactly the shape that lets a path rot unnoticed
+# (task 81). It exports the IN-REPO staged Phase 0 project through its own
+# dedicated Gradle task (`:web-runtime:exportWebSpike`), so it needs no demos
+# checkout. It stays out of the per-PR subset, which is chosen for speed.
+KANAMA_WEB_GATED_BENCHMARKS=(spike)
+
 # demo key -> the export/build key it runs against. Everything but soak is itself.
 kanama_web_demo_export_key() {
   case "$1" in
     soak) echo "dodge" ;;
     *) echo "$1" ;;
+  esac
+}
+
+# demo key -> the Gradle task that builds its export. Everything but the spike
+# goes through the shared `exportWeb` task with a `-PkanamaWebDemo` key; the
+# spike's staged benchmark project has had its own task since Phase 0.
+kanama_web_demo_export_task() {
+  case "$1" in
+    spike) echo ":web-runtime:exportWebSpike" ;;
+    *) echo ":web-runtime:exportWeb" ;;
+  esac
+}
+
+# demo key -> export directory, relative to the kanama repo root.
+kanama_web_demo_export_dir() {
+  case "$1" in
+    spike) echo "web-runtime/build/web-spike/export" ;;
+    *) echo "web-runtime/build/web-export/$1" ;;
   esac
 }
 
@@ -93,7 +120,7 @@ kanama_web_demo_export_args() {
 # these, so the local and CI numbers stay comparable.
 kanama_web_demo_timeout() {
   case "$1" in
-    match3|bunnymark|dodge|web3d) echo 300 ;;
+    match3|bunnymark|dodge|web3d|spike) echo 300 ;;
     platformer|squash|fps) echo 480 ;;
     charactercontroller|thirdperson|racing|citybuilder|tpsdemo) echo 600 ;;
     # The soak budget is derived from its own duration, never guessed: the driver
@@ -104,7 +131,11 @@ kanama_web_demo_timeout() {
 }
 
 kanama_web_demo_is_known() {
-  kanama_web_demo_project_dir "$1" >/dev/null 2>&1
+  # The spike is deliberately NOT in kanama_web_demo_project_dir: the
+  # fresh-checkout gate validates its --demo arguments against that mapping and
+  # cannot export the spike (it has no exportWeb key), so leaving it unknown
+  # there keeps that gate's rejection loud instead of failing mid-export.
+  [[ "$1" == "spike" ]] || kanama_web_demo_project_dir "$1" >/dev/null 2>&1
 }
 
 # Demos CI structurally cannot run -> the reason. This is NOT quarantine: nothing

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -36,9 +36,10 @@ import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { runSoak } from "./demos/soak.mjs";
 import { runVisibilityprobe } from "./demos/visibilityprobe.mjs";
+import { runSpike } from "./demos/spike.mjs";
 import { buildEnvelope, collectPayload, collectPerformance } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe, spike: runSpike };
 
 function parseArgs(argv) {
   const args = {};

--- a/scripts/web/drivers/demos/spike.mjs
+++ b/scripts/web/drivers/demos/spike.mjs
@@ -1,0 +1,250 @@
+// demos/spike.mjs -- the synthetic transport benchmark as a GATED smoke cell.
+//
+// Task 84 made the benchmark opt-in: `bridge.frame()`'s fallthrough is the real
+// `_process` and only a page that declares `globalThis.KanamaWebMode = "spike"`
+// (stamped by `stageWebSpikeGodotProject`) reaches the benchmark branch. Opt-in
+// with no gate is how a path rots unnoticed (task 81), so this driver proves the
+// branch is alive in BOTH directions on every run that includes it:
+//
+//   1. mode === "spike" -- the staging's mode line is present. If it ever goes
+//      missing the bridge falls back to "game" GAMEPLAY (by design) and this is
+//      the check that fails loudly instead of the run quietly measuring nothing.
+//   2. The benchmark branch actually ran: its distinctive counters advanced
+//      (frameIndex through both sample windows, 120 empty + 120 batched frame
+//      samples) AND the real path's distinctive counter did NOT (processCalls
+//      stays 0 in spike mode -- the exact counter task 84's demo drivers assert
+//      is NON-zero on the real path).
+//   3. The page's own Phase-0 harness verdict (18 structural checks: exact
+//      sample counts, the OPERATIONS-mutation batch crossing exactly once,
+//      read-your-write, hot-reload generation advance, stale-handle rejection)
+//      is folded into the envelope as page_* checks.
+//   4. Envelope-complete teardown: the driver ends the run the way dodge's
+//      SmokeQuit does -- it raises a quit flag the staged benchmark_controller
+//      polls, the SceneTree quits, every node exits, and live handles drain to
+//      zero.
+//
+// The page drives itself (samples, benchmarks, hot-reload, verdict); the driver
+// observes, then quits. There is no synthetic input.
+//
+// Transport-cost gating is STRUCTURAL, not wall-denominated: nothing paces rAF
+// in headless browsers (free-runs up to ~8.7x), so any ms/throughput number
+// grades the host. The page's exact-equality checks (one crossing per
+// OPERATIONS-command batch, zero buffer growths) are the transport regression
+// gate; the crossings-per-tick budget ratio is inapplicable here because the
+// spike never takes the _process/_physics_process tick paths its denominator
+// counts (see budgets.json).
+
+const SAMPLE_FRAMES = 120; // mirrors the bridge's SAMPLE_FRAMES
+const WARMUP_FRAMES = 30; // mirrors the bridge's WARMUP_FRAMES
+const SPIKE_FRAME_TOTAL = (WARMUP_FRAMES + SAMPLE_FRAMES) * 2;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const START = Date.now();
+const trace = (msg) => {
+  if (DEBUG) process.stderr.write(`[spike ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
+};
+
+const counters = (evaluate) =>
+  evaluate(`JSON.stringify((() => {
+    const bridge = globalThis.KanamaWebBridge;
+    return {
+      mode: bridge.mode,
+      frameIndex: bridge.frameIndex,
+      emptyFrameSamples: bridge.emptyFrameMs.length,
+      batchedFrameSamples: bridge.batchedFrameMs.length,
+      processCalls: bridge.processCalls,
+      physicsProcessCalls: bridge.physicsProcessCalls ?? 0,
+      appliedCommands: bridge.appliedCommands,
+      kotlinToGodotCalls: bridge.kotlinToGodotCalls,
+      readyCount: bridge.readyCount,
+      resourceLoads: bridge.resourceLoads,
+      resourceReleases: bridge.resourceReleases,
+      liveBrowserHandles: bridge.liveBrowserHandleCount,
+      commandBufferGrowths: bridge.commandBufferGrowths,
+      callbackErrors: bridge.callbackErrors,
+      lastCallbackError: bridge.lastCallbackError,
+      status: document.body.dataset.status ?? null,
+    };
+  })())`).then(JSON.parse);
+
+// The mode was wrong: the export under test is NOT the spike page (either a demo
+// export was pointed at this driver, or the staging lost its mode line and the
+// bridge fell back to "game" gameplay -- task 84's designed failure shape). The
+// benchmark lifecycle will never run, so report the one fact that matters and
+// fail fast rather than timing out.
+function wrongModeEnvelope(mode, startupDurationMs) {
+  return {
+    protocolVersion: 18,
+    startup: {
+      loaded: true,
+      outcome: `wrong-mode:${mode}`,
+      durationMs: startupDurationMs,
+    },
+    checks: {
+      mode: false,
+    },
+    handles: { liveAfterGameplay: 0, liveAfterTeardown: 0, staleRejected: 0 },
+    crossings: { kotlinToGodotCalls: 0 },
+    callbacks: { readyCount: 0 },
+    connections: { afterTeardownLiveHandles: 0 },
+    scheduler: { commandBufferGrowths: 0 },
+    teardown: { outcome: "not-run", ownerRegistriesToBaseline: false },
+    boundaryErrors: [
+      `expected bridge mode "spike", found "${mode}" -- the export under test does not opt in to the benchmark`,
+    ],
+  };
+}
+
+export async function runSpike({ url, evaluate, navigate, deadline }) {
+  const startupStart = Date.now();
+  trace("navigate");
+  await navigate(`${url}?spike=${Date.now()}`);
+
+  // The bridge object exists as soon as its script tag evaluates (before the
+  // wasm loads), and its mode is fixed at that moment from the shell's
+  // KanamaWebMode line -- so the opt-in check needs no gameplay to run.
+  let mode = null;
+  const bridgeDeadline = Math.min(deadline, Date.now() + 30_000);
+  while (mode === null && Date.now() < bridgeDeadline) {
+    try {
+      mode = await evaluate("globalThis.KanamaWebBridge ? globalThis.KanamaWebBridge.mode : null");
+    } catch {
+      // page mid-navigation; retry
+    }
+    if (mode === null) await delay(100);
+  }
+  if (mode === null) throw new Error("Kanama Web bridge never appeared on the spike page");
+  if (mode !== "spike") {
+    trace(`mode check FAILED: found "${mode}"`);
+    return wrongModeEnvelope(mode, Date.now() - startupStart);
+  }
+
+  let ready = false;
+  const readyDeadline = Math.min(deadline, Date.now() + 60_000);
+  while (!ready && Date.now() < readyDeadline) {
+    try {
+      ready = Boolean(await evaluate("globalThis.KanamaWebBridge?.firstHandle > 0"));
+    } catch {
+      // page mid-navigation; retry
+    }
+    if (!ready) await delay(100);
+  }
+  if (!ready) throw new Error("Kotlin/Wasm spike benchmark did not become ready");
+  const startupDurationMs = Date.now() - startupStart;
+  trace("ready; page is self-driving the benchmark");
+
+  // The page runs itself: 30+120 empty frames, 30+120 batched frames, then the
+  // call benchmarks, a hot-reload teardown/replacement cycle, and finish().
+  let status = null;
+  let lastTraced = 0;
+  while (Date.now() < deadline) {
+    const snap = await counters(evaluate);
+    status = snap.status;
+    if (status === "pass" || status === "fail") break;
+    if (DEBUG && Date.now() - lastTraced > 2_000) {
+      trace(`waiting: frameIndex=${snap.frameIndex} ready=${snap.readyCount} status=${status}`);
+      lastTraced = Date.now();
+    }
+    await delay(250);
+  }
+  if (status !== "pass" && status !== "fail") {
+    throw new Error("spike benchmark lifecycle did not reach a verdict before the deadline");
+  }
+  trace(`page verdict: ${status}`);
+
+  const results = await evaluate(
+    "globalThis.KanamaWebSpikeResults ? JSON.stringify(globalThis.KanamaWebSpikeResults) : null",
+  ).then((raw) => (raw ? JSON.parse(raw) : null));
+  if (!results) {
+    const fatal = await evaluate(
+      "document.querySelector('#kanama-results')?.textContent ?? 'no results element'",
+    );
+    throw new Error(`spike page reached status=${status} without publishing results: ${fatal}`);
+  }
+  const afterBenchmark = await counters(evaluate);
+  trace(
+    `benchmark done: frames=${afterBenchmark.frameIndex} applied=${afterBenchmark.appliedCommands} ` +
+      `live=${afterBenchmark.liveBrowserHandles} process=${afterBenchmark.processCalls}`,
+  );
+
+  // Full teardown: raise the quit flag the staged benchmark_controller polls;
+  // the SceneTree quits, every node exits, and the handle registry drains to
+  // zero (the dodge SmokeQuit pattern).
+  await evaluate("globalThis.KanamaWebSpikeQuitRequested = true; true");
+  const teardownUntil = Math.min(deadline, Date.now() + 15_000);
+  let drained = afterBenchmark;
+  while (Date.now() < teardownUntil) {
+    drained = await counters(evaluate);
+    if (drained.liveBrowserHandles === 0) break;
+    await delay(250);
+  }
+  trace(`teardown: live=${drained.liveBrowserHandles} callbackErrors=${drained.callbackErrors}`);
+
+  const checks = {
+    // The gate that makes the opt-in gated: the staging must still name the mode.
+    mode: afterBenchmark.mode === "spike",
+    // The benchmark branch ran: both sample windows completed on its own counters.
+    spikeBranchDispatched:
+      afterBenchmark.frameIndex >= SPIKE_FRAME_TOTAL &&
+      afterBenchmark.emptyFrameSamples === SAMPLE_FRAMES &&
+      afterBenchmark.batchedFrameSamples === SAMPLE_FRAMES,
+    // The branch, not just activity: in spike mode the real _process/_physics
+    // paths must never run (the demo drivers assert the exact inverse).
+    realProcessPathNotDispatched:
+      drained.processCalls === 0 && drained.physicsProcessCalls === 0,
+    // finish() published a complete report.
+    benchmarkReportPublished:
+      typeof results.completedAt === "string" && results.protocolVersion > 0,
+    fullTeardownToZero: drained.liveBrowserHandles === 0 && drained.callbackErrors === 0,
+  };
+  // The page's own Phase-0 verdict, check by check: exact sample counts, the
+  // OPERATIONS-mutation batch crossing exactly ONCE (the structural
+  // transport-cost gate), read-your-write, hot-reload generation advance,
+  // stale-handle invalidation, teardown of the first instance.
+  for (const [name, value] of Object.entries(results.checks ?? {})) {
+    checks[`page_${name}`] = value === true;
+  }
+
+  const boundaryErrors = [];
+  if (drained.callbackErrors !== 0) {
+    boundaryErrors.push(
+      `callbackErrors=${drained.callbackErrors}: ${drained.lastCallbackError ?? "unknown"}`,
+    );
+  }
+
+  return {
+    protocolVersion: results.protocolVersion,
+    startup: {
+      loaded: ready,
+      outcome: ready ? "ready" : "failed",
+      durationMs: startupDurationMs,
+    },
+    checks,
+    handles: {
+      liveAfterGameplay: afterBenchmark.liveBrowserHandles,
+      liveAfterTeardown: drained.liveBrowserHandles,
+      staleRejected: results.lifecycle?.staleHandleInvalidated === true ? 1 : 0,
+    },
+    crossings: {
+      kotlinToGodotCalls: drained.kotlinToGodotCalls,
+      appliedCommands: drained.appliedCommands,
+      spikeFrameDispatches: drained.frameIndex,
+      backendContractQueuedCrossings: results.backendContract?.queuedCrossings ?? 0,
+    },
+    callbacks: {
+      readyCount: drained.readyCount,
+    },
+    connections: {
+      afterTeardownLiveHandles: drained.liveBrowserHandles,
+    },
+    scheduler: {
+      commandBufferGrowths: drained.commandBufferGrowths,
+    },
+    teardown: {
+      outcome: checks.fullTeardownToZero ? "clean" : "incomplete",
+      ownerRegistriesToBaseline: drained.liveBrowserHandles === 0,
+    },
+    boundaryErrors,
+  };
+}

--- a/scripts/web/drivers/demos/spike.mjs
+++ b/scripts/web/drivers/demos/spike.mjs
@@ -71,9 +71,35 @@ const counters = (evaluate) =>
 // The mode was wrong: the export under test is NOT the spike page (either a demo
 // export was pointed at this driver, or the staging lost its mode line and the
 // bridge fell back to "game" gameplay -- task 84's designed failure shape). The
-// benchmark lifecycle will never run, so report the one fact that matters and
-// fail fast rather than timing out.
-function wrongModeEnvelope(mode, startupDurationMs) {
+// benchmark lifecycle will never run, so the envelope FAILS on the mode check --
+// and while it is here it records the other direction of the branch proof: after
+// a bounded window of real engine frames, the spike branch's distinctive
+// counters must have stayed INERT (the benchmark must never run where nothing
+// asked for it -- exactly the task-84 defect, three demos silently benchmarking).
+async function wrongModeEnvelope(evaluate, mode, startupDurationMs) {
+  const inertUntil = Date.now() + 20_000;
+  let inert = { rafTicks: 0, frameIndex: 0, emptyFrameSamples: 0, batchedFrameSamples: 0 };
+  while (Date.now() < inertUntil) {
+    try {
+      inert = await evaluate(`JSON.stringify((() => {
+        const bridge = globalThis.KanamaWebBridge;
+        return {
+          rafTicks: bridge.rafTick ?? 0,
+          frameIndex: bridge.frameIndex,
+          emptyFrameSamples: bridge.emptyFrameMs.length,
+          batchedFrameSamples: bridge.batchedFrameMs.length,
+        };
+      })())`).then(JSON.parse);
+    } catch {
+      // page mid-boot; retry
+    }
+    if (inert.rafTicks >= 120) break;
+    await delay(250);
+  }
+  trace(
+    `wrong mode "${mode}": after ${inert.rafTicks} engine frames the spike counters are ` +
+      `frameIndex=${inert.frameIndex} empty=${inert.emptyFrameSamples} batched=${inert.batchedFrameSamples}`,
+  );
   return {
     protocolVersion: 18,
     startup: {
@@ -82,10 +108,22 @@ function wrongModeEnvelope(mode, startupDurationMs) {
       durationMs: startupDurationMs,
     },
     checks: {
+      // The gate: this export did not opt in to the benchmark. FAILS the run.
       mode: false,
+      // The inverse branch proof, true when the benchmark stayed dormant over a
+      // window of real engine frames. The run still fails on `mode` above.
+      spikeCountersInertOutsideSpikeMode:
+        inert.rafTicks >= 120 &&
+        inert.frameIndex === 0 &&
+        inert.emptyFrameSamples === 0 &&
+        inert.batchedFrameSamples === 0,
     },
     handles: { liveAfterGameplay: 0, liveAfterTeardown: 0, staleRejected: 0 },
-    crossings: { kotlinToGodotCalls: 0 },
+    crossings: {
+      kotlinToGodotCalls: 0,
+      spikeFrameDispatches: Math.max(0, inert.frameIndex),
+      observedEngineFrames: Math.max(0, inert.rafTicks),
+    },
     callbacks: { readyCount: 0 },
     connections: { afterTeardownLiveHandles: 0 },
     scheduler: { commandBufferGrowths: 0 },
@@ -117,7 +155,7 @@ export async function runSpike({ url, evaluate, navigate, deadline }) {
   if (mode === null) throw new Error("Kanama Web bridge never appeared on the spike page");
   if (mode !== "spike") {
     trace(`mode check FAILED: found "${mode}"`);
-    return wrongModeEnvelope(mode, Date.now() - startupStart);
+    return wrongModeEnvelope(evaluate, mode, Date.now() - startupStart);
   }
 
   let ready = false;

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -29,9 +29,10 @@ import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { runSoak } from "./demos/soak.mjs";
 import { runVisibilityprobe } from "./demos/visibilityprobe.mjs";
+import { runSpike } from "./demos/spike.mjs";
 import { buildEnvelope, collectPayload, collectPerformance } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe, spike: runSpike };
 // macOS workstation path first, then the usual Linux install paths (the CI
 // matrix cell, Task 60h). Missing everywhere is a loud failure, never a silent
 // substitution of some other browser.

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -28,9 +28,10 @@ import { runCitybuilder } from "./demos/citybuilder.mjs";
 import { runTpsdemo } from "./demos/tpsdemo.mjs";
 import { runSoak } from "./demos/soak.mjs";
 import { runVisibilityprobe } from "./demos/visibilityprobe.mjs";
+import { runSpike } from "./demos/spike.mjs";
 import { buildEnvelope, collectPayload, collectPerformance } from "./envelope.mjs";
 
-const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe };
+const DEMOS = { match3: runMatch3, bunnymark: runBunnymark, dodge: runDodge, web3d: runWeb3d, platformer: runPlatformer, squash: runSquash, fps: runFps, charactercontroller: runCharactercontroller, thirdperson: runThirdperson, racing: runRacing, citybuilder: runCitybuilder, tpsdemo: runTpsdemo, soak: runSoak, visibilityprobe: runVisibilityprobe, spike: runSpike };
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseArgs(argv) {

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -36,7 +36,8 @@
 # `--demo-set pr` is the per-PR subset, `full` the whole corpus, and `ci` the
 # corpus minus the demos a hosted runner structurally cannot build (see
 # scripts/web/demos.sh). `full` always means FULL -- a local run is never quietly
-# narrowed.
+# narrowed. Both full and ci also run the gated benchmark cells (the spike
+# transport benchmark, opt-in since task 84 and gated here so it cannot rot).
 
 set -euo pipefail
 
@@ -100,7 +101,11 @@ SKIPPED_DEMOS=()
 case "${DEMO_SET:-}" in
   "") ;;
   pr) DEMOS+=("${KANAMA_WEB_PR_DEMOS[@]}") ;;
-  full) DEMOS+=("${KANAMA_WEB_ALL_DEMOS[@]}") ;;
+  # full and ci also carry the gated benchmark cells (the spike): task 84 made
+  # the transport benchmark opt-in, and an opt-in path with no gate is how a
+  # path rots unnoticed. The pr subset stays without them -- it is chosen for
+  # speed, and the benchmark gates the backend, not a per-PR gameplay claim.
+  full) DEMOS+=("${KANAMA_WEB_ALL_DEMOS[@]}" "${KANAMA_WEB_GATED_BENCHMARKS[@]}") ;;
   ci)
     # The corpus minus what a hosted runner cannot build. Skipped demos are
     # ANNOUNCED and recorded in the evidence; they are never silently dropped.
@@ -113,6 +118,7 @@ case "${DEMO_SET:-}" in
         DEMOS+=("$demo")
       fi
     done
+    DEMOS+=("${KANAMA_WEB_GATED_BENCHMARKS[@]}")
     ;;
   *) die "unknown --demo-set: $DEMO_SET (expected pr|full|ci)" ;;
 esac
@@ -223,7 +229,8 @@ for demo in "${DEMOS[@]}"; do
   # The build key can differ from the driver key: the soak gate drives the dodge
   # export. Everything else exports under its own name.
   export_key="$(kanama_web_demo_export_key "$demo")"
-  export_dir="$ROOT_DIR/web-runtime/build/web-export/$export_key"
+  export_dir="$ROOT_DIR/$(kanama_web_demo_export_dir "$export_key")"
+  export_task="$(kanama_web_demo_export_task "$export_key")"
 
   if [[ "$SKIP_EXPORT" -eq 0 ]]; then
     # Always export from a clean directory: a stale export silently re-runs an
@@ -232,20 +239,24 @@ for demo in "${DEMOS[@]}"; do
     gradle_args=(
       --no-daemon
       -Pkotlin.compiler.execution.strategy=in-process
-      :web-runtime:exportWeb
-      "-PkanamaWebDemo=$export_key"
+      "$export_task"
       "-PkanamaGodotExecutable=$GODOT_BIN"
       "-PkanamaWebTemplateRelease=$TEMPLATE"
     )
-    project_subdir="$(kanama_web_demo_project_dir "$export_key")"
-    if [[ -n "$project_subdir" ]]; then
-      project_dir="$DEMOS_DIR/$project_subdir"
-      [[ -d "$project_dir" ]] || die "$demo: demo project not found: $project_dir"
-      gradle_args+=("-P$(kanama_web_demo_project_property "$export_key")=$project_dir")
+    # The spike's dedicated task exports the in-repo staged benchmark project
+    # and takes no demo key; everything else goes through the shared exportWeb.
+    if [[ "$export_task" == ":web-runtime:exportWeb" ]]; then
+      gradle_args+=("-PkanamaWebDemo=$export_key")
+      project_subdir="$(kanama_web_demo_project_dir "$export_key")"
+      if [[ -n "$project_subdir" ]]; then
+        project_dir="$DEMOS_DIR/$project_subdir"
+        [[ -d "$project_dir" ]] || die "$demo: demo project not found: $project_dir"
+        gradle_args+=("-P$(kanama_web_demo_project_property "$export_key")=$project_dir")
+      fi
+      while IFS= read -r extra; do
+        [[ -n "$extra" ]] && gradle_args+=("$extra")
+      done < <(kanama_web_demo_export_args "$export_key")
     fi
-    while IFS= read -r extra; do
-      [[ -n "$extra" ]] && gradle_args+=("$extra")
-    done < <(kanama_web_demo_export_args "$export_key")
 
     if ! "$ROOT_DIR/gradlew" -p "$ROOT_DIR" "${gradle_args[@]}"; then
       echo "[web_ci_matrix] $demo: EXPORT FAILED" >&2

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -16,7 +16,7 @@
 #   scripts/web_export_smoke.sh \
 #       --engine <chrome|firefox|safari> \
 #       --export-dir <dir> \
-#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder|tpsdemo> \
+#       --demo <bunnymark|match3|dodge|web3d|platformer|squash|fps|charactercontroller|thirdperson|racing|citybuilder|tpsdemo|spike> \
 #       --result <result.json> \
 #       [--browser-binary <path>] \
 #       [--timeout <seconds>] \

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -463,10 +463,91 @@ tasks.register<Exec>("exportWebSpike") {
             from(webSpikeAssets.file("kanama-web-bridge.js"))
             into(exportDir)
         }
-        check(exportDir.resolve("index.html").isFile) { "Godot Web export did not produce index.html" }
-        check(exportDir.resolve("kanama-web-spike.js").isFile) {
-            "Kotlin/Wasm loader was not installed into the Web export"
+        val indexHtml = exportDir.resolve("index.html")
+        check(indexHtml.isFile) { "Godot Web export did not produce index.html" }
+        val spikeLoader = exportDir.resolve("kanama-web-spike.js")
+        val bridge = exportDir.resolve("kanama-web-bridge.js")
+        check(spikeLoader.isFile) { "Kotlin/Wasm loader was not installed into the Web export" }
+        check(bridge.isFile) { "Versioned JS bridge missing from the spike export" }
+
+        // Task 84 follow-up: the spike benchmark is now a GATED matrix cell, so its export
+        // gets the same hardening the demo exports have had since 57f/60h -- cache-busting
+        // buildId stamp, no leaked workstation paths, no source maps, and the
+        // kanama-web/export-report.json the smoke harness and the CI matrix cross-check.
+        val buildId =
+            MessageDigest.getInstance("SHA-256").let { digest ->
+                digest.update(spikeLoader.readBytes())
+                digest.update(bridge.readBytes())
+                digest.digest().joinToString("") { "%02x".format(it) }.substring(0, 16)
+            }
+        val originalIndex = indexHtml.readText()
+        check(originalIndex.contains("src=\"kanama-web-spike.js\"")) {
+            "Exported spike shell is missing the kanama-web-spike.js script tag"
         }
+        check(originalIndex.contains("src=\"kanama-web-bridge.js\"")) {
+            "Exported spike shell is missing the kanama-web-bridge.js script tag"
+        }
+        indexHtml.writeText(
+            originalIndex
+                .replace(
+                    "src=\"kanama-web-spike.js\"",
+                    "src=\"kanama-web-spike.js?v=$buildId\"",
+                )
+                .replace(
+                    "src=\"kanama-web-bridge.js\"",
+                    "src=\"kanama-web-bridge.js?v=$buildId\"",
+                )
+        )
+
+        val servedIndex = indexHtml.readText()
+        val stagingPath = webSpikeStaging.get().asFile.absolutePath
+        check(!servedIndex.contains(stagingPath)) {
+            "Exported spike index.html leaks the staging path $stagingPath"
+        }
+        check(!servedIndex.contains(System.getProperty("user.home"))) {
+            "Exported spike index.html leaks a workstation-absolute path"
+        }
+        check(fileTree(exportDir) { include("**/*.map") }.files.isEmpty()) {
+            "Web spike export must not ship source maps"
+        }
+
+        val protocolVersion = readProtocolVersion()
+        val servedFiles =
+            exportDir
+                .walkTopDown()
+                .filter { it.isFile }
+                .map { it.relativeTo(exportDir).invariantSeparatorsPath to it.length() }
+                .sortedBy { it.first }
+                .toList()
+        val totalBytes = servedFiles.sumOf { it.second }
+        val reportDir = exportDir.resolve("kanama-web")
+        reportDir.mkdirs()
+        reportDir
+            .resolve("export-report.json")
+            .writeText(
+                buildString {
+                    append("{\n")
+                    append("  \"demo\": \"spike\",\n")
+                    append("  \"protocolVersion\": $protocolVersion,\n")
+                    append("  \"buildId\": \"$buildId\",\n")
+                    append("  \"renderer\": \"$webRendererName\",\n")
+                    append("  \"threadsSupported\": $webThreadsSupported,\n")
+                    append("  \"sourceMaps\": false,\n")
+                    append("  \"totalBytes\": $totalBytes,\n")
+                    append("  \"files\": [\n")
+                    append(
+                        servedFiles.joinToString(",\n") { (path, size) ->
+                            "    {\"name\": \"$path\", \"bytes\": $size}"
+                        }
+                    )
+                    append("\n  ]\n")
+                    append("}\n")
+                }
+            )
+        logger.lifecycle(
+            "[kanama:web] exportWebSpike produced the spike export ($totalBytes bytes, protocol " +
+                "$protocolVersion, buildId $buildId) at $exportDir"
+        )
     }
 }
 

--- a/web-runtime/src/webSpikeGodot/project/benchmark_controller.gd
+++ b/web-runtime/src/webSpikeGodot/project/benchmark_controller.gd
@@ -3,6 +3,7 @@ extends Node
 var _bridge
 var _benchmark_callback
 var _reload_started := false
+var _quit_started := false
 
 
 func _ready() -> void:
@@ -14,11 +15,22 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	if _bridge == null or _reload_started or not _bridge.shouldReload():
+	if _bridge == null:
 		return
-	_reload_started = true
-	_bridge.recordReloadStarted()
-	get_tree().call_deferred("reload_current_scene")
+	if not _reload_started and _bridge.shouldReload():
+		_reload_started = true
+		_bridge.recordReloadStarted()
+		get_tree().call_deferred("reload_current_scene")
+		return
+	# Gated spike cell (task 84 follow-up): the smoke driver ends the run the way
+	# dodge's SmokeQuit does. It raises this page global after the benchmark
+	# verdict; quitting the SceneTree exits every node, so the bridge's live
+	# handle registry drains to zero and the driver can assert envelope-complete
+	# teardown instead of leaving the replacement instance (and its loaded
+	# texture) alive forever.
+	if not _quit_started and JavaScriptBridge.eval("globalThis.KanamaWebSpikeQuitRequested === true"):
+		_quit_started = true
+		get_tree().quit()
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Task 84 (#162) made the Web transport benchmark opt-in — and left it completely unexercised: no driver, no smoke wiring, no matrix cell, no budget entry. Opt-in with no gate is exactly the shape (task 81) that lets a path rot unnoticed. This PR makes the spike a **gated cell**, proving the benchmark path alive in **both directions** on every run tier that includes it.

## Per-layer changes

- **`web-runtime/build.gradle.kts` — `exportWebSpike` doLast parity.** The dedicated spike export task now gets the same hardening every demo export has had since 57f/60h: content-derived buildId cache-bust stamp, staging/home path-leak checks, no-source-maps check, and `kanama-web/export-report.json` (demo `"spike"`, protocol, buildId, per-file payload) — which is what the matrix reads for its protocol column.
- **`scripts/web/drivers/demos/spike.mjs`** (new), registered in **all three** engine drivers (`chrome_cdp.mjs`, `firefox_bidi.mjs`, `safari_webdriver.mjs` — Safari wiring is code-only, not run). The page self-drives its Phase-0 lifecycle (30+120 empty frames, 30+120 batched frames, call benchmarks, hot-reload teardown/replacement, verdict); the driver observes and asserts:
  1. `mode === "spike"` — the check that makes the opt-in *gated*. A staging that loses its mode line falls back to `"game"` gameplay (task 84's design) and fails here loudly.
  2. `spikeBranchDispatched` — the benchmark branch's distinctive counters advanced (`frameIndex ≥ 300`, exactly 120 empty + 120 batched frame samples), **and** `realProcessPathNotDispatched` — `processCalls === 0 && physicsProcessCalls === 0`, the exact inverse of the demo drivers' `realProcessPathDispatched` from #162. The branch, not just activity.
  3. The page's 19 structural checks folded in as `page_*` (exact sample counts, the 10000-mutation batch crossing the boundary exactly ONCE, read-your-write, generation advance, stale-handle invalidation, first-instance teardown).
  4. Envelope-complete teardown: the driver raises a page global (`KanamaWebSpikeQuitRequested`) that the staged `benchmark_controller.gd` polls (the dodge SmokeQuit pattern, new here); the SceneTree quits, every node exits, and live handles drain 1 → 0. Zero console errors, zero warnings.
  - The wrong-mode path is not a bare throw: it emits a failing envelope that also records the **inverse branch proof** — over a bounded window of real engine frames the spike counters stayed inert (`spikeFrameDispatches: 0` after 120+ frames).
- **`scripts/web/demos.sh`** — `KANAMA_WEB_GATED_BENCHMARKS=(spike)` plus `kanama_web_demo_export_task` / `kanama_web_demo_export_dir` mappings (the spike exports the in-repo staged project via `:web-runtime:exportWebSpike` into `web-runtime/build/web-spike/export`; no demos checkout needed). `spike` is deliberately NOT in `kanama_web_demo_project_dir`, so the fresh-checkout gate rejects `--demo spike` loudly instead of failing mid-export (verified below).
- **`scripts/web_ci_matrix.sh`** — folds the benchmark cells into the `full` and `ci` sets (never `pr`); the export step dispatches on the export task, and a missing spike export records a FAIL row against the correct dedicated dir rather than vanishing.
- **`scripts/web/budgets.json`** — spike entry: payload gated (47 MB ceiling over 40.26 MB measured, the corpus's standard headroom), crossings-per-tick **exempt with the reason recorded** (match3 precedent): the spike never takes the `_process`/`_physics_process` tick paths, so the ratio's denominator is structurally zero — `processTicks === physicsTicks === 0` is itself a driver assertion. Transport cost is gated *structurally* by the exact-equality `page_backend*` checks instead (see "budget note" below).
- **`docs/exporting/web.md`** — demo-set wording, a cadence-table row, and a Spike Benchmark Cell section.

## Validation (RAN / EXPECTED / MEASURED)

All local runs: macOS arm64, Chrome 151 headless / Firefox 153 headless, protocol 18.

**1. Export produces a protocol-18 artifact**
RAN: `./gradlew :web-runtime:exportWebSpike ...` (clean dir).
EXPECTED: report + stamped shell at the current protocol.
MEASURED: `[kanama:web] exportWebSpike produced the spike export (40255217 bytes, protocol 18, buildId 40faa1462e632dcd)`; exported `index.html` carries `globalThis.KanamaWebMode = "spike"`.

**2. spike × chrome + firefox smoke**
RAN: `scripts/web_export_smoke.sh --engine chrome|firefox --demo spike` against the built export, twice per engine.
EXPECTED: the schema-enforced wrapper PASS line with every new check true.
MEASURED: `web_export_smoke: PASS -- spike on chrome` and `... on firefox`; all 24 checks true on both engines (5 driver checks + 19 `page_*`); `liveAfterGameplay 1 → liveAfterTeardown 0`; zero console errors AND zero warnings; `performance.processTicks = physicsTicks = 0`.

**3. Falsification: the mode check observed FAILING (stripped mode line)**
RAN: copied the export, deleted the `KanamaWebMode = "spike"` line, ran the chrome smoke against the copy (original untouched; restored nothing — it was a copy).
EXPECTED: bridge falls back to `"game"` (the task-84 design) and the driver fails loudly on the mode check.
MEASURED: `web_export_smoke: FAILED`; driver log: `mode check FAILED: found "game"`; envelope `pass: false`, `startup.outcome: "wrong-mode:game"`, `checks.mode: false` — and `spikeCountersInertOutsideSpikeMode: true` (frameIndex/empty/batched all 0 after 125 real engine frames).

**4. Branch proof, both directions**
- Spike mode: `spikeBranchDispatched: true` (305/304 spike frame dispatches, 120+120 samples) with `realProcessPathNotDispatched: true` (`processCalls === 0`) — measured green in every passing run above.
- Normal demo export: RAN the spike driver against the **web3d** export. EXPECTED: mode check fails; spike counters do not advance. MEASURED: smoke exit 1, `mode check FAILED: found "web3d"`, `spikeFrameDispatches: 0` over 131 engine frames (`spikeCountersInertOutsideSpikeMode: true`).

**5. Budget / variance**
RAN: three full runs per engine (2 × smoke + 1 × matrix).
EXPECTED: stable-enough numbers to justify what is gated.
MEASURED: the structural counters are **identical across all three runs per engine** — chrome `kotlinToGodotCalls 186 / appliedCommands 260161 / spikeFrameDispatches 305`, firefox `185 / 260160 / 304` (the lifecycle is frame-count-structural, not wall-clocked; even the 1-count cross-engine difference is stable). Budget note: no crossings-per-tick ceiling is declared **not because of noise but because the ratio is structurally inapplicable** (zero tick denominator, recorded in `tickRatioNotApplicable`); the transport-cost regression gate is the exact-equality `page_backendQueuedCrossings === 1` (10000 queued mutations, ONE crossing) plus `page_backendNoBufferGrowth`, which is strictly tighter than any measured ceiling. Startup (wall-clock, recorded not gated): chrome 1201–1303 ms, firefox 5030–5229 ms.

**6. Matrix end-to-end**
RAN: `scripts/web_ci_matrix.sh --demo spike --engine chrome --engine firefox` **without** `--skip-export` (the new export arm exercised for real: matrix → `exportWebSpike` → smoke → schema → floor → budget).
EXPECTED: both cells PASS with protocol shown.
MEASURED: exit 0; `| spike | chrome | PASS | 9s | Google Chrome 151.0.0.0 | 18 |` and `| spike | firefox | PASS | 11s | Firefox 153.0 | 18 |`.
Set expansion verified by dry runs: `pr` → `match3 web3d dodge` (no spike); `ci` → corpus minus tpsdemo **plus spike**; `full` → all 12 **plus spike**. A missing spike export records `spike: no export at .../web-spike/export` and a FAIL row (no vanishing cell). Fresh-checkout gate: `--demo spike` → `unknown --demo: spike` (loud rejection, by design).

**7. No regression to an untouched demo cell**
RAN: `web_export_smoke.sh --engine chrome --demo web3d` against a fresh web3d export (protocol 18, buildId 63789313a47f1e45).
EXPECTED / MEASURED: `web_export_smoke: PASS -- web3d on chrome` (0.74 crossings/tick, within budget). Scaffold self-test: 12/12 passed.

## Run-tier recommendation

**`ci` + `full` (push to main + nightly), not `pr`.** The pr subset is chosen for speed and gameplay-class coverage; the spike gates the *backend transport contract*, which moves when the bridge/backend moves — main and nightly catch that within a day, and the falsification evidence shows a decayed mode line cannot fail silently in the meantime (it fails the very next ci/full run). Cost is negligible (~10 s/cell + one small export), so promoting it into `pr` later is a one-array move in `scripts/web/demos.sh` if the maintainer prefers.

## Follow-ups / notes

- The spike cell rides the existing `ci`-set path in `.github/workflows/web.yml` with no workflow change; first hosted-runner evidence will be the next push-to-main run. Local Linux was not tested (macOS-only workstation evidence, like every demo's first landing).
- Safari wiring is registered but deliberately unruled (Safari is a local gate; not run per standing policy).
- The fresh-checkout gate cannot export the spike (it only speaks `exportWeb` demo keys). It rejects `--demo spike` loudly today; teaching it the dedicated task is possible if the cell is ever wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
