### PR TITLE
docs: Safari is 13/13 as of 2026-08-20

### DIFF
--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -141,14 +141,15 @@ and `web_export_smoke.sh` fails any run below them:
 |---|---|---|---|---|
 | Chrome | 130 | tested (2026-07-28) | 150 (headless) | CI cell |
 | Firefox | 141 | tested (2026-07-28) | 152–153 (headless) | CI cell |
-| Safari | 26.5 | validated-at (2026-07-27) | 26.5 / WebKit 605.1.15, macOS 26.5.1 — 12 of 12 on 2026-07-27; `match3` failed the 2026-08-14 spot check and was fixed 2026-08-15 (harness, not the demo — see below). **The full corpus has not been re-run since the fix** | **spot-checked, not gated**; no headless mode, needs a logged-in GUI session, and cannot run two at once |
+| Safari | 26.5 | validated-at (2026-08-20) | 26.5 / WebKit 605.1.15, macOS 26.5.1 — **13 of 13 cells on 2026-08-20** (the twelve-demo corpus plus the spike cell), zero console errors corpus-wide, at protocol 20 | **spot-checked, not gated**; no headless mode, needs a logged-in GUI session, and cannot run two at once |
 
 **Safari is spot-checked, deliberately.** It has no headless mode, needs a
 logged-in GUI session with an unoccluded window, and cannot run two gates
 concurrently, so a CI cell would cost more than it returns (maintainer decision,
 2026-08-14). The trade is explicit: **between spot checks, the Safari claim can go
 stale without anything noticing.** It did — the corpus was 12/12 on 2026-07-27 and
-**11/12** when next run on 2026-08-14, with `match3` failing on the swap path.
+**11/12** when next run on 2026-08-14, with `match3` failing on the swap path. It is
+**13/13 as of 2026-08-20**, re-measured after the fix.
 
 **That was not a regression in Kanama or in the demo.** Root-caused 2026-08-15: the
 harness dispatched the swap gesture while the Safari window was **not focused**, and
@@ -162,8 +163,7 @@ Two things are worth carrying from it. **A locked screen voids a Safari run enti
 Safari suspends `requestAnimationFrame` for a non-visible page, so the engine advances a
 few frames and stops, and the run fails inside a demo assertion with nothing naming the
 cause; the driver now refuses to start in that state. And **quote the date a Safari
-result was last measured**, not the best result ever recorded — the corpus above has not
-been re-run since the fix, so 12/12 is a July number, not a current one.
+result was last measured**, not the best result ever recorded.
 
 **"Tested" and "validated-at" are different claims.** Tested means the gate was
 run on the floor version and on the one below it: Chrome 129 never boots the


### PR DESCRIPTION
W2's evidence has been a **July number carrying a caveat** since the 2026-08-14 spot check found match3 red. The corpus has been re-run after the fix:

**13 of 13 cells PASS at protocol 20 — zero console errors across all thirteen envelopes.**

## Four lines, deliberately

My first draft also explained *why* three demos had briefly gone red (a console-capture event shape) and compared per-engine coverage numbers. That's harness archaeology. A reader of `version-support.md` wants to know whether Safari works, at which version, and when it was last checked — not how the gate got confused.

The reasoning lives in `kanama-tasks/90`, where someone debugging the gate will actually look.

The section keeps its own standing advice: quote the date a Safari result was measured, not the best result ever recorded.

Verified: `mkdocs build --strict` clean, `check_doc_claims` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)