### PR TITLE
Task 65: gate the sample-map load instead of skipping the one input that fails

### DIFF
--- a/scripts/web/drivers/demos/citybuilder.mjs
+++ b/scripts/web/drivers/demos/citybuilder.mjs
@@ -11,6 +11,10 @@
 // and the scene root, draining every live handle to zero.
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+// Cells the authored sample city occupies -- 122 structures in `sample map/map.tres`,
+// recovered losslessly from the upstream binary and diffed tuple-for-tuple against it
+// (task 65). One cell per structure.
+const SAMPLE_MAP_CELLS = 122;
 const DEBUG = process.env.KANAMA_WEB_SMOKE_DEBUG === "1";
 const START = Date.now();
 const trace = (msg) => {
@@ -242,6 +246,16 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
       : 0;
   trace(`loaded: cells=${loadedCells?.count} selectorMoved=${selectorDisplacement.toFixed(2)}`);
 
+  // Task 65: press `load_resources` (key 8) and prove the AUTHORED sample city arrives.
+  // This gate did not exist because it could not pass: `sample map/map.res` was the
+  // upstream BINARY resource referencing GDScript the port deleted, so no script attached,
+  // `kotlinScriptInstance<DataMap>()` returned null, and loadMap silently fell back to a
+  // fresh empty map -- a no-op on desktop and Web alike. The smoke skipping key 8 is what
+  // let that survive: the one input that would have failed was the one never pressed.
+  await tap("load_resources");
+  const sampleCells = await usedCellsRetry(evaluate);
+  trace(`sample map: cells=${sampleCells?.count} (expected ${SAMPLE_MAP_CELLS})`);
+
   // Full teardown: smoke_teardown (method#1) releases hydrated structure assets, frees
   // the Audio autoload and the scene root; every node exits and releases its handles.
   trace("smoke_teardown");
@@ -282,6 +296,12 @@ export async function runCitybuilder({ url, evaluate, navigate, deadline }) {
       (savedCells?.count ?? 0) === (toggledCells?.count ?? -1) &&
       (loadedCells?.count ?? 0) === (savedCells?.count ?? -1) &&
       (loadedCells?.items[0]?.item ?? -2) === toggledItem,
+    // Exact, not a threshold: `sample map/map.tres` is a fixed authored asset (122
+    // structures, cash 5860, verified against the upstream original). If someone edits the
+    // map, this SHOULD fail and be updated deliberately rather than drift silently.
+    sampleMapLoadsAuthoredCity:
+      (sampleCells?.count ?? -1) === SAMPLE_MAP_CELLS &&
+      (sampleCells?.count ?? 0) > (loadedCells?.count ?? 0),
     processFramesAdvanced: peak.processCalls >= baseline.processCalls + 40,
     gameplayCommandsApplied: peak.appliedCommands > baseline.appliedCommands,
     crossingsAdvanced: peak.crossings > baseline.crossings,


### PR DESCRIPTION
Pairs with **kanama-demos#38**. That PR re-authors City-Builder's sample map; this one
makes the harness able to tell whether it works.

## The gate did not exist because it could not pass

The citybuilder driver never pressed `load_resources` (key 8). That was not a gap in
ambition — it is *why the defect survived*: `sample map/map.res` was the upstream **binary**
resource referencing GDScript the port deleted, so no script attached,
`kotlinScriptInstance<DataMap>()` returned null, and `loadMap` silently fell back to an
empty map. **The one input that would have failed was the one never pressed**, on desktop
and Web alike.

Same shape as the finding that started task 81: a Web smoke omitting exactly the assertion
that would have failed.

## The check

Tap `load_resources`, assert the authored city arrives: **122 cells**, one per structure in
`sample map/map.tres`.

Exact count, not a threshold. The sample map is a fixed authored asset, so an edit *should*
fail this check and be updated deliberately rather than drift silently past it.

## Proven both directions — and against the committed tree

| tree | result |
|---|---|
| fixed map, exported from a **clean clone** of demos#38 | cells 1 → **122**, smoke **PASS** |
| pre-fix binary map restored | **cells=0**, smoke **FAILED**, exactly one check false: `sampleMapLoadsAuthoredCity` |

`cells=0`, not 1 — the broken load *clears* the grid. That is the silent no-op made
visible.

## A process note worth keeping

My first green ran against a working tree that carried an uncommitted `Builder.kt` path
change, so it described nothing that existed in git — and the demos commit was in fact
**broken** (`map.res` deleted, `Builder.kt` still loading it). Caught by diffing the tree
against `HEAD` while restoring, fixed, and re-verified by exporting from a clean clone of
the commit. "Measure the repo, not a worktree" is already in our notes; this is it earned
again, and the reason the table above says *clean clone*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
