### PR TITLE
CHANGELOG: PropertyTweener.from, and say plainly that exports must be rebuilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ nineteen defects. The ones that change what a running script does:
 - **`tween_property` with a NUMBER had no arm.** Vector2, Color and Vector3 all worked,
   so a component path — `tween_property(node, "position:y", 4.0, 0.5)` — faulted the
   Web boundary. (Protocol 20.)
+- **`PropertyTweener.from` did not exist on Web.** A tween could not be given a custom
+  starting value, so a demo doing so had to drop the call and animate differently on Web
+  than on desktop — silently, since nothing failed. The Color arm is in; other value
+  types name the arms that do exist rather than failing vaguely. (Protocol 21.)
+
+**Web exports must be rebuilt.** The protocol moved 18 → 21 over these fixes (19 for the
+re-parent repair, 20 for the scalar tween arm, 21 for `PropertyTweener.from`). The
+generated proxies and the JS bridge compare it at startup, so an export built against an
+older protocol will refuse to run — rebuild rather than mixing.
 - Handle-seeding and snapshot-refresh parity fixes for objects arriving through
   sibling paths, and a self-snapshot refresh guarded for nodes outside the tree.
 


### PR DESCRIPTION
The Unreleased section I wrote yesterday was **already stale**. It missed `PropertyTweener.from` (#204) and stopped at protocol 20 while the code is at 21.

Both are user-facing, and they're the two things a reader actually needs:

- **`PropertyTweener.from` did not exist on Web.** A tween couldn't be given a custom starting value, so a demo doing so had to drop the call and animate differently on Web than on desktop — silently, since nothing failed.
- **The protocol moved 18 → 21** across these fixes (19 re-parent repair, 20 scalar tween arm, 21 `from`). The generated proxies and the JS bridge compare it at startup, so **an export built against an older protocol refuses to run**. That decides whether someone's existing export still works, which matters before the detail of what was fixed.

Adds both, with the rebuild note stated plainly rather than left implicit in three separate "(Protocol N.)" mentions.

Worth noting how this was found: the CHANGELOG went stale **within a day** of being written, on the most release-facing file in the repo. It's the same rot class as everything else this week — which is the argument for `audit_claims.sh` covering it eventually, since nothing currently checks that Unreleased describes what actually merged.

Verified: `mkdocs build --strict` clean, `audit_claims.sh` PASS all 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)