### PR TITLE
Task 86: repair the Safari gate — performance reaches the envelope; Safari budgets record-only until measured

### DIFF
--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -460,5 +460,10 @@
     "payloadBytes": "GATED. Bytes are host- and engine-independent by construction.",
     "startupMs": "RECORDED, NOT GATED. It is wall-clock and it does not survive a loaded machine: the same thirdperson build measured 4.4s on an idle Chrome and 64.7s on a Firefox sharing a busy workstation. A gate that red-lights because someone else was compiling is measuring the machine, and the failure it would catch (a demo that stops booting) already shows up as a driver timeout.",
     "crossingsPerTick": "GATED PER ENGINE. Engine-stable for most of the corpus (bunnymark 2.22/1.97, dodge 0.19/0.20, citybuilder 0.84/0.77, fps 1.10/1.02 for chrome/firefox). The per-engine split was introduced because Firefox measured 5-10x Chrome's ratio on the input-heavy demos (charactercontroller 4.50 -> 19.58, thirdperson 1.15 -> 6.01) and a Chrome-derived budget reddened main. Task 84 (2026-08-10) established that for those three demos the asymmetry was an artifact of the spike-benchmark fallthrough: the synthetic per-dispatch command scaled with Firefox's unpaced rAF. On the real _process path the asymmetry INVERTS (charactercontroller 1.86 -> 0.23, thirdperson 0.29 -> 0.12, racing 2.09 -> 0.68), because the residual crossings are physics-driven and wall-capped while unpaced rAF only inflates processTicks. Those three therefore take Chrome's ceiling on both engines as the conservative bound. The structure stays per-engine: it is still the right shape, and the rest of the corpus was never re-measured under it."
+  },
+  "enginePolicies": {
+    "safari": {
+      "recordOnly": "Hand-run local gate (no headless mode, no CI cell) whose ceilings were never measured: every number in this file was derived on Chrome/Firefox. Numbers are recorded for the corpus baseline; add measured safari engine entries and remove this policy to gate them (task 86)."
+    }
   }
 }

--- a/scripts/web/check_budgets.py
+++ b/scripts/web/check_budgets.py
@@ -118,6 +118,27 @@ def check(demo: str, measured: dict, budgets: dict, engine: str | None = None) -
 
     per_tick = measured["crossingsPerTick"]
     ticks = measured["ticksObserved"]
+
+    # An engine can be RECORD-ONLY (task 86): its crossings numbers are printed and
+    # recorded but gate nothing, with the reason stated. This is for Safari, whose
+    # ceilings were never measured -- `engine_limits` would otherwise silently grade
+    # it against the demo-level (chrome-era) number. Payload still gates above: it
+    # is a property of the export, not the engine. The reason requirement mirrors
+    # `tickRatioNotApplicable`: an exemption without a stated reason is not one.
+    engine_policy = (budgets.get("enginePolicies") or {}).get(engine or "")
+    if engine_policy is not None and "recordOnly" in (engine_policy or {}):
+        reason = engine_policy["recordOnly"]
+        if not reason:
+            raise BudgetError(
+                f"engine {engine!r} is recordOnly with no stated reason. An exemption "
+                f"without a stated reason is not an exemption."
+            )
+        print(
+            f"web_export_smoke: {demo} crossings/tick RECORDED, not gated, on "
+            f"{engine} (crossings/tick={per_tick} ticks={ticks}) -- {reason}"
+        )
+        return violations
+
     if limits.get("maxCrossingsPerTick") is None:
         # An exempt demo must SAY WHY. A null budget with no reason is an
         # unbudgeted demo wearing a budget's clothes, so it is a hard error.

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -226,10 +226,7 @@ async function main() {
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);
-    // eslint-disable-next-line no-unused-vars -- KANAMA-BLOCKED(since:2026-08-11, task:86): collected but not yet passed into buildEnvelope; the fix is task 86's call
     const performance = await collectPerformance(evaluate);
-    // Task 81: unlike the performance section above, this one IS in the Safari envelope --
-    // the schema's required-member gate depends on it on every engine.
     const exercisedMembers = await harvestExercisedMembers();
 
     // No SafariDriver console endpoint: rely on the demo's bridge telemetry.
@@ -237,6 +234,12 @@ async function main() {
       demo: args.demo,
       browser: { engine: "safari", name: "Safari", version: String(browserVersion) },
       payload,
+      // Task 86: this line was MISSING from 2026-07-29 (kanama#124) until today --
+      // collected two lines up, never placed in the envelope, so the budget stage
+      // failed every Safari run with "no performance section". Its numbers are
+      // record-only until measured Safari ceilings exist (budgets.json
+      // enginePolicies.safari).
+      performance,
       durationMs: Date.now() - startedAt,
       consoleEvents: [],
       demoResult,


### PR DESCRIPTION
## What

- **The one-line omission**: `safari_webdriver.mjs` collected the `performance` section and never placed it in `buildEnvelope`, so the budget stage failed EVERY Safari run with 'no performance section' from kanama#124 (2026-07-29) until today — two days after the last full Safari corpus run (task 69), so it was never observed. Found during the #164 review; flagged by #166's `no-unused-vars`; the `KANAMA-BLOCKED(task:86)` suppression is removed with the fix.
- **Engine-level record-only budget policy** (`check_budgets.py` + `budgets.json` `enginePolicies.safari`): with the section flowing, `engine_limits` would silently grade Safari against demo-level chrome-era ceilings never measured on Safari. Record-only prints + records crossings with the stated reason; **payload still gates** (a property of the export, not the engine); an empty reason is a hard `BudgetError`, mirroring `tickRatioNotApplicable`.

## Validation (RAN/EXPECTED/MEASURED)

1. Statics — eslint (suppression removed, `performance` now used) / shell lint / stale-blocker audit (markers 9→8, PASS) / budgets JSON: all green.
2. Three directions against a live Safari envelope: **record-only PASS** with the RECORDED line; **empty reason → BudgetError**; **policy removed → Safari IS graded** (tripped a synthetic 0.1 ceiling; restored).
3. **Full Safari corpus revalidation — 13/13 PASS at protocol 18** (`[web_ci_matrix] PASS -- 13 demo(s) x 1 engine(s)`, Safari 26.5, 2026-08-11): all 12 demos + the spike cell, the first complete Safari gate run since 2026-07-27 and the first ever with the census gate (#168) active on Safari. Every envelope `pass: true`.
4. **Recorded Safari baselines** (crossings/tick | ticks) for future gated ceilings: bunnymark 1.83|307, cc 0.42|8324, citybuilder 0.77|2756, dodge 0.20|4117, fps 1.05|952, match3 4.43|69, platformer 0.77|7641, racing 1.05|1990, squash 0.33|4866, thirdperson 0.11|15692, tpsdemo 1.35|2645, web3d 0.75|585, spike 0|0 (structurally exempt).
5. Claims sweep (task 85 discipline): no doc asserts a Safari run inside the broken window; web.md's Safari wording ('local pre-promotion gate') is again servable as written.

## Notes

The Safari gate was structurally un-passable for 13 days and nobody noticed because nobody ran it — 'a gate never observed failing' has a twin: a gate never run cannot be green. It is now exercised, recorded, and the stale-blocker audit would catch a recurrence of the suppression pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)