### PR TITLE
Task 88: make the post-teardown invariant real (9 tautological drivers + it was never enforced at all)

### DIFF
--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -401,7 +401,16 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -329,7 +329,16 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -270,7 +270,13 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
     crossingsAdvanced: peak.crossings > ready.crossings,
     // The spawn/free lifecycle works: mobs left the screen and released their handles
     // (>=2 observed drops during play) and stayed bounded by the peak — no leak.
-    mobsSpawnAndFree: peak.mobFrees >= 2 && atPeak.liveHandles <= peak.maxLiveHandles,
+    // Task 88: the second clause used to be `atPeak.liveHandles <= peak.maxLiveHandles`,
+    // which cannot be false (maxLiveHandles is a monotone high-water mark of
+    // liveHandles). Dropped rather than rewritten: the free path is already proven by
+    // the mobFrees count here, by the per-entity retention ratio (task 73) during play,
+    // and by liveAfterTeardown === 0 at the end. A clause that cannot fail only makes
+    // the check read stronger than it is.
+    mobsSpawnAndFree: peak.mobFrees >= 2,
     // Full teardown: quitting the tree drained every live handle to zero.
     fullTeardownToZero: settled.liveHandles === 0,
     // No handle kind is retained per spawned mob, measured at the post-restart
@@ -323,7 +329,16 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && last.callbackErrors === 0 && last.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: last.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `last.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        last.liveHandles === 0 &&
+        last.callbacks === 0 &&
+        last.pending === 0 &&
+        last.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -10,6 +10,12 @@
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
+// Task 88: prove the post-teardown invariant can FAIL. Set
+// KANAMA_WEB_T81_FALSIFY=pre-teardown-registries to judge ownerRegistriesToBaseline
+// against the mid-play sample (mobs alive, callbacks and coroutine jobs registered)
+// instead of the settled one. The run must go RED -- a gate only ever observed
+// passing is not evidence that it discriminates.
+const FALSIFY = process.env.KANAMA_WEB_T81_FALSIFY ?? "";
 const START = Date.now();
 const trace = (msg) => {
   if (DEBUG) process.stderr.write(`[dodge ${((Date.now() - START) / 1000).toFixed(1)}s] ${msg}\n`);
@@ -27,7 +33,7 @@ async function snapshot(evaluate) {
         const entry = Object.entries(bridge.match3ReadyByClass ?? {}).find(([n]) => n.endsWith(suffix));
         return entry?.[1] ?? 0;
       };
-      return {
+  return {
         mode: bridge.mode,
         protocol: bridge.results?.protocolVersion ?? 0,
         mainHandle: bridge.dodgeMainHandle,
@@ -288,6 +294,10 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   };
 
   const last = settled;
+  // Task 88 falsification hook: normally the settled post-teardown sample; the
+  // falsify mode judges the invariant against the mid-play peak instead, where mobs
+  // are alive and callbacks/jobs are registered, so the check must go false.
+  const registries = FALSIFY === "pre-teardown-registries" ? atPeak : last;
   const boundaryErrors = [];
   if (peak.callbackErrors !== 0) boundaryErrors.push(`callbackErrors=${peak.callbackErrors}`);
   if (settled.failure !== null) boundaryErrors.push(`failure: ${settled.failure}`);
@@ -335,10 +345,10 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
       // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
       // assert: every owner registry actually drained.
       ownerRegistriesToBaseline:
-        last.liveHandles === 0 &&
-        last.callbacks === 0 &&
-        last.pending === 0 &&
-        last.jobs === 0,
+        registries.liveHandles === 0 &&
+        registries.callbacks === 0 &&
+        registries.pending === 0 &&
+        registries.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -283,7 +283,16 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -458,7 +458,16 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -276,7 +276,16 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -449,7 +449,13 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
     handleGrowthDuringGameplay: peak.maxLiveHandles > ready.liveHandles,
     crossingsAdvanced: peak.crossings > ready.crossings,
     // Mobs freed themselves (squashed and/or walked off), bounded by the peak -- no leak.
-    mobsSpawnAndFree: state.mobFrees >= 2 && atPeak.liveHandles <= peak.maxLiveHandles,
+    // Task 88: the second clause used to be `atPeak.liveHandles <= peak.maxLiveHandles`,
+    // which cannot be false (maxLiveHandles is a monotone high-water mark of
+    // liveHandles). Dropped rather than rewritten: the free path is already proven by
+    // the mobFrees count here, by the per-entity retention ratio (task 73) during play,
+    // and by liveAfterTeardown === 0 at the end. A clause that cannot fail only makes
+    // the check read stronger than it is.
+    mobsSpawnAndFree: state.mobFrees >= 2,
     // Task 81: injected move_forward displaced the player through Input.is_action_pressed
     // -> physicsProcess -> move_and_slide -- the demo's input path, driven end to end.
     playerMovedOnInput,
@@ -511,7 +517,16 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -381,7 +381,16 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -367,7 +367,16 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
         checks.fullTeardownToZero && settled.callbackErrors === 0 && settled.failure === null
           ? "clean"
           : "incomplete",
-      ownerRegistriesToBaseline: settled.liveHandles <= peak.maxLiveHandles,
+      // Task 88: this was `settled.liveHandles <= peak.maxLiveHandles`, which is TRUE BY
+      // CONSTRUCTION -- maxLiveHandles is a monotone high-water mark of liveHandles and
+      // observe() merges the settled sample into peak before returning it. The field is
+      // the contract's post-teardown invariant, so it must assert what match3/tpsdemo
+      // assert: every owner registry actually drained.
+      ownerRegistriesToBaseline:
+        settled.liveHandles === 0 &&
+        settled.callbacks === 0 &&
+        settled.pending === 0 &&
+        settled.jobs === 0,
     },
     boundaryErrors,
   };

--- a/scripts/web/result_schema.py
+++ b/scripts/web/result_schema.py
@@ -182,10 +182,22 @@ def _validate_performance(performance: Any) -> None:
 def _validate_teardown(teardown: Any) -> None:
     path = "teardown"
     _check_type(_get(teardown, "outcome", path), str, f"{path}.outcome")
-    _check_type(
+    owner_registries_to_baseline = _check_type(
         _get(teardown, "ownerRegistriesToBaseline", path),
         bool,
         f"{path}.ownerRegistriesToBaseline",
+    )
+    # Task 88: this used to be TYPE-checked only, so the field could arrive `false` and
+    # the run still passed -- in every driver, including the two that computed it
+    # honestly. Proven by falsification: dodge judged against its mid-play sample
+    # reported ownerRegistriesToBaseline=false and still printed
+    # `web_export_smoke: PASS`. A post-teardown invariant that cannot fail the run is
+    # not an invariant, so enforce it the way liveAfterTeardown is enforced.
+    _require(
+        owner_registries_to_baseline is True,
+        f"{path}.ownerRegistriesToBaseline must be true after full teardown "
+        f"(every owner registry -- handles, signal callbacks, pending coroutines and "
+        f"registered jobs -- must drain to 0)",
     )
 
 


### PR DESCRIPTION
## What

`teardown.ownerRegistriesToBaseline` is the envelope's post-teardown invariant. It
was **`liveHandles <= peak.maxLiveHandles` in 9 of 11 gameplay drivers** — true by
construction, since `maxLiveHandles` is a monotone high-water mark of `liveHandles`
and `observe()` merges the settled sample into `peak` before returning it. Those
drivers attach `settled.callbacks/pending/jobs` to the envelope and asserted none
of them, so a regression leaving pending signal callbacks or coroutine jobs after
teardown passed in 9 demos while match3 and tpsdemo caught it.

## The part that only falsification found

Fixing the 9 drivers went green, so I ran the falsification —
`KANAMA_WEB_T81_FALSIFY=pre-teardown-registries`, judging the invariant against
dodge's mid-play sample. It reported `ownerRegistriesToBaseline: false` **and the
run still printed `web_export_smoke: PASS`.**

`result_schema.py` only TYPE-checked the field as a bool. **So this invariant has
never gated a run in ANY driver — including the two that computed it honestly.**
Repairing the 9 drivers alone would have been cosmetics.

## Changes

1. All 9 drivers assert the real invariant: handles, callbacks, pending coroutines
   and registered jobs all drained to 0.
2. **`result_schema.py` enforces it**, the way `liveAfterTeardown === 0` is enforced.
3. `mobsSpawnAndFree` in dodge and squash ANDed the same always-true comparison, so
   it reduced to the `mobFrees` count — dead clause dropped (the free path is proven
   by `mobFrees`, the task-73 retention ratio, and `liveAfterTeardown`).
4. `KANAMA_WEB_T81_FALSIFY=pre-teardown-registries` added to dodge so the proof is
   repeatable, matching the convention in platformer/thirdperson.

## Validation

**Both directions, against real captured envelopes** (a gate never observed failing
is not evidence):

- drained run → `satisfies schema v1`
- mid-play-judged run → `teardown.ownerRegistriesToBaseline must be true after full
  teardown (every owner registry -- handles, signal callbacks, pending coroutines
  and registered jobs -- must drain to 0)`

**Full `ci` demo set on Chrome, all 12 PASS** with the gate enforced:

```
match3 PASS | bunnymark PASS | dodge PASS | web3d PASS | platformer PASS
squash PASS | fps PASS | charactercontroller PASS | thirdperson PASS
racing PASS | citybuilder PASS | spike PASS
```

So the corpus genuinely drains — the invariant was simply never being checked.

**NOT run locally:** Firefox (workstation load average was 11 from unrelated host
processes, which produced 300s driver timeouts). CI runs Chrome + Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
