### PR TITLE
docs: state the real Safari coverage (11/12) and the spot-check policy

### DIFF
--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -141,7 +141,18 @@ and `web_export_smoke.sh` fails any run below them:
 |---|---|---|---|---|
 | Chrome | 130 | tested (2026-07-28) | 150 (headless) | CI cell |
 | Firefox | 141 | tested (2026-07-28) | 152–153 (headless) | CI cell |
-| Safari | 26.5 | validated-at (2026-07-27) | 26.5 / WebKit 605.1.15, macOS 26.5.1 | local gate; **no headless mode**, so it needs a logged-in GUI session |
+| Safari | 26.5 | validated-at (2026-07-27) | 26.5 / WebKit 605.1.15, macOS 26.5.1 — **11 of 12 demos as of 2026-08-14**, `match3` fails (see below) | **spot-checked, not gated**; no headless mode, needs a logged-in GUI session, and cannot run two at once |
+
+**Safari is spot-checked, deliberately.** It has no headless mode, needs a
+logged-in GUI session with an unoccluded window, and cannot run two gates
+concurrently, so a CI cell would cost more than it returns (maintainer decision,
+2026-08-14). The trade is explicit: **between spot checks, the Safari claim can go
+stale without anything noticing.** It did — the corpus was 12/12 on 2026-07-27 and
+**11/12** when next run on 2026-08-14, with `match3` failing deterministically on the
+swap/collapse path. That regression predates the task-88 work (a control built from
+`56087469` fails the same way), so it landed at some point in those five weeks
+unobserved. When quoting Safari evidence, quote **the date it was last run**, not the
+best result ever recorded.
 
 **"Tested" and "validated-at" are different claims.** Tested means the gate was
 run on the floor version and on the one below it: Chrome 129 never boots the


### PR DESCRIPTION
## What

The support matrix implied **12/12 on Safari**, dated 2026-07-27. The first Safari run
since then (2026-08-14) is **11/12** — `match3` fails deterministically, 3/3 runs, on
the swap/collapse path.

A control export from **pre-audit main (`56087469`)** fails too, so this is *not* from
the seventeen PRs merged on 2026-08-13..14 — it regressed somewhere in the five weeks
nobody ran the hand gate. Tracked as `kanama-tasks/89`.

## The policy, stated rather than implied

**Maintainer decision 2026-08-14: Safari stays spot-checked; no CI cell.** It has no
headless mode, needs a logged-in GUI session with an unoccluded window, and cannot run
two gates concurrently — a full corpus pass is ~40 minutes of real browser time. A cell
would cost more than it returns.

The docs now name the cost of that trade: **between spot checks, the Safari claim can go
stale without anything noticing.** It did. So the guidance is to quote **the date it was
last run**, not the best result ever recorded — which is how a five-week-old sentence
came to be cited as current evidence.

## Also relevant

Audit finding 11 is live on this path: the Safari envelope reports `console.errors: []`
on a run whose console was **never observable** (SafariDriver exposes no console
endpoint, so the driver hardwires it). A page-level JS error on Safari would not appear
in the evidence at all — worth fixing before bisecting task 89.

`mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)