### PR TITLE
Task 81 slice 1: platformer/squash drivers exercise gameplay; audio + HUD-score assertions

### DIFF
--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3150,6 +3150,28 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
 
+  val AUDIOSTREAMPLAYER_IS_PLAYING =
+    GodotCallDescriptor(
+      opcode = 287,
+      className = "AudioStreamPlayer",
+      methodName = "is_playing",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val LABEL_GET_TEXT =
+    GodotCallDescriptor(
+      opcode = 288,
+      className = "Label",
+      methodName = "get_text",
+      hash = 201670096L,
+      shape = GodotCallShape.NOARGS_RET_STRING,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 286
+  const val MAX_OPCODE = 288
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -3816,6 +3816,19 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\telif opcode == 188 and value is AudioStreamPlayer3D:")
     appendLine("\t\t\tresult = int((value as AudioStreamPlayer3D).is_playing())")
+    appendLine("\t\telif opcode == 287 and value is Node:")
+    appendLine("\t\t\t# Optional child path ('' = the receiver itself): harness drivers reach an")
+    appendLine(
+      "\t\t\t# un-scripted child AudioStreamPlayer (platformer SoundFootsteps) through the"
+    )
+    appendLine("\t\t\t# owning script's handle. A missing or non-player target reports 0, which a")
+    appendLine("\t\t\t# driver asserting 'playing' reads as false -- wrong paths cannot pass.")
+    appendLine("\t\t\tvar audio_query_path := String(args[2])")
+    appendLine(
+      "\t\t\tvar audio_query_node: Node = (value as Node) if audio_query_path.is_empty() else (value as Node).get_node_or_null(audio_query_path)"
+    )
+    appendLine("\t\t\tif audio_query_node is AudioStreamPlayer:")
+    appendLine("\t\t\t\tresult = int((audio_query_node as AudioStreamPlayer).is_playing())")
     appendLine("\t\telif opcode == 195 and value is Node3D:")
     appendLine("\t\t\tresult = int((value as Node3D).is_visible())")
     appendLine("\t\telif opcode == 196 and value != null:")
@@ -4070,6 +4083,25 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\telif opcode == 259 and value is LineEdit:")
     appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(String((value as LineEdit).text))")
     appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 288 and value is Node:")
+    appendLine(
+      "\t\t\t# Optional child path ('' = the receiver itself): the squash ScoreLabel IS the"
+    )
+    appendLine("\t\t\t# scripted node, while the platformer 'Coins' Label hangs beneath the Hud")
+    appendLine(
+      "\t\t\t# script's Control. A missing or non-Label target publishes no string, so the"
+    )
+    appendLine("\t\t\t# bridge's immediate string query fails loud instead of returning something")
+    appendLine("\t\t\t# that could pass as text.")
+    appendLine("\t\t\tvar label_query_path := String(args[2])")
+    appendLine(
+      "\t\t\tvar label_query_node: Node = (value as Node) if label_query_path.is_empty() else (value as Node).get_node_or_null(label_query_path)"
+    )
+    appendLine("\t\t\tif label_query_node is Label:")
+    appendLine(
+      "\t\t\t\t_kanama_bridge.recordImmediateStringResult(String((label_query_node as Label).text))"
+    )
+    appendLine("\t\t\t\tresult = 1")
     appendLine("\t\telif opcode == 266 and value is ConfigFile:")
     appendLine("\t\t\tvar has_key_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -256,6 +256,29 @@ class WebScriptCodeEmitterTest {
   }
 
   @Test
+  fun emitsGameplayAudioAndLabelQueryArmsInEveryProxy() {
+    // Task 81 slice 1: the coverage-gate drivers read footstep audio and HUD label text
+    // through the shared object-query channel; both arms accept an optional child path
+    // ('' = the receiver's own node) so a driver can reach un-scripted children.
+    val proxy =
+      WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+
+    assertTrue(proxy.contains("elif opcode == 287 and value is Node:"))
+    assertTrue(proxy.contains("if audio_query_node is AudioStreamPlayer:"))
+    assertTrue(proxy.contains("result = int((audio_query_node as AudioStreamPlayer).is_playing())"))
+    assertTrue(proxy.contains("elif opcode == 288 and value is Node:"))
+    assertTrue(proxy.contains("if label_query_node is Label:"))
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.recordImmediateStringResult(String((label_query_node as Label).text))"
+      )
+    )
+  }
+
+  @Test
   fun emitsExactSceneTreeLifecycleCallsInEveryProxy() {
     val proxy =
       WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -329,6 +329,8 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     284: {},
     285: {},
     286: {},
+    287: {},
+    288: {},
 }
 
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4504,6 +4504,34 @@
       "returnOwnership": "BORROWED",
       "semantics": "Queue a whole collision-mask write (robot/part death clears every mask bit at once).",
       "introducedBy": "60i-tpsdemo"
+    },
+    {
+      "opcode": 287,
+      "scope": "class",
+      "className": "AudioStreamPlayer",
+      "methodName": "is_playing",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Whether the non-positional stream is audibly playing (platformer footsteps gate: the Player pause-toggles SoundFootsteps with walking). The Web applier accepts an optional child node path in the query payload ('' = the receiver's own node) so harness drivers can reach an un-scripted child player through the owning script's handle -- see compositions.",
+      "introducedBy": "81-gameplay-gate"
+    },
+    {
+      "opcode": 288,
+      "scope": "class",
+      "className": "Label",
+      "methodName": "get_text",
+      "hash": 201670096,
+      "arguments": [],
+      "returnType": "String",
+      "shape": "NOARGS_RET_STRING",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "HUD label text read (platformer coin count, squash score) on the immediate string channel. The Web applier accepts an optional child node path in the query payload ('' = the receiver's own node) so drivers can read a Label beneath a scripted Control -- see compositions.",
+      "introducedBy": "81-gameplay-gate"
     }
   ],
   "compositions": [
@@ -4521,6 +4549,20 @@
         46
       ],
       "semantics": "Load with type AudioStream and CACHE_MODE_REUSE, synchronously assign a successful RETAINED_REFCOUNTED result, then release the temporary wrapper. A failed load performs no assignment, leaves the prior stream unchanged, and owns no handle."
+    },
+    {
+      "name": "AudioStreamPlayer.is_playing_at_path",
+      "opcodes": [
+        287
+      ],
+      "semantics": "When the query payload carries a non-empty child path, compose Node.get_node_or_null on the receiver with AudioStreamPlayer.is_playing on the resolved child; an empty payload (the shape's own spelling) reads the receiver itself. A missing or non-AudioStreamPlayer target reports false on the shared integer query channel."
+    },
+    {
+      "name": "Label.get_text_at_path",
+      "opcodes": [
+        288
+      ],
+      "semantics": "When the query payload carries a non-empty child path, compose Node.get_node_or_null on the receiver with Label.get_text on the resolved child; an empty payload (the shape's own spelling) reads the receiver itself. A missing or non-Label target publishes no string result, so the bridge's immediate string query fails loud rather than returning something that could pass as text."
     }
   ]
 }

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -5,8 +5,9 @@
 // the demo's entire scoring loop -- coins, HUD, footsteps -- was dark to every gate.)
 // The run:
 //   1. observes both frame pumps idling (physics AND process, commands applied),
-//   2. reads SoundFootsteps is_playing (op 287) while idle -- expected silent: the
-//      Player pause-toggles the stream with walking (autoplay + stream_paused),
+//   2. reads SoundFootsteps is_playing (op 287) while idle AND later during the walk
+//      hold -- a PIPELINE-LEVEL assertion (stream loaded + mixer playing), NOT a
+//      walking discriminator; see the MEASURED note at the check,
 //   3. walks: engine-level action injection (ops 86/87 -- browser key synthesis stalls
 //      headless Firefox and SafariDriver has no keys transport) in short in-page-released
 //      pulses, re-pinning the stance (op 142) each pulse so a free-running engine can
@@ -19,8 +20,8 @@
 //
 // Falsification harness (task 81 requires every gate provably able to fail): set
 // KANAMA_WEB_T81_FALSIFY to induce exactly one break and watch its check go false --
-//   no-input          -> pulses skipped: playerMovedOnInput + footstepsAudibleWhileWalking false
-//   wrong-audio-path  -> op 287 queries a nonexistent child: both footsteps checks false
+//   no-input          -> pulses skipped: playerMovedOnInput false
+//   wrong-audio-path  -> op 287 queries a nonexistent child: footstepsPipelineLive false
 //   no-coin           -> coin pin skipped: coinCollectedOnHud false
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -247,19 +248,25 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   let atPeak = gameplay.last ?? ready;
   trace(`idle: process=${peak.processCalls} physics=${peak.physicsCalls} applied=${peak.appliedCommands} live=${atPeak.liveHandles}`);
 
-  // --- Audio, idle direction (task 81 part C) --------------------------------------
-  // MEASURED in the real export (2026-08-11, macOS arm64, protocol 18, Chrome 151 +
-  // Firefox 153 headless): op 287 reads 0 while the player idles. Godot 4.7 parks a
-  // stream_paused playback in FADE_OUT_TO_PAUSE/PAUSED, and AudioServer's
-  // is_playback_active reports only PLAYING -- so is_playing DOES distinguish the
-  // pause-toggle and both directions are asserted in this one run.
+  // --- Audio (task 81 part C): PIPELINE-LEVEL, not a walking discriminator ---------
+  // MEASURED in the real export (2026-08-11, macOS arm64, protocol 18): op 287 reads 1
+  // while the player idles with stream_paused=true, and 1 during the walk hold. Root
+  // cause verified in the Godot 4.7 source: Web nothreads plays this ogg through the
+  // SAMPLE path, set_stream_paused pauses the audible sample (set_sample_playback_pause)
+  // but never removes it from AudioServer::sample_playback_list, and a sample's
+  // is_playing IS that list membership -- so on Web is_playing asserts "stream loaded +
+  // mixer entry live" and CANNOT see the pause-toggle. (On the desktop mixed path it
+  // would: set_playback_paused parks the node in FADE_OUT_TO_PAUSE/PAUSED and
+  // is_playback_active reports only PLAYING.) AudioStreamPlayer.get_stream_paused reads
+  // the mixed-list node state on both paths and would distinguish walking; noted as a
+  // follow-up, not in this parcel.
   const idleReads = [];
   for (let i = 0; i < 3; i += 1) {
     const playing = await footstepsPlaying(evaluate);
     if (playing !== null) idleReads.push(playing);
     await delay(120);
   }
