### PR TITLE
Task 64 tier 2: PropertyTweener.from, COLOR arm (protocol 21, opcode 290)

### DIFF
--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 20). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 21). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -133,7 +133,7 @@ handles. Gameplay coverage reports zero blocking calls;
 `GodotObject.emit_signal_typed` remains visible as one explicit nonblocking
 unsupported family rather than being pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 20). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 21). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -69,6 +69,7 @@ enum class GodotCallShape {
   OBJECT_RET_HANDLE,
   OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE,
   OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE,
+  COLOR_RET_HANDLE,
   CALLABLE_RET_HANDLE,
   NOARGS_RET_LONG_SINGLETON,
   STRINGNAME_OBJECT_RET_INT,
@@ -576,6 +577,22 @@ interface GodotBackendSpi {
     property: String,
     finalValue: Double,
     duration: Double,
+  ): GodotHandle? {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /**
+   * A fluent call taking a COLOR and returning the receiver -- `PropertyTweener.from(Color)`.
+   *
+   * Task 64 tier 2: Icone's fade sets a custom starting value so the tween runs from the opposite
+   * alpha rather than from wherever the modulate happened to be. Without this the web override had
+   * to drop `from(...)` entirely, which is a different animation.
+   */
+  fun invokeColorRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotColor,
   ): GodotHandle? {
     error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
   }
@@ -2063,6 +2080,17 @@ object GodotBackendCalls {
     )
   }
 
+  fun invokeColorRetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: GodotColor,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.COLOR_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeColorRetHandle(descriptor, resolve(selected, descriptor), receiver, value)
+  }
+
   fun invokeCallableRetHandle(
     descriptor: GodotCallDescriptor,
     receiver: GodotHandle,
@@ -2419,6 +2447,14 @@ class PropertyTweenerBackendContractProbe(private val handle: GodotHandle) {
       InitialGodotCallDescriptors.PROPERTYTWEENER_SET_EASE,
       handle,
       ease,
+    )
+
+  /** Task 64 tier 2: custom starting value, COLOR arm. */
+  fun from(value: GodotColor): GodotHandle? =
+    GodotBackendCalls.invokeColorRetHandle(
+      InitialGodotCallDescriptors.PROPERTY_TWEENER_FROM_COLOR,
+      handle,
+      value,
     )
 }
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3183,6 +3183,17 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
     )
 
+  val PROPERTY_TWEENER_FROM_COLOR =
+    GodotCallDescriptor(
+      opcode = 290,
+      className = "PropertyTweener",
+      methodName = "from",
+      hash = 4190193059L,
+      shape = GodotCallShape.COLOR_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 289
+  const val MAX_OPCODE = 290
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -134,7 +134,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
      * happened to name.
      */
-    const val PROTOCOL_VERSION = 20
+    const val PROTOCOL_VERSION = 21
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -3459,6 +3459,13 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\tresult_handle = receiver_handle")
     appendLine("\telif opcode == 42 and receiver is PropertyTweener:")
     appendLine("\t\t(receiver as PropertyTweener).set_ease(int(args[2]))")
+    appendLine("\t\tresult_handle = receiver_handle")
+    // Task 64 tier 2: from() takes a Variant; the COLOR arm carries its four components in
+    // the numeric slots the tween-property appliers already use.
+    appendLine("\telif opcode == 290 and receiver is PropertyTweener:")
+    appendLine(
+      "\t\t(receiver as PropertyTweener).from(Color(float(args[5]), float(args[6]), float(args[7]), float(args[8])))"
+    )
     appendLine("\t\tresult_handle = receiver_handle")
     appendLine("\telif opcode == 134 and receiver is Tween:")
     appendLine(

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 20"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 21"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -617,7 +617,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 20"))
+    assertTrue(protocol.contains("\"protocolVersion\": 21"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -628,7 +628,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=20\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=21\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1638,7 +1638,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 20"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 21"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -332,6 +332,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     287: {},
     288: {},
     289: {},
+    290: {},
 }
 
 
@@ -1232,6 +1233,23 @@ def body_OBJECT_RET_HANDLE(calls):
     ]
 
 
+def body_COLOR_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        "commands.flush()",
+        "return registerReturnedBrowserObject(",
+        "immediateWebColorRetHandle(",
+        "descriptor.opcode,",
+        "receiver.webId(),",
+        "value.r.toDouble(),",
+        "value.g.toDouble(),",
+        "value.b.toDouble(),",
+        "value.a.toDouble(),",
+        ")",
+        ")",
+    ]
+
+
 def body_OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -1888,6 +1906,10 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ],
         "GodotHandle?",
     ),
