### PR TITLE
Re-quarantine squash:chrome (death-phase choreography only); task-87 fix proven on the runner

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -436,12 +436,18 @@ Lifting one is a one-line deletion.
 <!-- KANAMA-BLOCKED(since:2026-07-28, task:71): the dodge quarantine below -->
 Currently quarantined: `dodge:firefox` — task 71, spawned mobs never free on a
 Linux host (dodge passes on macOS, and `dodge:chrome` passes on Linux, so it is
-neither a browser nor a demo property). `squash:firefox` and `squash:chrome`
-were both lifted on 2026-08-11: firefox because the task-71 signature stopped
-reproducing there (mobs freed on both engines) and the cell passed outright
-under the task-81 gameplay checks; chrome with the task-87 fix (physics ticks
-now refresh the transform snapshot, so held-input movement no longer collapses
-to one tick per rendered frame on a slow-rendering host).
+neither a browser nor a demo property). `squash:firefox` was lifted on
+2026-08-11 (the task-71 signature stopped reproducing there and the cell passes
+outright under the task-81 gameplay checks, death path included).
+<!-- KANAMA-BLOCKED(since:2026-08-12, task:81): the squash:chrome quarantine below -->
+`squash:chrome` is quarantined for its DEATH-PHASE choreography only: on the
+slow CI host the parked player is not reliably reached by a randomly-heading
+mob inside the driver's window (1-for-2 across runner outings). Its movement
+and score checks are green there — the task-87 lift's proof run measured
+displacement 1.283 (was 0.233 frame-quantized before the fix), so the fix is
+proven on that host and task 87 stays closed; the remaining fix is driver
+death-phase determinism (steer into a mob instead of parking), tracked under
+task 81's driver work.
 
 ### Bumping The Demos Pin
 

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -177,16 +177,18 @@ kanama_web_quarantine_reason() {
     dodge:firefox)
       echo "task 71 — spawned mobs never free on a Linux host; dodge passes on macOS"
       ;;
-    # squash:chrome was LIFTED 2026-08-11 with the task-87 fix: _physics_process now
-    # refreshes the transform snapshot, so held-input movement integrates per tick
-    # instead of collapsing to one tick per rendered frame (the runner's software-GL
-    # Chrome rendered ~1 frame per hold window -> playerDisplacement 0.233). The
-    # driver's 0.5 u movement gate is UNCHANGED; the lift's proof is this PR's own CI
-    # plus the next full-corpus main run — if squash:chrome reds again, re-quarantine
-    # and reopen task 87 rather than touching the gate.
-    # (squash:firefox was lifted the same day, maintainer decision: the task-71
-    # signature stopped reproducing — mobs freed on both engines, main run
-    # 31518477493 — and the cell passed outright under the task-81 gameplay checks.)
+    # KANAMA-BLOCKED(since:2026-08-12, task:81): squash death-phase choreography is
+    # timing-flaky on the slow runner. The task-87 lift's proof run (main
+    # 31559892674) PROVED the movement fix on this exact host — playerMovedOnInput
+    # PASSED at displacement 1.283 (was 0.233 quantized), score chain green — but
+    # playerFreedOnMobContact failed: the parked player waits for a randomly-heading
+    # mob, and on this host it is 1-for-2 across runner outings. Do NOT reopen task
+    # 87 (its mechanism is fixed and measured here); the fix is driver death-phase
+    # determinism (steer into a mob instead of parking), tracked under task 81's
+    # driver work. squash:firefox stays LIFTED and passing, death path included.
+    squash:chrome)
+      echo "task 81 — squash death-phase choreography is timing-flaky on a slow host (movement + score PROVEN green here; see the 2026-08-12 marker above)"
+      ;;
     *) : ;;
   esac
 }


### PR DESCRIPTION
Main run 31559892674 — the task-87 lift's designated proof run — split exactly as the lift caveat anticipated:

- **The task-87 mechanism is FIXED on the runner**: `playerMovedOnInput` PASSED at displacement **1.283** (was **0.233**, one quantized tick, before the fix) and the score chain ran green on the same host that motivated the quarantine. Task 87 stays closed.
- **What reds is the death phase**: `playerFreedOnMobContact` — the parked player waits for a randomly-heading mob, 1-for-2 across runner outings. Choreography timing on a slow host, not a dispatch defect.

Per the lift's own instruction (re-quarantine rather than touch the gate): squash:chrome returns to quarantine with a reason naming **task 81's driver work** (make the death phase deterministic — steer into a mob instead of parking), with a dated `KANAMA-BLOCKED` marker in demos.sh + web.md. The movement gate and death check are unweakened; squash:firefox keeps gating and passing (death path included).

Validation: `bash -n` + sourced probe (chrome quarantined with the new reason, firefox empty), mkdocs strict green, stale-blocker audit PASS (markers 6→8 with the two new task-81 markers), shell lint PASS. The decisive gate is this PR's merge: the next main run must go green with squash:chrome reporting-not-failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)