### PR TITLE
Task 88 finding 11: observe Safari's console instead of fabricating an empty one

### DIFF
--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -183,9 +183,55 @@ async function main() {
       );
       return exercisedAccumulator;
     };
+    // Task 88 finding 11: Safari used to ship `consoleEvents: []` unconditionally,
+    // because SafariDriver exposes no console endpoint like CDP's consoleAPICalled or
+    // BiDi's log entries. An empty list is BYTE-IDENTICAL to a genuinely clean run, so
+    // the envelope's zero-console-errors pass leg -- one of the four -- asserted nothing
+    // on the one engine this gate exists for. A page-level JS error on Safari simply did
+    // not appear in the evidence.
+    //
+    // Observe it in-page instead: wrap console.error and listen for `error` /
+    // `unhandledrejection`, accumulating into a global the driver reads back. This is a
+    // WEAKER guarantee than Chrome's and Firefox's protocol-level capture, and the code
+    // says so: the hook can only be installed once navigation RETURNS, so anything
+    // thrown before that is still missed. In practice the Kotlin/Wasm boot runs after
+    // the load event and takes seconds, so boot and the whole gameplay run are covered
+    // -- but "covered" and "guaranteed" are different words and this is the first.
+    const CONSOLE_HOOK = `(() => {
+      if (globalThis.__kanamaSafariConsole) return 1;
+      const sink = [];
+      globalThis.__kanamaSafariConsole = sink;
+      const original = console.error ? console.error.bind(console) : null;
+      console.error = (...parts) => {
+        try { sink.push({ type: "error", text: "console.error: " + parts.map(String).join(" ") }); } catch (_) {}
+        if (original) original(...parts);
+      };
+      addEventListener("error", (event) => {
+        sink.push({ type: "error", text: "uncaught: " + (event.message || String(event.error)) });
+      });
+      addEventListener("unhandledrejection", (event) => {
+        sink.push({ type: "error", text: "unhandled rejection: " + String(event.reason) });
+      });
+      return 1;
+    })()`;
+    let consoleAccumulator = [];
+    const harvestConsole = async () => {
+      try {
+        const captured = await evaluate("globalThis.__kanamaSafariConsole ?? []");
+        if (Array.isArray(captured)) consoleAccumulator = consoleAccumulator.concat(captured);
+      } catch {
+        // The page is mid-navigation or gone. Anything it captured is already merged.
+      }
+      return consoleAccumulator;
+    };
     const navigate = async (url) => {
       await harvestExercisedMembers();
-      return wd("POST", `/session/${sessionId}/url`, { url });
+      // A navigation destroys the hook with its realm, so drain before leaving and
+      // re-install after arriving -- the same shape as the exercised-member census.
+      await harvestConsole();
+      const result = await wd("POST", `/session/${sessionId}/url`, { url });
+      await evaluate(CONSOLE_HOOK);
+      return result;
     };
     const pointer = async (press, release) => {
       // Viewport-origin coordinates are CSS client pixels (W3C), which the demo
@@ -241,7 +287,8 @@ async function main() {
       // enginePolicies.safari).
       performance,
       durationMs: Date.now() - startedAt,
-      consoleEvents: [],
+      // Real captured events now, not a fabricated empty list (task 88 finding 11).
+      consoleEvents: await harvestConsole(),
       demoResult,
       exercisedMembers,
     });


### PR DESCRIPTION
## What

SafariDriver exposes **no console endpoint** — no CDP `consoleAPICalled`, no BiDi log
entries — so the driver shipped `consoleEvents: []` unconditionally.

An empty list is **byte-identical to a genuinely clean run**. So the envelope's
zero-console-errors pass leg — one of its four — asserted nothing on the one engine this
gate exists for, and a page-level JS error on Safari never appeared in the evidence at
all.

## Change

Observe it **in-page**: wrap `console.error`, listen for `error` and
`unhandledrejection`, accumulate into a global the driver reads back — drained before
each navigation and re-installed after, the same shape as the exercised-member census.

**Honest limitation, stated in the code:** this is *weaker* than Chrome's and Firefox's
protocol-level capture. The hook can only install once navigation **returns**, so
anything thrown before that is still missed. The Kotlin/Wasm boot runs after the load
event and takes seconds, so boot and the whole gameplay run are covered — but "covered"
and "guaranteed" are different words.

## Proven, not assumed

An empty console after this change looks identical to an empty console before it, so
"dodge is still green" proves nothing. A synthetic error was injected after the hook:

```
captured: ['error: console.error: KANAMA-PROBE synthetic console error']
pass = False
```

**Captured, and it failed the run.** Before this change that error was invisible and the
run stayed green. dodge with no injection: passes, console genuinely empty.

## ⚠️ This MASKS task 89 — it does not fix it

`match3` on Safari **failed 3/3 before this change and passes 3/3 after**, on the same
export and machine. Not because anything was repaired: the extra `evaluate` round-trip
after `navigate` shifts the timing.

That is evidence match3's Safari failure is a **race** — the driver proceeds before the
board has settled — and it explains the two different symptoms recorded in task 89
("board never settled" vs "swap did not complete") as the same race losing at two
different points.

**Do not read the green as a fix.** The delay is incidental; a faster machine or a future
driver change will re-expose it. Task 89 is updated with this evidence and its first
step revised: inspect `navigateAndSettle`'s settle predicate *before* bisecting the
five-week window, because a race that a ~100 ms round-trip resolves is far more likely
to be a missing wait than a functional regression — and a bisect would happily blame an
innocent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
