### PR TITLE
Task 88 (findings 9 + 10 + dead drains): gate-integrity batch

### DIFF
--- a/scripts/web/drivers/demos/spike.mjs
+++ b/scripts/web/drivers/demos/spike.mjs
@@ -243,8 +243,30 @@ export async function runSpike({ url, evaluate, navigate, deadline }) {
   for (const [name, value] of Object.entries(results.checks ?? {})) {
     checks[`page_${name}`] = value === true;
   }
+  // Task 88 (finding 9): budgets.json exempts spike from the crossings/tick ceiling
+  // BECAUSE these page checks gate transport cost structurally instead. Folding them from
+  // a dynamic dict meant absence contributed NOTHING: a bridge refactor that renamed or
+  // relocated finish()'s keys would silently add zero page_* checks, the five driver-level
+  // checks would still pass, the schema's checks-non-empty requirement would still be
+  // satisfied, and the one regression this cell exists to catch -- per-operation crossings
+  // instead of one batched crossing -- would be asserted nowhere. Require them by name.
+  const REQUIRED_PAGE_CHECKS = [
+    "backendQueuedCrossings",
+    "immediateResult",
+    "queuedMutation",
+    "freed",
+    "generationAdvanced",
+    "staleHandleInvalidated",
+  ];
+  const missingPageChecks = REQUIRED_PAGE_CHECKS.filter((name) => !(`page_${name}` in checks));
+  checks.pageChecksPresent = missingPageChecks.length === 0;
 
   const boundaryErrors = [];
+  if (missingPageChecks.length > 0) {
+    boundaryErrors.push(
+      `spike page checks missing, so the structural transport gate asserted nothing: ${missingPageChecks.join(", ")}`,
+    );
+  }
   if (drained.callbackErrors !== 0) {
     boundaryErrors.push(
       `callbackErrors=${drained.callbackErrors}: ${drained.lastCallbackError ?? "unknown"}`,

--- a/scripts/web_ci_matrix.sh
+++ b/scripts/web_ci_matrix.sh
@@ -171,6 +171,14 @@ else
 fi
 RESULT_DIR="$(cd "$RESULT_DIR" && pwd)"
 RUNS_DIR="$RESULT_DIR/runs"
+# Task 88 (finding 10): the evidence file is assembled by globbing this directory, but
+# `pass` is computed from THIS invocation's FAILED flag alone. Reusing a --result-dir
+# (the documented pre-release flow is a full run, then a narrow re-run of what failed)
+# left every higher-numbered record from the previous invocation in place, because
+# RUN_INDEX restarts at 0. The evidence then carried stale FAIL rows under pass=true --
+# or stale PASS rows padding a narrow run into a "corpus green" claim. CI only escaped
+# it because $RUNNER_TEMP is fresh per job.
+rm -rf "$RUNS_DIR"
 mkdir -p "$RUNS_DIR"
 
 absolutize_out() {

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendBookkeeping.kt
@@ -262,11 +262,6 @@ internal fun onWebQueueFree(objectId: Int) {
   }
 }
 
-internal fun clearWebBrowserHandles() {
-  browserHandles.keys.forEach(::clearWebPositionSnapshot)
-  browserHandles.clear()
-}
-
 internal fun discardWebBrowserHandle(handle: Int): Boolean {
   clearWebPositionSnapshot(handle)
   return browserHandles.remove(handle) != null

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -1234,32 +1234,6 @@
       this.liveBrowserHandleCount -= 1;
       this.freeBrowserHandleSlots.push(handle & BROWSER_HANDLE_SLOT_MASK);
     },
-    releaseRemainingBrowserHandles() {
-      for (let slotIndex = 1; slotIndex < this.browserHandleSlots.length; slotIndex += 1) {
-        const slot = this.browserHandleSlots[slotIndex];
-        if (!slot.live) continue;
-        if (slot.kind === "Sprite2D") this.objectFrees += 1;
-        for (const [handle, owner] of this.handleOwners) {
-          if ((handle & BROWSER_HANDLE_SLOT_MASK) !== slotIndex) continue;
-          if (slot.kind === "AudioStreamPlayer") {
-            this.audioPlayerStates.delete(handle);
-            this.match3AudioPlayerFrees += 1;
-          }
-          if (slot.kind === "Resource") this.resourcePathByHandle.delete(handle);
-          if (slot.kind === "SceneTree" && this.sceneTreeHandlesByOwner.get(owner) === handle) {
-            this.sceneTreeHandlesByOwner.delete(owner);
-          }
-          this.handleOwners.delete(handle);
-        }
-        slot.live = false;
-        slot.kind = null;
-        this.freeBrowserHandleSlots.push(slotIndex);
-      }
-      this.liveBrowserHandleCount = 0;
-      this.browserNodeHandlesByScript.clear();
-      this.tweenChildren.clear();
-      this.sceneTreeHandlesByOwner.clear();
-    },
     releaseBrowserHandlesOwnedBy(owner) {
       for (const tweenHandle of [...this.tweenChildren.keys()]) {
         if (this.handleOwners.get(tweenHandle) === owner) this.tweenChildren.delete(tweenHandle);


### PR DESCRIPTION
## Three independent gate-integrity items

**Finding 10 — stale rows in the release evidence.** `web_ci_matrix.sh` assembled
`evidence.json` by globbing an **accumulating** `runs/` dir while computing `pass`
from the CURRENT invocation's FAILED flag alone. `RUN_INDEX` restarts at 0, so
reusing a `--result-dir` — and the documented pre-release flow is a full run, then a
narrow re-run of what failed — left every higher-numbered record from the previous
invocation in place. The evidence then carried stale **FAIL rows under
`"pass": true`**, or stale PASS rows padding a narrow run into a "corpus green"
claim. CI escaped it only because `$RUNNER_TEMP` is fresh per job. The dir is now
cleared per invocation.

**Finding 9 — the spike's structural gate could vanish by absence.** The page checks
were folded from a dynamic dict (`Object.entries(results.checks ?? {})`), so absence
contributed **nothing**. `budgets.json` exempts spike from the crossings/tick ceiling
*precisely because* those checks gate transport cost structurally — a bridge refactor
renaming or relocating `finish()`'s keys would have added zero `page_*` checks, left
the five driver-level checks passing, satisfied the schema's checks-non-empty rule,
and quietly stopped asserting the one regression the cell exists to catch. Six checks
are now required **by name**.

**Both dead drains deleted**, each a loaded gun aimed at a gate repaired earlier
today:
- `releaseRemainingBrowserHandles` (bridge) — **zero callers**, and it ended with
  `this.liveBrowserHandleCount = 0`, a hard assignment rather than a drain result.
  Wired up, it would have made `liveAfterTeardown === 0` pass by construction —
  the very gate #176 just made real.
- `clearWebBrowserHandles` (Kotlin) — **zero callers**.

## Validation

**Finding 9 proven both directions** (end to end, against a real spike export):

- Dropping `backendQueuedCrossings` from the fold → `pass=False`,
  `pageChecksPresent=False`, and a boundaryError naming it:
  `spike page checks missing, so the structural transport gate asserted nothing: backendQueuedCrossings`
- Unmodified → `web_export_smoke: PASS`.

The injection was reverted before commit.

- `:web-runtime:compileKotlinWasmJs` + `ktfmtCheck` → BUILD SUCCESSFUL.
- **Full `ci` demo set on Chrome: 12/12 PASS.**

`match3` needed one export retry: **Godot aborted** (exit 134 / SIGABRT). Notably
**zero `SCRIPT ERROR` lines** were reported — which is now a meaningful negative,
because #181 makes the export fail on those. So the crash was Godot's, not the
emission's. Third such Godot crash today (cc: 139/SIGSEGV, match3: 134/SIGABRT ×2),
all transient, all clean on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
