### PR TITLE
Task 88 K6: a null object-array element stays null instead of minting a handle

### DIFF
--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -869,6 +869,7 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
           scriptType.customScriptIsResource,
           scriptType.arrayElementCustomScriptIsResource,
           scriptType.arrayElementString,
+          scriptType.arrayElementNullable,
           resolvedType.nullability == Nullability.NULLABLE,
           scriptType.narrow,
           scriptType.enumFqName,
@@ -1404,8 +1405,12 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
 
       if (fq == "kotlin.collections.List" || fq == "kotlin.collections.MutableList") {
         val isMutable = fq == "kotlin.collections.MutableList"
-        val elementDecl = type.arguments.firstOrNull()?.type?.resolve()?.declaration
+        val elementResolved = type.arguments.firstOrNull()?.type?.resolve()
+        val elementDecl = elementResolved?.declaration
         val elementFq = elementDecl?.qualifiedName?.asString()
+        // Task 88 K6: `List<Texture2D?>` vs `List<Texture2D>` decides whether a null
+        // array element can be delivered as null or must fail loudly.
+        val elementNullable = elementResolved?.isMarkedNullable == true
         if (elementFq == "kotlin.String") {
           return ScriptPropertyTypeModel(
             type = TypeMapping.ARRAY,
@@ -1428,6 +1433,7 @@ class KanamaProcessor(private val env: SymbolProcessorEnvironment) : SymbolProce
             hint = PROPERTY_HINT_TYPE_STRING,
             hintString = elementHint,
             arrayElementWrapperFqName = elementWrapper,
+            arrayElementNullable = elementNullable,
             isMutableList = isMutable,
           )
         }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModel.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/ScriptModel.kt
@@ -157,6 +157,15 @@ internal data class ScriptPropertyModel(
   val arrayElementCustomScriptIsResource: Boolean = false,
   val arrayElementString: Boolean = false,
   /**
+   * Source-level nullability of an object array's ELEMENT type (`List<Texture2D?>`). Distinct from
+   * [nullable], which is the nullability of the property itself.
+   *
+   * Task 88 K6: a Godot typed array genuinely can hold null, so the Web proxy pushes a 0 handle for
+   * one. Only a nullable element type can receive that as null; a non-nullable one must fail loudly
+   * rather than fabricate a wrapper over a minted handle, which is what shipped before.
+   */
+  val arrayElementNullable: Boolean = false,
+  /**
    * Source-level nullability of the property type. The JVM emitter does not need it
    * (VariantConverters handle null), but the iOS emitter does: an object-typed `@ScriptProperty`
    * delivers `null` for a 0 handle only when the Kotlin field is nullable. Phase 3.2
@@ -232,6 +241,15 @@ internal data class ScriptPropertyTypeModel(
   val customScriptIsResource: Boolean = false,
   val arrayElementCustomScriptIsResource: Boolean = false,
   val arrayElementString: Boolean = false,
+  /**
+   * Source-level nullability of an object array's ELEMENT type (`List<Texture2D?>`). Distinct from
+   * [nullable], which is the nullability of the property itself.
+   *
+   * Task 88 K6: a Godot typed array genuinely can hold null, so the Web proxy pushes a 0 handle for
+   * one. Only a nullable element type can receive that as null; a non-nullable one must fail loudly
+   * rather than fabricate a wrapper over a minted handle, which is what shipped before.
+   */
+  val arrayElementNullable: Boolean = false,
   val narrow: NarrowScalar? = null,
   val enumFqName: String? = null,
   val enumEntries: List<String> = emptyList(),

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -1806,8 +1806,21 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
             "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = values.map { requireNotNull(net.multigesture.kanama.web.webScriptInstance(it) as? $elementScript) { \"Array element is not a hydrated $elementScript\" } }"
           )
         } else if (property.type == TypeMapping.ARRAY && property.isMutable && wrapper != null) {
+          // Task 88 K6: 0 means the exported array held null at this index. A nullable
+          // element type takes it as null; a non-nullable one CANNOT represent it, so it
+          // fails here naming the property rather than handing back a wrapper over handle
+          // 0 that only explodes later, somewhere else, as someone else's bug.
+          val element =
+            if (property.arrayElementNullable) {
+              "if (it == 0) null else $wrapper(GodotHandle.fromBackendToken(it.toLong()))"
+            } else {
+              "if (it == 0) error(\"Kanama Web: exported array '${property.godotName}' on " +
+                "${input.model.simpleName} holds null, but its element type is non-nullable -- " +
+                "declare it List<${wrapper.substringAfterLast('.')}?>\") else " +
+                "$wrapper(GodotHandle.fromBackendToken(it.toLong()))"
+            }
           appendLine(
-            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = values.map { $wrapper(GodotHandle.fromBackendToken(it.toLong())) }"
+            "        ${propertyIndex + 1} -> (script as ${input.model.simpleName}).${property.kotlinName} = values.map { $element }"
           )
         }
       }
