### PR TITLE
Task 88 (findings 7 + K5): seeding parity for handles arriving through sibling paths

### DIFF
--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -3285,10 +3285,28 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t\t_kanama_bridge.recordImmediateObjectHandle(int(existing_handle))")
     appendLine("\t\t\t\treturn int(existing_handle)")
     appendLine("\t_kanama_object_handles[result_handle] = value")
+    // Task 88 (finding 7): seed the SAME three shapes _kanama_node_lookup seeds. This arm
+    // used to seed Node3D only, so a 2D node returned through this channel -- get_parent()
+    // (opcode 73) or duplicate() (114) -- arrived with no mirrored canvas snapshot, and the
+    // first position/scale/modulate/rotation read on it hit the backend's fail-loud
+    // "Missing Web ... snapshot" error. Copy-paste drift: node_lookup, packed-scene
+    // instantiate and the tween get_child arm were all fixed; this copy was missed.
+    appendLine("\tif value is Node2D:")
+    appendLine("\t\tvar node_2d := value as Node2D")
+    appendLine(
+      "\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, node_2d.position.x, node_2d.position.y, node_2d.scale.x, node_2d.scale.y, node_2d.modulate.r, node_2d.modulate.g, node_2d.modulate.b, node_2d.modulate.a, node_2d.rotation)"
+    )
     appendLine("\tif value is Node3D:")
     appendLine("\t\tvar node_3d := value as Node3D")
     appendLine(
       "\t\t_kanama_bridge.refreshNode3DSnapshot(result_handle, node_3d.position.x, node_3d.position.y, node_3d.position.z, node_3d.rotation.x, node_3d.rotation.y, node_3d.rotation.z, node_3d.scale.x, node_3d.scale.y, node_3d.scale.z)"
+    )
+    appendLine("\tif value is Control:")
+    appendLine("\t\t# Controls are CanvasItems but not Node2Ds: seed the mirrored canvas snapshot")
+    appendLine("\t\t# so modulate reads (HUD fades) resolve without a prior write.")
+    appendLine("\t\tvar control := value as Control")
+    appendLine(
+      "\t\t_kanama_bridge.refreshNode2DSnapshot(result_handle, control.position.x, control.position.y, control.scale.x, control.scale.y, control.modulate.r, control.modulate.g, control.modulate.b, control.modulate.a, control.rotation)"
     )
     appendLine("\tif value is SpriteFrames:")
     appendLine(

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -198,6 +198,17 @@ internal fun registerConstructedNode(token: Int, className: String): GodotHandle
       positionSnapshots[it] = GodotVector2(0.0f, 0.0f)
       scaleSnapshots[it] = GodotVector2(1.0f, 1.0f)
       modulateSnapshots[it] = GodotColor(1.0f, 1.0f, 1.0f, 1.0f)
+      // Task 88 (K5): seed the 3D transform mirror too. Only the 2D mirrors were seeded, so
+      // a ClassDB-constructed Node3D (a MeshInstance3D built at runtime, for instance) hit
+      // the backend's fail-loud "Missing Web Node3D ... snapshot" on its first
+      // getPosition/getRotation/getScale -- a script that only ever WROTE the transform was
+      // fine, which is why this stayed hidden. These are the true defaults of a
+      // freshly-constructed node (origin, no rotation, unit scale), exactly as the 2D
+      // seeds above are, so seeding both shapes is accurate rather than merely defensive:
+      // the class is not known to be 2D or 3D here, and the unused mirror is never read.
+      position3Snapshots[it] = GodotVector3(0.0f, 0.0f, 0.0f)
+      rotation3Snapshots[it] = GodotVector3(0.0f, 0.0f, 0.0f)
+      scale3Snapshots[it] = GodotVector3(1.0f, 1.0f, 1.0f)
       if (className == "Sprite2D") textureSnapshots[it] = 0
       GodotHandle.fromBackendToken(it.toLong())
     }


### PR DESCRIPTION
## What

Two copies of one class: **a seeding path that covers one dimension and not its
sibling**, so the first transform read on the uncovered shape hits the backend's
fail-loud `Missing Web ... snapshot` error at runtime, on Web only.

**Finding 7** — `_kanama_noargs_object` seeded `Node3D` only. A 2D node returned
through that channel — `get_parent()` (opcode 73) or `duplicate()` (114) — arrived
with no mirrored canvas snapshot, so a following `position` / `scale` / `modulate`
/ `rotation` read threw. Its three siblings were all fixed already
(`_kanama_node_lookup` seeds Node2D + Node3D + Control, `_kanama_packed_scene_instantiate`
seeds Node2D + Node3D, the tween `get_child` arm seeds Node2D) — this copy was
missed. Now seeds the same three shapes `node_lookup` does.

**K5** — `registerConstructedNode` seeded only the 2D mirrors (position, scale,
modulate), so a ClassDB-constructed **Node3D** errored on its first
`getPosition`/`getRotation`/`getScale`. A script that only ever *wrote* the
transform was fine, which is why it stayed hidden. Now seeds the 3D mirror with a
freshly-constructed node's true defaults (origin, no rotation, unit scale) — the
same thing the 2D seeds already do. The class is not known to be 2D or 3D at that
point and the unused mirror is never read, so seeding both shapes is accurate
rather than merely defensive.

## Validation

- `:processor:test`, `:web-runtime:compileKotlinWasmJs`, `ktfmtCheck` → all BUILD
  SUCCESSFUL.
- **Full `ci` demo set on Chrome: 12/12 PASS**, first attempt, no retries.

## Corpus impact: zero, by measurement

Neither is reachable today — every `getParent()`/`duplicate()` in the demo corpus is
3D and feeds `addChild` rather than a transform read, and no demo constructs a bare
`Node3D` and reads its transform back. **So no gate could have caught either**, and
the corpus passing is a no-regression result, not a proof of the fix. These are
library-correctness bugs for users, in the same bucket as #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
