### PR TITLE
Task 88 (finding 12 + B2): delete dead budget keys, bound the staged-args map

### DIFF
--- a/scripts/web/budgets.json
+++ b/scripts/web/budgets.json
@@ -9,7 +9,6 @@
   "fixtures": {
     "fake": {
       "maxPayloadBytes": 10000000,
-      "maxStartupMs": 60000,
       "maxCrossingsPerTick": 1000.0,
       "minTicksForVerdict": 0,
       "measuredOn": "n/a -- the scaffold self-test's static fixture, not a real demo"
@@ -409,7 +408,6 @@
     },
     "soak": {
       "maxPayloadBytes": 49000000,
-      "maxStartupMs": 8000,
       "maxCrossingsPerTick": 1.0,
       "minTicksForVerdict": 1000,
       "measuredOn": "2026-07-30, macOS arm64, Chrome 150 headless, protocol 15, 270s run",

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -1469,6 +1469,19 @@
       const id = this.nextStagedGenericArgsId;
       this.nextStagedGenericArgsId += 1;
       this.stagedGenericArgs.set(id, String(value));
+      // Task 88 (B2): every staged string is consumed by its applier arm in the same
+      // batch, so this map should never hold more than one batch's worth. It has no
+      // teardown drain and no leak gate can see it -- liveAfterTeardown counts browser
+      // handles, and the soak gate trends handles/callbacks/jobs -- so an entry that is
+      // never consumed (a stale target drops its command before takeStagedGenericArgs
+      // runs) would accumulate silently and forever. A ceiling well above any legitimate
+      // batch converts that invisible leak into a named failure.
+      if (this.stagedGenericArgs.size > 65536) {
+        throw new Error(
+          `Kanama Web staged generic-args map has ${this.stagedGenericArgs.size} unconsumed ` +
+            "entries: applier arms are not consuming what the encoder stages",
+        );
+      }
       return id;
     },
     takeStagedGenericArgs(id) {


### PR DESCRIPTION
## Finding 12 — a startup ceiling that looks enforced and is not

`budgets.json` carried `maxStartupMs` on the soak entry (8000) and the fake fixture
(60000). `check_budgets.py` reads neither — grep returns **0**.

Startup being ungated is deliberate (wall-clock does not survive a loaded machine —
the #128 lesson, and `gatingPolicy` documents it). But a per-demo ceiling that *looks*
enforced and is not is exactly how the Safari performance budget silently never ran
for a month. Removed rather than wired up, so the file states only what it enforces.

## B2 — an unbounded map no leak gate can see

`stagedGenericArgs` had no bound and no drain. Every staged string is consumed by its
applier arm in the same batch, so the map should never hold more than one batch's
worth — but nothing enforced that, and **no leak gate can observe it**:
`liveAfterTeardown` counts browser handles, and the soak gate trends handles,
callbacks and coroutine jobs. An entry that is never consumed (a stale target drops
its command before `takeStagedGenericArgs` runs) would accumulate silently and
forever.

Now bounded at 65536 — far above any legitimate batch — so the invisible
accumulation becomes a named failure instead.

## Validation

- `budgets.json` still parses; all 14 budget entries intact.
- Corpus subset on Chrome, chosen for relevance: **dodge, match3, spike, citybuilder —
  4/4 PASS.** spike is the demo that actually exercises the generic-call staging path,
  and citybuilder/match3 carry the object-array properties.

## Not in this PR, deliberately

**K6** (null array element mints a handle) turned out deeper than "low" on inspection.
The generated setter does `requireNotNull(webScriptInstance(it))` for a script-typed
array — so a null element **throws with a misleading message** — and fabricates a
live-looking wrapper for a wrapper-typed array. Passing `0` cannot work without first
deciding what a null element *means* in the user's Kotlin type (a nullable element
type). That is a type-model decision, not a patch; scoped in the task file.

**Finding 11** (Safari hardwires `consoleEvents: []`, making its zero-console-errors
leg vacuous) needs a real Safari gate run to change honestly, and Safari has no
headless mode. Left for a session that can drive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
