### PR TITLE
Task 87: physics ticks see a fresh transform snapshot — held-input movement is no longer frame-quantized

### DIFF
--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -133,7 +133,12 @@ mirrors crossings:
 - **Batching** — many mutations coalesce into one crossing (e.g. Bunnymark's
   single 256-position batch) instead of one call per operation.
 - **Property snapshots** — the Kotlin side keeps a read-your-write mirror of
-  Godot object state so reads need not round-trip through JS.
+  Godot object state so reads need not round-trip through JS. State the engine
+  mutates on its own (a body displaced by `move_and_slide`) is pushed back into
+  the mirror at the start of every `_process` **and** every `_physics_process`
+  dispatch (task 87: the per-tick transform refresh — refreshing only per
+  rendered frame collapsed held-input movement to one physics tick per frame
+  whenever physics outpaced rendering).
 - **Handle generations** — handles are opaque IDs across the bridge, not live
   pointers, so stale generations are detected and rejected explicitly.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -105,6 +105,21 @@ the default into GDScript and pushes it back into Kotlin at hydration), and a
 property type or hint outside the supported Web set is rejected with an error
 naming the property.
 
+**Physics loops should derive movement from velocity, not from re-reading a
+spatial value they just wrote.** On Web, spatial reads (`self.position`,
+`self.rotation`, …) come from a mirrored snapshot rather than a live engine
+call. The snapshot refreshes at the start of every `_process` **and** (since
+task 87) every `_physics_process` dispatch, so a per-tick read is coherent with
+the previous tick — but it is still a start-of-dispatch mirror: a value the
+engine changes *inside* the current tick (after `moveAndSlide()`, for example)
+is not visible until the next dispatch. Desktop reads the engine live, so a
+spelling that re-reads a just-written spatial value can be subtly
+platform-different even when it works. Preferred spelling: accumulate movement
+in `self.velocity` + `moveAndSlide()`, and derive orientation from the intended
+direction (as squash's Player does with `lookAtFromPosition(self.position,
+self.position + direction, UP)` — the *direction* is the input, not a read-back
+of engine physics).
+
 ## Build The Web Scripts
 
 `buildWebScripts` generates the GDScript proxy bundle (proxies + manifest +
@@ -421,13 +436,12 @@ Lifting one is a one-line deletion.
 <!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the dodge quarantine below -->
 Currently quarantined: `dodge:firefox` — task 71, spawned mobs never free on a
 Linux host (dodge passes on macOS, and `dodge:chrome` passes on Linux, so it is
-neither a browser nor a demo property) —
-<!-- KANAMA-BLOCKED(since:2026-08-11, task:87): the squash:chrome quarantine below -->
-and `squash:chrome` — task 87, held-input movement collapses to one physics tick
-per rendered frame on that runner's slow-rendering Chrome. `squash:firefox` was
-lifted on 2026-08-11: the task-71 signature stopped reproducing there (mobs
-freed on both engines) and the cell passed outright under the task-81 gameplay
-checks, so it gates again.
+neither a browser nor a demo property). `squash:firefox` and `squash:chrome`
+were both lifted on 2026-08-11: firefox because the task-71 signature stopped
+reproducing there (mobs freed on both engines) and the cell passed outright
+under the task-81 gameplay checks; chrome with the task-87 fix (physics ticks
+now refresh the transform snapshot, so held-input movement no longer collapses
+to one tick per rendered frame on a slow-rendering host).
 
 ### Bumping The Demos Pin
 

--- a/docs/game-dev/porting-gdscript.md
+++ b/docs/game-dev/porting-gdscript.md
@@ -41,6 +41,11 @@ of leaving a project-specific workaround.
   instead of raw `rpc("method_name")` strings.
 - For scenes with `MultiplayerSynchronizer`, verify every replicated custom
   `.:property` is exposed with `@ScriptProperty`.
+- If the port will also run on Web: physics loops should derive movement from
+  velocity (`self.velocity` + `moveAndSlide()`), not from re-reading a spatial
+  value they just wrote — Web spatial reads are a start-of-dispatch mirror, not
+  a live engine call. See the Web export guide's Web-Compatible Project Scripts
+  rules.
 
 When a typed lookup fails, check the actual runtime class before changing the
 helper. Godot often imports GLB scene roots as `Node3D`, with the mesh attached

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -2176,6 +2176,22 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       appendLine()
       appendLine("func _physics_process(delta: float) -> void:")
       appendLine("\tif _kanama_handle != 0:")
+      if (node3dAttachment) {
+        // Task 87: the transform snapshot must refresh per PHYSICS TICK, not only per
+        // rendered frame. Physics outpaces rendering whenever rAF is slow or unpaced
+        // (headless engines, low-FPS hosts), and a physics loop that WRITES a transform
+        // derived from a READ of it (squash's lookAtFromPosition(self.position, ...))
+        // teleported the body back to the frame-start position on every tick after the
+        // first inside one rendered frame — net movement collapsed to one tick per
+        // rendered frame (MEASURED 2026-08-11: 0.82 u per 600 ms hold on a free-running
+        // headless Chrome at ~4.4 ticks/frame; CI Linux Chrome quantized to exactly one
+        // tick, 0.233 u). move_and_slide displaces the body engine-side, so no Kotlin
+        // write-through can keep this mirror coherent — only an engine read-back can.
+        appendLine("\t\tvar physics_target3d: Node3D = self")
+        appendLine(
+          "\t\t_kanama_bridge.refreshNode3DSnapshot(_kanama_handle, physics_target3d.position.x, physics_target3d.position.y, physics_target3d.position.z, physics_target3d.rotation.x, physics_target3d.rotation.y, physics_target3d.rotation.z, physics_target3d.scale.x, physics_target3d.scale.y, physics_target3d.scale.z)"
+        )
+      }
       if (model.attachTo == "CharacterBody3D") {
         // Post-slide velocity refresh: the script reads self.velocity each tick, and after
         // move_and_slide the engine's velocity differs from the last written value.

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -237,6 +237,61 @@ class WebScriptCodeEmitterTest {
   }
 
   @Test
+  fun refreshesNode3DTransformSnapshotEveryPhysicsTick() {
+    // Task 87: `_process` refreshes the Node3D snapshot once per RENDERED frame, but physics
+    // runs several ticks inside one frame whenever rendering is slow or rAF is unpaced. A
+    // physics loop that WRITES a transform derived from READING it (squash's
+    // lookAtFromPosition(self.position, ...)) collapsed to one tick of net movement per
+    // rendered frame. The `_physics_process` emission must refresh the transform snapshot
+    // too, BEFORE the tick dispatches into Kotlin.
+    val physics =
+      VirtualModel(
+        "_physics_process",
+        "callPhysicsProcess",
+        "physicsProcess",
+        args = listOf(ArgModel("delta", TypeMapping.FLOAT)),
+      )
+    val body = model("Player").copy(attachTo = "CharacterBody3D", virtuals = listOf(physics))
+    val proxy =
+      WebScriptCodeEmitter(listOf(WebScriptInput(body, "res://kotlin-src/Player.kt")))
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+
+    val physicsFunc =
+      proxy
+        .substringAfter("func _physics_process(delta: float) -> void:")
+        .substringBefore("\nfunc ")
+    assertTrue(
+      physicsFunc.contains(
+        "_kanama_bridge.refreshNode3DSnapshot(_kanama_handle, physics_target3d.position.x"
+      ),
+      "physics tick must refresh the Node3D transform snapshot:\n$physicsFunc",
+    )
+    assertTrue(
+      physicsFunc.indexOf("refreshNode3DSnapshot") <
+        physicsFunc.indexOf("physicsFrame(_kanama_handle, delta)"),
+      "the refresh must land before the tick dispatch so Kotlin reads fresh state:\n$physicsFunc",
+    )
+    // The pre-existing CharacterBody3D post-slide velocity refresh stays.
+    assertTrue(physicsFunc.contains("refreshVelocitySnapshot(_kanama_handle,"))
+
+    // A 2D attachment carries no Node3D snapshot and must not gain the refresh.
+    val proxy2d =
+      WebScriptCodeEmitter(
+          listOf(WebScriptInput(model("Mover").copy(virtuals = listOf(physics)), "res://Mover.kt"))
+        )
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+    val physicsFunc2d =
+      proxy2d
+        .substringAfter("func _physics_process(delta: float) -> void:")
+        .substringBefore("\nfunc ")
+    assertFalse(physicsFunc2d.contains("refreshNode3DSnapshot"))
+  }
+
+  @Test
   fun emitsExactAudioPlayerCommandDecodersInEveryProxy() {
     val proxy =
       WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -177,16 +177,16 @@ kanama_web_quarantine_reason() {
     dodge:firefox)
       echo "task 71 — spawned mobs never free on a Linux host; dodge passes on macOS"
       ;;
-    # KANAMA-BLOCKED(since:2026-08-11, task:87): held-input movement collapses to one
-    # physics tick per rendered frame; the runner's software-GL Chrome renders ~1
-    # frame per hold window, so playerMovedOnInput reads a single tick (0.233 u).
-    # squash:firefox was LIFTED 2026-08-11 (maintainer decision): the task-71
-    # signature stopped reproducing (mobs freed on both engines, 2026-08-11 main
-    # run 31518477493) and the cell passed outright under the task-81 gameplay
-    # checks — it gates again.
-    squash:chrome)
-      echo "task 87 — per-frame transform snapshot collapses held-input movement on a slow-rendering host"
-      ;;
+    # squash:chrome was LIFTED 2026-08-11 with the task-87 fix: _physics_process now
+    # refreshes the transform snapshot, so held-input movement integrates per tick
+    # instead of collapsing to one tick per rendered frame (the runner's software-GL
+    # Chrome rendered ~1 frame per hold window -> playerDisplacement 0.233). The
+    # driver's 0.5 u movement gate is UNCHANGED; the lift's proof is this PR's own CI
+    # plus the next full-corpus main run — if squash:chrome reds again, re-quarantine
+    # and reopen task 87 rather than touching the gate.
+    # (squash:firefox was lifted the same day, maintainer decision: the task-71
+    # signature stopped reproducing — mobs freed on both engines, main run
+    # 31518477493 — and the cell passed outright under the task-81 gameplay checks.)
     *) : ;;
   esac
 }

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -51,18 +51,24 @@ const DROP_HEIGHT = 1.25;
 // never stretch a hold. The squash arena is walled (WorldBoundaryShape3D), so even a
 // free-running engine cannot carry the player anywhere dangerous.
 //
-// SIZED BY A FOUND DEFECT (task 81, 2026-08-11, filed in the PR): while a move action
-// is held, squash's Player calls lookAtFromPosition(self.position, ...) every physics
-// tick, and on Web `self.position` is the mirrored transform snapshot, which the proxy
-// refreshes only in _process -- once per RENDERED frame (_physics_process refreshes
-// only the velocity slot; see WebScriptCodeEmitter's _physics_process emission). Every
-// tick after the first inside one rendered frame therefore teleports the body back to
-// the frame-start position, so NET movement is one physics tick (14/60 = 0.23 u) per
-// rendered frame regardless of how many ticks the frame ran. MEASURED: 100ms holds
-// moved 0.23-0.35 u on a free-running headless Chrome instead of the naive 1.4 u. A
-// 600ms hold nets ~0.23 x rendered-frames, comfortably past the 0.5 u gate even on a
-// slow-framed headless engine, and on a display-paced engine (1 tick/frame) it is
-// simply full-speed movement.
+// SIZED BY A FOUND DEFECT (task 81, 2026-08-11), SINCE FIXED (task 87, same day):
+// while a move action is held, squash's Player calls lookAtFromPosition(self.position,
+// ...) every physics tick, and on Web `self.position` is the mirrored transform
+// snapshot. Before task 87 the proxy refreshed it only in _process -- once per
+// RENDERED frame -- so every tick after the first inside one rendered frame teleported
+// the body back to the frame-start position: NET movement collapsed to one physics
+// tick (14/60 = 0.23 u) per rendered frame. MEASURED pre-fix, 2026-08-11: 0.82 u per
+// 600 ms hold on a free-running headless Chrome at ~4.4 ticks/frame; CI's
+// slow-rendering Linux Chrome quantized a whole hold to exactly one tick, 0.233 u
+// (run 31518477493, the squash:chrome quarantine). Task 87 makes the _physics_process
+// dispatch refresh the transform snapshot too, so held movement integrates per TICK:
+// MEASURED post-fix, same host and hold, 5.13 u (= 22 ticks x 14/60 -- physically
+// correct 14 u/s of SIMULATED time; displacement scales with ticks run, not
+// wall-clock). Even a host that renders ONE frame in the whole window nets the
+// engine's physics catch-up budget (max_physics_steps_per_frame, default 8 ticks =
+// 1.87 u), not a single tick. The 0.5 u gate is deliberately UNCHANGED: it sits above
+// the old one-tick failure signature (0.233) and far below correct movement on any
+// host that renders at least one frame -- do not weaken it.
 const MOVE_HOLD_MS = 600;
 
 async function snapshot(evaluate) {

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -293,7 +293,11 @@ internal fun loadWebNode2DSnapshot(
 }
 
 /**
- * Node3D transform frame snapshot pushed from the bridge for scene-graph (non-constructed) nodes.
+ * Node3D transform snapshot pushed from the bridge for scene-graph (non-constructed) nodes. A
+ * scripted node's own proxy pushes it at the start of every `_process` AND every
+ * `_physics_process` dispatch (task 87: per-frame-only refresh collapsed held-input movement to
+ * one physics tick per rendered frame); node lookups and tween steps seed/refresh it for foreign
+ * handles.
  */
 internal fun loadWebNode3DSnapshot(
   objectId: Int,

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -294,10 +294,9 @@ internal fun loadWebNode2DSnapshot(
 
 /**
  * Node3D transform snapshot pushed from the bridge for scene-graph (non-constructed) nodes. A
- * scripted node's own proxy pushes it at the start of every `_process` AND every
- * `_physics_process` dispatch (task 87: per-frame-only refresh collapsed held-input movement to
- * one physics tick per rendered frame); node lookups and tween steps seed/refresh it for foreign
- * handles.
+ * scripted node's own proxy pushes it at the start of every `_process` AND every `_physics_process`
+ * dispatch (task 87: per-frame-only refresh collapsed held-input movement to one physics tick per
+ * rendered frame); node lookups and tween steps seed/refresh it for foreign handles.
  */
 internal fun loadWebNode3DSnapshot(
   objectId: Int,


### PR DESCRIPTION
# Task 87: physics ticks see a fresh transform snapshot — held-input movement is no longer frame-quantized

## The defect

On Web, spatial reads (`self.position`, `self.rotation`, …) come from the mirrored
snapshot, which the generated proxy refreshed only in `_process` — once per RENDERED
frame — while `_physics_process` refreshed only the CharacterBody3D velocity slot. A
physics loop that WRITES a transform derived from a READ of it (squash Player's
per-tick `lookAtFromPosition(self.position, self.position + direction, UP)`) therefore
teleported the body back to the frame-start position on every tick after the first
inside one rendered frame: net movement = one physics tick per rendered frame whenever
physics outpaces rendering. Filed from kanama#164's measurement; independently
confirmed by main run 31518477493 (squash:chrome on Linux, `playerDisplacement: 0.233`
= exactly one 14/60 tick for a whole 600 ms hold), quarantined under task 87.

## Fix-direction decision (spec offered three)

1. **CHOSEN — refresh the transform snapshot in the `_physics_process` emission too.**
   One `refreshNode3DSnapshot` bridge call per tick for Node3D-family attachments,
   emitted BEFORE the tick dispatches into Kotlin. It rides the existing snapshot
   channel (a Godot→Kotlin snapshot load), so it adds ZERO Kotlin→Godot crossings by
   construction — the gated crossings/tick budgets are structurally unaffected, and the
   measured numbers below confirm it.
2. **REJECTED — write-through after queued spatial writes.** It cannot fix this class:
   the stale value is UPSTREAM of the write (the written transform is derived from the
   stale read), and the displacement the mirror misses comes from `move_and_slide`,
   which moves the body ENGINE-side with no Kotlin write to write through. Only an
   engine read-back can restore that information, and per-tick read-back is exactly
   direction 1.
3. **DONE regardless — the portable-spelling rule** in web.md §Web-Compatible Project
   Scripts + a porting-gdscript.md checklist bullet: physics loops derive movement from
   velocity, not from re-reading a spatial value they just wrote.

## Per-layer changes

- `processor/.../WebScriptCodeEmitter.kt` — the `_physics_process` emission refreshes
  the Node3D snapshot (position/rotation/scale; rotation_degrees derived Kotlin-side)
  before `physicsFrame`, for every Node3D-family attachment. The pre-existing
  CharacterBody3D post-slide velocity refresh is unchanged.
- `processor/.../WebScriptCodeEmitterTest.kt` — new test: the refresh is present, lands
  before the tick dispatch, coexists with the velocity refresh, and does NOT appear for
  2D attachments.
- `web-runtime/.../WebBackendBookkeeping.kt` — `loadWebNode3DSnapshot` doc records the
  per-tick cadence (comment only).
- `scripts/web/drivers/demos/squash.mjs` — the MOVE_HOLD_MS sizing note re-measured in
  both directions; the 0.5 u movement gate is deliberately UNCHANGED (unweakened).
- `scripts/web/demos.sh` — squash:chrome quarantine LIFTED (see below).
- `docs/exporting/web.md`, `docs/contributing/web-internals.md`,
  `docs/game-dev/porting-gdscript.md` — quarantine paragraph updated; portable-spelling
  rule added; snapshot-cadence bullet updated.

No protocol change (no new opcodes/externs; the proxy and bridge ship together in an
export). No changes to `platform_backend_calls.json` / generated Web backend dispatch.

## Quarantine lift (squash:chrome)

The fix removes the exact mechanism the quarantine names. On the runner's
slow-rendering Chrome (~1 rendered frame per hold window) the broken build nets ONE
tick (0.233 u); the fixed build nets the engine's physics catch-up budget per rendered
frame (`max_physics_steps_per_frame`, default 8 → ≥1.87 u) plus every additional frame,
against an unchanged 0.5 u gate. **The lift's proof is this PR's own CI plus the next
full-corpus main run** — I cannot reproduce the Linux runner's software-GL pacing
locally. If squash:chrome reds again, re-quarantine and reopen task 87 rather than
touching the gate.

## Validation matrix (RAN / EXPECTED / MEASURED)

1. **Statics** — processor tests + jar green (the new WebScriptCodeEmitterTest cases pass: refresh present, before the tick dispatch, coexists with the velocity refresh, absent for 2D attachments); eslint clean; shell lint PASS; stale-blocker audit PASS (markers 8→6: the lifted quarantine's two task-87 markers removed with the lift, as the audit machinery is designed to force); mkdocs strict green.
2. **Broken direction (pre-fix)** — squash × chrome on the unmodified baseline: `playerDisplacement 0.817` (frame-quantized). The Linux runner's independent measurement was 0.233 = exactly one tick.
3. **Fixed direction** — squash × chrome: `playerDisplacement 5.133` (6.3x, physically correct), score 1, wrapper PASS. squash × firefox: `8.283`, PASS. platformer × firefox PASS.
4. **Full corpus × chrome**: 12/13 PASS in one matrix run + tpsdemo PASS on rerun — its single matrix failure was a one-shot flake in the driver's single-attempt position read under machine load (`could not read the player's global position`, tpsdemo.mjs:189); a retry loop there is a named follow-up, not a regression (rerun green first try, 1.76 crossings/tick within budget).
5. **Census gate satisfied in every run** (required_members lists all green).

