### PR TITLE
Task 88 (finding 3): keep script state across a tree exit; destroy at PREDELETE (protocol 19)

### DIFF
--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -134,7 +134,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
      * happened to name.
      */
-    const val PROTOCOL_VERSION = 18
+    const val PROTOCOL_VERSION = 19
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -2261,7 +2261,30 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\tif _kanama_handle != 0:")
     appendLine("\t\t_kanama_bridge.draw(_kanama_handle)")
     appendLine()
+    // Task 88 (finding 3): _exit_tree DISPATCHES, it no longer destroys.
+    //
+    // Godot fires _exit_tree on every tree exit, and a node that leaves may come straight
+    // back (object pooling, reparent-on-pickup). Destroying the Kotlin instance here meant
+    // the script could never return: _ready fires once per node and _kanama_ready_dispatched
+    // was latched true and never reset, so re-entry gave either a permanently dead script
+    // (no handle, every `if _kanama_handle != 0` guard false forever) or -- with
+    // @OnEnterTree -- a fresh instance whose @OnReady could never run. Desktop keeps the
+    // instance alive across a reparent; this makes Web match Godot and desktop.
+    //
+    // Because the instance now SURVIVES a tree exit, the latched _kanama_ready_dispatched
+    // becomes CORRECT rather than a bug: Godot's fire-once _ready semantics are exactly
+    // what we want for a node that came back with its state intact.
     appendLine("func _exit_tree() -> void:")
+    appendLine("\tif _kanama_handle == 0:")
+    appendLine("\t\treturn")
+    appendLine("\t_kanama_bridge.exitTree(_kanama_handle)")
+    appendLine()
+    // Destruction is PREDELETE only -- the one notification that means the node is really
+    // going away. Godot always exits the tree before deleting, so @OnExitTree has already
+    // run by the time we get here.
+    appendLine("func _notification(what: int) -> void:")
+    appendLine("\tif what != NOTIFICATION_PREDELETE:")
+    appendLine("\t\treturn")
     appendLine("\tif _kanama_handle == 0:")
     appendLine("\t\t_kanama_clear_callbacks()")
     appendLine("\t\treturn")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 18"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 19"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -606,7 +606,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 18"))
