### PR TITLE
Task 88 (finding 4): a queue_free'd node stays callable until end of frame

### DIFF
--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -2282,6 +2282,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine(
       "\t\tvar target_object: Object = self if object_handle == _kanama_handle else _kanama_object_handles.get(object_handle)"
     )
+    // Task 88 (finding 4): a queue_free'd node stays ALIVE until the end of the frame, and
+    // Godot (and the desktop backend) keep it callable for that window. The queue_free arm
+    // used to erase the handle up front, so a later command in the SAME batch could not
+    // resolve it, fell to this ladder's `else`, and took `push_error` + `break` -- dropping
+    // every remaining command and then tripping `check(applied == expected)` Kotlin-side.
+    // Identical Kotlin code works on desktop, so that divergence was a defect.
+    //
+    // The entry is now retired lazily instead: it survives while the node does, and is
+    // erased the first time resolution sees a genuinely freed instance. That keeps the
+    // shared dictionary from accumulating references to freed objects without needing a
+    // free-time hook on every acquired node.
+    appendLine("\t\tif target_object != null and not is_instance_valid(target_object):")
+    appendLine("\t\t\t_kanama_object_handles.erase(object_handle)")
+    appendLine("\t\t\ttarget_object = null")
     appendLine("\t\tif opcode == 1000 and object_handle == _kanama_handle:")
     appendLine("\t\t\tlast_value = bytes.decode_s32(offset + 8)")
     appendLine("\t\t\tset_meta(\"kanama_web_scalar\", last_value)")
@@ -2697,7 +2711,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 12")
     appendLine("\t\telif opcode == 15 and target_object is Node:")
-    appendLine("\t\t\t_kanama_object_handles.erase(object_handle)")
+    // Task 88 (finding 4): do NOT erase here -- the node is alive until the end of the
+    // frame and must stay callable for that window (Godot + desktop semantics). The
+    // lazy is_instance_valid sweep above retires the entry once the free actually lands.
     appendLine("\t\t\t(target_object as Node).queue_free()")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 8")


### PR DESCRIPTION
## What

In Godot a `queue_free`d node stays **alive and callable until the end of the
frame**, and the desktop backend matches that. The Web applier's `queue_free` arm
erased the handle **before** calling `queue_free()`, so a later command in the
*same batch* targeting that node could not resolve it, fell through the ladder to
`else` → `push_error` + `break`, dropped every remaining command, and then tripped
`check(applied == expected)` Kotlin-side — killing the run.

Identical Kotlin code works on desktop, so this was a silent cross-platform
divergence, not a rule.

**Maintainer decision (2026-08-13): match Godot semantics.**

## Change

- The `queue_free` arm no longer erases the handle; the node stays resolvable for
  the rest of the frame, as on desktop.
- The entry is retired **lazily** instead: resolution now erases it the first time
  it sees a genuinely freed instance (`is_instance_valid`). That keeps the shared
  handle dictionary from accumulating references to freed objects without needing a
  free-time hook on every acquired node.

## Validation

- `:processor:test` → BUILD SUCCESSFUL.
- **Full `ci` demo set on Chrome: 12/12 PASS.** This emits into *every* generated
  proxy, so the whole corpus is the relevant blast radius:

```
match3 PASS | bunnymark PASS | dodge PASS | web3d PASS | platformer PASS
squash PASS | fps PASS | charactercontroller PASS | thirdperson PASS
racing PASS | citybuilder PASS | spike PASS
```

dodge and squash matter most here — their mobs `queue_free` themselves constantly,
and both still drain to `liveAfterTeardown === 0` under the now-enforced
post-teardown invariant from #176.

## Scope note

A command targeting a node that is *genuinely* freed (past end of frame) still
reaches the ladder's `else` and aborts the batch. That is pre-existing behaviour
and unchanged here — this PR only restores the until-end-of-frame window the
decision asked for. Making a stale target a skipped no-op rather than a fatal batch
abort needs a central per-opcode size table in the applier (today each arm advances
the offset itself, so a command cannot be skipped without knowing its width). Worth
its own parcel; recorded rather than smuggled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
