### PR TITLE
Task 88 follow-up: derive the protocol check from the export manifest

### DIFF
--- a/scripts/fixtures/web-fake-export/kanama-web/KanamaWebProtocol.generated.json
+++ b/scripts/fixtures/web-fake-export/kanama-web/KanamaWebProtocol.generated.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 2,
+  "protocolVersion": 6,
+  "scripts": [
+    {
+      "id": 1,
+      "resourcePath": "res://kotlin-src/Fake.kt",
+      "className": "fake.FakeScript",
+      "attachTo": "Node",
+      "properties": [],
+      "virtuals": [{"id": 1, "name": "_ready", "arguments": [], "returnType": null}],
+      "methods": [],
+      "signals": []
+    }
+  ]
+}

--- a/scripts/web/drivers/demos/charactercontroller.mjs
+++ b/scripts/web/drivers/demos/charactercontroller.mjs
@@ -309,7 +309,6 @@ export async function runCharactercontroller({ url, evaluate, navigate, keys, de
   const protocolVersion = ready.protocol;
   const checks = {
     modeCharactercontroller: ready.mode === "charactercontroller",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.skinReady >= 1 &&

--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -267,7 +267,6 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeCitybuilder: ready.mode === "citybuilder",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.builderReady >= 1 && ready.viewReady >= 1 && ready.audioReady >= 1 && ready.smokeReady >= 1,
     // Injected build placed a structure on the grid at the mouse-ray cell.

--- a/scripts/web/drivers/demos/dodge.mjs
+++ b/scripts/web/drivers/demos/dodge.mjs
@@ -268,7 +268,6 @@ export async function runDodge({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady: ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1,
     mobsInstantiated: peak.mobInstantiations >= 4,
     mobsAddedToTree: peak.mobAddChildCommands >= peak.mobInstantiations,

--- a/scripts/web/drivers/demos/fps.mjs
+++ b/scripts/web/drivers/demos/fps.mjs
@@ -217,7 +217,6 @@ export async function runFps({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeFps: ready.mode === "fps",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.smokeReady >= 1 &&
       ready.playerReady >= 1 &&

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -234,7 +234,6 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
   const positionTweenDelta = afterSwap.positionTweenTargets - beforeSwap.positionTweenTargets;
 
   const checks = {
-    protocol19: firstRun.settled.protocol === 19 && secondRun.settled.protocol === 19,
     exactOriginalBoard:
       firstRun.board.pass === true && firstRun.settled.tileGrid.length === 64 &&
       firstRun.settled.tileReady >= 64 && firstRun.settled.playersConstructed === 12,

--- a/scripts/web/drivers/demos/platformer.mjs
+++ b/scripts/web/drivers/demos/platformer.mjs
@@ -388,7 +388,6 @@ export async function runPlatformer({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modePlatformer: ready.mode === "platformer",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.hudReady >= 1 && ready.coinReady >= 1,
     // Both frame pumps ran: _physics_process (player gravity/move_and_slide) and

--- a/scripts/web/drivers/demos/racing.mjs
+++ b/scripts/web/drivers/demos/racing.mjs
@@ -211,7 +211,6 @@ export async function runRacing({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeRacing: ready.mode === "racing",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.vehicleReady >= 1 && ready.viewReady >= 1 && ready.smokeReady >= 1,
     // Held forward drove the sphere racer; the camera rig followed it.

--- a/scripts/web/drivers/demos/soak.mjs
+++ b/scripts/web/drivers/demos/soak.mjs
@@ -185,7 +185,6 @@ export async function runSoak({ url, evaluate, navigate, deadline }) {
 
   const checks = {
     modeDodge: ready.mode === "dodge",
-    protocol19: ready.protocol === 19,
     // The run really lasted: several full rounds, and enough samples to judge.
     soakCyclesCompleted: cycles >= 2,
     soakSamplesCollected: samples.length >= 8,

--- a/scripts/web/drivers/demos/squash.mjs
+++ b/scripts/web/drivers/demos/squash.mjs
@@ -437,7 +437,6 @@ export async function runSquash({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeSquash: ready.mode === "squash",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.mainReady >= 1 && ready.playerReady >= 1 && ready.scoreLabelReady >= 1,
     // MobTimer spawned mobs; each initialize ran the look_at/rotate/rotation-read chain.

--- a/scripts/web/drivers/demos/thirdperson.mjs
+++ b/scripts/web/drivers/demos/thirdperson.mjs
@@ -296,7 +296,6 @@ export async function runThirdperson({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeThirdperson: ready.mode === "thirdperson",
-    protocol19: protocolVersion === 19,
     sceneScriptsReady:
       ready.playerReady >= 1 &&
       ready.demoPageReady >= 1 &&

--- a/scripts/web/drivers/demos/tpsdemo.mjs
+++ b/scripts/web/drivers/demos/tpsdemo.mjs
@@ -234,7 +234,6 @@ export async function runTpsdemo({ url, evaluate, navigate, deadline }) {
   const protocolVersion = menu.protocol;
   const checks = {
     modeTpsdemo: menu.mode === "tpsdemo",
-    protocol19: protocolVersion === 19,
     // The menu boots, and pressing Play streams the whole level in: the AnimationTree-driven
     // player, its input synchronizer, the shake camera, and the four red robots with their
     // detachable death parts.

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -238,7 +238,6 @@ export async function runWeb3d({ url, evaluate, navigate, deadline }) {
   const protocolVersion = ready.protocol;
   const checks = {
     modeWeb3d: ready.mode === "web3d",
-    protocol19: protocolVersion === 19,
     sceneReady: ready.mainReady >= 1,
     // 66b: the bridge crossing fired and the Kotlin @OnEnterTree body observed it.
     enterTreeDispatched: ready.enterTreeCalls >= 1 && (enterTreeProbe & 1) === 1,

--- a/scripts/web/result_schema.py
+++ b/scripts/web/result_schema.py
@@ -424,6 +424,13 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="print the current schema version and exit",
     )
+    parser.add_argument(
+        "--manifest",
+        help=(
+            "the export's KanamaWebProtocol.generated.json; when given, the envelope's "
+            "protocolVersion must equal the manifest's"
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.print_version:
@@ -445,6 +452,47 @@ def main(argv: list[str]) -> int:
     except SchemaError as error:
         print(f"web_export_smoke: result schema violation in {args.result}: {error}", file=sys.stderr)
         return 1
+
+    # Task 88 follow-up: the protocol pin used to live in all 12 demo drivers as a
+    # literal, with the number baked into the CHECK NAME too (`protocol18:
+    # protocolVersion === 18`). A bump then failed every demo on nothing but the pin --
+    # measured going 18 -> 19, which cost a full corpus run to discover. Worse, matching
+    # a literal only proves the runtime agrees with whatever number someone last typed.
+    #
+    # Comparing the RUNTIME's protocol against the MANIFEST OF THE EXPORT IT CAME FROM is
+    # both maintenance-free and a stronger invariant: it catches a stale export driven by
+    # a newer runtime (or the reverse), which the literal never could -- and that is a
+    # trap this project has hit ("rm -rf the export when in doubt; check the printed
+    # buildId/protocol").
+    if args.manifest:
+        try:
+            with open(args.manifest, encoding="utf-8") as handle:
+                manifest = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            print(
+                f"web_export_smoke: could not read manifest {args.manifest}: {error}",
+                file=sys.stderr,
+            )
+            return 2
+        declared = manifest.get("protocolVersion")
+        observed = envelope.get("protocolVersion")
+        if declared is None:
+            print(
+                f"web_export_smoke: manifest {args.manifest} declares no protocolVersion",
+                file=sys.stderr,
+            )
+            return 2
+        if declared != observed:
+            print(
+                f"web_export_smoke: protocol mismatch — the runtime reported "
+                f"{observed} but the export's manifest declares {declared}. The export "
+                f"and the Kotlin/Wasm runtime driving it are not from the same build.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"web_export_smoke: protocol {observed} matches the export manifest"
+        )
 
     print(f"web_export_smoke: result {args.result} satisfies schema v{SCHEMA_VERSION}")
     return 0

--- a/scripts/web/scaffold_selftest.sh
+++ b/scripts/web/scaffold_selftest.sh
@@ -34,6 +34,12 @@ run_case() {
   local result="$case_dir/result.json"
   mkdir -p "$export_dir"
   cp -R "$FIXTURE/index.html" "$FIXTURE/kanama-web-fake.js" "$export_dir/"
+  # A real export always ships its protocol manifest, and the smoke now checks the
+  # runtime's protocol against it. The fixture carries one too (declaring the same
+  # version the fake driver reports) so this stand-in stays faithful to the shape it
+  # stands in for -- otherwise the self-test's success case fails on a missing file
+  # rather than on anything it means to assert.
+  cp -R "$FIXTURE/kanama-web" "$export_dir/"
 
   local driver_cmd="python3 $FAKE_DRIVER --mode $mode"
   if [[ "$mode" == "mutate" ]]; then

--- a/scripts/web_export_smoke.sh
+++ b/scripts/web_export_smoke.sh
@@ -226,7 +226,8 @@ fi
 
 # --- validate the result envelope against the versioned schema. ---------------
 [[ -f "$RESULT" ]] || fail "driver produced no result at $RESULT"
-if ! python3 "$WEB_DIR/result_schema.py" "$RESULT"; then
+if ! python3 "$WEB_DIR/result_schema.py" "$RESULT" \
+  --manifest "$EXPORT_DIR/kanama-web/KanamaWebProtocol.generated.json"; then
   fail "result schema validation failed for $RESULT"
 fi
 


### PR DESCRIPTION
## What

The protocol pin lived in all **12 demo drivers** as a literal — with the number baked
into the check *name* as well:

```js
protocol18: protocolVersion === 18,
```

So bumping 18 → 19 for finding 3 (#186) failed **every demo** on nothing but the pin.
A full corpus run spent discovering a rename. **Godot 4.8 will bump it again.**

And matching a literal only proves the runtime agrees with whatever number someone
last typed.

## Change

The validator now compares the **runtime's** protocol against the manifest of **the
export it came from** (`--manifest`, passed by `web_export_smoke.sh`). The 12 literal
pins are gone.

This is maintenance-free *and* a strictly stronger invariant: it catches a **stale
export driven by a newer runtime** (or the reverse), which a literal never could — and
that is a trap this project has hit before ("`rm -rf` the export when in doubt; check
the printed buildId/protocol").

## Validation

**Both directions**, against a real fps envelope:

- matching manifest → exit 0, `web_export_smoke: protocol 19 matches the export manifest`
- manifest one version behind → **exit 1**:
  `protocol mismatch — the runtime reported 19 but the export's manifest declares 18.
  The export and the Kotlin/Wasm runtime driving it are not from the same build.`

**Full `ci` demo set on Chrome: 12/12 PASS**, and all **12** printed
`protocol 19 matches the export manifest` — so the new check ran on every demo rather
than silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
