### PR TITLE
Task 88 (findings 8 + 13): the schema's pass mirror encodes all four legs

### DIFF
--- a/scripts/web/check_budgets.py
+++ b/scripts/web/check_budgets.py
@@ -209,10 +209,14 @@ def main(argv: list[str]) -> int:
     measured = measurements(envelope)
 
     if args.report:
+        # Task 88 (finding 13): --report is contractually "print measurements, never fail",
+        # and measurements() deliberately yields None for absent fields -- so the unguarded
+        # division raised TypeError on exactly the partial envelope this mode exists for.
         payload = measured["payloadBytes"]
+        payload_text = "unreported" if payload is None else f"{payload / 1e6:.1f}MB"
         print(
             f"budget report: {demo} "
-            f"payload={payload / 1e6:.1f}MB "
+            f"payload={payload_text} "
             f"startup={measured['startupMs']}ms "
             f"crossings/tick={measured['crossingsPerTick']} "
             f"(ticks={measured['ticksObserved']}, sim={measured['simSeconds']}s)"

--- a/scripts/web/result_schema.py
+++ b/scripts/web/result_schema.py
@@ -383,11 +383,37 @@ def validate(envelope: Any, required_members: dict[str, Any] | None = None) -> N
     overall = _get(envelope, "pass", "envelope")
     _check_type(overall, bool, "pass")
     summary = envelope["assertions"]["summary"]
-    expected_pass = summary["failed"] == 0 and envelope["startup"]["loaded"] is True
+    # Task 88 (finding 8): this mirror used to encode only TWO of the four legs the sole
+    # producer of `pass` actually applies (drivers/envelope.mjs:203 also requires zero
+    # boundaryErrors and zero console errors). Two consequences, both bad: a genuine
+    # console-error failure arrived as a confusing "pass must reflect ..." SCHEMA
+    # violation, and the validator could not enforce the two missing legs at all -- an
+    # envelope built to the schema's own formula would have dropped the
+    # zero-console-errors gate while staying green here.
+    console = envelope["console"]
+    console_errors = console["errors"]
+    boundary_errors = console["boundaryErrors"]
+    expected_pass = (
+        summary["failed"] == 0
+        and envelope["startup"]["loaded"] is True
+        and len(console_errors) == 0
+        and len(boundary_errors) == 0
+    )
     _require(
         overall == expected_pass,
-        f"pass ({overall}) must reflect startup.loaded and zero failed assertions ({expected_pass})",
+        f"pass ({overall}) must reflect startup.loaded, zero failed assertions, zero "
+        f"console errors and zero boundary errors ({expected_pass}: "
+        f"failed={summary['failed']}, loaded={envelope['startup']['loaded']}, "
+        f"consoleErrors={len(console_errors)}, boundaryErrors={len(boundary_errors)})",
     )
+    # And the legs must be enforced, not merely mirrored: a `pass` envelope carrying
+    # errors is a contradiction the validator should reject on its own terms.
+    if overall:
+        _require(
+            len(console_errors) == 0 and len(boundary_errors) == 0,
+            f"pass is true but the run reported {len(console_errors)} console error(s) "
+            f"and {len(boundary_errors)} boundary error(s)",
+        )
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
## Finding 8 — the schema's `pass` mirror encoded 2 of 4 legs

`result_schema.py` computed `expected_pass = failed == 0 and startup.loaded`, but the
**sole producer** of `pass` (`drivers/envelope.mjs:203`) also requires zero
`boundaryErrors` and zero console errors. Measured against the old file, using a real
match3 envelope with one field mutated per case:

| envelope | OLD | NEW |
|---|---|---|
| clean | pass | pass |
| honest console-error failure (`pass=false` + a console error) | **exit 1** — `pass (False) must reflect startup.loaded and zero failed assertions (True)` | accepted |
| `pass=true` while carrying a console error | **exit 0** — accepted | **exit 1** — rejected |

Two distinct defects, both closed:

1. A **genuine page fault was misreported as a malformed envelope**. Every run whose
   only problem was a console error came back as "result schema validation failed",
   pointing the reader at the harness instead of at the page.
2. The validator **could not enforce two of the four legs at all** — an envelope
   claiming success while carrying errors passed. Anything built to the schema's own
   documented formula (a fourth driver, a `--driver-cmd` override, or an
   "alignment" edit to `envelope.mjs`) would silently have dropped the
   zero-console-errors gate while staying green here.

The mirror now encodes all four legs, and `pass` carrying errors is rejected on the
validator's own terms rather than only via the mirror.

## Finding 13 — `--report` crashed on exactly the input it exists for

`check_budgets.py --report` is contractually "print measurements, never fail", but
`measurements()` deliberately yields `None` for absent fields, so the unguarded
`payload / 1e6` raised `TypeError` on a partial envelope — the situation baseline
gathering uses `--report` for.

- OLD: `TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'`, exit 1
- NEW: `budget report: match3 payload=unreported startup=7340ms ...`, exit 0

## Validation

- Both findings proven **before and after** against crafted envelopes derived from a
  real passing run (fixtures above).
- **Full `ci` demo set on Chrome: 12/12 PASS**, first attempt, no retries — the
  stricter mirror does not reject any real envelope the corpus produces.

Note on method: my first before/after comparison was **invalid** — I ran the old
schema from `/tmp`, where it could not resolve `required_members.json`, so both
fixtures "failed" for an unrelated path reason. Re-run from inside the repo, the
comparison above is the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
