### PR TITLE
Lift squash:firefox from quarantine; re-label squash:chrome to task 87

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -416,10 +416,16 @@ A quarantined cell that **passes** is reported just as loudly, with an explicit
 "lift the quarantine" line, because a stale quarantine is worse than none.
 Lifting one is a one-line deletion.
 
-<!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the quarantined cells below -->
-Currently quarantined: `dodge:firefox`, `squash:chrome` and `squash:firefox` —
-task 71, spawned mobs never free on a Linux host. Both demos pass on macOS, and
-`dodge:chrome` passes on Linux, so it is neither a browser nor a demo property.
+<!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the dodge quarantine below -->
+Currently quarantined: `dodge:firefox` — task 71, spawned mobs never free on a
+Linux host (dodge passes on macOS, and `dodge:chrome` passes on Linux, so it is
+neither a browser nor a demo property) —
+<!-- KANAMA-BLOCKED(since:2026-08-11, task:87): the squash:chrome quarantine below -->
+and `squash:chrome` — task 87, held-input movement collapses to one physics tick
+per rendered frame on that runner's slow-rendering Chrome. `squash:firefox` was
+lifted on 2026-08-11: the task-71 signature stopped reproducing there (mobs
+freed on both engines) and the cell passed outright under the task-81 gameplay
+checks, so it gates again.
 
 ### Bumping The Demos Pin
 

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -170,9 +170,19 @@ kanama_web_demo_local_only_reason() {
 # archived, so a quarantine cannot outlive the defect it cites.
 kanama_web_quarantine_reason() {
   case "$1" in
-    # KANAMA-BLOCKED(since:2026-07-28, task:71): dodge/squash mobs never free on a Linux host
-    dodge:firefox|squash:chrome|squash:firefox)
-      echo "task 71 — spawned mobs never free on a Linux host; both demos pass on macOS"
+    # KANAMA-BLOCKED(since:2026-07-28, task:71): dodge mobs never free on a Linux host
+    dodge:firefox)
+      echo "task 71 — spawned mobs never free on a Linux host; dodge passes on macOS"
+      ;;
+    # KANAMA-BLOCKED(since:2026-08-11, task:87): held-input movement collapses to one
+    # physics tick per rendered frame; the runner's software-GL Chrome renders ~1
+    # frame per hold window, so playerMovedOnInput reads a single tick (0.233 u).
+    # squash:firefox was LIFTED 2026-08-11 (maintainer decision): the task-71
+    # signature stopped reproducing (mobs freed on both engines, 2026-08-11 main
+    # run 31518477493) and the cell passed outright under the task-81 gameplay
+    # checks — it gates again.
+    squash:chrome)
+      echo "task 87 — per-frame transform snapshot collapses held-input movement on a slow-rendering host"
       ;;
     *) : ;;
   esac


### PR DESCRIPTION
## What

- `squash:firefox` leaves quarantine and **gates again** (one-line deletion, per the quarantine design).
- `squash:chrome` stays quarantined but its reason now names the defect it actually absorbs: **task 87** (per-frame transform snapshot collapses held-input movement on a slow-rendering host), with its own dated `KANAMA-BLOCKED` marker.
- `dodge:firefox` unchanged (task 71, still reproducing).
- `docs/exporting/web.md` §Quarantined Cells updated to match.

## Why

On the 2026-08-11 main run (31518477493) — the first with the task-81 gameplay checks — the task-71 signature did **not** reproduce for squash: mobs freed on both Linux engines (`mobsSpawnAndFree` passed in both squash cells), and `squash:firefox` passed outright (its fourth recent pass, after three unprompted passes in task 84's corpus run). `squash:chrome`'s only failure was `playerMovedOnInput` at displacement **0.233 = exactly one physics tick** — the task-87 class, filed with evidence, unrelated to task 71.

Maintainer decision 2026-08-11: lift `squash:firefox` only; wait for the task-87 fix before touching `squash:chrome`.

## Validation

- RAN `bash -n scripts/web/demos.sh` + sourced function probe → EXPECTED reasons for dodge:firefox/squash:chrome, empty for squash:firefox → MEASURED exactly that.
- RAN `python3 scripts/audit_stale_blockers.py` → EXPECTED PASS with the new markers → MEASURED `PASS markers=8 tokens=8` (both cited tasks open).
- RAN `mkdocs build --strict` → PASS.
- The decisive gate is this PR's own merge: the next main-push corpus run is the first where `squash:firefox` gates — its recent record is 4/4 PASS across macOS and the Linux runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)