### PR TITLE
Web player-publish package: packageWebExport + itch/static-host guide + size gates (60i shape C, first half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ versioning once public releases begin.
 
 ### Added
 
+- **Web exports package into a publishable artifact.**
+  `:web-runtime:packageWebExport -PkanamaWebDemo=<demo>` zips an already-built,
+  smoke-validated Web export (index.html at the zip root, deterministic
+  `kanama-web-<demo>-v<version>.zip` name) after gating it: stale-export
+  refusal (demo/protocol/buildId cross-checks against
+  `kanama-web/export-report.json`), itch.io's HTML5 defaults (500 MB / 1000
+  files, measured output printed either way, tps-demo named as the documented
+  638 MB exception), and a byte-level no-local-paths scan.
+  `scripts/web_package_smoke.sh` proves the artifact is the game by unzipping
+  it to a scratch directory and driving that copy through the full export
+  smoke. Publishing guidance (itch.io via butler, generic static-HTTPS
+  hosting, why the nothreads export needs no COOP/COEP) is in
+  `docs/exporting/web.md` under "Publishing A Web Export". The Web backend's
+  status is unchanged: it remains Experimental.
 - **Exported desktop games can be built for another platform.** `./gradlew
   jlinkGameRuntimeCross -PkanamaRuntimeTarget=windows-x64` produces the bundled
   JVM runtime for a target other than the host, so a developer on macOS can ship

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -245,6 +245,85 @@ pass 13/13 of its own checks and still be rejected by the schema (which is what
 enforces `liveAfterTeardown === 0` and the required-member census), and that is
 exactly how one demo stayed un-gated on every engine for weeks.
 