## Budgets (crossings/tick, chrome, budgets.json measured → this run)

bunnymark 2.22→2.24 · cc 1.86→1.85 · citybuilder 0.84→0.84 · dodge 0.19→0.18 · fps 1.10→1.23 · match3 5.77→8.50 · platformer 1.05→1.04 · racing 2.09→2.09 · squash 0.58→0.67 · thirdperson 0.29→0.29 · web3d 0.83→0.75 · spike 0→0. Every cell within its ceiling; **no budget changed**. The fix adds zero Kotlin→Godot crossings by construction (the refresh rides the Godot→Kotlin snapshot channel). squash's +0.09 is the player actually moving (more slide-collision queries during real movement); match3's jump is small-denominator noise (69-tick window, 2D demo the fix does not touch).

## Task-77 evidence: the same-class hypothesis is REFUTED

cc × firefox on the FIXED build: 4/4 FAIL with the exact historical fingerprint `playerDisplacement: 0.667`. Control (cc exported from UNMODIFIED main, same machine load): 4/4 FAIL, byte-identical 0.667. Two conclusions, both firm: (1) this fix does not worsen cc — the fingerprint pre-exists identically and is load-correlated (the historical 2/4 coin flip lands tails consistently under a loaded host); (2) per-tick snapshot refresh does not move cc's signature at all, so task 77 is NOT the stale-transform-read class. Task 77 keeps its own identity; its 2026-08-11 hypothesis entry should flip to tested-and-refuted.

## kanama-tasks updates for the main session

Close task 87 (archive + index); flip task 77's hypothesis entry to refuted with the 4/4+4/4 control data; note the tpsdemo driver single-attempt position-read retry follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)