### PR TITLE
Gate: fail when a lifecycle annotation is imported but never applied

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,7 +51,10 @@ env:
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
   # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
-  DEMOS_REF: c85b83ad7978d2ab0778131774404c4ace065cb5
+  # Task 64/65: the @OnReady repair (demos#39) + the re-authored sample map (demos#38).
+  # Bumped WITH the annotation gate below: the gate fails against the previous pin, which
+  # still carries the FullScreenHandler bug -- both sides pin together or neither is green.
+  DEMOS_REF: 87e5cfc3fb5c38fddd21a2a71ee6e29a77f7d354
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -120,6 +120,13 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq ripgrep
 
+      - name: Unapplied lifecycle annotation check (kanama + pinned demos)
+        shell: bash
+        # Runs HERE and not only in local-ci because this is the one job with the demos
+        # checkout, and the demo scripts are where this shape has actually bitten.
+        run: |
+          python3 scripts/check_unapplied_annotations.py . kanama-demos
+
       - name: Report browser versions
         shell: bash
         run: |

--- a/scripts/check_unapplied_annotations.py
+++ b/scripts/check_unapplied_annotations.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail when a Kanama lifecycle annotation is imported but never applied.
+
+A dead lifecycle hook is invisible. `FullScreenHandler` imported `OnReady`, never
+applied it, and so `ready()` never dispatched -- upstream sets PROCESS_MODE_ALWAYS
+there precisely so the node survives a paused tree, and on desktop the fullscreen
+toggle had been dead whenever the game was paused. Nothing failed.
+
+Why this check and not something stronger:
+
+  * The Kotlin compiler does NOT warn here (verified on a full --rerun-tasks build):
+    there was no discarded signal to escalate.
+  * The processor DOES print the fact -- `virtuals=1` without the annotation,
+    `virtuals=2` with it -- but nothing compares that count to an expectation.
+  * The exercised-member census (task 81) asserts DISPATCH rather than spelling and
+    would be the better instrument, except it runs on Web only. This file's web
+    override legitimately has no `ready()` at all, so the Web census structurally
+    cannot see a desktop-only lifecycle bug. Until a desktop census exists (task 81
+    fix #3), a source check is the only net there is.
+
+So this is deliberately a TRIPWIRE FOR ONE SHAPE, not a general correctness gate: an
+import with no matching use. It cannot see a hook-shaped function in a file that never
+imports the annotation -- the same bug with no tell. Do not read a pass here as "the
+lifecycle wiring is right".
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Annotations whose absence silently disables behaviour. @ScriptClass/@ScriptProperty
+# are excluded on purpose: omitting those fails the build or drops a property the
+# generators already report, so they are not silent.
+LIFECYCLE_ANNOTATIONS = (
+    "OnReady",
+    "OnProcess",
+    "OnPhysicsProcess",
+    "OnInput",
+    "OnUnhandledInput",
+    "OnEnterTree",
+    "OnExitTree",
+    "OnDraw",
+    "RegisterFunction",
+    "Signal",
+)
+
+IMPORT_RE = re.compile(
+    r"^\s*import\s+net\.multigesture\.kanama\.annotations\.(\w+)\s*$", re.M
+)
+STAR_IMPORT_RE = re.compile(r"^\s*import\s+net\.multigesture\.kanama\.annotations\.\*", re.M)
+
+
+def findings_for(path: pathlib.Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    if STAR_IMPORT_RE.search(text):
+        # A star import makes "imported but unused" unanswerable by inspection; say so
+        # rather than pass silently.
+        return [f"{path}: star-imports the annotations package -- this check cannot verify it"]
+    out = []
+    for name in IMPORT_RE.findall(text):
+        if name not in LIFECYCLE_ANNOTATIONS:
+            continue
+        if not re.search(rf"@{name}\b", text):
+            out.append(
+                f"{path}: imports @{name} but never applies it -- "
+                f"the annotated behaviour is silently disabled"
+            )
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=["."],
+        help="directories to scan for .kt sources (default: cwd)",
+    )
+    args = parser.parse_args()
+
+    files: list[pathlib.Path] = []
+    for root in args.roots:
+        base = pathlib.Path(root)
+        if not base.exists():
+            print(f"[unapplied_annotations] SKIP missing root: {base}")
+            continue
+        files.extend(
+            p
+            for p in base.rglob("*.kt")
+            if "/build/" not in p.as_posix() and "/.git/" not in p.as_posix()
+        )
+
+    # An empty scan is a broken invocation, not a pass -- the vacuous-gate lesson.
+    if not files:
+        print(
+            "[unapplied_annotations] FAIL no .kt files found under "
+            f"{args.roots} -- refusing to report a vacuous pass"
+        )
+        return 2
+
+    findings = [f for path in sorted(files) for f in findings_for(path)]
+    for finding in findings:
+        print(f"[unapplied_annotations] {finding}")
+    if findings:
+        print(f"[unapplied_annotations] FAIL {len(findings)} finding(s) across {len(files)} files")
+        return 1
+    print(f"[unapplied_annotations] PASS {len(files)} files scanned, 0 findings")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -283,6 +283,14 @@ python3 "$ROOT_DIR/scripts/audit_value_type_wrappers.py" --strict
 stage "stale blocker claim audit"
 python3 "$ROOT_DIR/scripts/audit_stale_blockers.py"
 
+stage "unapplied lifecycle annotation check"
+# Tripwire for ONE shape: an annotation imported and never applied, which silently
+# disables the hook (FullScreenHandler's @OnReady, dead since the port). The compiler
+# does not warn and the Web census cannot see desktop-only wiring, so this is the only
+# net today. Scans this repo; the demos checkout is scanned in the web workflow, which
+# is where demo sources exist.
+python3 "$ROOT_DIR/scripts/check_unapplied_annotations.py" "$ROOT_DIR"
+
 stage "shell script lint (shellcheck)"
 # Hard-required (the unzip/ios_template_preflight precedent): the gate itself
 # prints install instructions and exits 2 when shellcheck is absent.


### PR DESCRIPTION
Follows the `FullScreenHandler` bug in **kanama-demos#39**: `OnReady` was imported and never applied, so `ready()` never dispatched and `setProcessMode(PROCESS_MODE_ALWAYS)` never ran. Upstream puts that in `_init()` precisely so the node survives a paused tree — so the desktop fullscreen toggle has been dead whenever the game is paused. **Nothing failed.**

## Why a source check, having ruled out the alternatives

I tested the obvious ones rather than assuming:

- **The Kotlin compiler does not warn.** A full `--rerun-tasks` compile emits no unused-import warning. There was no discarded signal to escalate.
- **The processor already prints the fact** — `virtuals=1` without the annotation, `virtuals=2` with it — but nothing compares that count to an expectation.
- **The exercised-member census (task 81) is the better instrument and cannot see this.** It asserts *dispatch* rather than spelling, which is the right idea — but it runs on Web only, and this file's web override legitimately has no `ready()` at all. The Web census structurally cannot see a desktop-only lifecycle bug. Until a desktop census exists (task 81 fix #3), a source check is the only net.

## Scope, stated in the file itself

Deliberately a **tripwire for one shape**: an import with no matching use. It cannot see a hook-shaped function in a file that never imports the annotation — the same bug with no tell. The docstring says a pass here is *not* "the lifecycle wiring is right", because that is exactly the overclaim that makes a gate worse than none.

`@ScriptClass`/`@ScriptProperty` are excluded on purpose: omitting those fails the build or drops a property the generators already report, so they aren't silent.

## Proven three directions

| input | result |
|---|---|
| pre-fix `FullScreenHandler` | **FAIL**, names the file and the annotation (exit 1) |
| kanama (2228 files) + demos (150) | **PASS**, 0 findings |
| empty directory | **FAIL** — refuses a vacuous pass (exit 2) |

That third row is the byte-identity lesson from this repo's own history: a gate reporting success over zero inputs is worse than no gate. Star imports of the annotations package are reported as *unverifiable* rather than quietly passed.

## Wiring

`scripts/local_ci.sh`, plus the web workflow's matrix job — the one place a demos checkout exists, which is where this shape has actually bitten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)