+## Publishing A Web Export
+
+`packageWebExport` turns an already-built, smoke-validated export into a
+publishable zip. It never builds or refreshes an export — a missing or stale
+one (wrong demo, wrong protocol version, a report that no longer matches the
+served bytes) fails loudly, so the artifact is always the export you
+validated:
+
+```sh
+./gradlew --no-daemon -Pkotlin.compiler.execution.strategy=in-process \
+  :web-runtime:packageWebExport -PkanamaWebDemo=match3
+```
+
+The zip lands in
+`web-runtime/build/distributions/kanama-web-<demo>-v<version>.zip` with
+`index.html` at the zip root. Before zipping, the gate:
+
+- quotes the export's `buildId` and protocol version from
+  `kanama-web/export-report.json` and rejects a stale export;
+- checks the payload against **itch.io's HTML5 defaults — at most 500 MB and
+  1000 files** — printing the measured size and file count either way; and
+- scans every served byte for workstation-absolute paths with
+  `scripts/web/check_no_local_paths.py`, the fresh-checkout gate's scanner.
+
+Validate the artifact itself — not the export directory it came from — before
+uploading. `web_package_smoke.sh` unzips the artifact to a scratch directory,
+serves that copy, and drives it through the full export smoke:
+
+```sh
+scripts/web_package_smoke.sh \
+  --zip web-runtime/build/distributions/kanama-web-match3-v<version>.zip \
+  --demo match3 --engine chrome --result /tmp/match3-package.json
+```
+
+Read the inner `web_export_smoke: PASS` line, as always.
+
+### itch.io
+
+Upload the zip with [butler](https://itch.io/docs/butler/) (it unpacks zips
+server-side; the channel name marks the upload as HTML5):
+
+```sh
+butler push web-runtime/build/distributions/kanama-web-<demo>-v<version>.zip \
+  <user>/<game>:html5
+```
+
+Then on the project's edit page, confirm the upload is set to **"This file
+will be played in the browser"**. Leave the SharedArrayBuffer support toggle
+**off**: exports use the `web_nothreads` template, so they need no
+cross-origin isolation and no COOP/COEP headers (see
+[Renderer And Thread Constraints](#renderer-and-thread-constraints)). That is
+also why itch.io-style hosting works at all — it serves games over HTTPS from
+a subpath inside an iframe, and the nothreads export is compatible with
+exactly that shape.
+
+### Any Static HTTPS Host
+
+Any static file host works if it serves two things:
+
+- **HTTPS.** Godot's Web export requires a secure context — `127.0.0.1` is
+  one, a plain-HTTP LAN or internet address is not, and the engine never
+  starts without one (the same constraint as
+  [Testing On A Phone Or Tablet](#testing-on-a-phone-or-tablet)).
+- A correct `application/wasm` MIME type for `.wasm` files.
+
+No COOP/COEP headers, no special subpath handling, and no server-side code
+are needed: unzip the artifact into any directory the host serves.
+
+### The tps-demo Exception
+
+tps-demo serves ~638 MB (570 MB of upstream demo assets in `index.pck`) and
+exceeds the itch.io defaults; `packageWebExport` fails it by name rather than
+producing an artifact nobody could upload. This is the same known exception
+recorded in `scripts/web/budgets.json` — shrinking it is asset work in the
+demo, not a packaging concern.
+
+Publishing changes nothing about the backend's status: Web remains
+Experimental, and exporting a game still requires a Kanama source checkout.
+
 ## Browser Matrix
 
 `web_ci_matrix.sh` is the corpus-wide gate: it exports each demo and drives it in

--- a/scripts/web_package_smoke.sh
+++ b/scripts/web_package_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# web_package_smoke.sh -- prove a packaged Web export zip IS the game.
+#
+# `packageWebExport` gates and zips an already-validated export, but a zip that
+# was gated is still only a zip: the proof that it is complete and servable is
+# serving THE UNZIPPED ARTIFACT and driving it like any export. This wrapper
+# unzips the artifact into a scratch directory, asserts the unzip produced a
+# non-empty tree rooted at index.html (an empty unzip passing vacuously is the
+# "two empty dirs diff identical" trap), then hands that copy to
+# scripts/web_export_smoke.sh -- which serves it with scripts/web/serve_export.py
+# and runs the full driver + envelope-schema gate. Read the inner
+# `web_export_smoke: PASS` line; this wrapper only adds the unzip step.
+#
+# Usage:
+#   scripts/web_package_smoke.sh \
+#       --zip <web-runtime/build/distributions/kanama-web-<demo>-v<version>.zip> \
+#       --demo <demo key, as passed to packageWebExport> \
+#       --engine <chrome|firefox|safari> \
+#       --result <result.json> \
+#       [--timeout <seconds>] \
+#       [--keep-dir]              # preserve the scratch dir for diagnosis
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ZIP=""
+DEMO=""
+ENGINE=""
+RESULT=""
+TIMEOUT=""
+KEEP_DIR=0
+
+die() {
+  echo "web_package_smoke: $*" >&2
+  exit 2
+}
+
+usage() {
+  sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --zip) ZIP="${2:?}"; shift 2 ;;
+    --demo) DEMO="${2:?}"; shift 2 ;;
+    --engine) ENGINE="${2:?}"; shift 2 ;;
+    --result) RESULT="${2:?}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?}"; shift 2 ;;
+    --keep-dir) KEEP_DIR=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$ZIP" ]] || die "--zip is required"
+[[ -n "$DEMO" ]] || die "--demo is required"
+[[ -n "$ENGINE" ]] || die "--engine is required"
+[[ -n "$RESULT" ]] || die "--result is required"
+[[ -f "$ZIP" ]] || die "zip not found: $ZIP (run :web-runtime:packageWebExport first)"
+ZIP="$(cd "$(dirname "$ZIP")" && pwd)/$(basename "$ZIP")"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/kanama-web-package.XXXXXX")"
+cleanup() {
+  if [[ "$KEEP_DIR" -eq 1 ]]; then
+    echo "web_package_smoke: scratch dir preserved at $SCRATCH"
+  else
+    rm -rf "$SCRATCH"
+  fi
+}
+trap cleanup EXIT
+
+EXPORT_COPY="$SCRATCH/export"
+mkdir -p "$EXPORT_COPY"
+unzip -q "$ZIP" -d "$EXPORT_COPY"
+
+# Anti-vacuous assertions: a non-zero file count AND the path used, printed,
+# before believing anything downstream.
+FILE_COUNT="$(find "$EXPORT_COPY" -type f | wc -l | tr -d ' ')"
+[[ "$FILE_COUNT" -gt 0 ]] || die "unzip of $ZIP produced no files at $EXPORT_COPY"
+[[ -f "$EXPORT_COPY/index.html" ]] || \
+  die "unzip of $ZIP has no index.html at the zip root ($EXPORT_COPY) -- itch.io requires it there"
+echo "web_package_smoke: unzipped $ZIP -> $EXPORT_COPY ($FILE_COUNT files)"
+
+# The full export smoke against the UNZIPPED COPY: it serves the copy with
+# scripts/web/serve_export.py, drives the demo in a real browser, and gates the
+# result envelope. A PASS here is the completeness proof for the zip.
+"$ROOT_DIR/scripts/web_export_smoke.sh" \
+  --engine "$ENGINE" \
+  --export-dir "$EXPORT_COPY" \
+  --demo "$DEMO" \
+  --result "$RESULT" \
+  ${TIMEOUT:+--timeout "$TIMEOUT"}
+
+echo "web_package_smoke: PASS -- $ZIP served and driven as $DEMO on $ENGINE ($RESULT)"