-  const footstepsSilentWhileIdle = idleReads.length >= 2 && idleReads.every((v) => v === 0);
+  const footstepsLiveWhileIdle = idleReads.length >= 2 && idleReads.every((v) => v === 1);
   trace(`audio idle reads=${JSON.stringify(idleReads)}`);
 
   // --- Walk pulses (task 81 part A) ------------------------------------------------
@@ -269,20 +276,20 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const startPosition = await playerPosition(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   let maxDisplacement = 0;
-  let footstepsAudibleWhileWalking = false;
+  let footstepsLiveDuringWalk = false;
   let walkPulses = 0;
   if (FALSIFY !== "no-input") {
     for (let pulse = 0; pulse < 10 && Date.now() < deadline; pulse += 1) {
       walkPulses += 1;
       await walkPulse(evaluate);
-      // Sample footsteps twice inside/around the hold window; the engine may be
-      // free-running, so the walking frames can sit anywhere inside it.
+      // Sample the audio pipeline twice inside/around the hold window (the engine may
+      // be free-running, so the walking frames can sit anywhere inside it).
       await delay(45);
       const mid = await footstepsPlaying(evaluate);
-      if (mid === 1) footstepsAudibleWhileWalking = true;
+      if (mid === 1) footstepsLiveDuringWalk = true;
       await delay(55);
       const late = await footstepsPlaying(evaluate);
-      if (late === 1) footstepsAudibleWhileWalking = true;
+      if (late === 1) footstepsLiveDuringWalk = true;
       const position = await playerPosition(evaluate);
       if (position) {
         const displacement = Math.hypot(position.x - ANCHOR[0], position.z - ANCHOR[2]);
@@ -290,7 +297,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
       }
       mergeSnap(peak, await snapshot(evaluate));
       trace(`pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)} audio=[${mid},${late}]`);
-      if (maxDisplacement > 0.5 && footstepsAudibleWhileWalking) break;
+      if (maxDisplacement > 0.5 && footstepsLiveDuringWalk) break;
       await delay(120);
     }
     // Park the player back on the spawn anchor before the scored phase.
@@ -299,7 +306,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
     trace("FALSIFY=no-input: walk pulses skipped");
   }
   const playerMovedOnInput = maxDisplacement > 0.5;
-  trace(`walk: pulses=${walkPulses} displacement=${maxDisplacement.toFixed(2)} audioWalk=${footstepsAudibleWhileWalking}`);
+  trace(`walk: pulses=${walkPulses} displacement=${maxDisplacement.toFixed(2)} audioWalk=${footstepsLiveDuringWalk}`);
 
   // --- Coin -> HUD score (task 81 part B) ------------------------------------------
   // Stance-place the player onto the coin; the Area3D overlap fires body_entered and the
@@ -348,11 +355,12 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
     // Task 81: injected move actions displaced the player through Input.get_axis ->
     // handleControls -> move_and_slide -- the demo's input path, driven end to end.
     playerMovedOnInput,
-    // Task 81: SoundFootsteps (autoplay, pause-toggled by walking) is SILENT while the
-    // player idles and AUDIBLE while it walks -- both directions of the pause-toggle in
-    // one run. See the MEASURED note at the idle read above.
-    footstepsSilentWhileIdle,
-    footstepsAudibleWhileWalking,
+    // Task 81: PIPELINE-LEVEL audio assertion -- SoundFootsteps' stream is loaded and
+    // its mixer entry live (op 287 = 1) while idling AND during the walk hold. On the
+    // Web sample path is_playing does NOT see the stream_paused walk-toggle (measured
+    // [1,1,1] idle / [1,1] walking; root cause in the comment at the idle read), so
+    // this catches a dead audio pipeline or a wrong node path, not a mute toggle.
+    footstepsPipelineLive: footstepsLiveWhileIdle && footstepsLiveDuringWalk,
     // Task 81: the coin was collected and the HUD "Coins" label advanced -- the full
     // Area3D overlap -> Player.collectCoin -> coinCollected signal -> Hud label chain.
     coinCollectedOnHud,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -38,16 +38,20 @@ const ANCHOR = [0, 0.6, 0];
 // The coin nearest the spawn platform chain: scenes/main.tscn places it at
 // (-3, 0.635, 0) above the platform-medium piece, ground-level footing on all sides.
 const COIN_PIN = [-3, 0.75, 0];
-// In-page hold per walk pulse; the release is scheduled IN PAGE so driver-transport
-// jank can never stretch a hold. MEASURED 2026-08-11 (macOS arm64, protocol 18): a
-// 600ms hold walks 2.35u on Chrome 151 headless and 1.19u on Firefox 153 headless --
-// one pulse clears the 0.5u gate on both, travelling straight -X along the platform
-// chain and stopping short of both the coin at x=-3 and the ~4.5u runway. The free-run
-// excursion the harness lore warns about did not materialize: engine progress during a
-// hold is BOUNDED by the driver's own evaluate traffic (100ms holds moved only
-// 0.22-0.27u on the same free-running Firefox), so wall-time holds under-run, never
-// over-run.
-const WALK_HOLD_MS = 600;
+// Walk-hold sizing, MEASURED 2026-08-11 (macOS arm64, protocol 18): wall-time holds
+// are unusable here because engine progress decouples from the wall clock in both
+// directions -- 100ms holds moved only 0.22-0.27u on free-running Firefox (progress
+// starved under driver evaluate traffic), while 400ms and 600ms holds BOTH ended at
+// x~-2.3 on Chrome (the engine catches up in bursts during the driver's quiet
+// delays), which is inside the coin's overlap reach (~x=-2.2: capsule 0.3 + coin
+// sphere 0.5) and let the walk itself collect the coin, un-falsifying the no-coin
+// break. The release is therefore gated IN PAGE on MEASURED displacement (op 138
+// polled every 25ms, released past WALK_RELEASE_AT) with a wall-time failsafe -- the
+// page's own event loop interleaves with engine frames, so the endpoint is bounded by
+// the threshold plus one burst (~0.6u) plus the deceleration slide (~0.4u), keeping
+// the walk clear of the coin while comfortably past the 0.5u movement gate.
+const WALK_RELEASE_AT = 0.7;
+const WALK_FAILSAFE_MS = 400;
 const AUDIO_CHILD_PATH = FALSIFY === "wrong-audio-path" ? "SoundFootstepsMissing" : "SoundFootsteps";
 
 async function snapshot(evaluate) {
@@ -133,8 +137,9 @@ async function hudCoinsText(evaluate) {
 
 // One walk pulse: re-pin the stance, press move_left+move_forward (the View camera is
 // yawed +45 deg, so this input pair rotates to exactly -X -- along the platform chain
-// toward the coin), and schedule the release IN PAGE so the hold length cannot be
-// stretched by driver-transport jank.
+// toward the coin), and release IN PAGE once the measured displacement passes
+// WALK_RELEASE_AT (wall-time failsafe at WALK_FAILSAFE_MS) so neither driver-transport
+// jank nor an engine catch-up burst can stretch the walk into the coin.
 async function walkPulse(evaluate) {
   await evaluate(`(() => {
     const bridge = globalThis.KanamaWebBridge;
@@ -143,12 +148,28 @@ async function walkPulse(evaluate) {
     bridge.immediateObjectQuery(142, handle, [${ANCHOR.join(", ")}].join(sep));
     bridge.immediateObjectQuery(86, handle, "move_left");
     bridge.immediateObjectQuery(86, handle, "move_forward");
-    setTimeout(() => {
+    const release = () => {
       try {
         bridge.immediateObjectQuery(87, bridge.platformerPlayerHandle, "move_left");
         bridge.immediateObjectQuery(87, bridge.platformerPlayerHandle, "move_forward");
       } catch {}
-    }, ${WALK_HOLD_MS});
+    };
+    const start = Date.now();
+    const watch = setInterval(() => {
+      let done = Date.now() - start >= ${WALK_FAILSAFE_MS};
+      try {
+        const x = bridge.immediateNoArgsVector3X(138, bridge.platformerPlayerHandle);
+        bridge.immediateNoArgsVector3Y();
+        const z = bridge.immediateNoArgsVector3Z();
+        if (Math.hypot(x - ${ANCHOR[0]}, z - ${ANCHOR[2]}) > ${WALK_RELEASE_AT}) done = true;
+      } catch {
+        done = true;
+      }
+      if (done) {
+        clearInterval(watch);
+        release();
+      }
+    }, 25);
     return true;
   })()`);
 }
@@ -288,10 +309,10 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
       await walkPulse(evaluate);
       // Sample the audio pipeline twice inside the hold window (the engine may be
       // free-running, so the walking frames can sit anywhere inside it).
-      await delay(150);
+      await delay(120);
       const mid = await footstepsPlaying(evaluate);
       if (mid === 1) footstepsLiveDuringWalk = true;
-      await delay(400);
+      await delay(260);
       const late = await footstepsPlaying(evaluate);
       if (late === 1) footstepsLiveDuringWalk = true;
       await delay(150);

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -38,12 +38,16 @@ const ANCHOR = [0, 0.6, 0];
 // The coin nearest the spawn platform chain: scenes/main.tscn places it at
 // (-3, 0.635, 0) above the platform-medium piece, ground-level footing on all sides.
 const COIN_PIN = [-3, 0.75, 0];
-// In-page hold per walk pulse. 100ms wall is ~0.1s simulated on a display-paced engine
-// and up to ~0.8s on free-running headless Firefox (~8x) -- at 4.2 u/s that bounds the
-// worst-case excursion per pulse to ~3.4 units plus deceleration slide, inside the
-// ~4.5 units of continuous platform running -X from the spawn. The release is scheduled
-// IN PAGE so driver-transport jank can never stretch a hold.
-const WALK_HOLD_MS = 100;
+// In-page hold per walk pulse; the release is scheduled IN PAGE so driver-transport
+// jank can never stretch a hold. MEASURED 2026-08-11 (macOS arm64, protocol 18): a
+// 600ms hold walks 2.35u on Chrome 151 headless and 1.19u on Firefox 153 headless --
+// one pulse clears the 0.5u gate on both, travelling straight -X along the platform
+// chain and stopping short of both the coin at x=-3 and the ~4.5u runway. The free-run
+// excursion the harness lore warns about did not materialize: engine progress during a
+// hold is BOUNDED by the driver's own evaluate traffic (100ms holds moved only
+// 0.22-0.27u on the same free-running Firefox), so wall-time holds under-run, never
+// over-run.
+const WALK_HOLD_MS = 600;
 const AUDIO_CHILD_PATH = FALSIFY === "wrong-audio-path" ? "SoundFootstepsMissing" : "SoundFootsteps";
 
 async function snapshot(evaluate) {
@@ -282,21 +286,27 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
     for (let pulse = 0; pulse < 10 && Date.now() < deadline; pulse += 1) {
       walkPulses += 1;
       await walkPulse(evaluate);
-      // Sample the audio pipeline twice inside/around the hold window (the engine may
-      // be free-running, so the walking frames can sit anywhere inside it).
-      await delay(45);
+      // Sample the audio pipeline twice inside the hold window (the engine may be
+      // free-running, so the walking frames can sit anywhere inside it).
+      await delay(150);
       const mid = await footstepsPlaying(evaluate);
       if (mid === 1) footstepsLiveDuringWalk = true;
-      await delay(55);
+      await delay(400);
       const late = await footstepsPlaying(evaluate);
       if (late === 1) footstepsLiveDuringWalk = true;
+      await delay(150);
+      const pressed = await evaluate(
+        'globalThis.KanamaWebBridge.immediateObjectQuery(69, globalThis.KanamaWebBridge.platformerPlayerHandle, "move_left")',
+      ).catch(() => null);
       const position = await playerPosition(evaluate);
       if (position) {
         const displacement = Math.hypot(position.x - ANCHOR[0], position.z - ANCHOR[2]);
         maxDisplacement = Math.max(maxDisplacement, displacement);
       }
       mergeSnap(peak, await snapshot(evaluate));
-      trace(`pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)} audio=[${mid},${late}]`);
+      trace(
+        `pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)} audio=[${mid},${late}] pressed=${pressed} pos=${position ? `(${position.x.toFixed(2)},${position.y.toFixed(2)},${position.z.toFixed(2)})` : "null"}`,
+      );
       if (maxDisplacement > 0.5 && footstepsLiveDuringWalk) break;
       await delay(120);
     }

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -1,18 +1,49 @@
-// demos/platformer.mjs -- Starter-Kit-3D-Platformer play + teardown assertions.
+// demos/platformer.mjs -- Starter-Kit-3D-Platformer gameplay + teardown assertions.
 //
-// The platformer is self-driven for smoke purposes: without any synthesized input the
-// CharacterBody3D player still runs gravity + move_and_slide every physics tick, coins
-// spin, clouds bob, and the View camera follows -- so _physics_process and _process both
-// advance with their command mutations applied. This driver OBSERVES that both frame
-// pumps run (physics AND process), that commands flow, then triggers
-// SmokeQuit.smoke_teardown and polls the live-handle count to zero.
+// Task 81 slice 1: this driver DRIVES gameplay; it is no longer observe-only. (Until
+// this parcel it injected no input at all, so the player stood still under gravity and
+// the demo's entire scoring loop -- coins, HUD, footsteps -- was dark to every gate.)
+// The run:
+//   1. observes both frame pumps idling (physics AND process, commands applied),
+//   2. reads SoundFootsteps is_playing (op 287) while idle -- expected silent: the
+//      Player pause-toggles the stream with walking (autoplay + stream_paused),
+//   3. walks: engine-level action injection (ops 86/87 -- browser key synthesis stalls
+//      headless Firefox and SafariDriver has no keys transport) in short in-page-released
+//      pulses, re-pinning the stance (op 142) each pulse so a free-running engine can
+//      never carry the player off the level and into Player's y<-10 scene reload;
+//      movement is proven by op 138 position reads and footsteps by op 287 going true,
+//   4. scores: pins the player onto the coin at (-3, 0.635, 0); the Area3D overlap fires
+//      body_entered -> Player.collectCoin -> coinCollected signal -> Hud, all real, and
+//      the HUD "Coins" Label is read back through op 288 and must reach >= 1,
+//   5. tears down via SmokeQuit.smoke_teardown and drains live handles to zero.
+//
+// Falsification harness (task 81 requires every gate provably able to fail): set
+// KANAMA_WEB_T81_FALSIFY to induce exactly one break and watch its check go false --
+//   no-input          -> pulses skipped: playerMovedOnInput + footstepsAudibleWhileWalking false
+//   wrong-audio-path  -> op 287 queries a nonexistent child: both footsteps checks false
+//   no-coin           -> coin pin skipped: coinCollectedOnHud false
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const FALSIFY = process.env.KANAMA_WEB_T81_FALSIFY ?? "";
 const START = Date.now();
 const trace = (msg) => {
   if (DEBUG) process.stderr.write(`[platformer ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
 };
+
+// Stance anchor: the Player's spawn (0, 0.49, 0), pinned slightly high so a pin never
+// wedges the capsule into the floor. Walk pulses re-pin here every pulse.
+const ANCHOR = [0, 0.6, 0];
+// The coin nearest the spawn platform chain: scenes/main.tscn places it at
+// (-3, 0.635, 0) above the platform-medium piece, ground-level footing on all sides.
+const COIN_PIN = [-3, 0.75, 0];
+// In-page hold per walk pulse. 100ms wall is ~0.1s simulated on a display-paced engine
+// and up to ~0.8s on free-running headless Firefox (~8x) -- at 4.2 u/s that bounds the
+// worst-case excursion per pulse to ~3.4 units plus deceleration slide, inside the
+// ~4.5 units of continuous platform running -X from the spawn. The release is scheduled
+// IN PAGE so driver-transport jank can never stretch a hold.
+const WALK_HOLD_MS = 100;
+const AUDIO_CHILD_PATH = FALSIFY === "wrong-audio-path" ? "SoundFootstepsMissing" : "SoundFootsteps";
 
 async function snapshot(evaluate) {
   try {
@@ -28,6 +59,8 @@ async function snapshot(evaluate) {
         protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
         mainHandle: bridge.platformerMainHandle,
         smokeQuitHandle: bridge.platformerSmokeQuitHandle,
+        playerHandle: bridge.platformerPlayerHandle,
+        hudHandle: bridge.platformerHudHandle,
         readyCount: bridge.readyCount,
         mainReady: classCount(".Main"),
         playerReady: classCount(".Player"),
@@ -52,6 +85,80 @@ async function snapshot(evaluate) {
   }
 }
 
+// Player world position through the immediate no-args Vector3 channel (op 138 =
+// Node3D.get_global_position on the Player script's handle).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.platformerPlayerHandle;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+// SoundFootsteps is_playing through op 287 (child-path payload on the Player's handle).
+// Returns 1/0, or null when the page could not be asked.
+async function footstepsPlaying(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      return bridge.immediateObjectQuery(287, bridge.platformerPlayerHandle, ${JSON.stringify(AUDIO_CHILD_PATH)});
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+// HUD "Coins" Label text through op 288 (child path under the Hud script's Control).
+// A wrong path publishes no string and the bridge throws -> null here -> check false.
+async function hudCoinsText(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      return bridge.immediateStringQuery(288, bridge.platformerHudHandle, "Coins");
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+// One walk pulse: re-pin the stance, press move_left+move_forward (the View camera is
+// yawed +45 deg, so this input pair rotates to exactly -X -- along the platform chain
+// toward the coin), and schedule the release IN PAGE so the hold length cannot be
+// stretched by driver-transport jank.
+async function walkPulse(evaluate) {
+  await evaluate(`(() => {
+    const bridge = globalThis.KanamaWebBridge;
+    const handle = bridge.platformerPlayerHandle;
+    const sep = String.fromCharCode(31);
+    bridge.immediateObjectQuery(142, handle, [${ANCHOR.join(", ")}].join(sep));
+    bridge.immediateObjectQuery(86, handle, "move_left");
+    bridge.immediateObjectQuery(86, handle, "move_forward");
+    setTimeout(() => {
+      try {
+        bridge.immediateObjectQuery(87, bridge.platformerPlayerHandle, "move_left");
+        bridge.immediateObjectQuery(87, bridge.platformerPlayerHandle, "move_forward");
+      } catch {}
+    }, ${WALK_HOLD_MS});
+    return true;
+  })()`);
+}
+
+async function pinPlayer(evaluate, target) {
+  try {
+    await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const sep = String.fromCharCode(31);
+      bridge.immediateObjectQuery(142, bridge.platformerPlayerHandle, [${target.join(", ")}].join(sep));
+      return true;
+    })()`);
+  } catch {}
+}
+
 async function observe(evaluate, seed, windowMs, deadline, predicate) {
   const peak = { ...seed };
   let last = null;
@@ -74,6 +181,16 @@ async function observe(evaluate, seed, windowMs, deadline, predicate) {
   return { last, peak };
 }
 
+function mergeSnap(peak, snap) {
+  if (!snap) return;
+  peak.processCalls = Math.max(peak.processCalls, snap.processCalls);
+  peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+  peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+  peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+  peak.crossings = Math.max(peak.crossings, snap.crossings);
+  peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+}
+
 export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const startupStart = Date.now();
   trace("navigate");
@@ -92,7 +209,9 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
       snap.hudReady >= 1 &&
       snap.coinReady >= 1 &&
       snap.mainHandle > 0 &&
-      snap.smokeQuitHandle > 0
+      snap.smokeQuitHandle > 0 &&
+      snap.playerHandle > 0 &&
+      snap.hudHandle > 0
     ) {
       ready = snap;
       break;
@@ -101,7 +220,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   }
   if (!ready) throw new Error("Kotlin/Wasm 3D platformer did not become ready");
   const startupDurationMs = Date.now() - startupStart;
-  trace(`ready: readyCount=${ready.readyCount} mainHandle=${ready.mainHandle} protocol=${ready.protocol}`);
+  trace(`ready: readyCount=${ready.readyCount} player=${ready.playerHandle} hud=${ready.hudHandle} protocol=${ready.protocol}`);
 
   // Observe the game running idle: the player's _physics_process (gravity +
   // move_and_slide) advances physicsCalls and its velocity/position mutations advance
@@ -125,8 +244,83 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
       snap.appliedCommands >= ready.appliedCommands + 30,
   );
   const peak = gameplay.peak;
-  const atPeak = gameplay.last ?? ready;
-  trace(`gameplay: process=${peak.processCalls} physics=${peak.physicsCalls} applied=${peak.appliedCommands} live=${atPeak.liveHandles}`);
+  let atPeak = gameplay.last ?? ready;
+  trace(`idle: process=${peak.processCalls} physics=${peak.physicsCalls} applied=${peak.appliedCommands} live=${atPeak.liveHandles}`);
+
+  // --- Audio, idle direction (task 81 part C) --------------------------------------
+  // MEASURED in the real export (2026-08-11, macOS arm64, protocol 18, Chrome 151 +
+  // Firefox 153 headless): op 287 reads 0 while the player idles. Godot 4.7 parks a
+  // stream_paused playback in FADE_OUT_TO_PAUSE/PAUSED, and AudioServer's
+  // is_playback_active reports only PLAYING -- so is_playing DOES distinguish the
+  // pause-toggle and both directions are asserted in this one run.
+  const idleReads = [];
+  for (let i = 0; i < 3; i += 1) {
+    const playing = await footstepsPlaying(evaluate);
+    if (playing !== null) idleReads.push(playing);
+    await delay(120);
+  }
+  const footstepsSilentWhileIdle = idleReads.length >= 2 && idleReads.every((v) => v === 0);
+  trace(`audio idle reads=${JSON.stringify(idleReads)}`);
+
+  // --- Walk pulses (task 81 part A) ------------------------------------------------
+  // Fixed short holds released in page; NO early exit of any hold, and no physics-count
+  // predicates (standing lore). The pulse LOOP stops once both movement and walking
+  // audio have been evidenced, or after the pulse budget.
+  const startPosition = await playerPosition(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  let maxDisplacement = 0;
+  let footstepsAudibleWhileWalking = false;
+  let walkPulses = 0;
+  if (FALSIFY !== "no-input") {
+    for (let pulse = 0; pulse < 10 && Date.now() < deadline; pulse += 1) {
+      walkPulses += 1;
+      await walkPulse(evaluate);
+      // Sample footsteps twice inside/around the hold window; the engine may be
+      // free-running, so the walking frames can sit anywhere inside it.
+      await delay(45);
+      const mid = await footstepsPlaying(evaluate);
+      if (mid === 1) footstepsAudibleWhileWalking = true;
+      await delay(55);
+      const late = await footstepsPlaying(evaluate);
+      if (late === 1) footstepsAudibleWhileWalking = true;
+      const position = await playerPosition(evaluate);
+      if (position) {
+        const displacement = Math.hypot(position.x - ANCHOR[0], position.z - ANCHOR[2]);
+        maxDisplacement = Math.max(maxDisplacement, displacement);
+      }
+      mergeSnap(peak, await snapshot(evaluate));
+      trace(`pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)} audio=[${mid},${late}]`);
+      if (maxDisplacement > 0.5 && footstepsAudibleWhileWalking) break;
+      await delay(120);
+    }
+    // Park the player back on the spawn anchor before the scored phase.
+    await pinPlayer(evaluate, ANCHOR);
+  } else {
+    trace("FALSIFY=no-input: walk pulses skipped");
+  }
+  const playerMovedOnInput = maxDisplacement > 0.5;
+  trace(`walk: pulses=${walkPulses} displacement=${maxDisplacement.toFixed(2)} audioWalk=${footstepsAudibleWhileWalking}`);
+
+  // --- Coin -> HUD score (task 81 part B) ------------------------------------------
+  // Stance-place the player onto the coin; the Area3D overlap fires body_entered and the
+  // whole collision -> cross-script call -> signal -> HUD chain is real. The pin repeats
+  // each poll (the coin bobs) until the HUD label advances.
+  let hudCoins = null;
+  if (FALSIFY !== "no-coin") {
+    for (let attempt = 0; attempt < 25 && Date.now() < deadline; attempt += 1) {
+      await pinPlayer(evaluate, COIN_PIN);
+      await delay(150);
+      hudCoins = await hudCoinsText(evaluate);
+      trace(`coin attempt#${attempt}: hud="${hudCoins}"`);
+      if (hudCoins !== null && Number.parseInt(hudCoins, 10) >= 1) break;
+    }
+  } else {
+    trace("FALSIFY=no-coin: coin pin skipped");
+    hudCoins = await hudCoinsText(evaluate);
+  }
+  const coinCollectedOnHud = hudCoins !== null && Number.parseInt(hudCoins, 10) >= 1;
+  mergeSnap(peak, await snapshot(evaluate));
+  atPeak = (await snapshot(evaluate)) ?? atPeak;
 
   // Full teardown: SmokeQuit.smoke_teardown (its only @RegisterFunction, method#1) frees
   // the scene root; every node exits the tree and releases its handles.
@@ -151,6 +345,17 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
     gameplayCommandsApplied: peak.appliedCommands >= ready.appliedCommands + 30,
     // move_and_slide/is_on_floor are immediate kotlin->godot crossings every physics tick.
     crossingsAdvanced: peak.crossings > ready.crossings,
+    // Task 81: injected move actions displaced the player through Input.get_axis ->
+    // handleControls -> move_and_slide -- the demo's input path, driven end to end.
+    playerMovedOnInput,
+    // Task 81: SoundFootsteps (autoplay, pause-toggled by walking) is SILENT while the
+    // player idles and AUDIBLE while it walks -- both directions of the pause-toggle in
+    // one run. See the MEASURED note at the idle read above.
+    footstepsSilentWhileIdle,
+    footstepsAudibleWhileWalking,
+    // Task 81: the coin was collected and the HUD "Coins" label advanced -- the full
+    // Area3D overlap -> Player.collectCoin -> coinCollected signal -> Hud label chain.
+    coinCollectedOnHud,
     fullTeardownToZero: settled.liveHandles === 0,
     // Godot runs every physics tick before the idle/_process pass inside one rAF
     // iteration; the bridge counts any same-tick physics-after-process dispatch.
@@ -180,6 +385,9 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
       processCalls: peak.processCalls,
       physicsProcessCalls: peak.physicsCalls,
       appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(maxDisplacement.toFixed(3)),
+      hudCoinsReported: hudCoins !== null ? Number.parseInt(hudCoins, 10) || 0 : 0,
+      walkPulses,
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -1,18 +1,54 @@
-// demos/squash.mjs -- squash-the-creeps play + teardown assertions for the Web smoke.
+// demos/squash.mjs -- squash-the-creeps gameplay + teardown assertions for the Web smoke.
 //
-// squash is self-driven: MobTimer autostarts and spawns a mob every 0.5s; each mob's
-// initialize runs look_at_from_position/rotate_y and reads its own rotation back, the
-// Player's _physics_process runs gravity + move_and_slide + the slide-collision query
-// loop every tick, and mobs queue_free themselves when they leave the screen. This
-// driver OBSERVES: mobs spawn (instantiate + add_child), physics advances, mobs free
-// themselves, then SmokeQuit.smoke_teardown drains every live handle to zero.
+// Task 81 slice 1: this driver DRIVES gameplay; it is no longer observe-only. (Until
+// this parcel it injected no input at all: the player stood still, no mob was ever
+// squashed, and the demo's entire scoring loop was dark to every gate.) MobTimer still
+// self-drives spawns (a mob every 0.5s; each initialize runs look_at_from_position/
+// rotate_y; walk-offs free themselves past the VisibleOnScreenNotifier3D), and this run
+// layers real play on top:
+//   1. movement: engine-level action injection (ops 86/87 -- browser key synthesis
+//      stalls headless Firefox; SafariDriver has no keys transport) in short
+//      in-page-released pulses while the player is stance-pinned in the air (op 142,
+//      re-pinned per pulse) -- airborne so no ground-level mob can reach the
+//      MobDetector and end the run early; movement is proven by op 138 position reads,
+//   2. score: the driver re-pins the player a body-height above the latest live mob
+//      (bridge.squashMobHandle, re-read every poll and stale-tolerated) and lets
+//      gravity close the gap; the landing is real -- slide-collision normal dot UP >
+//      0.1 -> Mob.squash -> squashed signal -> ScoreLabel -- and the score is read back
+//      through op 288 until the label reads "Score: 1"+,
+//   3. death: the player is parked at ground level; a mob reaching the MobDetector
+//      fires Player.die -> hit signal -> Main stops MobTimer + shows Retry, and the
+//      player script frees (liveScriptsByClass ".Player" drops to 0),
+//   4. teardown: SmokeQuit.smoke_teardown still drains every live handle to zero
+//      (SmokeQuit survives the player's free).
+//
+// Falsification harness (task 81 requires every gate provably able to fail): set
+// KANAMA_WEB_T81_FALSIFY to induce exactly one break and watch its check go false --
+//   no-input  -> movement pulses skipped: playerMovedOnInput false
+//   no-chase  -> mob-drop choreography skipped: mobSquashScoredOnHud false
+//   no-death  -> ground park skipped (player stays pinned aloft): playerFreedOnMobContact false
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const FALSIFY = process.env.KANAMA_WEB_T81_FALSIFY ?? "";
 const START = Date.now();
 const trace = (msg) => {
   if (DEBUG) process.stderr.write(`[squash ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
 };
+
+// Airborne stance anchor for movement pulses: mobs top out around y=1.1 and the
+// MobDetector rides the player's feet, so y=8 keeps every phase-1 frame out of reach.
+const AIR_ANCHOR = [0, 8, 0];
+// Drop height above a mob's root for the squash: the mob's box top sits ~1.07 above its
+// root and the player's sphere bottom ~0.02 below its own, so +1.25 leaves ~0.2 of fall.
+// The player's velocity.y keeps accumulating between pins (a teleport does not touch
+// velocity), so the swept move_and_slide contacts the box top within a tick or two --
+// faster than a 10-18 u/s mob can slide out from under the pin.
+const DROP_HEIGHT = 1.25;
+// In-page hold per movement pulse; released in page so driver-transport jank can never
+// stretch a hold. The squash arena is walled (WorldBoundaryShape3D), so even a
+// free-running engine cannot carry the player anywhere dangerous.
+const MOVE_HOLD_MS = 100;
 
 async function snapshot(evaluate) {
   try {
@@ -23,16 +59,25 @@ async function snapshot(evaluate) {
         const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
         return entry?.[1] ?? 0;
       };
+      const liveCount = (suffix) => {
+        const entry = Object.entries(bridge.liveScriptsByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
       return {
         mode: bridge.mode,
         protocol: bridge.results?.protocolVersion ?? bridge.protocolVersion ?? 0,
         mainHandle: bridge.squashMainHandle,
         smokeQuitHandle: bridge.squashSmokeQuitHandle,
+        playerHandle: bridge.squashPlayerHandle,
+        scoreLabelHandle: bridge.squashScoreLabelHandle,
+        mobHandle: bridge.squashMobHandle,
         readyCount: bridge.readyCount,
         mainReady: classCount(".Main"),
         playerReady: classCount(".Player"),
         scoreLabelReady: classCount(".ScoreLabel"),
         mobReady: classCount(".Mob"),
+        playerLive: liveCount(".Player"),
+        mobLive: liveCount(".Mob"),
         mobInstantiations: bridge.match3PackedSceneInstantiations,
         mobAddChildCommands: bridge.match3AddChildCommands,
         physicsCalls: bridge.physicsProcessCalls ?? 0,
@@ -53,32 +98,113 @@ async function snapshot(evaluate) {
   }
 }
 
-async function observe(evaluate, seed, windowMs, deadline, predicate) {
-  const peak = { mobFrees: 0, ...seed };
-  let last = null;
-  let prevLive = seed.maxLiveHandles;
-  const until = Math.min(deadline, Date.now() + windowMs);
-  while (Date.now() < until) {
-    const snap = await snapshot(evaluate);
-    if (snap) {
-      peak.mobInstantiations = Math.max(peak.mobInstantiations, snap.mobInstantiations);
-      peak.mobAddChildCommands = Math.max(peak.mobAddChildCommands, snap.mobAddChildCommands);
-      peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
-      peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
-      peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
-      peak.crossings = Math.max(peak.crossings, snap.crossings);
-      peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
-      // A drop in the live-handle count means a mob (walked off the level and past its
-      // VisibleOnScreenNotifier3D) freed itself and released its handles.
-      if (snap.liveHandles < prevLive) peak.mobFrees += 1;
-      prevLive = snap.liveHandles;
-      last = snap;
-      trace(`mobs=${snap.mobInstantiations} physics=${snap.physicsCalls} live=${snap.liveHandles} frees=${peak.mobFrees} errs=${snap.callbackErrors}`);
-      if (predicate && predicate(snap, peak)) break;
-    }
-    await delay(150);
+// Player world position (op 138 on the Player script's handle); null when unreadable
+// (page busy, or the player already freed on the death path).
+async function playerPosition(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const handle = bridge.squashPlayerHandle;
+      const x = bridge.immediateNoArgsVector3X(138, handle);
+      return { x, y: bridge.immediateNoArgsVector3Y(), z: bridge.immediateNoArgsVector3Z() };
+    })()`);
+  } catch {
+    return null;
   }
-  return { last, peak };
+}
+
+// One squash-chase step, entirely in page so the mob read and the pin land inside one
+// event-loop turn: re-read the LATEST mob handle (it goes stale when a mob frees --
+// squashed or walked off -- so every access tolerates a throw), read its position, and
+// pin the player DROP_HEIGHT above it.
+async function chaseStep(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const mob = bridge.squashMobHandle;
+      if (!mob) return { pinned: false, reason: "no-mob" };
+      let x, y, z;
+      try {
+        x = bridge.immediateNoArgsVector3X(138, mob);
+        y = bridge.immediateNoArgsVector3Y();
+        z = bridge.immediateNoArgsVector3Z();
+      } catch {
+        return { pinned: false, reason: "stale-mob" };
+      }
+      const sep = String.fromCharCode(31);
+      try {
+        bridge.immediateObjectQuery(142, bridge.squashPlayerHandle, [x, y + ${DROP_HEIGHT}, z].join(sep));
+      } catch {
+        return { pinned: false, reason: "player-gone" };
+      }
+      return { pinned: true, mob: { x, y, z } };
+    })()`);
+  } catch {
+    return { pinned: false, reason: "evaluate-failed" };
+  }
+}
+
+// One movement pulse: pin the airborne stance, hold move_forward (14 u/s immediately --
+// squash movement has no acceleration ramp), release in page.
+async function movePulse(evaluate) {
+  await evaluate(`(() => {
+    const bridge = globalThis.KanamaWebBridge;
+    const handle = bridge.squashPlayerHandle;
+    const sep = String.fromCharCode(31);
+    bridge.immediateObjectQuery(142, handle, [${AIR_ANCHOR.join(", ")}].join(sep));
+    bridge.immediateObjectQuery(86, handle, "move_forward");
+    setTimeout(() => {
+      try {
+        bridge.immediateObjectQuery(87, bridge.squashPlayerHandle, "move_forward");
+      } catch {}
+    }, ${MOVE_HOLD_MS});
+    return true;
+  })()`);
+}
+
+async function pinPlayer(evaluate, target) {
+  try {
+    await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      const sep = String.fromCharCode(31);
+      bridge.immediateObjectQuery(142, bridge.squashPlayerHandle, [${target.join(", ")}].join(sep));
+      return true;
+    })()`);
+  } catch {}
+}
+
+// ScoreLabel text through op 288 (empty child path: the ScoreLabel IS the scripted
+// node). A missing target publishes no string and the bridge throws -> null here.
+async function scoreText(evaluate) {
+  try {
+    return await evaluate(`(() => {
+      const bridge = globalThis.KanamaWebBridge;
+      return bridge.immediateStringQuery(288, bridge.squashScoreLabelHandle, "");
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+function mergeSnap(state, snap) {
+  if (!snap) return;
+  const peak = state.peak;
+  peak.mobInstantiations = Math.max(peak.mobInstantiations, snap.mobInstantiations);
+  peak.mobAddChildCommands = Math.max(peak.mobAddChildCommands, snap.mobAddChildCommands);
+  peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+  peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+  peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+  peak.crossings = Math.max(peak.crossings, snap.crossings);
+  peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+  // A drop in the live ".Mob" script count means a mob freed itself (squashed, or walked
+  // off past its VisibleOnScreenNotifier3D). Exact per class, so the player's own free
+  // on the death path can never masquerade as a mob free (the pre-81 driver inferred
+  // frees from total live-handle drops, which could).
+  if (state.prevMobLive !== null && snap.mobLive < state.prevMobLive) {
+    state.mobFrees += state.prevMobLive - snap.mobLive;
+  }
+  state.prevMobLive = snap.mobLive;
+  state.last = snap;
 }
 
 export async function runSquash({ url, evaluate, navigate, deadline }) {
@@ -98,7 +224,9 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
       snap.playerReady >= 1 &&
       snap.scoreLabelReady >= 1 &&
       snap.mainHandle > 0 &&
-      snap.smokeQuitHandle > 0
+      snap.smokeQuitHandle > 0 &&
+      snap.playerHandle > 0 &&
+      snap.scoreLabelHandle > 0
     ) {
       ready = snap;
       break;
@@ -107,35 +235,139 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   }
   if (!ready) throw new Error("Kotlin/Wasm squash-the-creeps did not become ready");
   const startupDurationMs = Date.now() - startupStart;
-  trace(`ready: readyCount=${ready.readyCount} mainHandle=${ready.mainHandle} protocol=${ready.protocol}`);
+  trace(`ready: readyCount=${ready.readyCount} player=${ready.playerHandle} score=${ready.scoreLabelHandle} protocol=${ready.protocol}`);
 
-  // Observe self-driven gameplay: MobTimer spawns mobs (instantiate + initialize with
-  // look_at_from_position/rotate_y + rotation read-back), the Player ticks physics with
-  // the slide-collision query loop, and the earliest mobs walk off and free themselves.
-  const seed = {
-    mobInstantiations: 0,
-    mobAddChildCommands: 0,
-    physicsCalls: ready.physicsCalls,
-    appliedCommands: ready.appliedCommands,
-    maxLiveHandles: ready.liveHandles,
-    crossings: ready.crossings,
-    callbackErrors: 0,
+  const state = {
+    peak: {
+      mobInstantiations: 0,
+      mobAddChildCommands: 0,
+      physicsCalls: ready.physicsCalls,
+      appliedCommands: ready.appliedCommands,
+      maxLiveHandles: ready.liveHandles,
+      crossings: ready.crossings,
+      callbackErrors: 0,
+    },
+    prevMobLive: ready.mobLive ?? null,
+    mobFrees: 0,
+    last: ready,
   };
-  const gameplay = await observe(evaluate, seed, 14_000, deadline, (snap, p) =>
-    p.mobInstantiations >= 4 && p.mobFrees >= 2,
-  );
-  const peak = gameplay.peak;
-  const atPeak = gameplay.last ?? ready;
-  trace(`gameplay: mobs=${peak.mobInstantiations} physics=${peak.physicsCalls} frees=${peak.mobFrees} live=${atPeak.liveHandles}`);
+
+  // --- Phase 1: movement (task 81 part A) ------------------------------------------
+  // Runs FIRST, airborne, before the arena fills: the pre-81 driver left the player
+  // standing at the spawn for its whole observe window, and whether a mob reached the
+  // MobDetector during it was pure spawn-angle luck that nothing measured.
+  let maxDisplacement = 0;
+  let movePulses = 0;
+  if (FALSIFY !== "no-input") {
+    for (let pulse = 0; pulse < 8 && Date.now() < deadline; pulse += 1) {
+      movePulses += 1;
+      await movePulse(evaluate);
+      await delay(130);
+      const position = await playerPosition(evaluate);
+      if (position) {
+        const displacement = Math.hypot(position.x - AIR_ANCHOR[0], position.z - AIR_ANCHOR[2]);
+        maxDisplacement = Math.max(maxDisplacement, displacement);
+      }
+      mergeSnap(state, await snapshot(evaluate));
+      trace(`pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)}`);
+      if (maxDisplacement > 0.5) break;
+      await delay(70);
+    }
+  } else {
+    trace("FALSIFY=no-input: movement pulses skipped");
+  }
+  const playerMovedOnInput = maxDisplacement > 0.5;
+  trace(`move: pulses=${movePulses} displacement=${maxDisplacement.toFixed(2)}`);
+
+  // --- Phase 2: squash a mob, read the score (task 81 part B) ------------------------
+  // The chase re-pins above the latest live mob every poll; mob spawn/free evidence for
+  // the long-standing checks keeps accruing through the same snapshots.
+  let score = null;
+  let chaseSteps = 0;
+  const chaseDeadline = Math.min(deadline, Date.now() + 30_000);
+  if (FALSIFY !== "no-chase") {
+    while (Date.now() < chaseDeadline) {
+      chaseSteps += 1;
+      const step = await chaseStep(evaluate);
+      await delay(70);
+      const text = await scoreText(evaluate);
+      if (text !== null) score = text;
+      const snap = await snapshot(evaluate);
+      mergeSnap(state, snap);
+      if (DEBUG && step) {
+        trace(`chase#${chaseSteps}: ${step.pinned ? `mob@(${step.mob.x.toFixed(1)},${step.mob.y.toFixed(1)},${step.mob.z.toFixed(1)})` : step.reason} score="${score}" mobs=${snap?.mobLive}`);
+      }
+      if (score !== null && /^Score: [1-9]\d*$/.test(score)) break;
+      // The player died mid-chase (a mob caught a grounded frame): record and move on
+      // honestly rather than chasing with a freed handle.
+      if (snap && snap.playerLive === 0) {
+        trace("chase aborted: player died before scoring");
+        break;
+      }
+    }
+  } else {
+    trace("FALSIFY=no-chase: squash chase skipped");
+    score = await scoreText(evaluate);
+  }
+  const mobSquashScoredOnHud = score !== null && /^Score: [1-9]\d*$/.test(score);
+  trace(`score: steps=${chaseSteps} label="${score}"`);
+
+  // --- Phase 3: death path (task 81 part B, run AFTER the score attempt) -------------
+  // Park the player at ground level and let a mob reach the MobDetector. From here on
+  // the player handle is left alone: it frees itself.
+  let playerFreedOnMobContact = false;
+  if (FALSIFY !== "no-death") {
+    await pinPlayer(evaluate, [0, 0.1, 0]);
+    const deathDeadline = Math.min(deadline, Date.now() + 30_000);
+    while (Date.now() < deathDeadline) {
+      const snap = await snapshot(evaluate);
+      mergeSnap(state, snap);
+      if (snap) {
+        trace(`death: playerLive=${snap.playerLive} mobs=${snap.mobLive} live=${snap.liveHandles}`);
+        if (snap.playerLive === 0) {
+          playerFreedOnMobContact = true;
+          break;
+        }
+      }
+      await delay(200);
+    }
+  } else {
+    trace("FALSIFY=no-death: player left pinned aloft");
+    await pinPlayer(evaluate, AIR_ANCHOR);
+  }
+
+  // Let any remaining self-driven evidence (spawns, walk-off frees) settle briefly if
+  // the long-standing thresholds have not been reached yet.
+  const evidenceDeadline = Math.min(deadline, Date.now() + 10_000);
+  while (
+    Date.now() < evidenceDeadline &&
+    !(state.peak.mobInstantiations >= 4 && state.mobFrees >= 2)
+  ) {
+    mergeSnap(state, await snapshot(evaluate));
+    await delay(200);
+  }
+  const peak = state.peak;
+  const atPeak = state.last ?? ready;
+  trace(`gameplay: mobs=${peak.mobInstantiations} physics=${peak.physicsCalls} frees=${state.mobFrees} live=${atPeak.liveHandles}`);
 
   // Full teardown: SmokeQuit.smoke_teardown (its only @RegisterFunction, method#1) frees
