### PR TITLE
Task 90: give Safari the same console event shape the other drivers use

### DIFF
--- a/scripts/web/drivers/envelope.mjs
+++ b/scripts/web/drivers/envelope.mjs
@@ -222,7 +222,10 @@ export function buildEnvelope({
       // Headless browsers reject pointer lock without a user gesture/focus; Godot's
       // mouse-capture request then surfaces as a WrongDocumentError (an async exception in
       // Chrome, a console error in Firefox). Environmental, not a game fault.
-      /WrongDocumentError/.test(event.text);
+      /WrongDocumentError/.test(event.text) ||
+      // Safari states the same refusal differently: it requires a genuine user gesture and a
+      // WebDriver-synthesized click does not qualify. Same environmental cause, same verdict.
+      /NotAllowedError.*Pointer lock requires a user gesture/.test(event.text);
     (isWarning ? consoleWarnings : consoleErrors).push(`${event.type}: ${event.text}`);
     lastWasWarning = isWarning;
   }

--- a/scripts/web/drivers/safari_webdriver.mjs
+++ b/scripts/web/drivers/safari_webdriver.mjs
@@ -286,16 +286,21 @@ async function main() {
       if (globalThis.__kanamaSafariConsole) return 1;
       const sink = [];
       globalThis.__kanamaSafariConsole = sink;
+      // Task 90: emit the SAME event shape the other drivers do -- type "console.error" or
+      // "exception", text RAW. envelope.mjs already classifies Godot's WARNING: lines and
+      // pointer-lock rejections as non-fatal; it could not do that for Safari while this hook
+      // invented its own type and double-prefixed the text ("console.error: WARNING: ..."),
+      // so every renderer warning read as a hard error and tpsdemo failed a leg Chrome passed.
       const original = console.error ? console.error.bind(console) : null;
       console.error = (...parts) => {
-        try { sink.push({ type: "error", text: "console.error: " + parts.map(String).join(" ") }); } catch (_) {}
+        try { sink.push({ type: "console.error", text: parts.map(String).join(" ") }); } catch (_) {}
         if (original) original(...parts);
       };
       addEventListener("error", (event) => {
-        sink.push({ type: "error", text: "uncaught: " + (event.message || String(event.error)) });
+        sink.push({ type: "exception", text: event.message || String(event.error) });
       });
       addEventListener("unhandledrejection", (event) => {
-        sink.push({ type: "error", text: "unhandled rejection: " + String(event.reason) });
+        sink.push({ type: "exception", text: String(event.reason) });
       });
       return 1;
     })()`;


### PR DESCRIPTION
The W2 corpus re-run came back **10/13**: fps, thirdperson and tpsdemo failed. All three loaded, passed **every gameplay check**, and failed only the zero-console-errors leg — the leg that asserted nothing on Safari until #192, three days ago.

**The cause was in #192's own hook, not in the demos.**

`envelope.mjs` *already* classifies Godot's `WARNING:` lines and pointer-lock refusals as non-fatal, and has since the Chrome and Firefox drivers were written. It couldn't do that for Safari because the hook invented its own event shape: type `"error"` instead of `"console.error"`, and text double-prefixed (`"console.error: WARNING: ..."`). Every renderer warning therefore read as a hard error.

Fixed by emitting the canonical shape, so the existing, already-reviewed classifier applies to all three engines — plus one line for Safari's wording of the pointer-lock refusal (Chrome/Firefox say `WrongDocumentError`, Safari says `NotAllowedError: Pointer lock requires a user gesture`; same cause, same verdict).

## Rejected: an allow-list

I wrote an `expected_console.json` with patterns and reasons before finding the classifier already existed. New config would have duplicated reviewed logic and become the kind of mute switch nobody re-reads. Deleted.

## Two measurements decided it, neither guessable

- Wrapping `console.warn` **separately** left all 7 tpsdemo lines in the *error* bucket — so Godot really does route `WARNING` through `console.error`. Not a classification artifact of the hook.
- The same tpsdemo export **passes on Chrome with zero console errors**, because Chrome's run never reaches those renderer paths:

| | dispatches | ticks | simulated |
|---|---|---|---|
| chrome | 663 | 189 | 30.6 s |
| **safari** | **2910** | **1284** | **99.5 s** |

**Chrome's green is the weaker result** — it passes partly by not looking as far. Worth remembering next time engines disagree.

## Verified both directions

- tpsdemo, fps and thirdperson all **PASS** on Safari (tpsdemo: 0 errors, 7 warnings)
- an injected `console.error` still **FAILS** the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)