### PR TITLE
Task 88 (finding 14): fail the export when Godot reports a script error

### DIFF
--- a/web-runtime/build.gradle.kts
+++ b/web-runtime/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.OutputStream
 import java.security.MessageDigest
 import java.util.zip.ZipFile
 
@@ -3128,5 +3129,63 @@ tasks.register<Zip>("packageWebExport") {
                     readExportReportField(report, "protocolVersion"),
                 )
         )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 88 (finding 14): a GDScript parse error must FAIL the export.
+//
+// Godot prints `SCRIPT ERROR: Parse Error: ...` and `Failed to load script ...` for a
+// proxy it cannot load, and then exits 0. MEASURED 2026-08-13: an emitter change that
+// broke every generated proxy produced 32 such lines, `BUILD SUCCESSFUL`, and a shippable
+// 42 MB artifact whose scripts could not load. The step that is supposed to prove the
+// emitted proxies are valid GDScript proved nothing, and only a downstream browser smoke
+// would have noticed.
+//
+// Applied to every `exportWeb*` task by name so a future export task inherits it instead
+// of having to remember. Godot's output is TEE'd rather than swallowed: a long export must
+// still stream live, or a stall becomes undebuggable.
+// ---------------------------------------------------------------------------
+tasks.withType<Exec>().matching { it.name.startsWith("exportWeb") }.configureEach {
+    val capturedGodotOutput = ByteArrayOutputStream()
+
+    fun tee(sink: OutputStream): OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                sink.write(b)
+                capturedGodotOutput.write(b)
+            }
+
+            override fun write(b: ByteArray, off: Int, len: Int) {
+                sink.write(b, off, len)
+                capturedGodotOutput.write(b, off, len)
+            }
+
+            override fun flush() {
+                sink.flush()
+                capturedGodotOutput.flush()
+            }
+        }
+
+    doFirst {
+        standardOutput = tee(System.out)
+        errorOutput = tee(System.err)
+    }
+
+    doLast {
+        val offenders =
+            capturedGodotOutput
+                .toString(Charsets.UTF_8)
+                .lines()
+                .filter { it.contains("SCRIPT ERROR") || it.contains("Failed to load script") }
+        check(offenders.isEmpty()) {
+            buildString {
+                append("Godot reported ${offenders.size} script error(s) while exporting, ")
+                append("so the export contains proxies that cannot load.\n")
+                append("The export step exits 0 on these, which is why this check exists.\n\n")
+                offenders.take(20).forEach { append("  ").append(it.trim()).append('\n') }
+                if (offenders.size > 20) append("  ... and ${offenders.size - 20} more\n")
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Godot prints `SCRIPT ERROR: Parse Error: ...` and `Failed to load script ...` for a
proxy it cannot load — **and then exits 0.**

Measured 2026-08-13, while attempting a different change: an emitter edit that broke
**every** generated proxy produced **32 such error lines**, `BUILD SUCCESSFUL`, exit
code 0, and a shippable **42 MB artifact whose scripts could not load.**

So the build step that is supposed to prove "the emitted proxies are valid GDScript"
proved nothing. A generator change that breaks the entire corpus still ships an
export, and only a downstream browser smoke would ever notice — after an export, an
HTTP server, and a browser run. This is the vacuous-gate class one layer earlier
than anything task 88 had examined, and it sat underneath every emitter parcel
merged today (#178, #179, #180).

## Change

`tasks.withType<Exec>().matching { it.name.startsWith("exportWeb") }` — applied by
name so a future export task inherits the check instead of having to remember it.

Godot's output is **tee'd, not swallowed**: a long export must still stream live or
a stall becomes undebuggable.

## Validation — both directions

A gate never observed failing is not evidence, so both were run end to end:

- **Passes**: a clean `dodge` export → exit 0, `BUILD SUCCESSFUL`, artifact produced.
- **Fails**: with the emitter deliberately emitting `self as CanvasItem` (invalid for
  a `Node`-extending script) → **exit 1**, and the failure names the offending
  scripts:

```
> Godot reported 6 script error(s) while exporting, so the export contains proxies that cannot load.
    SCRIPT ERROR: Parse Error: Invalid cast. Cannot convert from "res://kanama-web/generated/HUD.gd" to "CanvasItem".
    SCRIPT ERROR: Parse Error: Invalid cast. Cannot convert from "res://kanama-web/generated/Main.gd" to "CanvasItem".
```

The injection was reverted before commit; the emitter is untouched in this PR.

- **No false positives**: full `ci` demo set on Chrome, **12/12 PASS**, and **zero**
  script-error reports across all twelve exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
