### PR TITLE
Task 88 (finding 1): gate the _ready echo probe on the spike harness

### DIFF
--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -2135,10 +2135,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         methodArm(method) == WebMethodArm.INT_RET_INT
       }
     if (immediateMethod != null) {
+      // Task 88: gated on the spike harness. This is an echo probe for the transport
+      // benchmark, not gameplay -- unconditional, it invoked a USER method with a magic
+      // argument at every scene entry.
+      appendLine("\tif _kanama_bridge.shouldRunImmediateProbe():")
       appendLine(
-        "\tvar immediate_result := int(_kanama_bridge.callInt(_kanama_handle, ${immediateMethod.index + 1}, 47))"
+        "\t\tvar immediate_result := int(_kanama_bridge.callInt(_kanama_handle, ${immediateMethod.index + 1}, 47))"
       )
-      appendLine("\t_kanama_bridge.recordImmediateResult(immediate_result)")
+      appendLine("\t\t_kanama_bridge.recordImmediateResult(immediate_result)")
     }
     appendLine(
       "\t_kanama_bridge.recordReady(_kanama_handle, _KANAMA_SCRIPT_ID, ${quote(model.fqName)})"

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -905,6 +905,15 @@
     shouldDeferReady(scriptName) {
       return false;
     },
+    // Task 88: the _ready echo probe is SPIKE SCAFFOLDING and must not ride the default
+    // path. Every generated proxy used to call its first Int->Int @RegisterFunction with
+    // the literal 47 at scene entry -- harmless for WebSpikeScript.echo (whose round trip
+    // `finish()` asserts below), but a user script declaring `fun addScore(points: Long):
+    // Long` got a phantom +47 per instance, on Web only, silently. Same accident shape as
+    // tasks 82 and 84: benchmark scaffolding reachable by default instead of opted into.
+    shouldRunImmediateProbe() {
+      return this.mode === "spike";
+    },
     recordDeferredReady(scriptName) {
       this.match3DeferredReadyByClass[scriptName] =
         (this.match3DeferredReadyByClass[scriptName] ?? 0) + 1;


### PR DESCRIPTION
## What

Every generated proxy called its first `Int→Int` `@RegisterFunction` with the
literal **47** inside `_ready`:

```gdscript
var immediate_result := int(_kanama_bridge.callInt(_kanama_handle, <id>, 47))
```

`bridge.callInt` dispatches `"registered_function"` straight into the user's Kotlin
method. That is harmless for `WebSpikeScript.echo(value: Long): Long`, whose round
trip the spike's `finish()` asserts (`immediateResult: this.immediateResult === 47`)
— but a game script declaring `fun addScore(points: Long): Long` got a **phantom
+47 per instance at scene entry, on Web only, silently.** Desktop does not do this,
so the drift is invisible until someone compares numbers across platforms.

Same accident shape as tasks 82 and 84: benchmark scaffolding reachable **by
default** instead of opted into.

## Change

Gated on `bridge.shouldRunImmediateProbe()`, true only in spike mode — mirroring the
existing `shouldDeferReady` hook rather than special-casing a class name. The spike
harness keeps its echo round-trip check; nothing else fires it.

## Validation

- `:processor:test` → BUILD SUCCESSFUL.
- **Full `ci` demo set on Chrome: 12/12 PASS**, and critically **`spike` PASSES** —
  the one demo that legitimately depends on the probe firing, so this proves the
  gate lets it through rather than merely silencing it.

`match3` needed one export retry: **Godot itself aborted** (exit 134 / SIGABRT)
during export. Cleared staging, re-exported clean, smoke PASS. Second such Godot
crash today on this machine (cc hit exit 139 / SIGSEGV earlier) — both transient
and unrelated to this change, recorded rather than hidden.

## Corpus impact: zero, by measurement

246 `@RegisterFunction` sites across the demo corpus, **none** of that shape. So no
demo triggers it and **no gate could ever have caught it** — this is a library
correctness bug for users, not for us, which is exactly why it survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