--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
+import java.util.zip.ZipFile
 
 plugins {
     kotlin("multiplatform")
@@ -2908,6 +2909,224 @@ tasks.register<Exec>("exportWeb") {
         logger.lifecycle(
             "[kanama:web] exportWeb produced $demo export ($totalBytes bytes, protocol " +
                 "$protocolVersion, buildId $buildId) at $exportDir"
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 60i, shape C (first half) -- the player-publish package.
+//
+// `packageWebExport` zips an ALREADY-BUILT `web-runtime/build/web-export/<demo>`
+// into the artifact a finished game uploads to itch.io or any static HTTPS
+// host. It deliberately never builds or refreshes an export: the artifact must
+// be the export that was smoke-validated, so a missing or stale export is a
+// loud failure (the stale-export trap), never a rebuild trigger. The spike
+// benchmark is not a game and has no publish shape; only demo keys package.
+//
+// The gates mirror what a publish host enforces:
+//   - itch.io's HTML5 defaults: at most 500 MB and at most 1000 files, served
+//     from a subpath in an iframe over HTTPS (recorded in the 60i decision).
+//     tps-demo (638 MB) is the documented exception and fails here BY NAME.
+//   - zero workstation-absolute paths in any served byte, via the same scanner
+//     the fresh-checkout gate uses (scripts/web/check_no_local_paths.py).
+//   - freshness: the export's protocol must match the current generated
+//     protocol descriptor, its buildId must match the served entry scripts,
+//     and its report must name the requested demo.
+//
+// Docs: docs/exporting/web.md, "Publishing A Web Export". Validate the zip
+// itself with scripts/web_package_smoke.sh before uploading.
+
+val webPackagePublishLimitBytes = 500L * 1000L * 1000L // itch.io HTML5 default (500 MB)
+val webPackagePublishLimitFiles = 1000 // itch.io HTML5 default
+
+// Shared by the pre-zip gate and the post-zip belt-and-braces check.
+fun readExportReportField(report: File, key: String): String {
+    val match = Regex("\"$key\"\\s*:\\s*\"?([^\",\\n]+)\"?").find(report.readText())
+    return match?.groupValues?.get(1)
+        ?: error("export-report.json at $report has no \"$key\" field")
+}
+
+tasks.register("verifyWebExportForPackaging") {
+    group = "distribution"
+    description =
+        "Gates an already-built Web export (-PkanamaWebDemo) against the publish limits " +
+            "(itch.io HTML5 defaults), the stale-export checks, and the no-local-paths scan."
+    doLast {
+        val demo = webDemo.get()
+        stageTaskFor(demo) // key validation only: an unknown demo key fails with the canonical message
+
+        val exportDir = webExportRoot.get().dir(demo).asFile
+        check(exportDir.isDirectory) {
+            "No Web export to package at $exportDir. packageWebExport never builds one -- " +
+                "run :web-runtime:exportWeb -PkanamaWebDemo=$demo (and smoke it) first."
+        }
+        val servedFiles = exportDir.walkTopDown().filter { it.isFile }.toList()
+        check(servedFiles.isNotEmpty()) {
+            "Web export at $exportDir contains no files -- stale or interrupted export."
+        }
+        check(exportDir.resolve("index.html").isFile) {
+            "Web export at $exportDir has no index.html -- stale or interrupted export."
+        }
+
+        val report = exportDir.resolve("kanama-web/export-report.json")
+        check(report.isFile) {
+            "Web export at $exportDir has no kanama-web/export-report.json -- re-run exportWeb; " +
+                "packaging refuses a directory it cannot identify."
+        }
+        val reportDemo = readExportReportField(report, "demo")
+        val reportBuildId = readExportReportField(report, "buildId")
+        val reportProtocol = readExportReportField(report, "protocolVersion").toInt()
+        check(reportDemo == demo) {
+            "Stale export: $exportDir reports demo \"$reportDemo\" but -PkanamaWebDemo=$demo " +
+                "was requested -- the directory holds a different demo's export."
+        }
+
+        // Freshness against the repository: the export must carry the protocol the
+        // current generated descriptor declares. Without the generated web scripts
+        // there is no reference to judge freshness against -- that is a failure,
+        // not a skip (a gate that silently skips is no gate).
+        val protocolFile = webProxyResources.get().file("KanamaWebProtocol.generated.json").asFile
+        check(protocolFile.isFile) {
+            "Cannot judge export freshness: no generated protocol descriptor at $protocolFile. " +
+                "Run :web-runtime:buildWebScripts so the export can be checked against the " +
+                "current protocol."
+        }
+        val currentProtocol = readProtocolVersion()
+        check(reportProtocol == currentProtocol) {
+            "Stale export: $exportDir was built at protocol $reportProtocol but the current " +
+                "generated protocol is $currentProtocol -- re-run exportWeb before packaging."
+        }
+
+        // Freshness of the report itself: the buildId is derived from the two entry
+        // scripts, so a mismatch means the report describes different bytes than
+        // the directory serves (a half-rebuilt or hand-edited export).
+        val spikeLoader = exportDir.resolve("kanama-web-spike.js")
+        val bridge = exportDir.resolve("kanama-web-bridge.js")
+        check(spikeLoader.isFile && bridge.isFile) {
+            "Web export at $exportDir is missing its entry scripts (kanama-web-spike.js / " +
+                "kanama-web-bridge.js) -- stale or interrupted export."
+        }
+        val actualBuildId =
+            MessageDigest.getInstance("SHA-256").let { digest ->
+                digest.update(spikeLoader.readBytes())
+                digest.update(bridge.readBytes())
+                digest.digest().joinToString("") { "%02x".format(it) }.substring(0, 16)
+            }
+        check(actualBuildId == reportBuildId) {
+            "Stale export: export-report.json buildId $reportBuildId does not match the served " +
+                "entry scripts (computed $actualBuildId) -- re-run exportWeb before packaging."
+        }
+
+        // The publish limits (itch.io HTML5 defaults). The measured numbers are
+        // printed pass or fail, so the gate line is always the record.
+        val fileCount = servedFiles.size
+        val totalBytes = servedFiles.sumOf { it.length() }
+        val measured =
+            "%d files, %.1f MB (limits: %d files, %.0f MB)".format(
+                fileCount,
+                totalBytes / 1_000_000.0,
+                webPackagePublishLimitFiles,
+                webPackagePublishLimitBytes / 1_000_000.0,
+            )
+        logger.lifecycle(
+            "[kanama:web] packageWebExport gate: $demo at $exportDir -- $measured, " +
+                "buildId $reportBuildId, protocol $reportProtocol"
+        )
+        if (fileCount > webPackagePublishLimitFiles) {
+            throw GradleException(
+                "Web export $demo exceeds the itch.io HTML5 default file-count limit: $measured. " +
+                    "A payload over these defaults has no player-publish path."
+            )
+        }
+        if (totalBytes > webPackagePublishLimitBytes) {
+            val exception =
+                if (demo == "tpsdemo") {
+                    " tps-demo is the DOCUMENTED exception: it serves ~638 MB (570 MB of " +
+                        "upstream demo assets in index.pck), over the itch.io defaults by " +
+                        "design -- see docs/exporting/web.md (Publishing A Web Export) and " +
+                        "the known exception recorded in scripts/web/budgets.json. It has " +
+                        "no player-publish artifact at this size; shrinking it is demo " +
+                        "asset work, not a packaging concern."
+                } else {
+                    " A payload over these defaults has no player-publish path."
+                }
+            throw GradleException(
+                "Web export $demo exceeds the itch.io HTML5 default size limit: $measured.$exception"
+            )
+        }
+
+        // A published artifact must carry zero workstation paths in ANY served
+        // byte. Same scanner as the fresh-checkout gate (task 60g / W3): the repo
+        // checkout covers the build/staging trees, the home directory covers
+        // everything else this machine could leak (demos checkout, Gradle home).
+        logger.lifecycle("[kanama:web] packageWebExport gate: scanning $exportDir for local paths")
+        val scanProcess =
+            ProcessBuilder(
+                    "python3",
+                    rootProject.file("scripts/web/check_no_local_paths.py").absolutePath,
+                    exportDir.absolutePath,
+                    "--forbid",
+                    rootProject.projectDir.absolutePath,
+                    "--forbid",
+                    System.getProperty("user.home"),
+                )
+                .redirectErrorStream(true)
+                .start()
+        val scanOutput = scanProcess.inputStream.bufferedReader().readText().trim()
+        val scanExit = scanProcess.waitFor()
+        scanOutput.lines().forEach { logger.lifecycle("  $it") }
+        check(scanExit == 0) {
+            "check_no_local_paths failed for $exportDir (exit $scanExit) -- a published " +
+                "artifact must carry zero workstation paths; see the scanner output above."
+        }
+    }
+}
+
+tasks.register<Zip>("packageWebExport") {
+    group = "distribution"
+    description =
+        "Zips an already-built, gate-validated Web export (-PkanamaWebDemo) into the " +
+            "publishable player artifact (docs/exporting/web.md, Publishing A Web Export)."
+    dependsOn("verifyWebExportForPackaging")
+    archiveFileName.set(webDemo.map { "kanama-web-$it-v${project.version}.zip" })
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+    // The export's files sit at the ZIP ROOT -- itch.io requires index.html there.
+    from(webDemo.map { webExportRoot.get().dir(it) })
+
+    doLast {
+        val demo = webDemo.get()
+        val zipFile = archiveFile.get().asFile
+        // Belt and braces on the artifact itself: the content gate ran pre-zip,
+        // so re-assert the zip is non-empty, index.html-rooted, and inside the
+        // limits (a zip is smaller than its contents, so these cannot newly fail
+        // unless the packaging itself broke).
+        val entryNames =
+            ZipFile(zipFile).use { zip ->
+                zip.entries().asSequence().filter { !it.isDirectory }.map { it.name }.toList()
+            }
+        check(entryNames.isNotEmpty()) { "Packaged Web export $zipFile has no entries" }
+        check("index.html" in entryNames) {
+            "Packaged Web export $zipFile does not carry index.html at the zip root"
+        }
+        check(entryNames.size <= webPackagePublishLimitFiles) {
+            "Packaged Web export $zipFile carries ${entryNames.size} files, over the itch.io " +
+                "HTML5 default of $webPackagePublishLimitFiles"
+        }
+        check(zipFile.length() <= webPackagePublishLimitBytes) {
+            "Packaged Web export $zipFile is ${zipFile.length()} bytes, over the itch.io " +
+                "HTML5 default of $webPackagePublishLimitBytes"
+        }
+        val report = webExportRoot.get().dir(demo).asFile.resolve("kanama-web/export-report.json")
+        logger.lifecycle(
+            "[kanama:web] packageWebExport produced $zipFile -- ${entryNames.size} files, " +
+                "%.1f MB zipped, buildId %s, protocol %s".format(
+                    zipFile.length() / 1_000_000.0,
+                    readExportReportField(report, "buildId"),
+                    readExportReportField(report, "protocolVersion"),
+                )
         )
     }
 }


### PR DESCRIPTION
Implements the first half of the 60i package decision (shape C, decided 2026-08-11): a player-publish package for finished Web games. This closes the "no distribution path" half of the Web Supported bar. **The Supported flip itself is NOT in this PR** — it remains a post-4.8 maintainer wording pass, after the forced 4.8 revalidation covers this package. No support wording changes anywhere: Web stays Experimental.

## Per-layer changes

- **`web-runtime/build.gradle.kts`** — `verifyWebExportForPackaging` + `packageWebExport` (Zip, `distribution` group, same conventions as `packageDesktopKit`: reproducible order, no timestamps, deterministic `kanama-web-<demo>-v<version>.zip` name, `index.html` at the zip root as itch.io requires). The task **never builds an export** — it packages the export you smoke-validated, so a missing or stale one is a loud failure, not a rebuild trigger. Gates, in order: export exists + non-zero file count + `index.html`; `kanama-web/export-report.json` present, its `demo` matches the requested key, its protocol matches the **current generated descriptor** (the stale-export trap as a named failure class), its buildId matches a recomputed hash of the served entry scripts; itch.io HTML5 defaults (≤500 MB / ≤1000 files) with the measured numbers printed pass or fail; and the byte-level `scripts/web/check_no_local_paths.py` scan (the fresh-checkout gate's scanner) forbidding the repo checkout and `$HOME`. tps-demo over the size limit fails **by name** with the documented 638 MB exception. Post-zip belt-and-braces re-asserts the artifact (non-empty, index.html-rooted, inside limits) and prints the zipped size + buildId/protocol.
- **`scripts/web_package_smoke.sh`** — proves the artifact IS the game: unzips to a scratch dir, asserts a non-empty index.html-rooted tree (anti-vacuous: prints count + path), then drives the **unzipped copy** through `scripts/web_export_smoke.sh` (which serves it with `scripts/web/serve_export.py` and applies the full driver + envelope-schema gates). Shellcheck-clean, covered by `check_shell_lint.sh`'s existing glob.
- **`docs/exporting/web.md`** — new §Publishing A Web Export: the package invocation and its gates, the artifact-validation step, itch.io upload (butler push, the "played in the browser" setting, why the nothreads export needs **no** SharedArrayBuffer/COOP-COEP toggles and is exactly the subpath-iframe-HTTPS shape itch serves), generic static-HTTPS hosting (secure-context requirement, cross-linked to the phone-testing rationale; `application/wasm` MIME), and the tps-demo exception. Ends by stating the status is unchanged: Experimental, source-checkout export.
- **`CHANGELOG.md`** — Unreleased entry.

## Validation matrix (RAN / EXPECTED / MEASURED)

1. **Statics** — RAN `scripts/check_shell_lint.sh` → `PASS files=26 severity=warning shellcheck=0.11.0` (includes the new script); RAN `python3 scripts/audit_stale_blockers.py` → `PASS markers=6 tokens=6 skipped=0`; RAN `mkdocs build --strict` → exit 0, §Publishing A Web Export renders and both intra-page anchor targets exist in the built page. NOT RUN (with reason): eslint — no driver JS touched; ktfmt — no Kotlin touched (`*.gradle.kts` is excluded from ktfmt by policy).
2. **packageWebExport on a fresh web3d export** — RAN `exportWeb -PkanamaWebDemo=web3d` then `packageWebExport -PkanamaWebDemo=web3d`. EXPECTED a gated zip. MEASURED: gate line `web3d ... 12 files, 40.5 MB (limits: 1000 files, 500 MB), buildId 6b0822cfdeb90c22, protocol 18`; scanner `check_no_local_paths: OK`; artifact `kanama-web-web3d-v0.4.0.zip -- 12 files, 10.6 MB zipped, buildId 6b0822cfdeb90c22, protocol 18`.
3. **Both directions for every gate** (synthetics under `web-runtime/build/web-export/`, built to pass all earlier gates so the target gate is the one observed; the real web3d export verified untouched afterward):
   - missing export (`-PkanamaWebDemo=dodge`, none built): FAILED, `No Web export to package at ...` (exit 1).
   - file count (synthetic, 1009 files): gate printed `1009 files, 0.0 MB (limits: 1000 files, 500 MB)`, FAILED with `exceeds the itch.io HTML5 default file-count limit`.
   - size (synthetic, 501.0 MB): gate printed `5 files, 501.0 MB`, FAILED with `exceeds the itch.io HTML5 default size limit`.
   - local paths (path injected into a **copy** of the real export, never the real one): FAILED, scanner quoted `index.html: embeds '/Users/lmuller/dev/kanama/.claude/worktrees/webpkg' at byte 3478`.
   - bonus, stale-export demo mismatch (real web3d copy under the `fps` key): FAILED, `reports demo "web3d" but -PkanamaWebDemo=fps`.
   - pass direction for all gates = the real web3d run in (2).
4. **tps exception path** — SIMULATED the 638 MB case (synthetic `tpsdemo` export, 638.0 MB; the real tps export is the documented local-only tier). EXPECTED a loud failure naming the exception. MEASURED: gate printed `5 files, 638.0 MB (limits: 1000 files, 500 MB)`, then `tps-demo is the DOCUMENTED exception: it serves ~638 MB (570 MB of upstream demo assets in index.pck) ... no player-publish artifact at this size`.
5. **Unzip → serve → smoke on the real artifact** — RAN `scripts/web_package_smoke.sh --zip .../kanama-web-web3d-v0.4.0.zip --demo web3d --engine chrome`. EXPECTED the wrapper PASS line on the unzipped copy. MEASURED: `unzipped ... (12 files)`; `web_export_smoke: PASS -- web3d on chrome` (chrome 151.0.0.0 vs floor 130; payload 40.5MB, startup 2614ms, 0.74 crossings/tick); envelope `pass: true`, `liveAfterTeardown: 0`, 0 console errors; then `web_package_smoke: PASS`.
6. **mkdocs strict** — green (see 1); the new section and its TOC anchor are present in `site/exporting/web/index.html`.

## Notes

- The 60g constraint stands: there is still no runtime-only *developer* package for Web (shape B, post-4.8, its own task). This artifact packages a **finished game's export**, which sidesteps that constraint entirely.
- The Supported flip remains a post-4.8 maintainer wording pass (60i §Package shape options); nothing in this PR widens a support claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