-  // the scene root; every node exits the tree and releases its handles.
+  // the scene root; every node exits the tree and releases its handles. SmokeQuit
+  // survives the player's death-path free, so this works in every phase outcome.
   trace("smoke_teardown");
   await evaluate(
     "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.squashSmokeQuitHandle, 1); true",
   );
-  const teardown = await observe(evaluate, peak, 8_000, deadline, (snap) => snap.liveHandles === 0);
-  const settled = teardown.last ?? atPeak;
+  let settled = atPeak;
+  const teardownDeadline = Math.min(deadline, Date.now() + 8_000);
+  while (Date.now() < teardownDeadline) {
+    const snap = await snapshot(evaluate);
+    if (snap) {
+      mergeSnap(state, snap);
+      settled = snap;
+      if (snap.liveHandles === 0) break;
+    }
+    await delay(150);
+  }
   trace(`teardown: live=${settled.liveHandles} callbacks=${settled.callbacks} errs=${settled.callbackErrors}`);
 
   const protocolVersion = ready.protocol;
@@ -152,8 +384,17 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
     physicsFramesAdvanced: peak.physicsCalls >= ready.physicsCalls + 60,
     handleGrowthDuringGameplay: peak.maxLiveHandles > ready.liveHandles,
     crossingsAdvanced: peak.crossings > ready.crossings,
