### PR TITLE
thirdperson driver: 120s bounded combat window for slow-host death pacing

### DIFF
--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -231,7 +231,15 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
     await evaluate(
       "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.tpSmokeQuitHandle, 3); true",
     );
-    const combatDeadline = Math.min(deadline, Date.now() + 30_000);
+    // Window MEASURED both ways (2026-08-12): healthy hosts break out in 1-3s, but the
+    // first gated runner outing (main 31623511177) showed damage DISPATCHED (census
+    // BeeBot.damage/BeetleBot.damage = 1) with neither live count dropping in 30s wall --
+    // the death sequence (coroutine + smoke-puff await) appears paced by RENDERED frames,
+    // and that runner's software-GL Chrome renders ~1-2 fps. 120s bounds the wait without
+    // weakening the check (it still requires both real deaths); if this window ever proves
+    // insufficient there, plan B is demos-side: the smoke_combat path shortens the
+    // cosmetic death delay, and the pacing question gets the task-74 histogram recipe.
+    const combatDeadline = Math.min(deadline, Date.now() + 120_000);
     while (Date.now() < combatDeadline) {
       const snap = await snapshot(evaluate);
       if (snap) {


### PR DESCRIPTION
Main run 31623511177 (the #172 proof run) went red on `thirdperson:chrome` only: `botsKilledByDamageCall` false while the census PROVES both damage dispatches ran on that host (`BeeBot.damage: 1`, `BeetleBot.damage: 1`) and squash passed both engines while gating. The bots' death sequence (~2 simulated seconds: coroutine + smoke-puff await) appears paced by RENDERED frames, and the runner's software-GL Chrome renders ~1-2 fps — 30s of wall was too short exactly there and nowhere else.

Fix: the bounded kill-detection window goes 30s → 120s with the measured rationale in place. Healthy hosts break out in seconds, so the cost on green runs is zero; the check itself is unweakened — both real deaths are still required. Plan B if the runner still overruns: shorten the cosmetic death delay in the demos-side smoke_combat path and settle the pacing question with the task-74 histogram recipe.

## Validation (corrected — see the comment below)

- eslint clean.
- thirdperson × chrome, fresh protocol-18 export built from the demos tree AT the merged demos#36 pin: `web_export_smoke: PASS` (combat broke out of the window in seconds; 0.23 crossings/tick within budget).
- An earlier body of this PR claimed a local PASS that had actually FAILED — that failure was a stale local demos WORKING TREE (fetched but never advanced past demos#35, so the export lacked `smoke_combat` and the driver's method-#3 call faulted). Not a code defect; the runner is immune (it builds at the DEMOS_REF pin). Corrected here rather than overwritten silently.

The decisive gate is the post-merge main run on the slow runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)