### PR TITLE
Task 81 complete: thirdperson combat gated, squash death phase deterministic, tps retry

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,7 +51,7 @@ env:
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
   # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
-  DEMOS_REF: 5e0b606aeab5f41591371b1b4c663bd2fc582841
+  DEMOS_REF: c85b83ad7978d2ab0778131774404c4ace065cb5
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -439,15 +439,12 @@ Linux host (dodge passes on macOS, and `dodge:chrome` passes on Linux, so it is
 neither a browser nor a demo property). `squash:firefox` was lifted on
 2026-08-11 (the task-71 signature stopped reproducing there and the cell passes
 outright under the task-81 gameplay checks, death path included).
-<!-- KANAMA-BLOCKED(since:2026-08-12, task:81): the squash:chrome quarantine below -->
-`squash:chrome` is quarantined for its DEATH-PHASE choreography only: on the
-slow CI host the parked player is not reliably reached by a randomly-heading
-mob inside the driver's window (1-for-2 across runner outings). Its movement
-and score checks are green there — the task-87 lift's proof run measured
-displacement 1.283 (was 0.233 frame-quantized before the fix), so the fix is
-proven on that host and task 87 stays closed; the remaining fix is driver
-death-phase determinism (steer into a mob instead of parking), tracked under
-task 81's driver work.
+`squash:chrome` was lifted on 2026-08-12: its quarantine covered the
+death-phase choreography only (the parked player waited for a randomly-heading
+mob, 1-for-2 on the slow runner), and the driver now steers the player into a
+mob instead of parking — deterministic by construction, 3/3 Chrome + 3/3
+Firefox local repeats green; the runner-scale proof is the lifting PR's own CI
+plus the next main full-corpus run.
 
 ### Bumping The Demos Pin
 

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -3767,6 +3767,16 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
       "\t\t\t(value as RigidBody3D).apply_force(Vector3(force_parts[0], force_parts[1], force_parts[2]), Vector3(force_parts[3], force_parts[4], force_parts[5]))"
     )
     appendLine("\t\t\tresult = 1")
+    // Opcode 159 was in the contract (and the generated backend REQUIRES it in
+    // invokeVector3Vector3Arg's opcode set) since 60f, but this applier arm was never
+    // emitted: every Web RigidBody3D.apply_impulse threw "was not applied", and nothing
+    // noticed until task 81 fix #3 first drove a bot's damage() on Web.
+    appendLine("\t\telif opcode == 159 and value is RigidBody3D:")
+    appendLine("\t\t\tvar impulse_parts := String(args[2]).split_floats(\"\\u001f\")")
+    appendLine(
+      "\t\t\t(value as RigidBody3D).apply_impulse(Vector3(impulse_parts[0], impulse_parts[1], impulse_parts[2]), Vector3(impulse_parts[3], impulse_parts[4], impulse_parts[5]))"
+    )
+    appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 155 and value is CollisionObject3D:")
     appendLine("\t\t\tvar mask_parts := String(args[2]).split(\"\\u001f\")")
     appendLine(

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -334,6 +334,28 @@ class WebScriptCodeEmitterTest {
   }
 
   @Test
+  fun emitsRigidBodyImpulseQueryArmInEveryProxy() {
+    // Task 81 fix #3's found framework gap: opcode 159 (RigidBody3D.apply_impulse) was in
+    // the contract and the generated backend requires it (invokeVector3Vector3Arg's
+    // opcode set is {108, 154, 159}), but the applier arm was never emitted -- every Web
+    // apply_impulse threw "was not applied", and nothing noticed because no gate ever ran
+    // a bot's damage() on Web until the thirdperson combat port.
+    val proxy =
+      WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+
+    assertTrue(proxy.contains("elif opcode == 159 and value is RigidBody3D:"))
+    assertTrue(
+      proxy.contains(
+        "(value as RigidBody3D).apply_impulse(Vector3(impulse_parts[0], impulse_parts[1], " +
+          "impulse_parts[2]), Vector3(impulse_parts[3], impulse_parts[4], impulse_parts[5]))"
+      )
+    )
+  }
+
+  @Test
   fun emitsExactSceneTreeLifecycleCallsInEveryProxy() {
     val proxy =
       WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))

--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -177,18 +177,12 @@ kanama_web_quarantine_reason() {
     dodge:firefox)
       echo "task 71 — spawned mobs never free on a Linux host; dodge passes on macOS"
       ;;
-    # KANAMA-BLOCKED(since:2026-08-12, task:81): squash death-phase choreography is
-    # timing-flaky on the slow runner. The task-87 lift's proof run (main
-    # 31559892674) PROVED the movement fix on this exact host — playerMovedOnInput
-    # PASSED at displacement 1.283 (was 0.233 quantized), score chain green — but
-    # playerFreedOnMobContact failed: the parked player waits for a randomly-heading
-    # mob, and on this host it is 1-for-2 across runner outings. Do NOT reopen task
-    # 87 (its mechanism is fixed and measured here); the fix is driver death-phase
-    # determinism (steer into a mob instead of parking), tracked under task 81's
-    # driver work. squash:firefox stays LIFTED and passing, death path included.
-    squash:chrome)
-      echo "task 81 — squash death-phase choreography is timing-flaky on a slow host (movement + score PROVEN green here; see the 2026-08-12 marker above)"
-      ;;
+    # squash:chrome was quarantined 2026-08-12 for its death-phase choreography only
+    # (the parked player waited for a randomly-heading mob, 1-for-2 on the slow
+    # runner). Lifted the same day once the driver STEERS into a mob instead of
+    # parking (task 81 driver determinism): 3/3 chrome + 3/3 firefox local repeats
+    # green, death in 1-4 steer steps; the runner-scale proof is the lifting PR's
+    # own CI plus the next main full-corpus run.
     *) : ;;
   esac
 }

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -87,6 +87,19 @@ async function playerPosition(evaluate) {
   }
 }
 