-    // Mobs left the level and released their handles, bounded by the peak — no leak.
-    mobsSpawnAndFree: peak.mobFrees >= 2 && atPeak.liveHandles <= peak.maxLiveHandles,
+    // Mobs freed themselves (squashed and/or walked off), bounded by the peak -- no leak.
+    mobsSpawnAndFree: state.mobFrees >= 2 && atPeak.liveHandles <= peak.maxLiveHandles,
+    // Task 81: injected move_forward displaced the player through Input.is_action_pressed
+    // -> physicsProcess -> move_and_slide -- the demo's input path, driven end to end.
+    playerMovedOnInput,
+    // Task 81: a real landing squashed a mob and the score chain ran end to end
+    // (slide-collision normal check -> Mob.squash -> squashed signal -> ScoreLabel).
+    mobSquashScoredOnHud,
+    // Task 81: a mob reached the ground-level MobDetector, Player.die ran, and the
+    // player script freed -- the demo's lose path, previously dark on every gate.
+    playerFreedOnMobContact,
     fullTeardownToZero: settled.liveHandles === 0,
     // Godot runs every physics tick before the idle/_process pass inside one rAF
     // iteration; the bridge counts any same-tick physics-after-process dispatch.
@@ -184,6 +425,10 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
       mobInstantiations: peak.mobInstantiations,
       mobAddChildCommands: peak.mobAddChildCommands,
       appliedCommands: peak.appliedCommands,
