### PR TITLE
Bump DEMOS_REF to the demos main carrying the converged Icone

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,10 +51,9 @@ env:
   # Kanama PR. Bump it deliberately when a demo port lands (see
   # docs/exporting/web.md, "Bumping the demos pin").
   # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
-  # Task 64/65: the @OnReady repair (demos#39) + the re-authored sample map (demos#38).
-  # Bumped WITH the annotation gate below: the gate fails against the previous pin, which
-  # still carries the FullScreenHandler bug -- both sides pin together or neither is green.
-  DEMOS_REF: 87e5cfc3fb5c38fddd21a2a71ee6e29a77f7d354
+  # Task 64: adds the converged Icone (demos#40), which calls PropertyTweener.from -- an arm
+  # that only exists from kanama#204 onward. Both sides pin together or neither is green.
+  DEMOS_REF: fa4cb1b6608f36142872e0ac14a4d052deb3d70f
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
demos#40 deletes Icone's web override, so the shared file's `tweener?.from(source)` now compiles on Web — which only works from #204 (opcode 290, protocol 21) onward.

**Both sides pin together or neither is green.** The old pin still carries the override, so CI would otherwise keep exercising the path this parcel replaced — a green that tests the old behaviour.

New pin `fa4cb1b6` = demos#40. Verified locally before bumping: thirdperson exports against this exact commit and passes on **Chrome and Safari**, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)