### PR TITLE
Task 88 (K3): do not pin a live script handle in the browser-handle map

### DIFF
--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -380,7 +380,22 @@ fun kanamaWebSetLongProperty(objectId: Int, propertyId: Int, value: Double): Int
 
 @JsExport
 fun kanamaWebSetObjectProperty(objectId: Int, propertyId: Int, value: Int): Int {
-  if (value != 0) registerWebBrowserHandle(value, WebBrowserHandleKind.RESOURCE)
+  // Task 88 (K3): a property value that is a LIVE SCRIPT is tracked by `instances`, not by
+  // the browser-handle map, and nothing ever removes it from that map again --
+  // `kanamaWebFree` clears snapshots, signal callbacks, scheduler jobs and the instance but
+  // not `browserHandles`, and the JS release sweep skips script handles (they sit outside
+  // BROWSER_HANDLE_NAMESPACE). Registering one here therefore made `requireLive`'s
+  // `check(containsWebBrowserHandle(token))` fall back TRUE for a script that had already
+  // died, so the stale-handle guard passed and the real failure surfaced later with an
+  // unrelated message. Reachable today: FPS scene-assigns `player` to every Enemy and
+  // reloads after death.
+  //
+  // Guard mirrors registerReturnedNode (WebBackendBookkeeping.kt): skip live instances, and
+  // leave a handle that is already tracked under another kind alone (a node can be both an
+  // exported property and a requireAs child -- City-Builder's view camera).
+  if (value != 0 && !instances.isLive(value) && !containsWebBrowserHandle(value)) {
+    registerWebBrowserHandle(value, WebBrowserHandleKind.RESOURCE)
+  }
   return webCallbackBoundary(objectId, "property_set", "property", propertyId) { record ->
     KanamaWebProjectRegistry.setObjectProperty(record.scriptId, propertyId, record.script, value)
     1
@@ -406,7 +421,14 @@ fun kanamaWebSetObjectArrayProperty(objectId: Int, propertyId: Int, encodedValue
   val values =
     encodedValues.takeIf { it.isNotEmpty() }?.split(',')?.map(String::toInt)?.toIntArray()
       ?: IntArray(0)
-  values.forEach { registerWebBrowserHandle(it, WebBrowserHandleKind.RESOURCE) }
+  // Task 88 (K3): same guard as the scalar arm above -- a live script in an exported array
+  // is tracked by `instances` and must not be pinned in the browser-handle map, which has
+  // no removal path for it.
+  values.forEach {
+    if (!instances.isLive(it) && !containsWebBrowserHandle(it)) {
+      registerWebBrowserHandle(it, WebBrowserHandleKind.RESOURCE)
+    }
+  }
   return webCallbackBoundary(objectId, "property_set", "property", propertyId) { record ->
     KanamaWebProjectRegistry.setObjectArrayProperty(
       record.scriptId,


### PR DESCRIPTION
## What

`kanamaWebSetObjectProperty` registered **any** non-zero property value as a
RESOURCE browser handle — including a **live script** handle. Nothing ever removes
it again:

- `kanamaWebFree` clears snapshots, signal callbacks, scheduler jobs and the
  instance, but not `browserHandles`;
- the JS release sweep (`releaseBrowserHandlesOwnedBy`) skips script handles, which
  sit outside `BROWSER_HANDLE_NAMESPACE`;
- `clearWebBrowserHandles()` exists but has **zero callers**.

So `requireLive`'s fallback — `check(containsWebBrowserHandle(token))` when the
instance is dead — returned **true for an already-freed script**. The stale-handle
guard passed, and the real failure surfaced later with an unrelated message
("command callback is not installed…", "Missing Web … snapshot") instead of
`Stale Kanama Web browser handle=N`. Each property-referenced script that dies also
left one permanent map entry, invisible to `liveAfterTeardown` (which counts the
JS-side number).

**Reachable today:** FPS's `scenes/main.tscn` scene-assigns `player` to every
Enemy, and FPS reloads after death, so player scripts really do die.

## Fix

The guard mirrors `registerReturnedNode` in the same file: skip live instances, and
leave a handle already tracked under another kind alone (a node can be both an
exported property and a `requireAs` child — City-Builder's view camera, per that
function's own comment). Applied to the array arm too.

A live script is tracked by `instances`; pinning it in the browser-handle map was
the bug.

## Validation

- `:web-runtime:compileKotlinWasmJs` → BUILD SUCCESSFUL; `ktfmtCheck` → clean.
- **Full `ci` demo set on Chrome: 12/12 PASS** — including the demos this change is
  most likely to disturb: **fps** (the reachable case), **citybuilder** (the view
  camera that is both property and `requireAs` child), **thirdperson** and **tps**.

`charactercontroller` failed its first export with **Godot itself segfaulting**
(exit 139 / SIGSEGV) while reimporting PNG textures — a Godot crash in the asset
import phase, not a Kanama failure. Cleared the staging dir and re-exported: clean,
and the smoke passes (`web_export_smoke: PASS`). Recorded rather than hidden.

**NOT proven at runtime:** that `requireLive` now *rejects* a dead script handle.
The fix direction is argued from the code (the registration that defeated the guard
is gone); demonstrating the throw needs a driver probe that deliberately touches a
freed script handle and asserts `handles.staleRejected > 0`. That probe does not
exist and is the natural follow-up — it is the same "assert the effect, not the
dispatch" theme as the rest of task 88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