+      playerDisplacement: Number(maxDisplacement.toFixed(3)),
+      scoreReported: mobSquashScoredOnHud ? Number.parseInt(score.slice("Score: ".length), 10) : 0,
+      mobFrees: state.mobFrees,
+      chaseSteps,
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -350,7 +350,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
       await delay(200);
     }
   } else {
-    trace("FALSIFY=no-death: player left pinned aloft");
+    trace("FALSIFY=no-death: player kept pinned aloft");
     await pinPlayer(evaluate, AIR_ANCHOR);
   }
 
@@ -361,6 +361,9 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
     Date.now() < evidenceDeadline &&
     !(state.peak.mobInstantiations >= 4 && state.mobFrees >= 2)
   ) {
+    // The no-death falsification must hold the player OUT of harm's way for the whole
+    // settle window, or a wandering mob would kill it anyway and un-falsify the check.
+    if (FALSIFY === "no-death") await pinPlayer(evaluate, AIR_ANCHOR);
     mergeSnap(state, await snapshot(evaluate));
     await delay(200);
   }

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -7,10 +7,11 @@
 // rotate_y; walk-offs free themselves past the VisibleOnScreenNotifier3D), and this run
 // layers real play on top:
 //   1. movement: engine-level action injection (ops 86/87 -- browser key synthesis
