### PR TITLE
Task 80 slice 6: differential desktop <-> Web harness (Kanama half)

### DIFF
--- a/scripts/web/differential_diff.py
+++ b/scripts/web/differential_diff.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Diff a demo's hydrated state between desktop and Web (task 80 slice 6).
+
+Task 64 made one Kotlin source compile for both platforms, which makes this possible:
+the same `differential_probe()` runs on desktop and on Web, so its output must be
+byte-identical. A difference is by definition a bug — one of the two hydration paths
+delivered a different value for the same declaration.
+
+This is the only technique in task 80 that catches the silent-wrong-VALUE class.
+Everything else — the degradation manifest, the census, the coverage report — proves a
+member *dispatched*, not that it carried the right value. cc's tilt limits and fps's
+`max_distance` dispatched perfectly on both platforms and simply held different numbers.
+
+WHAT IT DELIBERATELY DOES NOT COMPARE: object identity. Handle numbers legitimately
+differ between platforms, so the probe reports object fields as presence (0/1) rather
+than value. Comparing identity would report a difference that is not a defect, and a
+check that cries wolf gets ignored.
+
+Inputs:
+  --web      a smoke result envelope carrying `differential`
+  --desktop  a desktop headless smoke log containing a `KANAMA-DIFF <script> <payload>` line
+
+Usage:
+    python3 scripts/web/differential_diff.py --web result.json --desktop desktop.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DESKTOP_LINE = re.compile(r"KANAMA-DIFF\s+(?P<script>\S+)\s+(?P<payload>.+?)\s*$")
+
+
+def _parse_payload(payload: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for entry in payload.split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        key, _, value = entry.partition("=")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--web", type=Path, required=True)
+    parser.add_argument("--desktop", type=Path, required=True)
+    args = parser.parse_args()
+
+    if not args.web.is_file():
+        print(f"differential_diff: FAIL — web envelope not found: {args.web}", file=sys.stderr)
+        return 2
+    if not args.desktop.is_file():
+        print(f"differential_diff: FAIL — desktop log not found: {args.desktop}", file=sys.stderr)
+        return 2
+
+    envelope = json.loads(args.web.read_text())
+    block = envelope.get("differential")
+    if not block:
+        print(
+            f"differential_diff: FAIL — {args.web} carries no `differential` section; the "
+            "driver did not run the probe",
+            file=sys.stderr,
+        )
+        return 2
+    if not block.get("available"):
+        print(
+            f"differential_diff: FAIL — the Web run reported the probe unavailable: "
+            f"{block.get('reason', 'no reason given')}",
+            file=sys.stderr,
+        )
+        return 2
+
+    web_script = block.get("script")
+    web_payload = block.get("payload")
+    if not web_payload:
+        print(
+            "differential_diff: FAIL — the Web probe returned an empty payload; the call "
+            "reached the bridge but produced nothing to compare",
+            file=sys.stderr,
+        )
+        return 2
+
+    desktop_payload = None
+    for line in args.desktop.read_text(errors="replace").splitlines():
+        match = DESKTOP_LINE.search(line)
+        if match and match.group("script") == web_script:
+            desktop_payload = match.group("payload")
+    if desktop_payload is None:
+        print(
+            f"differential_diff: FAIL — no `KANAMA-DIFF {web_script} ...` line in "
+            f"{args.desktop}. The desktop run did not emit the probe (is "
+            "KANAMA_DEMO_SMOKE_QUIT=1 set?), so there is nothing to compare — which is "
+            "NOT the same as the two agreeing.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A differential that compares a BROKEN desktop run against a healthy Web one reports
+    # garbage as a platform bug. MEASURED on the first run of this tool: a worktree whose
+    # assets had not been imported produced `textures=0` and null cursors on desktop
+    # against `textures=5` on Web -- three "divergences" that were entirely a missing
+    # `--import` pass. Resource-load failures invalidate the comparison, so refuse it.
+    # (Leaked-RID and "resources still in use at exit" errors are normal on a headless
+    # quit and are deliberately NOT treated as invalidating.)
+    load_failures = [
+        line.strip()
+        for line in args.desktop.read_text(errors="replace").splitlines()
+        if "Failed loading resource" in line or "Unable to open file" in line
+    ]
+    if load_failures:
+        print(
+            f"differential_diff: FAIL — the desktop run could not load "
+            f"{len(load_failures)} resource(s), so its values are not comparable. Run "
+            f"`godot --headless --import --path <project>` first.",
+            file=sys.stderr,
+        )
+        for failure in load_failures[:5]:
+            print(f"  {failure}", file=sys.stderr)
+        return 2
+
+    web_fields = _parse_payload(web_payload)
+    desktop_fields = _parse_payload(desktop_payload)
+    # A comparison over zero fields would "agree" vacuously.
+    if not web_fields or not desktop_fields:
+        print(
+            "differential_diff: FAIL — a payload parsed to zero fields "
+            f"(web={len(web_fields)}, desktop={len(desktop_fields)})",
+            file=sys.stderr,
+        )
+        return 2
+
+    differences: list[str] = []
+    for key in sorted(set(web_fields) | set(desktop_fields)):
+        web_value = web_fields.get(key)
+        desktop_value = desktop_fields.get(key)
+        if web_value != desktop_value:
+            differences.append(
+                f"  {key}: desktop={desktop_value!r} web={web_value!r}"
+                + (" (missing on web)" if web_value is None else "")
+                + (" (missing on desktop)" if desktop_value is None else "")
+            )
+
+    print(f"differential_diff: {web_script}")
+    print(f"  desktop : {desktop_payload}")
+    print(f"  web     : {web_payload}")
+
+    if differences:
+        print(
+            f"differential_diff: FAIL — {len(differences)} field(s) differ between "
+            f"platforms for the SAME Kotlin source:",
+            file=sys.stderr,
+        )
+        for difference in differences:
+            print(difference, file=sys.stderr)
+        return 1
+
+    print(f"  MATCH — {len(web_fields)} field(s) identical on both platforms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/web/drivers/chrome_cdp.mjs
+++ b/scripts/web/drivers/chrome_cdp.mjs
@@ -345,7 +345,7 @@ async function main() {
 
     // Drive the demo. The demo module returns startup + assertion + lifecycle
     // facts; console/exception capture stays here where CDP delivers it.
-    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline });
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline, exportDir: args["export-dir"] });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/demos/match3.mjs
+++ b/scripts/web/drivers/demos/match3.mjs
@@ -11,6 +11,8 @@
 // crossings, then tears the scene down twice to baseline and proves stale
 // handles are rejected.
 