+    assertTrue(protocol.contains("\"protocolVersion\": 19"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -617,7 +617,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=18\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=19\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1587,7 +1587,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 18"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 19"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -309,7 +309,7 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -267,7 +267,7 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeCitybuilder: ready.mode === "citybuilder",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
     // Injected build placed a structure on the grid at the mouse-ray cell.

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -268,7 +268,7 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -217,7 +217,7 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -234,7 +234,7 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol18: firstRun.settled.protocol === 18 && secondRun.settled.protocol === 18,
+    protocol19: firstRun.settled.protocol === 19 && secondRun.settled.protocol === 19,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -388,7 +388,7 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -211,7 +211,7 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -185,7 +185,7 @@ export async function runSoak({ url, evaluate, navigate, deadline }) {
 
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol18: ready.protocol === 18,
+    protocol19: ready.protocol === 19,
     // The run really lasted: several full rounds, and enough samples to judge.
     soakCyclesCompleted: cycles >= 2,
     soakSamplesCollected: samples.length >= 8,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -437,7 +437,7 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -296,7 +296,7 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -234,7 +234,7 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
   const protocolVersion = menu.protocol;
   const checks = {
     modeTpsdemo: menu.mode === "tpsdemo",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     // The menu boots, and pressing Play streams the whole level in: the AnimationTree-driven
     // player, its input synchronizer, the shake camera, and the four red robots with their
     // detachable death parts.

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -238,7 +238,7 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol18: protocolVersion === 18,
+    protocol19: protocolVersion === 19,
     sceneReady: ready.mainReady >= 1,
     // 66b: the bridge crossing fired and the Kotlin @OnEnterTree body observed it.
     enterTreeDispatched: ready.enterTreeCalls >= 1 && (enterTreeProbe & 1) === 1,

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt
@@ -565,10 +565,34 @@ fun kanamaWebCallPacked(objectId: Int, methodId: Int): String {
   }
 }
 
+/**
+ * Task 88 (finding 3): dispatch the script's `@OnExitTree` WITHOUT destroying it.
+ *
+ * Godot fires `_exit_tree` on every tree exit, and a node that leaves the tree may come straight
+ * back (object pooling, reparent-on-pickup). Destroying the Kotlin instance here — which is what
+ * this path used to do — meant the script could never come back: `_ready` fires once per node, and
+ * `_kanama_ready_dispatched` was latched true and never reset, so re-entry gave either a
+ * permanently dead script or a fresh instance whose `@OnReady` could never run. Desktop keeps the
+ * instance alive across a reparent; this makes Web match.
+ *
+ * Destruction now happens in [kanamaWebFree], which the proxy calls from NOTIFICATION_PREDELETE —
+ * the only notification that means the node is really going away.
+ */
 @JsExport
-fun kanamaWebFree(objectId: Int): Int {
+fun kanamaWebExitTree(objectId: Int): Int {
   return webCallbackBoundary(objectId, "_exit_tree") { record ->
     KanamaWebProjectRegistry.exitTree(record.scriptId, record.script)
+    commands.flush()
+    1
+  }
+}
+
+@JsExport
+fun kanamaWebFree(objectId: Int): Int {
+  // The script's @OnExitTree already ran in kanamaWebExitTree when the node left the
+  // tree; this is destruction only. Godot always exits the tree before deleting a node,
+  // so the ordering holds.
+  return webCallbackBoundary(objectId, "free") { record ->
     commands.flush()
     drawCommands.clear()
     clearWebPositionSnapshot(objectId)

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 18;
+  const KANAMA_WEB_PROTOCOL_VERSION = 19;
 
   function commandWordCount(opcode) {
     if (
@@ -1043,6 +1043,17 @@
     },
     roundTrip(value) {
       return this.api.kanamaWebRoundTrip(value);
+    },
+    // Task 88 (finding 3): the script's @OnExitTree, dispatched on EVERY tree exit and
+    // without destroying the instance -- a node that leaves the tree may come back.
+    exitTree(handle) {
+      return this.invoke(
+        handle,
+        "_exit_tree",
+        "_exit_tree",
+        () => this.api.kanamaWebExitTree(handle),
+        0,
+      );
     },
     free(handle) {
       const scriptName = this.match3ScriptNamesByHandle.get(handle);


### PR DESCRIPTION
## What

Godot fires `_exit_tree` on **every** tree exit, and a node that leaves may come
straight back — object pooling, reparent-on-pickup. Web destroyed the Kotlin instance
there, so the script could never return:

- `_ready` fires once per node, and `_kanama_ready_dispatched` was latched `true` and
  **never reset anywhere** (three occurrences in the emitter, none clearing it);
- without `@OnEnterTree` the handle was never recreated, so every
  `if _kanama_handle != 0` guard was false forever — the script was silently dead;
- with `@OnEnterTree` a fresh instance appeared whose `ready()` could never dispatch,
  so `@OnReady` wiring never ran and all state was back to constructor defaults.

Desktop keeps the instance alive across a reparent. This makes Web match Godot and
desktop. **Maintainer decision 2026-08-13: match Godot semantics.**

## Change

`kanamaWebFree` was doing two jobs. Split them:

| trigger | now does |
|---|---|
| `_exit_tree` | `kanamaWebExitTree` — dispatch `@OnExitTree`, **no destroy** |
| `NOTIFICATION_PREDELETE` | `kanamaWebFree` — **destroy only** |

PREDELETE is the only notification meaning the node is really going away, and Godot
always exits the tree before deleting, so `@OnExitTree` has already run.

**The elegant part:** because the instance now *survives* a tree exit, the latched
`_kanama_ready_dispatched` becomes **correct** rather than a bug — Godot's fire-once
`_ready` is exactly right for a node that came back with its state intact. No reset
needed.

Protocol **18 → 19** (new bridge entry point; the proxy compares versions at startup).

## Validation

`:processor:test`, `:web-runtime:compileKotlinWasmJs`, `ktfmtCheck` → green.

**Full `ci` demo set on Chrome: 12/12 PASS at protocol 19.**

The first corpus run failed 10/12 — and what it caught is worth stating, because it
is the reassuring part. Every failure was the hardcoded `protocol18` driver check.
On all ten: `liveAfterTeardown` **0**, teardown `clean`, `ownerRegistriesToBaseline`
**true**, **zero** console errors. So moving destruction to PREDELETE did not strand
handles or delay the drain past the settle window — the main risk, measured and
clear — and the failures were purely the protocol pin.

## Recorded smell (not fixed here)

A protocol bump requires editing **12 driver files**, and the check *name* encodes the
number (`protocol18: protocolVersion === 18`). Deriving it from the manifest would
make the next bump — Godot 4.8 is coming — a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