-//      stalls headless Firefox; SafariDriver has no keys transport) in short
-//      in-page-released pulses while the player is stance-pinned in the air (op 142,
-//      re-pinned per pulse) -- airborne so no ground-level mob can reach the
-//      MobDetector and end the run early; movement is proven by op 138 position reads,
+//      stalls headless Firefox; SafariDriver has no keys transport) as a fixed
+//      in-page-released hold from an airborne stance pin (op 142) -- airborne so no
+//      ground-level mob can reach the MobDetector and end the run early; movement is
+//      proven by op 138 position reads (threshold sized by a found Web parity defect,
+//      see the MOVE_HOLD_MS note),
 //   2. score: the driver re-pins the player a body-height above the latest live mob
 //      (bridge.squashMobHandle, re-read every poll and stale-tolerated) and lets
 //      gravity close the gap; the landing is real -- slide-collision normal dot UP >
@@ -36,8 +37,9 @@ const trace = (msg) => {
   if (DEBUG) process.stderr.write(`[squash ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
 };
 
-// Airborne stance anchor for movement pulses: mobs top out around y=1.1 and the
-// MobDetector rides the player's feet, so y=8 keeps every phase-1 frame out of reach.
+// Airborne stance anchor for movement holds: mobs top out around y=1.1 and the
+// MobDetector rides the player's feet, so y=8 keeps the hold's early frames out of
+// reach while the arena is still filling.
 const AIR_ANCHOR = [0, 8, 0];
 // Drop height above a mob's root for the squash: the mob's box top sits ~1.07 above its
 // root and the player's sphere bottom ~0.02 below its own, so +1.25 leaves ~0.2 of fall.
@@ -45,10 +47,23 @@ const AIR_ANCHOR = [0, 8, 0];
 // velocity), so the swept move_and_slide contacts the box top within a tick or two --
 // faster than a 10-18 u/s mob can slide out from under the pin.
 const DROP_HEIGHT = 1.25;
-// In-page hold per movement pulse; released in page so driver-transport jank can never
-// stretch a hold. The squash arena is walled (WorldBoundaryShape3D), so even a
+// In-page hold per movement attempt; released in page so driver-transport jank can
+// never stretch a hold. The squash arena is walled (WorldBoundaryShape3D), so even a
 // free-running engine cannot carry the player anywhere dangerous.
-const MOVE_HOLD_MS = 100;
+//
+// SIZED BY A FOUND DEFECT (task 81, 2026-08-11, filed in the PR): while a move action
+// is held, squash's Player calls lookAtFromPosition(self.position, ...) every physics
+// tick, and on Web `self.position` is the mirrored transform snapshot, which the proxy
+// refreshes only in _process -- once per RENDERED frame (_physics_process refreshes
+// only the velocity slot; see WebScriptCodeEmitter's _physics_process emission). Every
+// tick after the first inside one rendered frame therefore teleports the body back to
+// the frame-start position, so NET movement is one physics tick (14/60 = 0.23 u) per
+// rendered frame regardless of how many ticks the frame ran. MEASURED: 100ms holds
+// moved 0.23-0.35 u on a free-running headless Chrome instead of the naive 1.4 u. A
+// 600ms hold nets ~0.23 x rendered-frames, comfortably past the 0.5 u gate even on a
+// slow-framed headless engine, and on a display-paced engine (1 tick/frame) it is
+// simply full-speed movement.
+const MOVE_HOLD_MS = 600;
 
 async function snapshot(evaluate) {
   try {
@@ -144,21 +159,22 @@ async function chaseStep(evaluate) {
   }
 }
 
-// One movement pulse: pin the airborne stance, hold move_forward (14 u/s immediately --
-// squash movement has no acceleration ramp), release in page.
+// One movement attempt: pin the airborne stance, hold move_forward, release in page.
+// Returns the pin result and the engine's own view of the pressed state for the trace.
 async function movePulse(evaluate) {
-  await evaluate(`(() => {
+  return await evaluate(`(() => {
     const bridge = globalThis.KanamaWebBridge;
     const handle = bridge.squashPlayerHandle;
     const sep = String.fromCharCode(31);
-    bridge.immediateObjectQuery(142, handle, [${AIR_ANCHOR.join(", ")}].join(sep));
+    const pinned = bridge.immediateObjectQuery(142, handle, [${AIR_ANCHOR.join(", ")}].join(sep));
     bridge.immediateObjectQuery(86, handle, "move_forward");
+    const pressed = bridge.immediateObjectQuery(69, handle, "move_forward");
     setTimeout(() => {
       try {
         bridge.immediateObjectQuery(87, bridge.squashPlayerHandle, "move_forward");
       } catch {}
     }, ${MOVE_HOLD_MS});
-    return true;
+    return { pinned, pressed };
   })()`);
 }
 
@@ -259,25 +275,27 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   let maxDisplacement = 0;
   let movePulses = 0;
   if (FALSIFY !== "no-input") {
-    for (let pulse = 0; pulse < 8 && Date.now() < deadline; pulse += 1) {
+    for (let attempt = 0; attempt < 3 && Date.now() < deadline; attempt += 1) {
       movePulses += 1;
-      await movePulse(evaluate);
-      await delay(130);
+      const pulseState = await movePulse(evaluate);
+      // Wait out the full in-page hold plus a margin, then read where it ended up.
+      await delay(MOVE_HOLD_MS + 150);
       const position = await playerPosition(evaluate);
       if (position) {
         const displacement = Math.hypot(position.x - AIR_ANCHOR[0], position.z - AIR_ANCHOR[2]);
         maxDisplacement = Math.max(maxDisplacement, displacement);
       }
       mergeSnap(state, await snapshot(evaluate));
-      trace(`pulse#${pulse}: displacement=${maxDisplacement.toFixed(2)}`);
+      trace(
+        `move#${attempt}: displacement=${maxDisplacement.toFixed(2)} pinned=${pulseState?.pinned} pressed=${pulseState?.pressed} pos=${position ? `(${position.x.toFixed(2)},${position.y.toFixed(2)},${position.z.toFixed(2)})` : "null"}`,
+      );
       if (maxDisplacement > 0.5) break;
-      await delay(70);
     }
   } else {
     trace("FALSIFY=no-input: movement pulses skipped");
   }
   const playerMovedOnInput = maxDisplacement > 0.5;
-  trace(`move: pulses=${movePulses} displacement=${maxDisplacement.toFixed(2)}`);
+  trace(`move: attempts=${movePulses} displacement=${maxDisplacement.toFixed(2)}`);
 
   // --- Phase 2: squash a mob, read the score (task 81 part B) ------------------------
   // The chase re-pins above the latest live mob every poll; mob spawn/free evidence for

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -1663,7 +1663,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ): String {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(259, 278))
+    require(descriptor.opcode in setOf(259, 278, 288))
     commands.flush()
     return immediateWebStringQuery(descriptor.opcode, receiver.webId(), "")
   }

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -320,8 +320,22 @@
     web3dSmokeQuitHandle: 0,
     platformerMainHandle: 0,
     platformerSmokeQuitHandle: 0,
+    // Task 81: the platformer driver drives gameplay -- the Player handle carries the
+    // action press/release (ops 86/87), stance pins (142), position reads (138) and the
+    // SoundFootsteps is_playing query (287); the Hud handle carries the "Coins" Label
+    // text read (288).
+    platformerPlayerHandle: 0,
+    platformerHudHandle: 0,
     squashMainHandle: 0,
     squashSmokeQuitHandle: 0,
+    // Task 81: the squash driver drives gameplay -- the Player handle carries movement
+    // injection and stance pins; the ScoreLabel handle carries the score text read (288);
+    // the Mob handle is the LATEST ready mob, the driver's squash target. Mobs free
+    // themselves (squash or screen-exit), so this goes stale -- the driver re-reads it
+    // every poll and tolerates a stale-handle throw.
+    squashPlayerHandle: 0,
+    squashScoreLabelHandle: 0,
+    squashMobHandle: 0,
     fpsSmokeHandle: 0,
     fpsPlayerHandle: 0,
     charSmokeQuitHandle: 0,
@@ -2410,6 +2424,16 @@
       if (this.mode === "platformer" && scriptName.endsWith(".SmokeQuit")) {
         this.platformerSmokeQuitHandle = handle;
       }
+      if (this.mode === "platformer" && scriptName.endsWith(".Player")) {
+        // Task 81: the driver injects movement (ops 86/87), pins the stance (142), reads
+        // positions (138) and queries SoundFootsteps is_playing (287) through this handle.
+        this.platformerPlayerHandle = handle;
+      }
+      if (this.mode === "platformer" && scriptName.endsWith(".Hud")) {
+        // Task 81: the driver reads the "Coins" Label under the Hud Control (288) to
+        // assert the collision -> cross-script call -> signal -> HUD chain end to end.
+        this.platformerHudHandle = handle;
+      }
       if (this.mode === "squash" && scriptName.endsWith(".Main")) {
         this.squashMainHandle = handle;
       }
@@ -2417,6 +2441,21 @@
         // The driver calls SmokeQuit.smoke_teardown (method#1) to free the scene root and
         // drain live handles to zero for the teardown assertion.
         this.squashSmokeQuitHandle = handle;
+      }
+      if (this.mode === "squash" && scriptName.endsWith(".Player")) {
+        // Task 81: movement injection, stance pins, and position reads ride this handle.
+        this.squashPlayerHandle = handle;
+      }
+      if (this.mode === "squash" && scriptName.endsWith(".ScoreLabel")) {
+        // Task 81: the driver reads this Label's own text (288, empty child path) to
+        // assert the squash -> squashed signal -> ScoreLabel chain scored.
+        this.squashScoreLabelHandle = handle;
+      }
+      if (this.mode === "squash" && scriptName.endsWith(".Mob")) {
+        // Task 81: the LATEST ready mob is the driver's squash target. Mobs free
+        // themselves, so this handle goes stale; the driver re-reads it each poll and
+        // tolerates a stale-handle throw rather than the bridge tracking frees here.
+        this.squashMobHandle = handle;
       }
       if (this.mode === "fps" && scriptName.endsWith(".Smoke")) {
         // The scene-root Smoke script's smoke_teardown (method#1) frees the Audio autoload


### PR DESCRIPTION
Task 81 measured that `platformer.mjs` and `squash.mjs` inject **no input at all** — the only two drivers with zero injection — leaving each demo's entire scoring loop dark to every gate. This slice makes both drivers play their game and assert the score from the HUD, plus the first audio assertion anywhere in the harness. Fix #1 from the task (census-as-gate in `result_schema.py`) is **NOT** in this parcel; this is fix #2.

## What changed, per layer

**Contract** (`scripts/platform_backend_calls.json`, append-only 286 → 288; hashes validated against `extension_api.json`; regen idempotent):
- **287** `AudioStreamPlayer.is_playing` (NOARGS_RET_BOOL, IMMEDIATE) — hash 36873697.
- **288** `Label.get_text` (NOARGS_RET_STRING, IMMEDIATE) — hash 201670096.
- Both ride existing shapes, so `GodotBackendContract.kt` needed **no** enum/SPI/forwarder change and desktop/iOS are untouched. Each Web applier accepts an optional child-path payload (`''` = the receiver's own node), documented at the entry and in `compositions` (`*_at_path`).
- `InitialGodotCallDescriptors.generated.kt` regenerated (MAX_OPCODE 286 → 288).

**Web dispatch** (`scripts/generate_web_backend.py` + regenerated `WebCommonGodotBackend.generated.kt`): WEB_POLICY entries `287: {}` / `288: {}`; the only generated diff is 288 joining the NOARGS_RET_STRING opcode guard (287's shape body has no per-opcode guard). `--check` green.

**Emitter** (`processor/.../WebScriptCodeEmitter.kt`): two new `_kanama_object_query` arms sharing the contract numbering 1:1. 287 resolves the optional child path and reports `is_playing` on the integer channel (missing/non-player target reads 0 — a wrong path cannot pass an "audible" assertion). 288 resolves the path and publishes `Label.text` via `recordImmediateStringResult` (missing/non-Label target publishes nothing, so the bridge's string query **fails loud**). Covered by a new processor test (`emitsGameplayAudioAndLabelQueryArmsInEveryProxy`).

**Bridge** (`kanama-web-bridge.js`): `platformerPlayerHandle`, `platformerHudHandle`, `squashPlayerHandle`, `squashScoreLabelHandle`, `squashMobHandle` (latest ready `.Mob`; goes stale when a mob frees — the drivers re-read it per poll and tolerate the stale-handle throw), each commented with why it exists.

**Drivers** (`platformer.mjs`, `squash.mjs`): headers rewritten — the "self-driven, observe-only" design they documented is no longer true. All injection is engine-level (ops 86/87 + stance pins via 142; movement evidence via 138), with releases scheduled **in page** so driver-transport jank can never stretch a hold. New checks:
- platformer: `playerMovedOnInput`, `footstepsPipelineLive` (see audio verdict below), `coinCollectedOnHud` (stance-pin onto the coin at (-3, 0.635, 0); the Area3D overlap → `Player.collectCoin` → `coinCollected` signal → Hud label chain is all real; read back via op 288).
- squash: `playerMovedOnInput`, `mobSquashScoredOnHud` (re-pin the player 1.25u above the latest live mob and let gravity land it; real slide-collision normal·UP check → `Mob.squash` → `squashed` signal → ScoreLabel; read via op 288), `playerFreedOnMobContact` (death path: park at ground level, a mob reaches the MobDetector, `.Player` live count drains to 0 — run after the score attempt, before teardown; SmokeQuit survives the free). `mobsSpawnAndFree` now counts frees from the per-class `.Mob` live count instead of total live-handle drops, so the player's own death-path free can't masquerade as a mob free.
- Protocol stays **18** — opcode additions have never bumped it (60i precedent) and nothing asserts otherwise.

## The audio verdict (task 81 part C — measured, not guessed)

Op 287 reads **1 while the player idles with `stream_paused=true` and 1 while walking**, so on Web `is_playing` cannot see the footsteps pause-toggle. Root cause verified in the Godot 4.7 source: Web nothreads plays this ogg through the **sample** path; `set_stream_paused` does pause the audible sample (`set_sample_playback_pause`) but never removes it from `AudioServer::sample_playback_list`, and a sample's `is_playing` *is* that list membership. (On the desktop mixed path it would distinguish: `set_playback_paused` parks the node in FADE_OUT_TO_PAUSE/PAUSED and `is_playback_active` reports only PLAYING.) The check is therefore **pipeline-level** — SoundFootsteps' stream loaded + mixer entry live, sampled while idling AND during the walk hold — and its comment says exactly that. `AudioStreamPlayer.get_stream_paused` (same hash family) reads the mixed-list node state on both paths and *would* distinguish walking: named follow-up, not in this parcel.

## Found defect (documented, not fixed here)

While a move action is held, squash's `Player` calls `lookAtFromPosition(self.position, ...)` every physics tick, and on Web `self.position` is the mirrored transform snapshot, which the proxy refreshes only in `_process` — once per **rendered frame** (`_physics_process` refreshes only the velocity slot; see the emitter's `_physics_process` emission). Every tick after the first inside one rendered frame teleports the body back to the frame-start position, so net movement is one physics tick per rendered frame regardless of how many ticks the frame ran. MEASURED: 100ms holds moved 0.23–0.35u on free-running headless Chrome instead of the naive ~1.4u. Invisible at 1 tick/frame (display-paced play), real whenever physics outpaces rendering. Deserves its own task: per-physics-tick transform refresh for Node3D-attached scripts, or a documented Web semantics note.

A second measured surprise, recorded in the drivers: engine progress during a hold **decouples from wall time in both directions** (starved under driver evaluate traffic: 100ms FF holds moved 0.22–0.27u; catch-up bursts during quiet driver delays: 400ms and 600ms Chrome platformer holds both ended at x≈-2.3). The platformer walk release is therefore gated **in page on measured displacement** (op 138 every 25ms, release past 0.7u, 400ms wall failsafe) — wall-time holds alone either under-run the movement gate or overshoot into the coin.

## Validation matrix (all local, macOS arm64, protocol 18, Chrome 151 headless / Firefox 153 headless)

1. **Drift gates** — RAN: `generate_platform_backend_contract.py --check`, `generate_web_backend.py --check`, `./gradlew ktfmtCheck :processor:test jar`. EXPECTED: all green. MEASURED: `[platform_backend_contract] PASS`, `[web_backend] PASS`, ktfmtCheck + processor tests + jar green.
2. **platformer × chrome + firefox** — RAN: `scripts/web_export_smoke.sh --engine {chrome,firefox} --export-dir web-runtime/build/web-export/platformer --demo platformer` (fresh export, buildId ceef717d38fae077). EXPECTED: `web_export_smoke: PASS` with all new checks true. MEASURED: **PASS/PASS**, all 13 checks true both engines; displacement 1.83 (chrome) / 1.17 (firefox); HUD "Coins" = 1 on the first pin attempt on both; liveAfterTeardown 0.
3. **squash × chrome + firefox** — RAN: same shape. EXPECTED: PASS with all new checks true. MEASURED: **PASS/PASS**, all 15 checks true both engines; displacement 0.82 / 8.52; ScoreLabel "Score: 1" on chase step 1 on both; `.Player` drained to 0 on the death path on both; teardown to zero after it.
4. **Sentinels (emitter change regenerates every proxy)** — RAN: fps + thirdperson × chrome + firefox. EXPECTED: PASS. MEASURED: fps **PASS/PASS** (1.21 / 1.13 crossings/tick), thirdperson **PASS/PASS** (0.29 / 0.12). One honest wrinkle: the first thirdperson × firefox attempt timed out in the driver's 120s ready window under host load (fps × firefox had just recorded a 268s startup on the same busy host); the retry passed with startup 64.8s. `budgets.json` documents exactly this variance (startup recorded, not gated); no orphaned browser profiles before the retry.
5. **Falsification runs** (Chrome; every new check observed FALSE under its induced break via `KANAMA_WEB_T81_FALSIFY`, a permanent documented env hook — re-runnable one-liners, guaranteed-restored state):
   - `no-input` (platformer): `playerMovedOnInput` + `footstepsPipelineLive` false (both walk-dependent; the break removes the walk) — envelope pass=false.
   - `wrong-audio-path`: `footstepsPipelineLive` false **alone** (op 287 on a nonexistent child reads 0).
   - `no-coin`: `coinCollectedOnHud` false **alone**, HUD stayed "0" (this break is what forced the displacement-gated release: with 600ms wall holds the walk itself entered the coin's overlap and un-falsified the check — caught by running the falsification, exactly why these runs exist).
   - `no-input` (squash): `playerMovedOnInput` false alone (chase still scored, death still ran).
   - `no-chase`: `mobSquashScoredOnHud` false alone — score stayed 0, proving the green runs' "Score: 1" comes from the choreographed landing, not spawn luck.
   - `no-death`: `playerFreedOnMobContact` false alone (the falsify branch re-pins the player aloft through the evidence window so a wandering mob can't un-falsify it).
6. **Budgets** (gated per engine, from the green envelopes): platformer 1.04 (chrome, max 2.1) / 0.76 (firefox, max 2.0); squash 0.66 (chrome, max 2.0) / 0.28 (firefox, max 2.0); fps 1.21 (max 2.2) / 1.13 (max 2.0); thirdperson 0.29 / 0.12 (max 2.0). **No budget number changed** — the added gameplay (walking crossings, coin/squash events, immediate queries) stays well inside every existing ceiling.

Full corpus not run locally (CI runs the PR subset; full corpus on main post-merge).

## Choreography stability notes per engine

- **Chrome**: platformer walk releases at ~1.8u in one pulse; squash squash lands on chase step 1 (the accumulated fall velocity closes the 0.2u drop gap within a tick or two of the pin, faster than a 10–18 u/s mob can escape); death arrives ~2.5s after ground-park.
- **Firefox**: startup 19–28s (platformer/squash); the same single walk pulse suffices (1.17u); squash movement hold ran much further (8.5u — walled arena bounds it by construction, max possible ≈ z=-20); squash + death identical shape to Chrome. The free-run excursion feared by the harness lore inverts in practice: engine progress during a hold is bounded by the driver's own evaluate traffic, so holds under-run rather than over-run; the platformer's displacement-gated release also caps the one catch-up-burst case.
- **CI note**: squash cells may be quarantined on Linux (the dodge/squash Firefox quarantine is the maintainer's call — quarantine wiring untouched). The macOS local runs above are the gating evidence for this parcel.

## Named follow-ups (not in this parcel)

1. **Census-as-gate** (task 81 fix #1): make `result_schema.py` fail when a per-demo required member list is missing — the fix that scales.
2. **`AudioStreamPlayer.get_stream_paused` opcode** — the walking discriminator `is_playing` cannot be on the Web sample path; would upgrade `footstepsPipelineLive` to a true both-directions pause-toggle assertion.
3. **Per-physics-tick transform refresh** for Node3D-attached scripts (the found defect above) — squash movement (and any script that writes position from a snapshot read per tick) runs at one tick per rendered frame on Web whenever physics outpaces rendering.
4. **Web wrapper API parity**: `AudioStreamPlayer.isPlaying()` / `Label.text` getter members were NOT added to the web wrappers — the drivers reach both ops through the bridge; wrapper members are parity items for when a ported script needs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
