### PR TITLE
Task 64 tier 2: the SCALAR tween arm (protocol 20, opcode 289)

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 19). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 20). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -133,7 +133,7 @@ handles. Gameplay coverage reports zero blocking calls;
 `GodotObject.emit_signal_typed` remains visible as one explicit nonblocking
 unsupported family rather than being pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 19). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 20). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -68,6 +68,7 @@ enum class GodotCallShape {
   LONG_ARG_SINGLETON,
   OBJECT_RET_HANDLE,
   OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE,
+  OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE,
   CALLABLE_RET_HANDLE,
   NOARGS_RET_LONG_SINGLETON,
   STRINGNAME_OBJECT_RET_INT,
@@ -554,6 +555,26 @@ interface GodotBackendSpi {
     target: GodotHandle,
     property: String,
     finalValue: GodotVector3,
+    duration: Double,
+  ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /**
+   * SCALAR property tweener -- `tween_property(node, "position:y", 4.0, 0.5)`.
+   *
+   * The sibling of the Vector2/Color/Vector3 variants, and the one that was missing: a component
+   * path like `"position:y"` takes a NUMBER, so third-person's coin spill (CoinsContainer) had no
+   * arm at all and faulted the Web boundary when a beetle attack landed. Every other tween shape
+   * was present, which is exactly why nobody noticed.
+   */
+  fun invokeObjectNodePathDoubleDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: Double,
     duration: Double,
   ): GodotHandle? {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
@@ -2020,6 +2041,28 @@ object GodotBackendCalls {
     )
   }
 
+  fun invokeObjectNodePathDoubleDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: Double,
+    duration: Double,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeObjectNodePathDoubleDoubleRetHandle(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      target,
+      property,
+      finalValue,
+      duration,
+    )
+  }
+
   fun invokeCallableRetHandle(
     descriptor: GodotCallDescriptor,
     receiver: GodotHandle,
@@ -2319,6 +2362,22 @@ class TweenBackendContractProbe(private val handle: GodotHandle) {
   ): GodotHandle? =
     GodotBackendCalls.invokeObjectNodePathVector3DoubleRetHandle(
       InitialGodotCallDescriptors.TWEEN_TWEEN_PROPERTY_VECTOR3,
+      handle,
+      target,
+      property,
+      finalValue,
+      duration,
+    )
+
+  /** Scalar variant: a component path such as `"position:y"` takes a number. */
+  fun tweenProperty(
+    target: GodotHandle,
+    property: String,
+    finalValue: Double,
+    duration: Double,
+  ): GodotHandle? =
+    GodotBackendCalls.invokeObjectNodePathDoubleDoubleRetHandle(
+      InitialGodotCallDescriptors.TWEEN_TWEEN_PROPERTY_DOUBLE,
       handle,
       target,
       property,

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3172,6 +3172,17 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
 
+  val TWEEN_TWEEN_PROPERTY_DOUBLE =
+    GodotCallDescriptor(
+      opcode = 289,
+      className = "Tween",
+      methodName = "tween_property",
+      hash = 4049770449L,
+      shape = GodotCallShape.OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 288
+  const val MAX_OPCODE = 289
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -134,7 +134,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
      * happened to name.
      */
-    const val PROTOCOL_VERSION = 19
+    const val PROTOCOL_VERSION = 20
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -3417,7 +3417,9 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\tif opcode == 38 and receiver is Tween:")
     appendLine("\t\t(receiver as Tween).set_parallel(bool(args[2]))")
     appendLine("\t\tresult_handle = receiver_handle")
-    appendLine("\telif (opcode == 39 or opcode == 40 or opcode == 136) and receiver is Tween:")
+    appendLine(
+      "\telif (opcode == 39 or opcode == 40 or opcode == 136 or opcode == 289) and receiver is Tween:"
+    )
     appendLine("\t\tvar proposed_handle := int(args[2])")
     appendLine("\t\tvar target_handle := int(args[3])")
     appendLine(
@@ -3435,6 +3437,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\telif target != null and opcode == 136:")
     appendLine(
       "\t\t\ttweener = (receiver as Tween).tween_property(target, NodePath(String(args[4])), Vector3(float(args[5]), float(args[6]), float(args[7])), float(args[8]))"
+    )
+    // Task 64: the SCALAR arm. A component path ("position:y") takes a plain number, so this
+    // passes float(args[5]) straight through rather than composing a vector.
+    appendLine("\t\telif target != null and opcode == 289:")
+    appendLine(
+      "\t\t\ttweener = (receiver as Tween).tween_property(target, NodePath(String(args[4])), float(args[5]), float(args[6]))"
     )
     appendLine("\t\tif tweener != null:")
     appendLine("\t\t\t_kanama_object_handles[proposed_handle] = tweener")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 19"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 20"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -617,7 +617,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 19"))
+    assertTrue(protocol.contains("\"protocolVersion\": 20"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -628,7 +628,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=19\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=20\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1638,7 +1638,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 19"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 20"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -331,6 +331,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     286: {},
     287: {},
     288: {},
+    289: {},
 }
 
 
@@ -1231,6 +1232,25 @@ def body_OBJECT_RET_HANDLE(calls):
     ]
 
 
+def body_OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        "require(duration.isFinite() && duration >= 0.0)",
+        "require(finalValue.isFinite())",
+        "commands.flush()",
+        "return registerReturnedBrowserObject(",
+        "immediateWebTweenPropertyDouble(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "target.webId(),",
+        "property,",
+        "finalValue,",
+        "duration,",
+        ")",
+        ")",
+    ]
+
+
 def body_OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -1858,6 +1878,16 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ],
         "GodotHandle?",
     ),
+    "OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE": (
+        [
+            "receiver: GodotHandle",
+            "target: GodotHandle",
+            "property: String",
+            "finalValue: Double",
+            "duration: Double",
+        ],
+        "GodotHandle?",
+    ),
     "CALLABLE_RET_HANDLE": (
         ["receiver: GodotHandle", "target: GodotHandle", "method: String"],
         "GodotHandle?",
@@ -2174,6 +2204,7 @@ EMIT_ORDER = [
     "LONG_ARG_SINGLETON",
     "OBJECT_RET_HANDLE",
     "OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE",
+    "OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE",
     "CALLABLE_RET_HANDLE",
     "NOARGS_RET_LONG_SINGLETON",
     "STRINGNAME_OBJECT_RET_INT",

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4532,6 +4532,26 @@
       "returnOwnership": "BORROWED",
       "semantics": "HUD label text read (platformer coin count, squash score) on the immediate string channel. The Web applier accepts an optional child node path in the query payload ('' = the receiver's own node) so drivers can read a Label beneath a scripted Control -- see compositions.",
       "introducedBy": "81-gameplay-gate"
+    },
+    {
+      "opcode": 289,
+      "scope": "class",
+      "className": "Tween",
+      "methodName": "tween_property",
+      "hash": 4049770449,
+      "arguments": [
+        "Object",
+        "NodePath",
+        "Variant",
+        "float"
+      ],
+      "returnType": "PropertyTweener",
+      "shape": "OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "RETAINED_REFCOUNTED",
+      "semantics": "SCALAR variant of the property tweener: a component path such as \"position:y\" takes a number, not a vector. Its absence is why third-person's coin spill (CoinsContainer) faulted the Web boundary -- every other tween shape existed, so nothing flagged the hole.",
+      "introducedBy": "64-tween-double-arm",
+      "descriptorName": "TWEEN_TWEEN_PROPERTY_DOUBLE"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -139,6 +139,15 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
   trace(`signalProbe: mask=${signalProbe}`);
 
+  // Task 64: the scalar tween arm (see Main.scalar_tween_probe). 1 = a NUMBER final value
+  // produced a live PropertyTweener instead of faulting the boundary.
+  const scalarTween = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("scalar_tween_probe")}, 0)`,
+    ),
+  );
+  trace(`scalarTweenProbe: ${scalarTween}`);
+
   // Task 80 dispatch-shape conformance: Main.dispatch_probe (method#16, Int->Int)
   // returns a mask. Every bit is a shape task 80 admitted, exercised through the REAL crossing
   // (Kotlin asks Godot to call the method by name, Godot dispatches to the generated GDScript
@@ -292,6 +301,9 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     // argument-dropped member a build error, so the fixture failed to compile when this probe
     // first tried it -- see the note on signal_probe in Main.kt.
     signalShapesDeliverPayloads: signalProbe === 3,
+    // Task 64: tween_property with a NUMBER. Vector2/Color/Vector3 all had arms and this one
+    // did not, so third-person's coin spill faulted the Web boundary on a component path.
+    scalarTweenArmDelivers: scalarTween === 1,
     // Task 80 slice 2: every admitted dispatch shape round-tripped its VALUE, not just its call.
     dispatchShapesRoundTrip: dispatchProbe === 127,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -224,7 +224,7 @@
         },
         {
           "member": "Player.damage",
-          "reason": "Boundary-crossing (BeetleBot attack / bee Bullet both reach it via collider.call) but currently FAULTS on Web when it lands: the coin-spill -> CoinsContainer tween passes a NUMBER to Tween.tween_property, the known gap (task 57e backlog / task 81 confirmed break #3). MEASURED 2026-08-12: a beetle attack landing during an extended thirdperson run fatals the boundary (why the driver runs combat BEFORE movement). Require only after the tween number arm lands."
+          "reason": "Boundary-crossing (BeetleBot attack / bee Bullet both reach it via collider.call) but currently FAULTS on Web when it lands: the coin-spill -> CoinsContainer tween passes a NUMBER to Tween.tween_property, the known gap (task 57e backlog / task 81 confirmed break #3). MEASURED 2026-08-12: a beetle attack landing during an extended thirdperson run fatals the boundary (why the driver runs combat BEFORE movement). The tween NUMBER arm LANDED (task 64, opcode 289): a component path such as 'position:y' now has a real arm instead of unsupportedWebGameplayCall, and the web3d fixture proves it (scalar_tween_probe). Still not promotable to required here, for a DIFFERENT reason: no driver spills coins, so the member is never exercised and promoting it would fail the gate. Needs a driver step first."
         }
       ]
     },

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -628,11 +628,30 @@ class Tween internal constructor(backendHandle: BackendGodotHandle) : GodotObjec
             duration,
           )
           ?.let(::PropertyTweener)
+      // Task 64: a component path -- "position:y", "modulate:a" -- takes a NUMBER. This arm
+      // was missing while Vector2/Color/Vector3 all existed, so third-person's coin spill
+      // reached `unsupportedWebGameplayCall` and faulted the boundary the moment a beetle
+      // attack landed. Int/Long are accepted too: a caller writing `0` for a float property
+      // should not have to know the difference.
+      is Double -> tweenPropertyScalar(target, property, finalValue, duration)
+      is Float -> tweenPropertyScalar(target, property, finalValue.toDouble(), duration)
+      is Int -> tweenPropertyScalar(target, property, finalValue.toDouble(), duration)
+      is Long -> tweenPropertyScalar(target, property, finalValue.toDouble(), duration)
       else ->
         unsupportedWebGameplayCall(
           "Tween.tween_property final value ${finalValue?.let { it::class.simpleName } ?: "null"}"
         )
     }
+
+  private fun tweenPropertyScalar(
+    target: GodotObject,
+    property: String,
+    finalValue: Double,
+    duration: Double,
+  ): PropertyTweener? =
+    TweenBackendContractProbe(backendHandle)
+      .tweenProperty(target.backendHandle, property, finalValue, duration)
+      ?.let(::PropertyTweener)
 
   fun bindNode(node: Node): Tween {
     val returned = TweenBackendContractProbe(backendHandle).bindNode(node.backendHandle)

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -184,6 +184,18 @@ internal fun immediateWebTweenPropertyVector3(
     "globalThis.KanamaWebBridge.immediateTweenPropertyVector3(opcode, tweenId, targetId, property, x, y, z, duration)"
   )
 
+internal fun immediateWebTweenPropertyDouble(
+  opcode: Int,
+  tweenId: Int,
+  targetId: Int,
+  property: String,
+  value: Double,
+  duration: Double,
+): Int =
+  js(
+    "globalThis.KanamaWebBridge.immediateTweenPropertyDouble(opcode, tweenId, targetId, property, value, duration)"
+  )
+
 internal fun immediateWebTweenCallback(
   opcode: Int,
   tweenId: Int,

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -1246,6 +1246,32 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     )
   }
 
+  override fun invokeObjectNodePathDoubleDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    target: GodotHandle,
+    property: String,
+    finalValue: Double,
+    duration: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(duration.isFinite() && duration >= 0.0)
+    require(finalValue.isFinite())
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebTweenPropertyDouble(
+        descriptor.opcode,
+        receiver.webId(),
+        target.webId(),
+        property,
+        finalValue,
+        duration,
+      )
+    )
+  }
+
   override fun invokeCallableRetHandle(
     descriptor: GodotCallDescriptor,
     callSite: GodotCallSite,

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -381,6 +381,19 @@ class Main(godotObject: GodotHandle) :
    * payload "reaches Kotlin only through a named registered-method connect", an escape hatch the
    * build no longer permits anyone to take.
    */
+  /**
+   * Task 64: the SCALAR tween arm. Before it existed, `tween_property` with a NUMBER fell to
+   * `unsupportedWebGameplayCall` and faulted the boundary -- Vector2/Color/Vector3 all had arms,
+   * so a shape audit saw a full set and third-person's coin spill died on a component path
+   * (`"position:y"`). Returns 1 when the tweener came back live.
+   */
+  @RegisterFunction("scalar_tween_probe")
+  fun scalarTweenProbe(value: Long): Long {
+    val tween = self.createTween() ?: return 0L
+    val tweener = tween.tweenProperty(self, "position:y", 0.0, 0.05)
+    return if (tweener != null) 1L else 0L
+  }
+
   @RegisterFunction("signal_probe")
   fun signalProbe(value: Long): Long {
     var mask = 0L

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 19;
+  const KANAMA_WEB_PROTOCOL_VERSION = 20;
 
   function commandWordCount(opcode) {
     if (
@@ -2027,6 +2027,12 @@
       // Rides the generic tween-property flow: the "property" slot carries the method name
       // and the returned CallbackTweener registers as a tween child for release.
       return this.immediateTweenProperty(opcode, tweenHandle, targetHandle, method, []);
+    },
+    immediateTweenPropertyDouble(opcode, tweenHandle, targetHandle, property, value, duration) {
+      // Task 64: the SCALAR arm. A component path like "position:y" takes a number, and its
+      // absence is why third-person's coin spill faulted the boundary -- every other tween
+      // shape was here, so the hole never showed up in a shape audit.
+      return this.immediateTweenProperty(opcode, tweenHandle, targetHandle, property, [value, duration]);
     },
     immediateTweenPropertyVector2(opcode, tweenHandle, targetHandle, property, x, y, duration) {
       if (this.mode === "match3" && property === "position") {


### PR DESCRIPTION
`Tween.tween_property` had arms for **Vector2, Color and Vector3** — and none for a **number**. A component path is the common case:

```kotlin
tween.tweenProperty(self, "position:y", y, 0.5)   // CoinsContainer.kt:43
```

So third-person's coin spill reached `unsupportedWebGameplayCall` and **faulted the Web boundary** the moment a beetle attack landed. A shape audit saw a full set of tween arms, which is exactly why the hole survived — the missing one was the scalar, not an exotic type.

`CoinsContainer` is already single-sourced, so this repairs a shipped demo **with no demo edit**.

## End to end, mirroring the Vector3 family

Contract shape + `invokeObjectNodePathDoubleDoubleRetHandle` (default error body, so desktop and iOS are untouched) → opcode 289 appended → descriptors regenerated → `WEB_POLICY` + signature + emit order + body in `generate_web_backend.py` → wasm transport extern → bridge arm → **GDScript proxy arm** → Kotlin API arm.

The API takes `Int`/`Long`/`Float` as well: someone writing `0` for a float property shouldn't have to know the difference.

**Protocol 19 → 20 in _both_ places** — the emitter constant *and* the bridge's `KANAMA_WEB_PROTOCOL_VERSION`. Bumping only the emitter presents as a silent "scene did not become ready", which is how this run first failed.

## Proven both directions

| | result |
|---|---|
| web3d fixture probe | returns **1** — a real `PropertyTweener` came back |
| same probe forced null | **FAILS** the run |
| web3d chrome / firefox | **PASS / PASS** |
| thirdperson chrome | **PASS**, zero console errors |

## The honest limit

thirdperson's smoke **does not spill coins**, so `CoinsContainer.add_coin` is still never exercised. That run proves nothing *regressed* — it does not prove the spill works. **The fixture probe is what proves the arm.**

`required_members.json` carried "require only after the tween number arm lands"; that note now says the arm landed and that a **driver step** is what blocks promotion instead. Filing the driver step is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)