### PR TITLE
Task 88: flush the command buffer at every Web boundary that runs user Kotlin

### DIFF
--- a/scripts/check_web_callback_flush.py
+++ b/scripts/check_web_callback_flush.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Every Web callback boundary that runs user Kotlin must flush the command buffer.
+
+Task 88. The three `kanamaWebDispatchSignal*` entry points ran a user lambda and
+returned WITHOUT `commands.flush()`, while every sibling boundary flushed. Because the
+next per-frame entry point opens with `commands.clear()` -- a pure discard, not a flush
+-- every QUEUED_MUTATION issued from a Kotlin lambda signal callback was silently
+thrown away. `kanamaWebCallInt` had the same gap.
+
+Nothing could see it. The exercised-member census records the callback as *dispatched*,
+so the gate went green while the whole effect was discarded; it only ever surfaced as
+unexplained symptoms in manual play-testing ("charactercontroller: the eyes never
+blink" -- `Timer.start` is a QUEUED_MUTATION and was the sole statement in that lambda).
+
+The rule this enforces: a boundary that dispatches into user script code must end its
+`webCallbackBoundary` block with `commands.flush()`. A callback that happens to end on
+an IMMEDIATE_RESULT call is rescued by accident (immediate arms flush first) -- that
+accident is exactly why this survived so long, so it does not count as compliance.
+
+Usage:
+    python3 scripts/check_web_callback_flush.py [--main <path to Main.kt>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_MAIN = Path("web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt")
+
+# A boundary "runs user Kotlin" if its body invokes one of these dispatch entry points.
+# Property accessors are deliberately NOT in this set -- see EXEMPT_PREFIXES below.
+USER_DISPATCH_CALLS = (
+    "KanamaWebProjectRegistry.call",
+    "KanamaWebProjectRegistry.ready",
+    "KanamaWebProjectRegistry.enterTree",
+    "KanamaWebProjectRegistry.exitTree",
+    "KanamaWebProjectRegistry.process",
+    "KanamaWebProjectRegistry.physicsProcess",
+    "KanamaWebProjectRegistry.input",
+    "KanamaWebProjectRegistry.unhandledInput",
+    "KanamaWebProjectRegistry.draw",
+    "WebSignalCallbackRegistry.dispatch",
+)
+
+# Boundaries that dispatch into user code but legitimately do not flush `commands`.
+# Each entry must carry a reason; an unexplained exemption is the thing this gate exists
+# to prevent.
+EXEMPTIONS = {
+    # _draw owns a SEPARATE buffer (drawCommands) with its own clear/flush pair, and its
+    # return value IS that buffer's applied count. Flushing `commands` here would be
+    # unrelated work on the draw path.
+    "kanamaWebDraw": "uses the dedicated drawCommands buffer (own clear/flush)",
+}
+
+# Property get/set boundaries assign fields rather than run user method bodies, and the
+# create/ready sequence that pushes them flushes afterwards. They are out of scope for
+# this gate BY NAME so that a future dispatch-style boundary cannot hide behind the
+# same exemption. Revisit if @ScriptProperty ever accepts custom setter bodies.
+EXEMPT_PREFIXES = ("kanamaWebGet", "kanamaWebSet")
+
+FLUSH = "commands.flush()"
+
+
+def boundaries(source: str) -> list[tuple[str, int, str]]:
+    """Return (name, 1-based line, body) for every top-level kanamaWeb* function."""
+    lines = source.split("\n")
+    found: list[tuple[str, int, str]] = []
+    for index, line in enumerate(lines):
+        match = re.match(r"fun (kanamaWeb\w+)\(", line)
+        if not match:
+            continue
+        cursor = index + 1
+        body: list[str] = []
+        while cursor < len(lines) and not re.match(r"(@JsExport|fun kanamaWeb)", lines[cursor]):
+            body.append(lines[cursor])
+            cursor += 1
+        found.append((match.group(1), index + 1, "\n".join(body)))
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main", type=Path, default=DEFAULT_MAIN)
+    args = parser.parse_args()
+
+    path = args.main
+    if not path.is_file():
+        print(f"check_web_callback_flush: FAIL — Main.kt not found at {path}", file=sys.stderr)
+        return 1
+
+    source = path.read_text()
+    found = boundaries(source)
+
+    # Assert a non-empty extraction before believing any result: a parser that silently
+    # matches nothing would report a clean bill of health for a broken file.
+    if not found:
+        print(
+            f"check_web_callback_flush: FAIL — parsed 0 kanamaWeb* boundaries from {path}; "
+            "the extraction pattern no longer matches the source",
+            file=sys.stderr,
+        )
+        return 1
+
+    checked = 0
+    violations: list[str] = []
+    for name, line, body in found:
+        if "webCallbackBoundary" not in body:
+            continue
+        if not any(call in body for call in USER_DISPATCH_CALLS):
+            continue
+        if name.startswith(EXEMPT_PREFIXES):
+            continue
+        if name in EXEMPTIONS:
+            continue
+        checked += 1
+        if FLUSH not in body:
+            violations.append(
+                f"  {path}:{line}  {name} dispatches into user Kotlin but never calls "
+                f"{FLUSH}; every queued mutation it issues is discarded by the next "
+                f"commands.clear()"
+            )
+
+    if not checked:
+        print(
+            "check_web_callback_flush: FAIL — matched 0 user-dispatch boundaries; the "
+            "USER_DISPATCH_CALLS table has drifted from the source",
+            file=sys.stderr,
+        )
+        return 1
+
+    if violations:
+        print(
+            f"check_web_callback_flush: FAIL — {len(violations)} boundary/boundaries run "
+            f"user Kotlin without flushing the command buffer:",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(violation, file=sys.stderr)
+        print(
+            "\nAdd `commands.flush()` as the last statement of the webCallbackBoundary "
+            "block. Do NOT rely on the callback ending with an immediate call — that "
+            "rescue is accidental and shape-dependent (task 88).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check_web_callback_flush: OK — {checked} user-dispatch boundaries all flush "
+        f"({len(EXEMPTIONS)} documented exemption(s), parsed {len(found)} kanamaWeb* "
+        f"functions from {path})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -237,6 +237,10 @@ python3 "$ROOT_DIR/scripts/check_gdextension_modernization.py"
 stage "native call surface prewarm audit"
 python3 "$ROOT_DIR/scripts/check_native_call_surface.py"
 
+stage "web callback flush audit"
+python3 "$ROOT_DIR/scripts/check_web_callback_flush.py" --main \
+  "$ROOT_DIR/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt"
+
 stage "vararg ptrcall audit"
 python3 "$ROOT_DIR/scripts/audit_vararg_ptrcalls.py"
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -430,8 +430,13 @@ fun kanamaWebCallString(objectId: Int, methodId: Int, value: String): Int {
 @JsExport
 fun kanamaWebCallInt(objectId: Int, methodId: Int, value: Int): Int {
   return webCallbackBoundary(objectId, "registered_function", "method", methodId) { record ->
-    KanamaWebProjectRegistry.callLong(record.scriptId, methodId, record.script, value.toLong())
-      .toInt()
+    val result =
+      KanamaWebProjectRegistry.callLong(record.scriptId, methodId, record.script, value.toLong())
+    // Task 88: same missing flush as the signal boundaries — its siblings callNoArgs and
+    // callLongVoid both flush, this one did not, so a user's `fun f(x: Long): Long` lost
+    // every mutation it queued.
+    commands.flush()
+    result.toInt()
   }
 }
 
@@ -606,6 +611,13 @@ fun kanamaWebMatch3Group6CancellationProbe(objectId: Int): Int {
 fun kanamaWebDispatchSignal0(objectId: Int, callbackId: Int): Int {
   return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch0") {
     WebSignalCallbackRegistry.dispatch(objectId, callbackId)
+    // Task 88: a boundary that runs user Kotlin MUST flush before returning. Signal lambdas
+    // did not, and the next per-frame entry point opens with `commands.clear()` — a pure
+    // discard — so every queued mutation issued from a lambda callback was thrown away.
+    // It survived only when an IMMEDIATE_RESULT call happened to follow the last mutation
+    // (immediate arms flush first), which is why cc's blink timers were dead while
+    // thirdperson's Resume button worked. Enforced by check_web_callback_flush.py.
+    commands.flush()
     1
   }
 }
@@ -619,6 +631,7 @@ fun kanamaWebDispatchSignal0(objectId: Int, callbackId: Int): Int {
 fun kanamaWebDispatchSignal1(objectId: Int, callbackId: Int, packed: String): Int {
   return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch1") {
     WebSignalCallbackRegistry.dispatchScalar(objectId, callbackId, packed)
+    commands.flush()
     1
   }
 }
@@ -627,6 +640,7 @@ fun kanamaWebDispatchSignal1(objectId: Int, callbackId: Int, packed: String): In
 fun kanamaWebDispatchSignalObject(objectId: Int, callbackId: Int, argHandle: Int): Int {
   return webCallbackBoundary(objectId, "_kanama_web_signal_dispatch_object") {
     WebSignalCallbackRegistry.dispatchObject(objectId, callbackId, argHandle)
+    commands.flush()
     1
   }
 }


### PR DESCRIPTION
## What

Four Web callback boundaries ran user Kotlin and returned **without flushing the
command buffer**, while every sibling boundary flushed:

| Boundary | Notes |
|---|---|
| `kanamaWebDispatchSignal0` / `1` / `Object` | the reported bug |
| `kanamaWebCallInt` | same drift — siblings `callNoArgs` and `callLongVoid` both flush |

The next per-frame entry point opens with `commands.clear()`, which is a **pure
discard** (`commandCount = 0; wordCount = 0`), so **every `QUEUED_MUTATION` issued
from a Kotlin lambda signal callback was silently thrown away.**

It survived because a callback is rescued whenever an `IMMEDIATE_RESULT` call
follows its last mutation (immediate arms flush first). That is why
`DemoPage.resumeDemo()` works — it ends on `Input.setMouseMode` (op 126, immediate)
— while `SophiaSkin`'s blink timers were dead: `Timer.start` (op 62, queued) was
the *sole* statement in each lambda.

**Confirmed dead on Web before this PR** (swept all 46 `.connect(` sites in the corpus):

- charactercontroller — the blink chain. **This is the documented "eyes never blink"
  reviewer gotcha in `WEB-NEXT-KICKOFF.md`, previously unexplained.**
- charactercontroller — the flag-win reaction (`setPhysicsProcess(false)`,
  `skin.idle()`, `setEmitting(false)`).
- third-person — footstep audio (`setPitchScale` + `play`).
- third-person — the keyboard/joypad instruction toggle (`setVisible` ×2).

**No gate could see it.** The exercised-member census records a callback as
*dispatched*, so it went green while the entire effect was discarded.

## The invariant

`scripts/check_web_callback_flush.py` (wired into `local_ci.sh`) fails any boundary
that invokes a user dispatch entry point without `commands.flush()`. It asserts a
**non-empty extraction** before believing a clean result — a parser that silently
matched nothing would otherwise certify a broken file.

`kanamaWebDraw` (separate `drawCommands` buffer with its own clear/flush) and the
property accessors are recorded as **explicit, reasoned exemptions** rather than
silent omissions.

## Validation — RAN / NOT RUN

**RAN**

- `check_web_callback_flush.py` **proven both directions**: passes here
  (`20 user-dispatch boundaries all flush`), and **fails against unmodified
  `origin/main` naming exactly these four boundaries** (Main.kt 431/606/619/627).
- `:web-runtime:compileKotlinWasmJs` → BUILD SUCCESSFUL, no warnings.
- `ktfmtCheck` → BUILD SUCCESSFUL.
- cc Web export (protocol 18, buildId `f50450943ec9786d`) +
  `web_export_smoke.sh --engine chrome` → **`web_export_smoke: PASS`**, within budget.
- The **same export + smoke from unmodified `origin/main`** as a baseline.

**MEASURED runtime proof** (cc on Chrome, fixed vs unmodified main):

```
exercisedMembers.charactercontroller.SophiaSkin.~kotlinSignalCallback   4  ->  11
```

SophiaSkin's only two lambda subscriptions are the blink timers, and the chain is
self-perpetuating. On main the queued `Timer.start` is discarded so the chain dies
after its scene-configured starts (**4**); with the flush it keeps running (**11**),
in a run with slightly *less* simulated time (121.4s → 117.9s).

⚠️ **Do not read the crossings delta as evidence.** `crossingsPerTick` moved
1.84 → 1.41 and `appliedCommands` 4750 → 2877 — the opposite of what adding flushes
should do — because `physicsTicks` differed 735 → 465 between runs and every
tick-normalised number moved with it. That is run-to-run variance. Only the
dispatch *count* discriminates here.

**NOT RUN**

- **The full corpus on both engines.** Only cc/Chrome was exercised.

## Risk a reviewer must weigh

`commands` is a single global buffer, so flushing inside a signal callback can now
cross a **parent's** pending commands earlier than before if a signal is dispatched
mid-batch. The JS side groups a batch by owner before applying, so ordering within
an owner is preserved and this is very likely benign — but it is a behaviour change
on a shared buffer, and a full-corpus both-engine run is exactly what would catch
it. **Please do not merge on the unit evidence alone.**

## Follow-up (not in this PR)

The census certifies that user code *ran*, not that its effect *landed* — which is
why it stayed green through this bug. A gate asserting one lambda-callback **effect**
(cc's blink, or third-person's `setVisible` toggle, which is directly readable) is
the natural next task-81 slice.

Full audit context: `kanama-tasks/88-agent-surface-audit-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