@@ -2069,11 +2082,19 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
           appendLine(
             "\t\t\tproperty_value_handle = int(property_value.call(\"_kanama_ensure_created\"))"
           )
-          appendLine("\t\tif property_value_handle == 0:")
+          // Task 88 K6: a null element must stay null. Minting a handle for it -- which is
+          // what "handle == 0 -> allocate" did unconditionally -- hands the script a LIVE
+          // wrapper over an empty Resource where its export held nothing, and the scalar arm
+          // one screen up already guards with `if != null`. Godot typed arrays really can
+          // hold null, so 0 is pushed across and the Kotlin side decides what it means.
+          appendLine("\t\tif property_value == null:")
+          appendLine("\t\t\tproperty_value_handle = 0")
+          appendLine("\t\telse:")
+          appendLine("\t\t\tif property_value_handle == 0:")
           appendLine(
-            "\t\t\tproperty_value_handle = int(_kanama_bridge.allocateBrowserHandle(\"Resource\", _kanama_handle))"
+            "\t\t\t\tproperty_value_handle = int(_kanama_bridge.allocateBrowserHandle(\"Resource\", _kanama_handle))"
           )
-          appendLine("\t\t_kanama_object_handles[property_value_handle] = property_value")
+          appendLine("\t\t\t_kanama_object_handles[property_value_handle] = property_value")
           appendLine(
             "\t\tproperty_handles_${index + 1} += (\",\" if not property_handles_${index + 1}.is_empty() else \"\") + str(property_value_handle)"
           )

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -550,6 +550,17 @@ class WebScriptCodeEmitterTest {
     assertTrue(mainProxy.contains("setLongProperty(_kanama_handle, 1, width)"))
     assertTrue(mainProxy.contains("setObjectProperty(_kanama_handle, 2, property_handle_2)"))
     assertTrue(mainProxy.contains("setObjectArrayProperty(_kanama_handle, 3, property_handles_3)"))
+    // Task 88 K6: a null element must NOT be minted a handle. `textures` here is
+    // non-nullable (List<Texture2D>), so the proxy pushes 0 and the Kotlin side is the
+    // one that refuses it -- the proxy's job is only to stop lying about what was there.
+    assertTrue(mainProxy.contains("if property_value == null:"))
+    assertTrue(mainProxy.contains("\t\t\tproperty_value_handle = 0"))
+    // ...and minting still happens for a REAL element that has no handle yet.
+    assertTrue(
+      mainProxy.contains(
+        "property_value_handle = int(_kanama_bridge.allocateBrowserHandle(\"Resource\", _kanama_handle))"
+      )
+    )
     assertTrue(mainProxy.contains("func _kanama_node_lookup(args: Array) -> int:"))
     assertTrue(mainProxy.contains("recordImmediateObjectHandle(script_handle)"))
     assertTrue(mainProxy.contains("if is_same(_kanama_object_handles[existing_handle], value):"))
@@ -623,9 +634,49 @@ class WebScriptCodeEmitterTest {
     assertTrue(registry.contains("(script as Main).width = value"))
     assertTrue(registry.contains("(script as Main).tileScene = handle?.let"))
     assertTrue(registry.contains("(script as Main).textures = values.map"))
+    // Task 88 K6, NON-nullable element type: 0 cannot be represented, so the generated
+    // setter refuses it by name instead of fabricating a wrapper over handle 0.
+    assertTrue(registry.contains("holds null, but its element type is non-nullable"))
+    assertTrue(registry.contains("declare it List<Texture2D?>"))
+    assertFalse(registry.contains("(script as Main).textures = values.map { if (it == 0) null"))
     assertTrue(registry.contains("(script as Main).input("))
     assertTrue(registry.contains("(script as Main).onTilePressed(Vector2i(x, y))"))
     assertTrue(registry.contains("(script as Tile).inputEvent("))
+  }
+
+  @Test
+  fun `task 88 K6 -- a nullable object-array element receives null instead of a minted handle`() {
+    // The other direction of the assertion above: same property, element type declared
+    // nullable. Godot typed arrays genuinely can hold null, so this is the shape that can
+    // represent one -- and it must map handle 0 to null, not to a live wrapper.
+    val model =
+      ScriptModel(
+        simpleName = "Main",
+        fqName = "net.multigesture.kanama.demos.match3.Main",
+        attachTo = "Node2D",
+        isTool = false,
+        isGlobalClass = false,
+        properties =
+          listOf(
+            ScriptPropertyModel(
+              kotlinName = "textures",
+              godotName = "textures",
+              type = TypeMapping.ARRAY,
+              isMutable = true,
+              arrayElementWrapperFqName = "net.multigesture.kanama.api.Texture2D",
+              arrayElementNullable = true,
+            )
+          ),
+        toolButtons = emptyList(),
+        virtuals = emptyList(),
+        methods = emptyList(),
+        signals = emptyList(),
+      )
+    val registry =
+      WebScriptCodeEmitter(listOf(WebScriptInput(model, "res://Main.kt"))).registrySource()
+
+    assertTrue(registry.contains("if (it == 0) null else"))
+    assertFalse(registry.contains("holds null, but its element type is non-nullable"))
   }
 
   // ---------- Task 66a: virtuals the Web backend does not dispatch ----------


### PR DESCRIPTION
Closes the last **buildable-without-a-decision** finding but one from the task 88 audit.

## The defect

The object-array property arm minted a browser handle whenever an element's handle came
back `0` — and a **null** element comes back `0`:

```gdscript
if property_value_handle == 0:
    property_value_handle = int(_kanama_bridge.allocateBrowserHandle("Resource", ...))
```

So a script whose exported array held `null` was handed a **live wrapper over a freshly
allocated empty Resource**, indistinguishable from a real object. The scalar arm one
screen up already guards with `if != null`. Only the array arm didn't.

## The fix

Godot typed arrays genuinely can hold null, so the proxy now pushes `0` across and the
Kotlin side decides what it means — the maintainer's call was to make the element type
carry it:

| declared element type | a null element becomes |
|---|---|
| `List<Texture2D?>` | **`null`** — nothing minted |
| `List<Texture2D>` | a **loud failure** naming the property and the fix |

The non-nullable case cannot represent null at all, so the generated setter refuses it:

```
Kanama Web: exported array 'textures' on Main holds null, but its element type is
non-nullable -- declare it List<Texture2D?>
```

That is deliberately not a silent drop and not a fabricated wrapper: both of those are
the silent-degradation class this audit exists to kill. It fails where the cause is,
naming the fix, instead of exploding three frames later as someone else's bug.

Element nullability needed a new model field — `nullable` already existed but describes
the **property**, not its element. Resolved from the KSP type argument and threaded
through both model structs.

## Proven both directions

In `WebScriptCodeEmitterTest`:

- nullable element → emits `if (it == 0) null else …`, and **not** the error
- non-nullable element → emits the named error, and **not** the null mapping
- minting still happens for a real element that has no handle yet (so the fix didn't
  just delete the allocation path)
- the proxy emits `if property_value == null: property_value_handle = 0`

Runtime: match3 exports and **passes on Chrome**. It declares `List<Texture2D>`, so it
exercises the non-nullable arm; its scene holds no nulls, which is exactly why nothing
changes for it — the corpus never hit this, which is why it survived unnoticed.

## Scope

Web only. The finding is in `WebScriptCodeEmitter`; the desktop and iOS paths convert
arrays through their own conversion and do not mint handles for null. The new model
field is inert for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