+// A single op-138 read can come back null under host load (the page briefly busy or
+// mid-frame) -- observed as a one-shot flake in the kanama#170 validation. Retries are
+// BOUNDED and the caller's null handling is unchanged, so a position that STAYS
+// unreadable (dead bridge, freed player) still fails exactly as loudly as before.
+async function playerPositionRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const position = await playerPosition(evaluate);
+    if (position || attempt >= attempts) return position;
+    trace(`position read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 const keyExpression = (type, code, key, keyCode) => `(() => {
   const canvas = document.querySelector("canvas");
   canvas.focus();
@@ -162,7 +175,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   // itself consumes physics frames and must not eat into the movement window.
   await observe(evaluate, { ...seedFrom(ready), callbackErrors: 0 }, 2_000, deadline, null);
   const baseline = (await snapshot(evaluate)) ?? ready;
-  const startPosition = await playerPosition(evaluate);
+  const startPosition = await playerPositionRetry(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   trace(`start position: ${JSON.stringify(startPosition)}`);
 
@@ -177,7 +190,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
     (snap, p) => p.physicsCalls >= baseline.physicsCalls + 150,
   );
   await keyUp();
-  const runPosition = await playerPosition(evaluate);
+  const runPosition = await playerPositionRetry(evaluate);
   const peak = gameplay.peak;
   const atPeak = gameplay.last ?? ready;
   const displacement = runPosition

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -73,6 +73,19 @@ async function usedCells(evaluate) {
   }
 }
 
+// A single grid read can come back null under host load (the page briefly busy or
+// mid-frame) -- the same one-shot flake shape kanama#170's validation caught on the
+// op-138 position reads. Retries are BOUNDED and the caller's null handling is
+// unchanged, so a grid that STAYS unreadable still fails exactly as loudly as before.
+async function usedCellsRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const cells = await usedCells(evaluate);
+    if (cells || attempt >= attempts) return cells;
+    trace(`grid read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 // The selector's world position (opcode 138 on the Builder's selector property handle):
 // it lerps toward the mouse-ray cell every process tick.
 async function selectorPosition(evaluate) {
@@ -169,7 +182,7 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
     (snap) => snap.processCalls >= ready.processCalls + 30,
   );
   const baseline = settledStart.last ?? ready;
-  const baselineCells = await usedCells(evaluate);
+  const baselineCells = await usedCellsRetry(evaluate);
   if (!baselineCells) throw new Error("could not read the GridMap used cells");
   const selectorStart = await selectorPosition(evaluate);
   trace(`baseline: cells=${baselineCells.count} selector=${JSON.stringify(selectorStart)}`);

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -109,6 +109,19 @@ async function playerPosition(evaluate) {
   }
 }
 
+// A single op-138 read can come back null under host load (the page briefly busy or
+// mid-frame) -- observed as a one-shot flake in the kanama#170 validation. Retries are
+// BOUNDED and the caller's null handling is unchanged, so a position that STAYS
+// unreadable (dead bridge, freed player) still fails exactly as loudly as before.
+async function playerPositionRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const position = await playerPosition(evaluate);
+    if (position || attempt >= attempts) return position;
+    trace(`position read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 // SoundFootsteps is_playing through op 287 (child-path payload on the Player's handle).
 // Returns 1/0, or null when the page could not be asked.
 async function footstepsPlaying(evaluate) {
@@ -300,7 +313,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   // Fixed short holds released in page; NO early exit of any hold, and no physics-count
   // predicates (standing lore). The pulse LOOP stops once both movement and walking
   // audio have been evidenced, or after the pulse budget.
-  const startPosition = await playerPosition(evaluate);
+  const startPosition = await playerPositionRetry(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   let maxDisplacement = 0;
   let footstepsLiveDuringWalk = false;

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -73,6 +73,19 @@ async function playerPosition(evaluate) {
   }
 }
 
+// A single op-138 read can come back null under host load (the page briefly busy or
+// mid-frame) -- observed as a one-shot flake in the kanama#170 validation. Retries are
+// BOUNDED and the caller's null handling is unchanged, so a position that STAYS
+// unreadable (dead bridge, freed player) still fails exactly as loudly as before.
+async function playerPositionRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const position = await playerPosition(evaluate);
+    if (position || attempt >= attempts) return position;
+    trace(`position read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 async function observe(evaluate, seed, windowMs, deadline, predicate) {
   const peak = { ...seed };
   let last = null;
@@ -144,7 +157,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
     (snap) => snap.physicsCalls >= ready.physicsCalls + 30,
   );
   const baseline = resumed.last ?? ready;
-  const startPosition = await playerPosition(evaluate);
+  const startPosition = await playerPositionRetry(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
 
@@ -165,7 +178,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
     (snap, p) => snap.physicsCalls >= p.physicsCalls && snap.physicsCalls > baseline.physicsCalls + 120,
   );
   const measured = warm.last ?? baseline;
-  const measuredStart = await playerPosition(evaluate);
+  const measuredStart = await playerPositionRetry(evaluate);
 
   await keyDown();
   const gameplay = await observe(
@@ -176,7 +189,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
     null,
   );
   await keyUp();
-  const runPosition = await playerPosition(evaluate);
+  const runPosition = await playerPositionRetry(evaluate);
   const peak = gameplay.peak;
   const atPeak = gameplay.last ?? baseline;
   const measureFrom = measuredStart ?? startPosition;

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -17,9 +17,14 @@
 //      gravity close the gap; the landing is real -- slide-collision normal dot UP >
 //      0.1 -> Mob.squash -> squashed signal -> ScoreLabel -- and the score is read back
 //      through op 288 until the label reads "Score: 1"+,
-//   3. death: the player is parked at ground level; a mob reaching the MobDetector
-//      fires Player.die -> hit signal -> Main stops MobTimer + shows Retry, and the
-//      player script frees (liveScriptsByClass ".Player" drops to 0),
+//   3. death: the player is steered INTO the latest live mob at the mob's own height
+//      (the phase-2 chase step with a ground-level pin: beside the mob, not above it,
+//      so the contact is lateral and cannot read as a landing). The MobDetector
+//      overlap fires Player.die -> hit signal -> Main stops MobTimer + shows Retry,
+//      and the player script frees (liveScriptsByClass ".Player" drops to 0). Until
+//      task 81's determinism pass this phase PARKED the player at the arena center
+//      and waited for a randomly-heading mob -- 1-for-2 on the slow CI runner (the
+//      run that quarantined squash:chrome); steering removes the spawn-angle luck,
 //   4. teardown: SmokeQuit.smoke_teardown still drains every live handle to zero
 //      (SmokeQuit survives the player's free).
 //
@@ -27,7 +32,7 @@
 // KANAMA_WEB_T81_FALSIFY to induce exactly one break and watch its check go false --
 //   no-input  -> movement pulses skipped: playerMovedOnInput false
 //   no-chase  -> mob-drop choreography skipped: mobSquashScoredOnHud false
-//   no-death  -> ground park skipped (player stays pinned aloft): playerFreedOnMobContact false
+//   no-death  -> death steer skipped (player stays pinned aloft): playerFreedOnMobContact false
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
@@ -47,6 +52,16 @@ const AIR_ANCHOR = [0, 8, 0];
 // velocity), so the swept move_and_slide contacts the box top within a tick or two --
 // faster than a 10-18 u/s mob can slide out from under the pin.
 const DROP_HEIGHT = 1.25;
+// Lateral offset for the death steer: pin the player BESIDE the mob at the mob's own
+// y, never above it. Geometry (player.tscn/mob.tscn): the MobDetector's disc
+// (r=0.908, half-height 0.072) rides at player-root +1.06 and the mob's box spans its
+// root to ~+1.07, so two roots at the same y overlap the detector into the box top by
+// ~0.08 across the full disc radius -- the same contact that kills a legitimately
+// standing player. The 0.5 side step keeps the player's body sphere (r=0.79 at +0.77)
+// penetrating LESS laterally than it would vertically, so the depenetration normal
+// stays sideways and Player's slide-collision loop cannot read the contact as a
+// landing (normal-dot-UP > 0.1 would squash the mob instead of dying to it).
+const DEATH_SIDE_STEP = 0.5;
 // In-page hold per movement attempt; released in page so driver-transport jank can
 // never stretch a hold. The squash arena is walled (WorldBoundaryShape3D), so even a
 // free-running engine cannot carry the player anywhere dangerous.
@@ -137,8 +152,10 @@ async function playerPosition(evaluate) {
 // One squash-chase step, entirely in page so the mob read and the pin land inside one
 // event-loop turn: re-read the LATEST mob handle (it goes stale when a mob frees --
 // squashed or walked off -- so every access tolerates a throw), read its position, and
-// pin the player DROP_HEIGHT above it.
-async function chaseStep(evaluate) {
+// pin the player at the given offsets from it. Phase 2 pins DROP_HEIGHT above the mob
+// (a real landing squashes it); phase 3 pins BESIDE it at the mob's own y (see
+// DEATH_SIDE_STEP), forcing MobDetector contact that cannot read as a landing.
+async function chaseStep(evaluate, offsetX, offsetY) {
   try {
     return await evaluate(`(() => {
       const bridge = globalThis.KanamaWebBridge;
@@ -154,7 +171,7 @@ async function chaseStep(evaluate) {
       }
       const sep = String.fromCharCode(31);
       try {
-        bridge.immediateObjectQuery(142, bridge.squashPlayerHandle, [x, y + ${DROP_HEIGHT}, z].join(sep));
+        bridge.immediateObjectQuery(142, bridge.squashPlayerHandle, [x + ${offsetX}, y + ${offsetY}, z].join(sep));
       } catch {
         return { pinned: false, reason: "player-gone" };
       }
@@ -314,7 +331,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   if (FALSIFY !== "no-chase") {
     while (Date.now() < chaseDeadline) {
       chaseSteps += 1;
-      const step = await chaseStep(evaluate);
+      const step = await chaseStep(evaluate, 0, DROP_HEIGHT);
       await delay(70);
       const text = await scoreText(evaluate);
       if (text !== null) score = text;
@@ -339,24 +356,37 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   trace(`score: steps=${chaseSteps} label="${score}"`);
 
   // --- Phase 3: death path (task 81 part B, run AFTER the score attempt) -------------
-  // Park the player at ground level and let a mob reach the MobDetector. From here on
-  // the player handle is left alone: it frees itself.
+  // Steer the player INTO the latest live mob at the mob's own height: the phase-2
+  // chase step with a side-step pin instead of a drop (see DEATH_SIDE_STEP for the
+  // geometry). Re-pinned every poll, exactly like the chase, so a mob that frees
+  // mid-approach (walk-off, or a contact the engine resolved as a squash) is simply
+  // replaced by the next spawn -- MobTimer keeps spawning until the death itself stops
+  // it. The pre-determinism driver parked the player at the arena center instead and
+  // waited for a randomly-heading mob to wander in, which the slow CI runner proved to
+  // be a coin flip (the squash:chrome quarantine this steer lifts).
   let playerFreedOnMobContact = false;
+  let deathSteps = 0;
   if (FALSIFY !== "no-death") {
-    await pinPlayer(evaluate, [0, 0.1, 0]);
     const deathDeadline = Math.min(deadline, Date.now() + 30_000);
     while (Date.now() < deathDeadline) {
+      deathSteps += 1;
+      const step = await chaseStep(evaluate, DEATH_SIDE_STEP, 0);
+      await delay(150);
       const snap = await snapshot(evaluate);
       mergeSnap(state, snap);
       if (snap) {
-        trace(`death: playerLive=${snap.playerLive} mobs=${snap.mobLive} live=${snap.liveHandles}`);
+        if (DEBUG && step) {
+          trace(
+            `death#${deathSteps}: ${step.pinned ? `mob@(${step.mob.x.toFixed(1)},${step.mob.y.toFixed(1)},${step.mob.z.toFixed(1)})` : step.reason} playerLive=${snap.playerLive} mobs=${snap.mobLive} live=${snap.liveHandles}`,
+          );
+        }
         if (snap.playerLive === 0) {
           playerFreedOnMobContact = true;
           break;
         }
       }
-      await delay(200);
     }
+    trace(`death: steps=${deathSteps} freed=${playerFreedOnMobContact}`);
   } else {
     trace("FALSIFY=no-death: player kept pinned aloft");
     await pinPlayer(evaluate, AIR_ANCHOR);
@@ -421,8 +451,9 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
     // Task 81: a real landing squashed a mob and the score chain ran end to end
     // (slide-collision normal check -> Mob.squash -> squashed signal -> ScoreLabel).
     mobSquashScoredOnHud,
-    // Task 81: a mob reached the ground-level MobDetector, Player.die ran, and the
-    // player script freed -- the demo's lose path, previously dark on every gate.
+    // Task 81: steered mob contact fired the MobDetector, Player.die ran, and the
+    // player script freed -- the demo's lose path, driven DETERMINISTICALLY by the
+    // death steer (the park-and-wait predecessor hinged on spawn-angle luck).
     playerFreedOnMobContact,
     fullTeardownToZero: settled.liveHandles === 0,
     // Godot runs every physics tick before the idle/_process pass inside one rAF
@@ -458,6 +489,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
       scoreReported: mobSquashScoredOnHud ? Number.parseInt(score.slice("Score: ".length), 10) : 0,
       mobFrees: state.mobFrees,
       chaseSteps,
+      deathSteps,
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -364,6 +364,25 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   // it. The pre-determinism driver parked the player at the arena center instead and
   // waited for a randomly-heading mob to wander in, which the slow CI runner proved to
   // be a coin flip (the squash:chrome quarantine this steer lifts).
+  // The spawn/free evidence (mobsInstantiated, mobsSpawnAndFree) must settle BEFORE the
+  // death steer: the death stops the MobTimer through Main._on_player_hit, so a steer
+  // that connects in its first seconds -- measured 3 steps / ~1 s on a free-running
+  // engine -- would cap mobInstantiations below the long-standing thresholds forever.
+  // The player waits ALOFT for the whole window (re-pinned every poll, the same hold the
+  // no-death falsification uses) so no wandering mob can end the run early.
+  const evidenceDeadline = Math.min(deadline, Date.now() + 15_000);
+  while (
+    Date.now() < evidenceDeadline &&
+    !(state.peak.mobInstantiations >= 4 && state.mobFrees >= 2)
+  ) {
+    await pinPlayer(evaluate, AIR_ANCHOR);
+    mergeSnap(state, await snapshot(evaluate));
+    await delay(200);
+  }
+  trace(
+    `evidence: mobs=${state.peak.mobInstantiations} frees=${state.mobFrees} playerLive=${state.last?.playerLive}`,
+  );
+
   let playerFreedOnMobContact = false;
   let deathSteps = 0;
   if (FALSIFY !== "no-death") {
@@ -390,20 +409,6 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   } else {
     trace("FALSIFY=no-death: player kept pinned aloft");
     await pinPlayer(evaluate, AIR_ANCHOR);
-  }
-
-  // Let any remaining self-driven evidence (spawns, walk-off frees) settle briefly if
-  // the long-standing thresholds have not been reached yet.
-  const evidenceDeadline = Math.min(deadline, Date.now() + 10_000);
-  while (
-    Date.now() < evidenceDeadline &&
-    !(state.peak.mobInstantiations >= 4 && state.mobFrees >= 2)
-  ) {
-    // The no-death falsification must hold the player OUT of harm's way for the whole
-    // settle window, or a wandering mob would kill it anyway and un-falsify the check.
-    if (FALSIFY === "no-death") await pinPlayer(evaluate, AIR_ANCHOR);
-    mergeSnap(state, await snapshot(evaluate));
-    await delay(200);
   }
   const peak = state.peak;
   const atPeak = state.last ?? ready;

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -5,11 +5,21 @@
 // SmokeQuit.smoke_resume (method#1) to press through, then holds move_up via the trusted
 // per-engine key transport and PROVES movement by reading the player's global position
 // through the bridge's immediate Vector3 channel (opcode 138). Enemy AI is self-evidencing
-// while the world runs (beetle-bot navigation, bee-bot bobbing). smoke_teardown (method#2)
-// releases the scene caches and frees the root, draining every live handle to zero.
+// while the world runs (beetle-bot navigation, bee-bot bobbing). COMBAT is driven next
+// (task 81 fix #3): SmokeQuit.smoke_combat (method#3) ports the desktop smoke's two
+// damage(Vector3, Vector3) calls -- the FPS damage bug's sibling shape -- onto the scene's
+// own bee and beetle, and the driver asserts both deaths (liveScriptsByClass decrement on
+// the death coroutine's free, the fps.mjs pattern) while the exercised-member census gates
+// the BeeBot.damage/BeetleBot.damage dispatches. smoke_teardown (method#2) releases the
+// scene caches and frees the root, draining every live handle to zero.
+//
+// Falsification (task 81 requires every gate provably able to fail): set
+// KANAMA_WEB_T81_FALSIFY=no-combat to skip the smoke_combat dispatch and watch
+// botsKilledByDamageCall go false (and the census gate fail naming both damage members).
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+const FALSIFY = process.env.KANAMA_WEB_T81_FALSIFY ?? "";
 const START = Date.now();
 const trace = (msg) => {
   if (DEBUG) process.stderr.write(`[thirdperson ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
@@ -22,6 +32,10 @@ async function snapshot(evaluate) {
       if (!bridge) return null;
       const classCount = (suffix) => {
         const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
+        return entry?.[1] ?? 0;
+      };
+      const liveCount = (suffix) => {
+        const entry = Object.entries(bridge.liveScriptsByClass ?? {}).find(([n]) => n.endsWith(suffix));
         return entry?.[1] ?? 0;
       };
       return {
@@ -38,6 +52,10 @@ async function snapshot(evaluate) {
         beeReady: classCount(".BeeBot"),
         beetleReady: classCount(".BeetleBot"),
         boxReady: classCount(".Box"),
+        // LIVE, not cumulative: decrements on the _exit_tree free, which is what lets
+        // the combat gate see a damaged bot actually die (the fps.mjs enemyLive pattern).
+        beeLive: liveCount(".BeeBot"),
+        beetleLive: liveCount(".BeetleBot"),
         smokeQuitReady: classCount(".SmokeQuit"),
         physicsCalls: bridge.physicsProcessCalls ?? 0,
         // Task 84: real _process dispatches. This demo has no mode branch in the
@@ -200,6 +218,48 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     : 0;
   trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
 
+  // --- Combat: the desktop smoke's damage routines, ported (task 81 fix #3) ---------
+  //
+  // SmokeQuit.smoke_combat (method#3) calls damage(Vector3, Vector3) on the scene's own
+  // bee and beetle through Object.call -- the same boundary crossing Bullet/Grenade/
+  // MeleeAttackArea combat uses, and the registered-method shape that killed the whole
+  // combat system silently (the FPS damage bug's sibling; the desktop SmokeQuit tested
+  // it, the Web path never did). The bots' death coroutines queue_free them ~2 SIMULATED
+  // seconds later (smoke puff awaited, coin burst zeroed by the smoke method), so the
+  // assertion is the EFFECT: each live script count drops below its pre-combat value.
+  // The exercised-member census independently gates the BeeBot.damage/BeetleBot.damage
+  // dispatches (scripts/web/required_members.json).
+  const combatBefore = (await snapshot(evaluate)) ?? atPeak;
+  const beesBefore = combatBefore.beeLive ?? 0;
+  const beetlesBefore = combatBefore.beetleLive ?? 0;
+  let beesAfter = beesBefore;
+  let beetlesAfter = beetlesBefore;
+  if (FALSIFY !== "no-combat") {
+    trace(`smoke_combat: bees=${beesBefore} beetles=${beetlesBefore}`);
+    await evaluate(
+      "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpSmokeQuitHandle, 3); true",
+    );
+    const combatDeadline = Math.min(deadline, Date.now() + 30_000);
+    while (Date.now() < combatDeadline) {
+      const snap = await snapshot(evaluate);
+      if (snap) {
+        beesAfter = snap.beeLive;
+        beetlesAfter = snap.beetleLive;
+        peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
+        peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
+        peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
+        peak.crossings = Math.max(peak.crossings, snap.crossings);
+        peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+        trace(`combat: bees=${snap.beeLive} beetles=${snap.beetleLive} errs=${snap.callbackErrors}`);
+        if (snap.beeLive < beesBefore && snap.beetleLive < beetlesBefore) break;
+      }
+      await delay(200);
+    }
+    trace(`combat done: bees=${beesAfter}/${beesBefore} beetles=${beetlesAfter}/${beetlesBefore}`);
+  } else {
+    trace("FALSIFY=no-combat: smoke_combat not dispatched");
+  }
+
   // Full teardown: smoke_teardown (method#2) releases the scene caches and frees the
   // root; every node exits the tree and releases its handles.
   trace("smoke_teardown");
@@ -226,6 +286,14 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     bootPausedThenResumed: ready.physicsCalls === 0 && baseline.physicsCalls > 0,
     // Synthetic move_up displaced the player through the camera-relative controller.
     playerMovedOnInput: displacement > 1.0,
+    // Task 81 fix #3: smoke_combat's damage(Vector3, Vector3) calls killed a bee AND a
+    // beetle -- both death coroutines freed their scripts. Before this port the shape
+    // was driver-invoked zero times on Web while the desktop smoke tested it twice.
+    botsKilledByDamageCall:
+      beesBefore >= 1 &&
+      beetlesBefore >= 1 &&
+      beesAfter < beesBefore &&
+      beetlesAfter < beetlesBefore,
     physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
     // MEASURED 2026-08-10 (macOS arm64, Chrome 151 headless, protocol 18, task 84): the
     // gameplay window applies ~680 commands over its baseline, so +80 keeps an 8x margin
@@ -270,6 +338,10 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
       appliedCommands: peak.appliedCommands,
       processCalls: settled.processCalls,
       playerDisplacement: Number(displacement.toFixed(3)),
+      beesBeforeCombat: beesBefore,
+      beesAfterCombat: beesAfter,
+      beetlesBeforeCombat: beetlesBefore,
+      beetlesAfterCombat: beetlesAfter,
     },
     callbacks: {
       pendingSignalCallbacks: settled.callbacks,

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -2,16 +2,18 @@
 // Web smoke.
 //
 // The demo boots PAUSED behind its instructions page: the driver first dispatches
-// SmokeQuit.smoke_resume (method#1) to press through, then holds move_up via the trusted
-// per-engine key transport and PROVES movement by reading the player's global position
-// through the bridge's immediate Vector3 channel (opcode 138). Enemy AI is self-evidencing
-// while the world runs (beetle-bot navigation, bee-bot bobbing). COMBAT is driven next
-// (task 81 fix #3): SmokeQuit.smoke_combat (method#3) ports the desktop smoke's two
-// damage(Vector3, Vector3) calls -- the FPS damage bug's sibling shape -- onto the scene's
-// own bee and beetle, and the driver asserts both deaths (liveScriptsByClass decrement on
-// the death coroutine's free, the fps.mjs pattern) while the exercised-member census gates
-// the BeeBot.damage/BeetleBot.damage dispatches. smoke_teardown (method#2) releases the
-// scene caches and frees the root, draining every live handle to zero.
+// SmokeQuit.smoke_resume (method#1) to press through. COMBAT runs next (task 81 fix #3):
+// SmokeQuit.smoke_combat (method#3) ports the desktop smoke's two damage(Vector3, Vector3)
+// calls -- the FPS damage bug's sibling shape -- onto the scene's own near bee and beetle,
+// and the driver asserts both deaths (liveScriptsByClass decrement on the death
+// coroutine's free, the fps.mjs pattern) while the exercised-member census gates the
+// BeeBot.damage/BeetleBot.damage dispatches. Combat runs BEFORE movement on purpose: see
+// the ORDER IS LOAD-BEARING note at the combat phase. Then the driver holds move_up via
+// the trusted per-engine transport and PROVES movement by reading the player's global
+// position through the bridge's immediate Vector3 channel (opcode 138); remaining enemy
+// AI is self-evidencing while the world runs (far bots navigate and bob). smoke_teardown
+// (method#2) releases the scene caches and frees the root, draining every live handle to
+// zero.
 //
 // Falsification (task 81 requires every gate provably able to fail): set
 // KANAMA_WEB_T81_FALSIFY=no-combat to skip the smoke_combat dispatch and watch
@@ -194,34 +196,12 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     (snap) => snap.physicsCalls >= pausedBefore + 30,
   );
   const baseline = resumed.last ?? ready;
-  const startPosition = await playerPositionRetry(evaluate);
-  if (!startPosition) throw new Error("could not read the player's global position");
-  trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
+  trace(`resumed: physics=${baseline.physicsCalls}`);
 
-  // Hold move_up for a FIXED wall-time (no early exit: the tick rate races past any
-  // physics-count predicate before the first observe sample, cutting the hold short —
-  // played sessions with a fixed 3s hold consistently cover ~8 units).
-  await keyDown();
-  const gameplay = await observe(
-    evaluate,
-    { ...seedFrom(baseline), callbackErrors: 0 },
-    3_000,
-    deadline,
-    null,
-  );
-  await keyUp();
-  const runPosition = await playerPositionRetry(evaluate);
-  const peak = gameplay.peak;
-  const atPeak = gameplay.last ?? baseline;
-  const displacement = runPosition
-    ? Math.hypot(runPosition.x - startPosition.x, runPosition.z - startPosition.z)
-    : 0;
-  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
-
-  // --- Combat: the desktop smoke's damage routines, ported (task 81 fix #3) ---------
+  // --- Combat FIRST: the desktop smoke's damage routines, ported (task 81 fix #3) ----
   //
   // SmokeQuit.smoke_combat (method#3) calls damage(Vector3, Vector3) on the scene's own
-  // bee and beetle through Object.call -- the same boundary crossing Bullet/Grenade/
+  // near bee and beetle through Object.call -- the same boundary crossing Bullet/Grenade/
   // MeleeAttackArea combat uses, and the registered-method shape that killed the whole
   // combat system silently (the FPS damage bug's sibling; the desktop SmokeQuit tested
   // it, the Web path never did). The bots' death coroutines queue_free them ~2 SIMULATED
@@ -229,11 +209,23 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   // assertion is the EFFECT: each live script count drops below its pre-combat value.
   // The exercised-member census independently gates the BeeBot.damage/BeetleBot.damage
   // dispatches (scripts/web/required_members.json).
-  const combatBefore = (await snapshot(evaluate)) ?? atPeak;
-  const beesBefore = combatBefore.beeLive ?? 0;
-  const beetlesBefore = combatBefore.beetleLive ?? 0;
+  //
+  // ORDER IS LOAD-BEARING (MEASURED 2026-08-12): run the combat BEFORE the movement
+  // hold. Moving first walks the player into GroundEnemy's detection range, the beetle
+  // chases and lands an attack ~1 s after the hold ends, and its collider.call("damage")
+  // into the PLAYER reaches the coin-spill -> CoinsContainer tween, whose NUMBER final
+  // value is the known Web Tween.tween_property gap (task 57e backlog / task 81
+  // confirmed break #3) -- a FATAL boundary failure that then stops every later
+  // dispatch, including the combat calls this phase exists to make. Killing the near
+  // bots first removes the only AI that can reach the driver's path, and the movement
+  // baseline is re-snapshotted AFTER the deaths so the movement-window thresholds stay
+  // measured against movement alone (a bound met partly by combat traffic proves
+  // nothing).
+  const beesBefore = baseline.beeLive ?? 0;
+  const beetlesBefore = baseline.beetleLive ?? 0;
   let beesAfter = beesBefore;
   let beetlesAfter = beetlesBefore;
+  let combatErrors = 0;
   if (FALSIFY !== "no-combat") {
     trace(`smoke_combat: bees=${beesBefore} beetles=${beetlesBefore}`);
     await evaluate(
@@ -245,11 +237,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
       if (snap) {
         beesAfter = snap.beeLive;
         beetlesAfter = snap.beetleLive;
-        peak.physicsCalls = Math.max(peak.physicsCalls, snap.physicsCalls);
-        peak.appliedCommands = Math.max(peak.appliedCommands, snap.appliedCommands);
-        peak.maxLiveHandles = Math.max(peak.maxLiveHandles, snap.maxLiveHandles);
-        peak.crossings = Math.max(peak.crossings, snap.crossings);
-        peak.callbackErrors = Math.max(peak.callbackErrors, snap.callbackErrors);
+        combatErrors = Math.max(combatErrors, snap.callbackErrors);
         trace(`combat: bees=${snap.beeLive} beetles=${snap.beetleLive} errs=${snap.callbackErrors}`);
         if (snap.beeLive < beesBefore && snap.beetleLive < beetlesBefore) break;
       }
@@ -259,6 +247,33 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   } else {
     trace("FALSIFY=no-combat: smoke_combat not dispatched");
   }
+
+  // Movement baseline AFTER the combat settles, so the movement-window thresholds
+  // measure the movement window alone.
+  const moveBaseline = (await snapshot(evaluate)) ?? baseline;
+  const startPosition = await playerPositionRetry(evaluate);
+  if (!startPosition) throw new Error("could not read the player's global position");
+  trace(`move baseline: physics=${moveBaseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
+
+  // Hold move_up for a FIXED wall-time (no early exit: the tick rate races past any
+  // physics-count predicate before the first observe sample, cutting the hold short —
+  // played sessions with a fixed 3s hold consistently cover ~8 units).
+  await keyDown();
+  const gameplay = await observe(
+    evaluate,
+    { ...seedFrom(moveBaseline), callbackErrors: combatErrors },
+    3_000,
+    deadline,
+    null,
+  );
+  await keyUp();
+  const runPosition = await playerPositionRetry(evaluate);
+  const peak = gameplay.peak;
+  const atPeak = gameplay.last ?? moveBaseline;
+  const displacement = runPosition
+    ? Math.hypot(runPosition.x - startPosition.x, runPosition.z - startPosition.z)
+    : 0;
+  trace(`ran: displacement=${displacement.toFixed(2)} physics=${peak.physicsCalls} live=${atPeak.liveHandles}`);
 
   // Full teardown: smoke_teardown (method#2) releases the scene caches and frees the
   // root; every node exits the tree and releases its handles.
@@ -294,15 +309,15 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
       beetlesBefore >= 1 &&
       beesAfter < beesBefore &&
       beetlesAfter < beetlesBefore,
-    physicsFramesAdvanced: peak.physicsCalls >= baseline.physicsCalls + 40,
+    physicsFramesAdvanced: peak.physicsCalls >= moveBaseline.physicsCalls + 40,
     // MEASURED 2026-08-10 (macOS arm64, Chrome 151 headless, protocol 18, task 84): the
     // gameplay window applies ~680 commands over its baseline, so +80 keeps an 8x margin
     // on the REAL _process path. The threshold is unchanged and was NOT re-derived from
     // the pre-84 runs, which were inflated by the benchmark's synthetic per-dispatch
     // scalar mutation -- a lower bound met partly by scaffolding proves nothing, so it
     // had to be re-measured even though the number stayed put.
-    gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands + 80,
-    crossingsAdvanced: peak.crossings > baseline.crossings,
+    gameplayCommandsApplied: peak.appliedCommands > moveBaseline.appliedCommands + 80,
+    crossingsAdvanced: peak.crossings > moveBaseline.crossings,
     // Task 84: this demo runs the engine's REAL `_process`, not the transport benchmark.
     // MEASURED 793 (Chrome) / 7405 (Firefox) process dispatches; it was exactly 0 on both
     // before the fix. Asserted as > 0 rather than a magnitude because the count tracks the

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -78,6 +78,19 @@ async function playerPosition(evaluate) {
   }
 }
 
+// A single op-138 read can come back null under host load (the page briefly busy or
+// mid-frame) -- observed as a one-shot flake in the kanama#170 validation. Retries are
+// BOUNDED and the caller's null handling is unchanged, so a position that STAYS
+// unreadable (dead bridge, freed player) still fails exactly as loudly as before.
+async function playerPositionRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const position = await playerPosition(evaluate);
+    if (position || attempt >= attempts) return position;
+    trace(`position read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 async function observe(evaluate, seed, windowMs, deadline, predicate) {
   const peak = { ...seed };
   let last = null;
@@ -163,7 +176,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     (snap) => snap.physicsCalls >= pausedBefore + 30,
   );
   const baseline = resumed.last ?? ready;
-  const startPosition = await playerPosition(evaluate);
+  const startPosition = await playerPositionRetry(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   trace(`resumed: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
 
@@ -179,7 +192,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     null,
   );
   await keyUp();
-  const runPosition = await playerPosition(evaluate);
+  const runPosition = await playerPositionRetry(evaluate);
   const peak = gameplay.peak;
   const atPeak = gameplay.last ?? baseline;
   const displacement = runPosition

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -76,6 +76,19 @@ async function playerPosition(evaluate) {
   }
 }
 
+// A single op-138 read can come back null under host load (the page briefly busy or
+// mid-frame) -- observed as a one-shot flake in the kanama#170 validation. Retries are
+// BOUNDED and the caller's null handling is unchanged, so a position that STAYS
+// unreadable (dead bridge, freed player) still fails exactly as loudly as before.
+async function playerPositionRetry(evaluate, attempts = 5) {
+  for (let attempt = 1; ; attempt += 1) {
+    const position = await playerPosition(evaluate);
+    if (position || attempt >= attempts) return position;
+    trace(`position read null (attempt ${attempt}/${attempts}); retrying`);
+    await delay(250);
+  }
+}
+
 function seedFrom(snap) {
   return {
     processCalls: snap.processCalls,
@@ -185,7 +198,7 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
     (snap) => snap.physicsCalls >= level.physicsCalls + 120,
   );
   const baseline = settled.last ?? level;
-  const startPosition = await playerPosition(evaluate);
+  const startPosition = await playerPositionRetry(evaluate);
   if (!startPosition) throw new Error("could not read the player's global position");
   trace(`settled: physics=${baseline.physicsCalls} start=${JSON.stringify(startPosition)}`);
 
@@ -200,7 +213,7 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
     null,
   );
   await action(87, "move_forward");
-  const runPosition = await playerPosition(evaluate);
+  const runPosition = await playerPositionRetry(evaluate);
   const peak = gameplay.peak;
   const atPeak = gameplay.last ?? baseline;
   const displacement = runPosition

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -203,11 +203,28 @@
       ]
     },
     "thirdperson": {
-      "required": [],
-      "todo": [
+      "required": [
+        {
+          "member": "SmokeQuit.smoke_combat",
+          "reason": "The driver's combat entry (method#3): dispatches the desktop smoke's ported damage routines. If this stops crossing, the two damage members below lose their driver."
+        },
         {
           "member": "BeeBot.damage",
-          "reason": "Task 81 fix #3: the desktop SmokeQuit calls damage twice; the Web driver never does. The (VECTOR3, VECTOR3) damage shape is the FPS bug's sibling -- port the desktop smoke routines, then require BeeBot/BeetleBot/Box.damage here."
+          "reason": "Task 81 fix #3: the (VECTOR3, VECTOR3) registered-method shape, the FPS damage bug's sibling -- the desktop SmokeQuit tested it, the Web path dispatched it zero times until smoke_combat. Measured on chrome AND firefox envelopes 2026-08-12; KANAMA_WEB_T81_FALSIFY=no-combat suppresses exactly this."
+        },
+        {
+          "member": "BeetleBot.damage",
+          "reason": "The second desktop damage routine (kotlin-src/SmokeQuit.kt:267 sibling), same shape and evidence as BeeBot.damage; the driver additionally asserts both death frees via liveScriptsByClass."
+        }
+      ],
+      "todo": [
+        {
+          "member": "Box.damage",
+          "reason": "Same (VECTOR3, VECTOR3) shape, but no driver choreography destroys a box yet (the desktop smoke does not call it either); the grenade/bullet paths that reach it are ranked gaps #8/#9 in the task-81 spec."
+        },
+        {
+          "member": "Player.damage",
+          "reason": "Boundary-crossing (BeetleBot attack / bee Bullet both reach it via collider.call) but currently FAULTS on Web when it lands: the coin-spill -> CoinsContainer tween passes a NUMBER to Tween.tween_property, the known gap (task 57e backlog / task 81 confirmed break #3). MEASURED 2026-08-12: a beetle attack landing during an extended thirdperson run fatals the boundary (why the driver runs combat BEFORE movement). Require only after the tween number arm lands."
         }
       ]
     },

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -1113,6 +1113,22 @@
       this.tweenCallbacks.delete(handle);
       this.noArgsVector3Callbacks.delete(handle);
       this.handleOwners.delete(handle);
+      // A spawned SCRIPTED child is deliberately routed through its instantiator (the
+      // immediatePackedSceneInstantiate re-point; task-60h/#125 separated routing from
+      // lifetime) -- but that routing had no story for the instantiator dying FIRST.
+      // MEASURED (task 81 fix #3, 2026-08-12, thirdperson): a BeeBot's death coroutine
+      // spawns a SmokePuff and queue_frees the bee; the puff's own later self
+      // queue_free (opcode 15, its animation-finished coroutine) then grouped under the
+      // dead bee's owner entry and flushGroup threw "callback is not installed", a
+      // fatal that stopped every later dispatch. When the dying proxy clears, re-point
+      // every child that carries its OWN installed callbacks at itself -- such a child
+      // is a live scripted proxy that can apply its own commands. Children WITHOUT
+      // callbacks are plain acquired handles and keep the existing release-sweep path.
+      for (const [child, owner] of this.handleOwners) {
+        if (owner === handle && child !== handle && this.applyCallbacks.has(child)) {
+          this.handleOwners.set(child, child);
+        }
+      }
     },
     ownerForHandle(handle) {
       const owner = this.handleOwners.get(handle);


### PR DESCRIPTION
Task 81's last driver-determinism parcel: the thirdperson combat port is gated on both engines, squash's death phase is deterministic (quarantine lifted), and the one-shot position reads have bounded retries. Two real Web-runtime defects were found and fixed on the way — both had been unreachable by every gate until this parcel first drove the code, which is task 81's thesis in one PR.

**Pairs with kanama-demos#36 (https://github.com/falcon4ever/kanama-demos/pull/36) — merge ordering: the demos PR merges FIRST, then `DEMOS_REF` in `.github/workflows/web.yml` is bumped to its merge commit (standing pattern, cf. #133/#149; the bump can land as this PR's last commit or as the usual follow-up pin PR). This PR's thirdperson driver dispatches `SmokeQuit.smoke_combat` (method#3), which only exists in that demos PR.** The PR-subset CI here (match3/web3d/dodge) is demos-independent and green either way; the thirdperson required-members rows make the next full-corpus run on main depend on the pin.

## What changed

### A. thirdperson combat port (task 81 fix #3)
- `scripts/web/drivers/demos/thirdperson.mjs`: dispatches `SmokeQuit.smoke_combat` (method#3, demos PR) which calls `damage(Vector3, Vector3)` — the FPS `damage` bug's sibling shape — on the scene's own near bee and beetle via `Object.call`; asserts BOTH deaths via `liveScriptsByClass` decrement (`botsKilledByDamageCall`, the fps.mjs pattern). Combat runs BEFORE the movement hold — order is load-bearing and MEASURED (see below).
- `scripts/web/required_members.json`: thirdperson promotes `BeeBot.damage`, `BeetleBot.damage` (+ their driver `SmokeQuit.smoke_combat`) from todo to required — each confirmed against a measured envelope on BOTH engines first. New honest todo rows: `Box.damage` (no driver destroys a box yet) and `Player.damage` (crosses the boundary but currently FAULTS when a hit lands — see finding 3).
- **Found + fixed 1 — opcode 159 applier arm was never emitted** (`WebScriptCodeEmitter.kt` + test): `RigidBody3D.apply_impulse` has been in the contract and the generated backend's required opcode set (`invokeVector3Vector3Arg` = {108, 154, 159}) since 60f, but the GDScript applier arm did not exist — every Web `apply_impulse` threw `was not applied`, fatally. First reachable when this parcel first dispatched a bot's `damage()` on Web.
- **Found + fixed 2 — spawner-first death stranded a spawned script's routing** (`kanama-web-bridge.js` `clearProxyCallbacks`): the `immediatePackedSceneInstantiate` re-point (the #125 routing/lifetime split) had no story for the instantiator dying first. MEASURED: the bee's death coroutine spawns a SmokePuff; after the bee freed, the puff's own self `queue_free` (diagnosed via a patched export bridge copy: opcode=15, receiver=65600) grouped under the dead bee (owner=65584) and `flushGroup` threw — a fatal that stopped all later dispatch. Fix: when a proxy clears, children carrying their OWN installed callbacks are re-pointed at themselves. The loud throw stays.
- **Finding 3 (recorded, not fixed here)**: `Player.damage` landing on Web reaches the coin-spill → `CoinsContainer` tween with a NUMBER final value — the known `Tween.tween_property` gap (task 57e backlog / task 81 confirmed break #3) — and FATALS the run. This is why combat runs before movement (moving first walks the player into GroundEnemy's aggro; its attack ~1 s later killed run 1). Recorded as a `Player.damage` todo row; requires the tween number arm to lift.

### B. squash death-phase determinism + quarantine lift
- `scripts/web/drivers/demos/squash.mjs`: phase 3 no longer parks the player and waits for a randomly-heading mob (1-for-2 on the slow runner — the `squash:chrome` quarantine). It steers the player INTO the latest live mob using the phase-2 chase step with a ground-level side-step pin (`DEATH_SIDE_STEP` — geometry from player.tscn/mob.tscn cited in the comment: lateral contact cannot read as a landing, and the MobDetector disc overlaps the mob box by construction). The spawn/free evidence window moved BEFORE the death phase because the steer kills fast enough to stop the MobTimer under the long-standing `mobsInstantiated >= 4` threshold (measured; thresholds unchanged). `no-death` falsification unchanged; `deathSteps` reported in the envelope.
- `scripts/web/demos.sh` + `docs/exporting/web.md`: `squash:chrome` quarantine lifted with its `KANAMA-BLOCKED(task:81)` markers (`audit_stale_blockers.py` PASS after removal). Runner-scale proof, per the established caveat wording: **this PR's own CI plus the next main full-corpus run** — the local proof is 3/3 Chrome + 3/3 Firefox repeats, death in 1–4 steer steps.

### C. bounded retry on one-shot reads
- `tpsdemo.mjs` raised on a single null op-138 position read (one-shot flake seen twice in the #170 validation under host load). All phase-boundary single-shot reads now retry bounded (5 × 250 ms) with the caller's null handling preserved — the raise still raises after exhaustion, displacement checks still fail — applied uniformly to tpsdemo, thirdperson, platformer, charactercontroller, racing (position) and citybuilder (the raising GridMap baseline read). In-loop polls keep single reads (their loops already retry). The retry did NOT trigger in any local run (no host load); the `position read null (attempt n/5); retrying` trace line is the observable when it does.

## Validation (RAN / EXPECTED / MEASURED)

1. **Statics** — RAN: `cd scripts/web && npm ci && npx eslint .` (clean, re-run after final edit); `scripts/check_shell_lint.sh` (0); `python3 scripts/audit_stale_blockers.py` (PASS markers=6 tokens=6 after the lift); `./gradlew ktfmtFormat` + `ktfmtCheck` (0, emitter + test touched); `mkdocs build --strict` (0); `:processor:test` WebScriptCodeEmitterTest (BUILD SUCCESSFUL, new arm test included). EXPECTED: all green. MEASURED: all green (final sweep re-run below).
2. **thirdperson × chrome + firefox** — EXPECTED: wrapper PASS, `botsKilledByDamageCall` true, censuses carry the promoted members. MEASURED: `web_export_smoke: PASS -- thirdperson on chrome` (tp-chrome-5: bees 3→2, beetles 4→3, census `BeeBot.damage=1`, `BeetleBot.damage=1`, `SmokeQuit.smoke_combat=1`, teardown to zero) and `web_export_smoke: PASS -- thirdperson on firefox` (tp-firefox-1: same members, same deltas).
3. **squash repeats** — EXPECTED: ≥3 green per engine on the final driver. MEASURED: chrome 3/3 `web_export_smoke: PASS` (death steps 4/4/1; evidence mobs 9/9/8, frees 2) + firefox 3/3 PASS (death steps 1/1/1). One earlier chrome run failed BEFORE the evidence-window reorder (`mobsInstantiated` 3<4 — the steer killed too fast); that failure motivated the reorder and is part of the record. On the FINAL branch tip (after the emitter/bridge commits): squash chrome PASS inside the full-corpus run + a 4th firefox PASS against the corpus-built export (death steps 4, score 1) — so both engines are green on exactly the code under review.
4. **Falsification** — EXPECTED: `KANAMA_WEB_T81_FALSIFY=no-combat` fails exactly the new check AND the census gate by name. MEASURED: run FAILED with `botsKilledByDamageCall` the only false check, and `result_schema.py`: `required registered member(s) did not run: SmokeQuit.smoke_combat …; BeeBot.damage …; BeetleBot.damage …`. The death-phase check's no-death falsification was proven in #164 and its hook is unchanged.
5. **tpsdemo × chrome** — EXPECTED: PASS with the retry in place. MEASURED: `web_export_smoke: PASS -- tpsdemo on chrome` (inside the full-corpus run, freshly exported at the branch tip). The retry never TRIGGERED locally (no host load, all reads succeeded first attempt — reported honestly); when it does, the `position read null (attempt n/5); retrying` trace is the observable, and exhaustion still raises.
6. **Full corpus × chrome; sentinels × firefox** — EXPECTED: 13/13 (12 demos + spike) chrome; sentinels PASS. MEASURED: `web_ci_matrix.sh --demo-set full --engine chrome` (demos = the paired branch) → **13/13 PASS, gate pass=true, skipped=[]** — first full-corpus contact with the squash:chrome lift, the thirdperson required members, the 159 arm and the bridge re-point all live at once. Sentinels: `PASS -- fps on firefox` + `PASS -- platformer on firefox` (+ the squash firefox pass above), all against the corpus-built exports.
7. **Demos desktop smoke (thirdperson)** — RAN: import + headless run with `KANAMA_DEMO_SMOKE_QUIT=1` from the paired demos branch. MEASURED: exit 0 / exit 0, no hard-error patterns (desktop untouched by the demos PR's code change, which is Web-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