+    "COLOR_RET_HANDLE": (
+        ["receiver: GodotHandle", "value: GodotColor"],
+        "GodotHandle?",
+    ),
     "CALLABLE_RET_HANDLE": (
         ["receiver: GodotHandle", "target: GodotHandle", "method: String"],
         "GodotHandle?",
@@ -2205,6 +2227,7 @@ EMIT_ORDER = [
     "OBJECT_RET_HANDLE",
     "OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE",
     "OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE",
+    "COLOR_RET_HANDLE",
     "CALLABLE_RET_HANDLE",
     "NOARGS_RET_LONG_SINGLETON",
     "STRINGNAME_OBJECT_RET_INT",

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4552,6 +4552,23 @@
       "semantics": "SCALAR variant of the property tweener: a component path such as \"position:y\" takes a number, not a vector. Its absence is why third-person's coin spill (CoinsContainer) faulted the Web boundary -- every other tween shape existed, so nothing flagged the hole.",
       "introducedBy": "64-tween-double-arm",
       "descriptorName": "TWEEN_TWEEN_PROPERTY_DOUBLE"
+    },
+    {
+      "opcode": 290,
+      "scope": "class",
+      "className": "PropertyTweener",
+      "methodName": "from",
+      "hash": 4190193059,
+      "arguments": [
+        "Variant"
+      ],
+      "returnType": "PropertyTweener",
+      "shape": "COLOR_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "RETAINED_REFCOUNTED",
+      "semantics": "Custom starting value for a property tween, COLOR arm. Icone's fade runs from the opposite alpha rather than from wherever modulate happened to sit; without it the web override had to drop from() and animate differently than desktop.",
+      "introducedBy": "64-tier2-property-tweener-from",
+      "descriptorName": "PROPERTY_TWEENER_FROM_COLOR"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -148,6 +148,14 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
   trace(`scalarTweenProbe: ${scalarTween}`);
 
+  // Task 64 tier 2: PropertyTweener.from (see Main.tweener_from_probe).
+  const tweenerFrom = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("tweener_from_probe")}, 0)`,
+    ),
+  );
+  trace(`tweenerFromProbe: ${tweenerFrom}`);
+
   // Task 80 dispatch-shape conformance: Main.dispatch_probe (method#16, Int->Int)
   // returns a mask. Every bit is a shape task 80 admitted, exercised through the REAL crossing
   // (Kotlin asks Godot to call the method by name, Godot dispatches to the generated GDScript
@@ -304,6 +312,9 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     // Task 64: tween_property with a NUMBER. Vector2/Color/Vector3 all had arms and this one
     // did not, so third-person's coin spill faulted the Web boundary on a component path.
     scalarTweenArmDelivers: scalarTween === 1,
+    // Task 64 tier 2: from() returned the SAME tweener, which is what the fluent contract
+    // promises -- a dropped call returns null and clears this.
+    propertyTweenerFromDelivers: tweenerFrom === 1,
     // Task 80 slice 2: every admitted dispatch shape round-tripped its VALUE, not just its call.
     dispatchShapesRoundTrip: dispatchProbe === 127,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -723,6 +723,28 @@ class PropertyTweener internal constructor(backendHandle: BackendGodotHandle) :
   fun setEase(ease: Long): PropertyTweener =
     wrapOrThis(PropertyTweenerBackendContractProbe(backendHandle).setEase(ease))
 
+  /**
+   * Task 64 tier 2: a custom starting value, COLOR arm.
+   *
+   * Desktop takes `Any?` because it rides a Variant ptrcall. Web needs a typed arm per
+   * value shape, and Color is the one the corpus uses (Icone's fade). Anything else names
+   * the arms that DO exist rather than failing vaguely -- the tween-property family taught
+   * us that a partial set of arms looks complete from the outside.
+   */
+  fun from(value: Any?): PropertyTweener =
+    when (value) {
+      is Color ->
+        wrapOrThis(
+          PropertyTweenerBackendContractProbe(backendHandle)
+            .from(GodotColor(value.r, value.g, value.b, value.a))
+        )
+      else ->
+        unsupportedWebGameplayCall(
+          "PropertyTweener.from value ${value?.let { it::class.simpleName } ?: "null"} " +
+            "(the Web backend has the Color arm only)"
+        )
+    }
+
   private fun wrapOrThis(value: BackendGodotHandle?): PropertyTweener =
     if (value == null || value.backendToken() == backendHandle.backendToken()) this
     else PropertyTweener(value)

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebBackendTransport.kt
@@ -184,6 +184,15 @@ internal fun immediateWebTweenPropertyVector3(
     "globalThis.KanamaWebBridge.immediateTweenPropertyVector3(opcode, tweenId, targetId, property, x, y, z, duration)"
   )
 
+internal fun immediateWebColorRetHandle(
+  opcode: Int,
+  objectId: Int,
+  r: Double,
+  g: Double,
+  b: Double,
+  alpha: Double,
+): Int = js("globalThis.KanamaWebBridge.immediateColorRetHandle(opcode, objectId, r, g, b, alpha)")
+
 internal fun immediateWebTweenPropertyDouble(
   opcode: Int,
   tweenId: Int,

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -1272,6 +1272,27 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     )
   }
 
+  override fun invokeColorRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: GodotColor,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    commands.flush()
+    return registerReturnedBrowserObject(
+      immediateWebColorRetHandle(
+        descriptor.opcode,
+        receiver.webId(),
+        value.r.toDouble(),
+        value.g.toDouble(),
+        value.b.toDouble(),
+        value.a.toDouble(),
+      )
+    )
+  }
+
   override fun invokeCallableRetHandle(
     descriptor: GodotCallDescriptor,
     callSite: GodotCallSite,

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -31,6 +31,7 @@ import net.multigesture.kanama.api.SceneTree
 import net.multigesture.kanama.api.WorldEnvironment
 import net.multigesture.kanama.api.genericWebGameplayFallback
 import net.multigesture.kanama.api.lookAt
+import net.multigesture.kanama.types.Color
 import net.multigesture.kanama.types.NodePath
 import net.multigesture.kanama.types.Vector2
 import net.multigesture.kanama.types.Vector2i
@@ -392,6 +393,28 @@ class Main(godotObject: GodotHandle) :
     val tween = self.createTween() ?: return 0L
     val tweener = tween.tweenProperty(self, "position:y", 0.0, 0.05)
     return if (tweener != null) 1L else 0L
+  }
+
+  /**
+   * Task 64 tier 2: PropertyTweener.from, COLOR arm. Returns 1 when the call came back with
+   * a live tweener.
+   *
+   * `from` is SELF-RETURNING, so a broken arm and a working one both hand back the same
+   * handle -- "it returned something" proves nothing. The probe therefore asserts the
+   * returned tweener is the SAME object the tween produced (identity), which is what the
+   * fluent contract promises and what a dropped call would break by returning null.
+   */
+  @RegisterFunction("tweener_from_probe")
+  fun tweenerFromProbe(value: Long): Long {
+    // A COLOR property, because from() must agree with the tween's value type -- Godot
+    // rejects "float and Color" outright, which is exactly what the first draft of this
+    // probe did. Sun is the fixture's DirectionalLight3D and light_color is a real Color.
+    val sun = self.getAsOrNull(NodePath("Sun"), ::Node3D) ?: return 0L
+    val tween = self.createTween() ?: return 0L
+    val tweener =
+      tween.tweenProperty(sun, "light_color", Color(1f, 1f, 1f, 1f), 0.05) ?: return 0L
+    val chained = tweener.from(Color(0.5f, 0.5f, 0.5f, 1f))
+    return if (chained.handle.value == tweener.handle.value) 1L else 0L
   }
 
   @RegisterFunction("signal_probe")

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 20;
+  const KANAMA_WEB_PROTOCOL_VERSION = 21;
 
   function commandWordCount(opcode) {
     if (
@@ -2027,6 +2027,15 @@
       // Rides the generic tween-property flow: the "property" slot carries the method name
       // and the returned CallbackTweener registers as a tween child for release.
       return this.immediateTweenProperty(opcode, tweenHandle, targetHandle, method, []);
+    },
+    immediateColorRetHandle(opcode, objectId, r, g, b, a) {
+      // Task 64 tier 2: a fluent PropertyTweener call that returns the receiver, so it
+      // reuses the tween-callback channel and reports the SAME handle back rather than
+      // minting one -- the proxy sets result_handle = receiver_handle.
+      const callback = this.callbackFor(this.tweenCallbacks, objectId, "Godot PropertyTweener color");
+      this.immediateObjectHandleResult = null;
+      callback(opcode, objectId, 0, 0, "", r, g, b, a);
+      return this.immediateObjectHandleResult === objectId ? objectId : 0;
     },
     immediateTweenPropertyDouble(opcode, tweenHandle, targetHandle, property, value, duration) {
       // Task 64: the SCALAR arm. A component path like "position:y" takes a number, and its


### PR DESCRIPTION
Icone's fade sets a custom starting value so the tween runs from the opposite alpha rather than from wherever `modulate` sat. The Web backend had **no `from` at all**, so the web override dropped it — a different animation from desktop, silently.

Same layer walk as the scalar tween arm (#200): contract shape + `invokeColorRetHandle` (default error body, so desktop and iOS are untouched), opcode 290, regenerated descriptors, generator policy/signature/emit-order/body, wasm extern, bridge arm, **GDScript proxy arm**, Kotlin API arm. Protocol 20 → 21 **in both places**.

The API has the Color arm only and **says so** when handed anything else, naming the arms that exist. The tween-property family taught us a partial set looks complete from outside — that's how the scalar hole survived.

## Two things the first attempt got wrong, both caught by running it

- **The probe tweened `position:y` (a float) and passed a Color.** Godot rejected the type mismatch outright: `from()` must agree with the tween's value type. It now tweens the fixture Sun's `light_color`, a real Color property.
- **The first falsification passed** — which should be impossible. The export had failed to build and the smoke ran the **stale** one, the trap our own ops notes warn about. Re-run with the export dir removed first, and falsified properly by passing a value type the Web backend has no arm for: that **fails** the run.

## Verified

- web3d **chrome + firefox PASS**, probe returns 1
- thirdperson **chrome AND safari PASS** with the converged Icone, zero console errors

Pairs with **kanama-demos#40**, which converges Icone and deletes its override (14 → 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)