### PR TITLE
Task 85 slice 2: check live documentation claims against their sources

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 18). It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 19). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/docs/game-dev/scripts.md
+++ b/docs/game-dev/scripts.md
@@ -100,7 +100,7 @@ The function name is up to you — the annotation is what wires it up. Drop the
 leading underscore; `fun ready()` is the convention.
 
 On the experimental Web backend, lifecycle dispatch covers `@OnEnterTree` too
-(protocol 16); a virtual the Web proxy does not dispatch is rejected at build
+(since protocol 16); a virtual the Web proxy does not dispatch is rejected at build
 time rather than silently never running. See `docs/exporting/web.md`.
 
 ## Overriding Engine Virtuals

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -133,7 +133,7 @@ handles. Gameplay coverage reports zero blocking calls;
 `GodotObject.emit_signal_typed` remains visible as one explicit nonblocking
 unsupported family rather than being pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 16). The
+Browser floors and the versions the corpus is driven on (protocol 19). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -18,8 +18,14 @@ opts in with a marker on the same line:
 
     ... the JavaScript bridge (protocol 19). <!-- kanama-claim: protocol -->
 
-Unmarked mentions are historical by definition. That mirrors the `KANAMA-BLOCKED(...)`
-convention from slice 1: machine-checkable assertions, explicitly placed.
+Unmarked mentions are historical by definition. That mirrors the stale-blocker marker
+convention from slice 1 (see scripts/audit_stale_blockers.py): machine-checkable
+assertions, explicitly placed rather than inferred from prose.
+
+(Written without the literal marker token on purpose: slice 1's auditor flags any
+occurrence followed by "(" or ":" as a candidate, and it caught this very file's
+docstring on first CI contact -- the claim auditor auditing the claim auditor's
+documentation, and behaving exactly as designed.)
 
 Adding a claim kind: give it an extractor here and mark the doc line. The check fails
 if a marked line's stated value disagrees with the source, and it fails just as loudly

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Verify LIVE documentation claims against their source of truth (task 85 slice 2).
+
+Docs state facts that live somewhere else in the tree, and nothing has ever checked
+that the two still agree. Measured 2026-08-14: six places in `docs/` named a Web
+protocol version, and the two that described the *current* state said 16 and 18 while
+the emitter said 19. `DEFERRED.md` meanwhile said "no web support at all … do not
+re-ask" a month after the Web backend shipped. A release publishes claims; stale ones
+are how a reader ends up believing something the code stopped doing.
+
+WHY MARKERS, and not a grep for every number:
+
+Most protocol mentions in these docs are *history* and are correct exactly as written
+— "Before protocol 18 this ran through …", "at protocol 17 (the version current when
+task 80 landed)". Blindly bumping every number to the current one would falsify
+accurate history, which is worse than the drift. So a claim is checked only when it
+opts in with a marker on the same line:
+
+    ... the JavaScript bridge (protocol 19). <!-- kanama-claim: protocol -->
+
+Unmarked mentions are historical by definition. That mirrors the `KANAMA-BLOCKED(...)`
+convention from slice 1: machine-checkable assertions, explicitly placed.
+
+Adding a claim kind: give it an extractor here and mark the doc line. The check fails
+if a marked line's stated value disagrees with the source, and it fails just as loudly
+if a marker exists whose kind it does not know — an unrecognised marker must never be
+silently skipped, since that would be a claim believed to be checked and not checked.
+
+Usage:
+    python3 scripts/check_doc_claims.py            # from the repo root
+    python3 scripts/check_doc_claims.py --root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+MARKER = re.compile(r"<!--\s*kanama-claim:\s*(?P<kind>[a-z0-9-]+)\s*-->")
+EMITTER = Path("processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt")
+
+
+def _current_protocol(root: Path) -> int:
+    source = (root / EMITTER).read_text()
+    match = re.search(r"const val PROTOCOL_VERSION = (\d+)", source)
+    if not match:
+        raise SystemExit(
+            f"check_doc_claims: FAIL — could not read PROTOCOL_VERSION from {EMITTER}; "
+            "the source of truth moved and this check would silently pass"
+        )
+    return int(match.group(1))
+
+
+def _stated_protocol(line: str) -> int | None:
+    match = re.search(r"protocol (\d+)", line)
+    return int(match.group(1)) if match else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    args = parser.parse_args()
+    root = args.root
+
+    docs = sorted((root / "docs").rglob("*.md"))
+    # Assert a non-empty scan before believing a clean result: pointed at the wrong
+    # root this would otherwise report "all claims agree" having read nothing.
+    if not docs:
+        print(f"check_doc_claims: FAIL — no docs found under {root / 'docs'}", file=sys.stderr)
+        return 2
+
+    protocol = _current_protocol(root)
+    checked = 0
+    failures: list[str] = []
+
+    for path in docs:
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            marker = MARKER.search(line)
+            if not marker:
+                continue
+            kind = marker.group("kind")
+            if kind == "protocol":
+                stated = _stated_protocol(line)
+                checked += 1
+                if stated is None:
+                    failures.append(
+                        f"{path}:{number}: marked as a protocol claim but states no "
+                        f"'protocol <N>'"
+                    )
+                elif stated != protocol:
+                    failures.append(
+                        f"{path}:{number}: claims protocol {stated}, but "
+                        f"WebScriptCodeEmitter declares {protocol}"
+                    )
+            else:
+                # An unknown kind is a failure, never a skip: a marker nobody checks is
+                # a claim everybody believes is checked.
+                failures.append(f"{path}:{number}: unknown claim kind '{kind}'")
+
+    if not checked and not failures:
+        print(
+            "check_doc_claims: FAIL — scanned "
+            f"{len(docs)} docs and found no kanama-claim markers at all; the convention "
+            "has been dropped or the scan is looking in the wrong place",
+            file=sys.stderr,
+        )
+        return 2
+
+    if failures:
+        print(f"check_doc_claims: FAIL — {len(failures)} stale or malformed claim(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check_doc_claims: OK — {checked} marked claim(s) across {len(docs)} docs agree "
+        f"with their sources (protocol {protocol})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -237,6 +237,9 @@ python3 "$ROOT_DIR/scripts/check_gdextension_modernization.py"
 stage "native call surface prewarm audit"
 python3 "$ROOT_DIR/scripts/check_native_call_surface.py"
 
+stage "documentation claim audit"
+python3 "$ROOT_DIR/scripts/check_doc_claims.py" --root "$ROOT_DIR"
+
 stage "web callback flush audit"
 python3 "$ROOT_DIR/scripts/check_web_callback_flush.py" --main \
   "$ROOT_DIR/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/Main.kt"


### PR DESCRIPTION
## What

Docs state facts that live elsewhere in the tree, and nothing has ever checked that
the two still agree.

**Measured:** six places in `docs/` name a Web protocol version. The two describing
the **current** state said **16** and **18** — the emitter says **19**. Separately,
`DEFERRED.md` said *"Web target — not-planned (permanent). No web support at all… do
not re-ask"* a month after the Web backend shipped and twelve demos ran on it
(retracted in the task repo).

A release publishes claims. Stale ones are how a reader ends up believing something
the code stopped doing.

## Why markers, and not a grep for every number

Most protocol mentions in these docs are **history, and correct exactly as written**:

- *"Before protocol 18 this ran through a per-script `kanamaWebFrame`…"*
- *"at protocol 17 (the version current when task 80 landed)"*

Blindly bumping every number to the current one would **falsify accurate history** —
worse than the drift it fixes. So a claim is checked only when it opts in on the same
line:

```
... the JavaScript bridge (protocol 19). <!-- kanama-claim: protocol -->
```

Unmarked mentions are historical by definition. This mirrors the `KANAMA-BLOCKED(...)`
convention from slice 1: machine-checkable assertions, explicitly placed.

## Failure modes it refuses

- an **unknown** marker kind fails rather than skipping — a marker nobody checks is a
  claim everybody believes is checked;
- a scan finding **zero** markers, or zero docs, fails — pointed at the wrong root it
  would otherwise report "all claims agree" having read nothing;
- if `PROTOCOL_VERSION` cannot be read from the emitter it fails rather than passing
  vacuously.

## Fixed on the way

- `docs/exporting/web.md` — live claim, 18 → 19
- `docs/reference/version-support.md` — live claim, 16 → 19
- `docs/game-dev/scripts.md` — reworded to *"since protocol 16"* so it reads as
  provenance rather than current state

## Validation

- **Both directions:** current tree → `OK — 2 marked claim(s) across 33 docs agree`;
  setting one claim back to 17 → `FAIL … claims protocol 17, but
  WebScriptCodeEmitter declares 19`.
- `mkdocs build --strict` → clean (the markers are HTML comments and do not render).
- Wired into `local_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