+import { resolveMethodId } from "../envelope.mjs";
+
 const OFFSET = 68;
 const BOARD = 8;
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -203,10 +205,26 @@ function teardownClean(t) {
   );
 }
 
-export async function runMatch3({ url, evaluate, navigate, pointer }) {
+export async function runMatch3({ url, evaluate, navigate, pointer, exportDir }) {
   const startupStart = Date.now();
   const firstRun = await navigateAndSettle(navigate, evaluate, url, "first");
   const startupDurationMs = Date.now() - startupStart;
+
+  // Task 80 slice 6: read the demo's hydrated-state dump WHILE THE BOARD IS ALIVE. Run
+  // after teardown it returns null -- the bridge zeroes match3MainHandle when Main frees,
+  // and a null payload would look like "the probe is broken" rather than "asked too late".
+  // Ids are resolved from the export manifest, never hardcoded: adding a
+  // @RegisterFunction renumbers the rest (this probe took id 1 and pushed the existing
+  // two down), so a hardcoded call would dispatch a different method and still "work".
+  const probeId = resolveMethodId(exportDir, "match3.Main", "differential_probe");
+  const differentialPayload =
+    probeId === null
+      ? null
+      : await evaluate(
+          `(() => { const b = globalThis.KanamaWebBridge;` +
+            ` if (!b || !b.match3MainHandle) return null;` +
+            ` return String(b.callPacked(b.match3MainHandle, ${probeId})); })()`,
+        );
 
   const legalSwap = findLegalSwap(firstRun.settled.tileGrid);
   if (!legalSwap) throw new Error("Settled Match3 board has no legal swap");
@@ -273,7 +291,17 @@ export async function runMatch3({ url, evaluate, navigate, pointer }) {
     (firstTeardown.sceneTreeStaleProbe === 1 ? 1 : 0) +
     (secondTeardown.sceneTreeStaleProbe === 1 ? 1 : 0);
 
+  // Task 80 slice 6: read the demo's own hydrated-state dump. The SAME Kotlin runs on
+  // desktop, which prints it to stdout under the smoke env var, so the two payloads must
+  // be byte-identical; differential_diff.py compares them. The method id is resolved from
+  // the export manifest rather than hardcoded -- ids are positional, so adding a
+  // @RegisterFunction above this one would silently renumber it and a hardcoded call
+  // would dispatch a different method while still appearing to work.
   return {
+    differential:
+      probeId === null
+        ? { available: false, reason: "differential_probe not found in the export manifest" }
+        : { available: true, script: "match3.Main", payload: differentialPayload },
     protocolVersion: firstRun.settled.protocol,
     startup: {
       loaded: firstRun.board.pass === true,

--- a/scripts/web/drivers/envelope.mjs
+++ b/scripts/web/drivers/envelope.mjs
@@ -129,6 +129,35 @@ export async function collectExercisedMembers(evaluate, exportDir) {
 }
 
 /**
+ * Task 80 slice 6: resolve a registered method's NAME to the id the bridge dispatches on.
+ *
+ * The reverse of the census resolution above. Method ids are positional, so a driver must
+ * never hardcode one -- adding a @RegisterFunction above another silently renumbers it,
+ * and the call would then dispatch a DIFFERENT method while still "working".
+ *
+ * Returns null when the manifest or the method is missing, so the caller can report the
+ * probe as unavailable rather than calling id 0 and reporting a confident wrong answer.
+ */
+export function resolveMethodId(exportDir, className, methodName) {
+  try {
+    const manifestPath = path.join(exportDir, "kanama-web", "KanamaWebProtocol.generated.json");
+    const scripts = JSON.parse(fs.readFileSync(manifestPath, "utf-8")).scripts ?? [];
+    // Package spelling differs per demo -- match3's manifest says
+    // `net.multigesture.kanama.demos.match3.Main` while fps says `fps.Enemy` -- so match
+    // on the tail rather than the full string. An exact-equality lookup silently found
+    // nothing for match3 and would have reported "probe unavailable" for a probe that
+    // was present.
+    const tail = (name) => String(name).split(".").pop();
+    const script = scripts.find(
+      (entry) => entry.className === className || tail(entry.className) === tail(className),
+    );
+    return script?.methods?.find((method) => method.name === methodName)?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Merges two exercised-member censuses, summing dispatch counts (task 81).
  *
  * A navigation resets the page's bridge, so a driver that navigates more than
@@ -225,6 +254,7 @@ export function buildEnvelope({
     // Optional: absent when the page could not be asked. The schema validates it
     // when present, and the budget gate reports "not measured" rather than
     // quietly passing.
+    ...(demoResult.differential ? { differential: demoResult.differential } : {}),
     ...(performance ? { performance } : {}),
     // Task 81: absent only when the page could not be asked -- and then a demo
     // with a non-empty required-member list FAILS the schema, so this section

--- a/scripts/web/drivers/firefox_bidi.mjs
+++ b/scripts/web/drivers/firefox_bidi.mjs
@@ -314,7 +314,7 @@ async function main() {
         ],
       });
 
-    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline });
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, keys, deadline, exportDir: args["export-dir"] });
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -222,7 +222,7 @@ async function main() {
       await wd("DELETE", `/session/${sessionId}/actions`);
     };
 
-    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline });
+    const demoResult = await runDemo({ url: args.url, evaluate, navigate, pointer, deadline , exportDir: args["export-dir"]});
 
     const browserVersion = await evaluate("navigator.userAgent");
     const payload = collectPayload(args["export-dir"], args.url, args["source-checksum"]);


### PR DESCRIPTION
## What

The Kanama half of task 80 slice 6 — the **differential desktop ↔ Web** harness. Pairs
with **kanama-demos#37**, which adds `differential_probe()` to match3's `Main`.

This is the only technique in task 80 that catches the **silent-wrong-value** class:
everything else proves a member *dispatched*, not that it carried the right value.

## Pieces

- **`envelope.mjs: resolveMethodId(exportDir, class, method)`** — the reverse of the
  census's id→name resolution. Method ids are **positional**: adding `differential_probe`
  to match3's `Main` took **id 1** and pushed the existing two methods down, so a
  hardcoded id would dispatch a *different* method while still appearing to work. It
  matches on the class **tail**, because package spelling differs per demo (match3's
  manifest says `net.multigesture.kanama.demos.match3.Main`, fps says `fps.Enemy`) —
  exact equality silently found nothing and would have reported a present probe as
  unavailable.
- **`envelope.mjs`: a `differential` section.** `buildEnvelope` builds from a fixed field
  list and silently drops unknown keys — the same behaviour that swallows
  visibilityprobe's beacons — so this needs an explicit field.
- **The three engine drivers** pass `exportDir` through to the demo module.
- **`match3.mjs`** calls the probe **while the board is alive**. Run after teardown it
  returns `null`, because the bridge zeroes `match3MainHandle` when Main frees — which
  reads as "the probe is broken" rather than "asked too late".
- **`differential_diff.py`** compares the two payloads.

## Proven three directions, end to end

1. **Identical payloads MATCH** — 8 fields, real desktop headless run vs real Chrome run.
2. **A crafted divergence FAILS**, naming both fields:
   `offset: desktop='68' web='64'` / `textures: desktop='5' web='4'`.
3. **A desktop run whose assets were never imported is REFUSED, not compared.**

That third guard exists because of what happened on this tool's very first run: it
reported `textures=0` and null cursors on desktop against `textures=5` on Web — three
"divergences" that were *entirely* a missing `--import` pass. A differential that
compares a broken run against a healthy one reports garbage as a platform bug, so
resource-load failures now invalidate the comparison. (Leaked-RID and
"resources still in use at exit" errors are normal on a headless quit and are
deliberately not treated as invalidating.)

## Landing order

The Web driver degrades to `differential: { available: false }` when the probe is absent,
so this is safe to land before kanama-demos#37 and the `DEMOS_REF` pin — CI runs against
the currently pinned demos ref, where the probe does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
