### PR TITLE
Web: InputMap, InputEventKey, process-mode and Window-mode families (task 64 tier 3, protocol 22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added — Web input-map, key-event, process-mode and window-mode families
+
+- **Web protocol 21 → 22.** The Kotlin/Wasm backend admits the call families the
+  third-person demo's shared `Player.kt` and `FullScreenHandler.kt` need so they
+  can later compile on Web without `web/kotlin-src` overrides (task 64 tier 3):
+  `InputMap.hasAction` / `addAction` / `actionAddEvent` / `eraseAction`,
+  `InputEventKey.create()` / `from()` with `keycode` / `physicalKeycode` and the
+  `KEY_*` constants, `InputEvent.isEcho()` / `isAction()`,
+  `InputEventWithModifiers.isAltPressed()`, `Node.setProcessMode` /
+  `getProcessMode` with `PROCESS_MODE_*`, `SceneTree.getRoot()`, and a
+  handle-taking `Window(...)` with `setMode` / `getMode`. `Node3D.setVisible` /
+  `show()` are now members and `InputEventMouseButton.MOUSE_BUTTON_RIGHT` exists.
+  One new contract shape (`STRINGNAME_OBJECT_ARG_SINGLETON`) carries the
+  action-plus-event call; `actionAddEvent` fails loud if the engine did not
+  attach the event. The in-repo `web3d` fixture proves every family delivered a
+  VALUE (`Main.input_map_probe`, required by the smoke gate, must return 255).
+  **Existing Web exports must be rebuilt**: a protocol-21 export refuses to load
+  against a protocol-22 bridge, and vice versa.
+
 ### Changed — Godot baseline
 
 - **Godot baseline re-pinned to 4.7.2 stable** (task 91). `scripts/upgrade_godot.sh`

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -316,7 +316,7 @@ a payload can never split the list.
 fixture declares one registered function per shape and drives each through the
 real crossing — Kotlin asks Godot to call it BY NAME, Godot dispatches to the
 generated proxy, the proxy takes the arm — then compares the value that came
-back against the value that went out (`Main.dispatch_probe`, driver method #16,
+back against the value that went out (`Main.dispatch_probe`, resolved by name in the driver,
 must return the full mask — 127). A shape that only the emitter tests cover is a
 shape nothing has ever actually run, and the manifest cannot see a shape that
 dispatches but delivers the WRONG VALUE. The mixed-channel bit carries a

--- a/docs/contributing/web-internals.md
+++ b/docs/contributing/web-internals.md
@@ -65,7 +65,7 @@ Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 21); startup rejects a mismatch <!-- kanama-claim: protocol -->
+`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 22); startup rejects a mismatch <!-- kanama-claim: protocol -->
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -5,7 +5,7 @@
 The Web backend is **Experimental (Kotlin/Wasm preview)** on the Godot 4.7 stable
 baseline. It compiles Kanama project scripts to **Kotlin/Wasm** and runs them
 against a Godot 4.7 Web export through a generated per-call proxy and a versioned
-JavaScript bridge (protocol 21). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
+JavaScript bridge (protocol 22). <!-- kanama-claim: protocol --> It is **not a Supported target**: the renderer is
 single-thread Compatibility only, the browser matrix and performance budgets are
 still being hardened, and there is no packaged install path yet.
 

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -131,7 +131,7 @@ FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles
 to WebAssembly and talks to the Godot 4.7 Web export (Emscripten/Wasm) through a
 generated per-call proxy and a versioned JavaScript bridge
 (`web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js`, currently
-protocol 21). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
+protocol 22). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
 `scripts/platform_backend_calls.json`, and
 `scripts/generate_web_gameplay_coverage.py` fails loudly if a call the demo
 executes has no admitted backend family. See
@@ -149,7 +149,7 @@ calls that the backend does not model (`GodotObject.emit_signal_typed` among
 them) stay listed as explicit nonblocking unsupported entries rather than being
 pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 21). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 22). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -96,6 +96,7 @@ enum class GodotCallShape {
   STRINGNAME_LONG_ARG,
   STRINGNAME_VECTOR2_ARG,
   STRINGNAME_OBJECT_ARG,
+  STRINGNAME_OBJECT_ARG_SINGLETON,
   STRINGNAME_RET_VECTOR2,
   NOARGS_RET_STRING,
   STRINGNAME_RET_STRING,
@@ -865,6 +866,21 @@ interface GodotBackendSpi {
     descriptor: GodotCallDescriptor,
     callSite: GodotCallSite,
     receiver: GodotHandle,
+    name: String,
+    value: GodotHandle,
+  ) {
+    error("Platform backend has not implemented ${descriptor.className}.${descriptor.methodName}")
+  }
+
+  /**
+   * Singleton call carrying a name and one object handle -- `InputMap.action_add_event(action,
+   * event)` (task 64 tier 3). No receiver: the singleton is reached through the active script
+   * owner, and the object argument is a handle that owner already tracks (the constructed
+   * InputEventKey).
+   */
+  fun invokeStringNameObjectArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
     name: String,
     value: GodotHandle,
   ) {
@@ -1919,6 +1935,22 @@ object GodotBackendCalls {
     )
   }
 
+  fun invokeStringNameObjectArgSingleton(
+    descriptor: GodotCallDescriptor,
+    name: String,
+    value: GodotHandle,
+  ) {
+    requireShape(descriptor, GodotCallShape.STRINGNAME_OBJECT_ARG_SINGLETON)
+    val selected = requireBackend()
+    selected.requireLive(value)
+    selected.invokeStringNameObjectArgSingleton(
+      descriptor,
+      resolve(selected, descriptor),
+      name,
+      value,
+    )
+  }
+
   fun invokeStringNameRetVector2(
     descriptor: GodotCallDescriptor,
     receiver: GodotHandle,
@@ -2316,6 +2348,14 @@ class NodeBackendContractProbe(private val handle: GodotHandle) {
 
   fun getParent(): GodotHandle? =
     GodotBackendCalls.invokeNoArgsRetHandle(InitialGodotCallDescriptors.NODE_GET_PARENT, handle)
+
+  /** Task 64 tier 3: process mode as its enum integer (FullScreenHandler's PROCESS_MODE_ALWAYS). */
+  fun setProcessMode(mode: Long) {
+    GodotBackendCalls.invokeLongArg(InitialGodotCallDescriptors.NODE_SET_PROCESS_MODE, handle, mode)
+  }
+
+  fun getProcessMode(): Long =
+    GodotBackendCalls.invokeNoArgsRetLong(InitialGodotCallDescriptors.NODE_GET_PROCESS_MODE, handle)
 }
 
 /** Typed SceneTree lifecycle slice used by Match3's deterministic smoke exit. */
@@ -2336,6 +2376,12 @@ class SceneTreeBackendContractProbe(private val handle: GodotHandle) {
       method,
     )
   }
+
+  /**
+   * Root window as a tracked node handle (task 64 tier 3: FullScreenHandler wraps it as Window).
+   */
+  fun getRoot(): GodotHandle? =
+    GodotBackendCalls.invokeNoArgsRetHandle(InitialGodotCallDescriptors.SCENETREE_GET_ROOT, handle)
 }
 
 /** Typed Tween slice used by Match3 animation and feedback. */
@@ -2951,6 +2997,56 @@ class InputEventBackendContractProbe(private val handle: GodotHandle) {
       handle,
       action,
     )
+
+  /** Task 64 tier 3: key-repeat echo flag (FullScreenHandler ignores echoes). */
+  fun isEcho(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(InitialGodotCallDescriptors.INPUTEVENT_IS_ECHO, handle)
+}
+
+/** Typed modifier-state read on a key/mouse event (task 64 tier 3: alt+Enter fullscreen). */
+@InternalKanamaBackendApi
+class InputEventWithModifiersBackendContractProbe(private val handle: GodotHandle) {
+  fun isAltPressed(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(
+      InitialGodotCallDescriptors.INPUTEVENTWITHMODIFIERS_IS_ALT_PRESSED,
+      handle,
+    )
+}
+
+/**
+ * Typed InputEventKey slice (task 64 tier 3). The setters are queued mutations on a constructed
+ * event; the getters read the engine value back, so a probe can prove the write LANDED rather than
+ * echo a Kotlin-side mirror.
+ */
+@InternalKanamaBackendApi
+class InputEventKeyBackendContractProbe(private val handle: GodotHandle) {
+  fun setKeycode(keycode: Long) {
+    GodotBackendCalls.invokeLongArg(
+      InitialGodotCallDescriptors.INPUTEVENTKEY_SET_KEYCODE,
+      handle,
+      keycode,
+    )
+  }
+
+  fun getKeycode(): Long =
+    GodotBackendCalls.invokeNoArgsRetLong(
+      InitialGodotCallDescriptors.INPUTEVENTKEY_GET_KEYCODE,
+      handle,
+    )
+
+  fun setPhysicalKeycode(physicalKeycode: Long) {
+    GodotBackendCalls.invokeLongArg(
+      InitialGodotCallDescriptors.INPUTEVENTKEY_SET_PHYSICAL_KEYCODE,
+      handle,
+      physicalKeycode,
+    )
+  }
+
+  fun getPhysicalKeycode(): Long =
+    GodotBackendCalls.invokeNoArgsRetLong(
+      InitialGodotCallDescriptors.INPUTEVENTKEY_GET_PHYSICAL_KEYCODE,
+      handle,
+    )
 }
 
 /** Typed mouse-button query used by Match3 tile input. */
@@ -3377,4 +3473,53 @@ object InputActionBackendContractProbe {
 
   fun getMouseMode(): Long =
     GodotBackendCalls.invokeNoArgsRetLongSingleton(InitialGodotCallDescriptors.INPUT_GET_MOUSE_MODE)
+}
+
+/**
+ * Typed InputMap singleton slice (task 64 tier 3). Third-person's Player registers its own key
+ * bindings at startup: has_action -> add_action -> action_add_event on a constructed InputEventKey.
+ * Every call is immediate so the sequence composes in order and the caller can close() the event
+ * handle right after attaching it.
+ */
+@InternalKanamaBackendApi
+object InputMapBackendContractProbe {
+  fun hasAction(action: String): Boolean =
+    GodotBackendCalls.invokeStringNameRetBoolSingleton(
+      InitialGodotCallDescriptors.INPUTMAP_HAS_ACTION,
+      action,
+    )
+
+  /** The shape carries the name only; Godot's default deadzone (0.2) is what the engine applies. */
+  fun addAction(action: String) {
+    GodotBackendCalls.invokeStringNameArgSingleton(
+      InitialGodotCallDescriptors.INPUTMAP_ADD_ACTION,
+      action,
+    )
+  }
+
+  fun actionAddEvent(action: String, event: GodotHandle) {
+    GodotBackendCalls.invokeStringNameObjectArgSingleton(
+      InitialGodotCallDescriptors.INPUTMAP_ACTION_ADD_EVENT,
+      action,
+      event,
+    )
+  }
+
+  fun eraseAction(action: String) {
+    GodotBackendCalls.invokeStringNameArgSingleton(
+      InitialGodotCallDescriptors.INPUTMAP_ERASE_ACTION,
+      action,
+    )
+  }
+}
+
+/** Typed Window mode slice on a tracked Window handle (task 64 tier 3: F11 fullscreen toggle). */
+@InternalKanamaBackendApi
+class WindowBackendContractProbe(private val handle: GodotHandle) {
+  fun setMode(mode: Long) {
+    GodotBackendCalls.invokeLongArg(InitialGodotCallDescriptors.WINDOW_SET_MODE, handle, mode)
+  }
+
+  fun getMode(): Long =
+    GodotBackendCalls.invokeNoArgsRetLong(InitialGodotCallDescriptors.WINDOW_GET_MODE, handle)
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -3001,6 +3001,14 @@ class InputEventBackendContractProbe(private val handle: GodotHandle) {
   /** Task 64 tier 3: key-repeat echo flag (FullScreenHandler ignores echoes). */
   fun isEcho(): Boolean =
     GodotBackendCalls.invokeNoArgsRetBool(InitialGodotCallDescriptors.INPUTEVENT_IS_ECHO, handle)
+
+  /** Task 64 tier 3: is this event bound to [action] (pressed or not)? exact_match baked false. */
+  fun isAction(action: String): Boolean =
+    GodotBackendCalls.invokeStringNameRetBool(
+      InitialGodotCallDescriptors.INPUTEVENT_IS_ACTION,
+      handle,
+      action,
+    )
 }
 
 /** Typed modifier-state read on a key/mouse event (task 64 tier 3: alt+Enter fullscreen). */

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3194,6 +3194,160 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
     )
 
+  val INPUTMAP_HAS_ACTION =
+    GodotCallDescriptor(
+      opcode = 291,
+      className = "InputMap",
+      methodName = "has_action",
+      hash = 2619796661L,
+      shape = GodotCallShape.STRINGNAME_RET_BOOL_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTMAP_ADD_ACTION =
+    GodotCallDescriptor(
+      opcode = 292,
+      className = "InputMap",
+      methodName = "add_action",
+      hash = 1195233573L,
+      shape = GodotCallShape.STRINGNAME_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTMAP_ACTION_ADD_EVENT =
+    GodotCallDescriptor(
+      opcode = 293,
+      className = "InputMap",
+      methodName = "action_add_event",
+      hash = 518302593L,
+      shape = GodotCallShape.STRINGNAME_OBJECT_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTMAP_ERASE_ACTION =
+    GodotCallDescriptor(
+      opcode = 294,
+      className = "InputMap",
+      methodName = "erase_action",
+      hash = 3304788590L,
+      shape = GodotCallShape.STRINGNAME_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENTKEY_SET_KEYCODE =
+    GodotCallDescriptor(
+      opcode = 295,
+      className = "InputEventKey",
+      methodName = "set_keycode",
+      hash = 888074362L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENTKEY_GET_KEYCODE =
+    GodotCallDescriptor(
+      opcode = 296,
+      className = "InputEventKey",
+      methodName = "get_keycode",
+      hash = 1585896689L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENTKEY_SET_PHYSICAL_KEYCODE =
+    GodotCallDescriptor(
+      opcode = 297,
+      className = "InputEventKey",
+      methodName = "set_physical_keycode",
+      hash = 888074362L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENTKEY_GET_PHYSICAL_KEYCODE =
+    GodotCallDescriptor(
+      opcode = 298,
+      className = "InputEventKey",
+      methodName = "get_physical_keycode",
+      hash = 1585896689L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENT_IS_ECHO =
+    GodotCallDescriptor(
+      opcode = 299,
+      className = "InputEvent",
+      methodName = "is_echo",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUTEVENTWITHMODIFIERS_IS_ALT_PRESSED =
+    GodotCallDescriptor(
+      opcode = 300,
+      className = "InputEventWithModifiers",
+      methodName = "is_alt_pressed",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_SET_PROCESS_MODE =
+    GodotCallDescriptor(
+      opcode = 301,
+      className = "Node",
+      methodName = "set_process_mode",
+      hash = 1841290486L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val WINDOW_SET_MODE =
+    GodotCallDescriptor(
+      opcode = 302,
+      className = "Window",
+      methodName = "set_mode",
+      hash = 3095236531L,
+      shape = GodotCallShape.LONG_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val WINDOW_GET_MODE =
+    GodotCallDescriptor(
+      opcode = 303,
+      className = "Window",
+      methodName = "get_mode",
+      hash = 2566346114L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val NODE_GET_PROCESS_MODE =
+    GodotCallDescriptor(
+      opcode = 304,
+      className = "Node",
+      methodName = "get_process_mode",
+      hash = 739966102L,
+      shape = GodotCallShape.NOARGS_RET_LONG,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 290
+  const val MAX_OPCODE = 304
 }

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3348,6 +3348,17 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
 
+  val INPUTEVENT_IS_ACTION =
+    GodotCallDescriptor(
+      opcode = 305,
+      className = "InputEvent",
+      methodName = "is_action",
+      hash = 1558498928L,
+      shape = GodotCallShape.STRINGNAME_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 304
+  const val MAX_OPCODE = 305
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -3816,6 +3816,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int((value as InputEventKey).physical_keycode)")
     appendLine("\t\telif opcode == 299 and value is InputEvent:")
     appendLine("\t\t\tresult = int((value as InputEvent).is_echo())")
+    appendLine("\t\telif opcode == 305 and value is InputEvent:")
+    appendLine("\t\t\tresult = int((value as InputEvent).is_action(StringName(String(args[2]))))")
     appendLine("\t\telif opcode == 300 and value is InputEventWithModifiers:")
     appendLine("\t\t\tresult = int((value as InputEventWithModifiers).alt_pressed)")
     appendLine("\t\telif opcode == 303 and value is Window:")

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -134,7 +134,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
      * happened to name.
      */
-    const val PROTOCOL_VERSION = 21
+    const val PROTOCOL_VERSION = 22
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -3155,6 +3155,26 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 12")
+    // Task 64 tier 3: one-int32 queued setters (enum values cross as their integer). The
+    // engine-property spelling matches the sky_mode arm above, which the export accepts.
+    appendLine("\t\telif opcode == 295 and target_object is InputEventKey:")
+    appendLine("\t\t\t(target_object as InputEventKey).keycode = bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 297 and target_object is InputEventKey:")
+    appendLine(
+      "\t\t\t(target_object as InputEventKey).physical_keycode = bytes.decode_s32(offset + 8)"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 301 and target_object is Node:")
+    appendLine("\t\t\t(target_object as Node).process_mode = bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
+    appendLine("\t\telif opcode == 302 and target_object is Window:")
+    appendLine("\t\t\t(target_object as Window).mode = bytes.decode_s32(offset + 8)")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 12")
     appendLine("\t\telse:")
     appendLine(
       "\t\t\tpush_error(\"Invalid Kanama Web command opcode/object: %d/%d\" % [opcode, object_handle])"
@@ -3762,6 +3782,46 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\telif opcode == 87:")
     appendLine("\t\t\tInput.action_release(StringName(String(args[2])))")
     appendLine("\t\t\tresult = 0")
+    // Task 64 tier 3: the InputMap singleton (third-person's Player registers its own bindings).
+    // Singleton opcodes ride the active script's own query channel, so `value` is `self` here.
+    appendLine("\t\telif opcode == 291:")
+    appendLine("\t\t\tresult = int(InputMap.has_action(StringName(String(args[2]))))")
+    appendLine("\t\telif opcode == 292:")
+    appendLine("\t\t\tInputMap.add_action(StringName(String(args[2])))")
+    appendLine("\t\t\tresult = 0")
+    appendLine("\t\telif opcode == 293:")
+    // Action name and event handle packed with the unit separator (the emit-signal-object
+    // spelling). The event was constructed under this same owner, so it resolves from this
+    // script's handle table; an unknown handle reports 0 and the Kotlin side fails loud.
+    appendLine("\t\t\tvar add_event_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar add_event_handle := int(add_event_parts[1])")
+    appendLine("\t\t\tvar add_event: Object = _kanama_object_handles.get(add_event_handle)")
+    appendLine("\t\t\tif add_event is InputEvent:")
+    appendLine(
+      "\t\t\t\tInputMap.action_add_event(StringName(add_event_parts[0]), add_event as InputEvent)"
+    )
+    appendLine("\t\t\t\tresult = 1")
+    appendLine("\t\t\telse:")
+    appendLine(
+      "\t\t\t\tpush_error(\"Unknown Kanama Web InputMap event handle: %d\" % add_event_handle)"
+    )
+    appendLine("\t\t\t\tresult = 0")
+    appendLine("\t\telif opcode == 294:")
+    appendLine("\t\t\tInputMap.erase_action(StringName(String(args[2])))")
+    appendLine("\t\t\tresult = 0")
+    // Task 64 tier 3: engine-side reads that let a probe prove a queued setter LANDED.
+    appendLine("\t\telif opcode == 296 and value is InputEventKey:")
+    appendLine("\t\t\tresult = int((value as InputEventKey).keycode)")
+    appendLine("\t\telif opcode == 298 and value is InputEventKey:")
+    appendLine("\t\t\tresult = int((value as InputEventKey).physical_keycode)")
+    appendLine("\t\telif opcode == 299 and value is InputEvent:")
+    appendLine("\t\t\tresult = int((value as InputEvent).is_echo())")
+    appendLine("\t\telif opcode == 300 and value is InputEventWithModifiers:")
+    appendLine("\t\t\tresult = int((value as InputEventWithModifiers).alt_pressed)")
+    appendLine("\t\telif opcode == 303 and value is Window:")
+    appendLine("\t\t\tresult = int((value as Window).mode)")
+    appendLine("\t\telif opcode == 304 and value is Node:")
+    appendLine("\t\t\tresult = int((value as Node).process_mode)")
     appendLine("\t\telif opcode == 90 and value is CharacterBody3D:")
     appendLine("\t\t\tresult = int((value as CharacterBody3D).move_and_slide())")
     appendLine("\t\telif opcode == 91 and value is CharacterBody3D:")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 21"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 22"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -390,6 +390,69 @@ class WebScriptCodeEmitterTest {
   }
 
   @Test
+  fun emitsInputMapAndInputEventKeyArmsInEveryProxy() {
+    // Task 64 tier 3: the families third-person's shared Player.kt / FullScreenHandler.kt need.
+    // The singleton InputMap arms ride the active script's own query channel; action_add_event
+    // resolves the packed event handle from THIS script's handle table (the construct path
+    // interns it there) and reports 1 only when it attached, so the Kotlin side can fail loud.
+    val proxy =
+      WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))
+        .proxySources()
+        .single { it.sourceResourcePath.isNotEmpty() }
+        .source
+
+    assertTrue(proxy.contains("elif opcode == 291:"))
+    assertTrue(proxy.contains("result = int(InputMap.has_action(StringName(String(args[2]))))"))
+    assertTrue(proxy.contains("elif opcode == 292:"))
+    assertTrue(proxy.contains("InputMap.add_action(StringName(String(args[2])))"))
+    assertTrue(proxy.contains("elif opcode == 293:"))
+    assertTrue(proxy.contains("var add_event_parts := String(args[2]).split(\"\\u001f\")"))
+    assertTrue(
+      proxy.contains("var add_event: Object = _kanama_object_handles.get(add_event_handle)")
+    )
+    assertTrue(
+      proxy.contains(
+        "InputMap.action_add_event(StringName(add_event_parts[0]), add_event as InputEvent)"
+      )
+    )
+    assertTrue(proxy.contains("Unknown Kanama Web InputMap event handle: %d"))
+    assertTrue(proxy.contains("elif opcode == 294:"))
+    assertTrue(proxy.contains("InputMap.erase_action(StringName(String(args[2])))"))
+
+    // Engine-side reads, guarded by class so a wrong-typed handle reports 0 rather than throwing.
+    assertTrue(proxy.contains("elif opcode == 296 and value is InputEventKey:"))
+    assertTrue(proxy.contains("result = int((value as InputEventKey).keycode)"))
+    assertTrue(proxy.contains("elif opcode == 298 and value is InputEventKey:"))
+    assertTrue(proxy.contains("result = int((value as InputEventKey).physical_keycode)"))
+    assertTrue(proxy.contains("elif opcode == 299 and value is InputEvent:"))
+    assertTrue(proxy.contains("result = int((value as InputEvent).is_echo())"))
+    assertTrue(proxy.contains("elif opcode == 300 and value is InputEventWithModifiers:"))
+    assertTrue(proxy.contains("result = int((value as InputEventWithModifiers).alt_pressed)"))
+    assertTrue(proxy.contains("elif opcode == 303 and value is Window:"))
+    assertTrue(proxy.contains("result = int((value as Window).mode)"))
+    assertTrue(proxy.contains("elif opcode == 304 and value is Node:"))
+    assertTrue(proxy.contains("result = int((value as Node).process_mode)"))
+
+    // Queued one-int32 setters: 12-byte commands, matching the bridge's three-word block.
+    assertTrue(proxy.contains("elif opcode == 295 and target_object is InputEventKey:"))
+    assertTrue(
+      proxy.contains("(target_object as InputEventKey).keycode = bytes.decode_s32(offset + 8)")
+    )
+    assertTrue(proxy.contains("elif opcode == 297 and target_object is InputEventKey:"))
+    assertTrue(
+      proxy.contains(
+        "(target_object as InputEventKey).physical_keycode = bytes.decode_s32(offset + 8)"
+      )
+    )
+    assertTrue(proxy.contains("elif opcode == 301 and target_object is Node:"))
+    assertTrue(
+      proxy.contains("(target_object as Node).process_mode = bytes.decode_s32(offset + 8)")
+    )
+    assertTrue(proxy.contains("elif opcode == 302 and target_object is Window:"))
+    assertTrue(proxy.contains("(target_object as Window).mode = bytes.decode_s32(offset + 8)"))
+  }
+
+  @Test
   fun emitsExactSceneTreeLifecycleCallsInEveryProxy() {
     val proxy =
       WebScriptCodeEmitter(listOf(WebScriptInput(model("Main"), "res://kotlin-src/Main.kt")))
@@ -617,7 +680,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 21"))
+    assertTrue(protocol.contains("\"protocolVersion\": 22"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -628,7 +691,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=21\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=22\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1638,7 +1701,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 21"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 22"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -426,6 +426,10 @@ class WebScriptCodeEmitterTest {
     assertTrue(proxy.contains("result = int((value as InputEventKey).physical_keycode)"))
     assertTrue(proxy.contains("elif opcode == 299 and value is InputEvent:"))
     assertTrue(proxy.contains("result = int((value as InputEvent).is_echo())"))
+    assertTrue(proxy.contains("elif opcode == 305 and value is InputEvent:"))
+    assertTrue(
+      proxy.contains("result = int((value as InputEvent).is_action(StringName(String(args[2]))))")
+    )
     assertTrue(proxy.contains("elif opcode == 300 and value is InputEventWithModifiers:"))
     assertTrue(proxy.contains("result = int((value as InputEventWithModifiers).alt_pressed)"))
     assertTrue(proxy.contains("elif opcode == 303 and value is Window:"))

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -347,6 +347,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     302: {},
     303: {},
     304: {},
+    305: {},
 }
 
 

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -333,6 +333,20 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     288: {},
     289: {},
     290: {},
+    291: {},
+    292: {},
+    293: {},
+    294: {},
+    295: {},
+    296: {},
+    297: {},
+    298: {},
+    299: {},
+    300: {},
+    301: {},
+    302: {},
+    303: {},
+    304: {},
 }
 
 
@@ -1787,6 +1801,23 @@ def body_STRINGNAME_OBJECT_ARG(calls):
     ]
 
 
+def body_STRINGNAME_OBJECT_ARG_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// Task 64 tier 3: action name and event handle packed into one query string (unit",
+        "// separator) on the active script's own query channel; the applier resolves the event",
+        "// from that script's handle table. Immediate so the queued keycode writes land first and",
+        "// the caller may close() the event right after.",
+        "immediateWebObjectQuery(",
+        "descriptor.opcode,",
+        "requireActiveWebScriptHandle(),",
+        'name + "\u001f" + value.webId().toString(),',
+        ")",
+    ]
+
+
 def body_STRINGNAME_RET_VECTOR2(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -2100,6 +2131,7 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         ["receiver: GodotHandle", "name: String", "value: GodotHandle"],
         "",
     ),
+    "STRINGNAME_OBJECT_ARG_SINGLETON": (["name: String", "value: GodotHandle"], ""),
     "STRINGNAME_RET_VECTOR2": (["receiver: GodotHandle", "name: String"], "GodotVector2"),
     "NOARGS_RET_STRING": (["receiver: GodotHandle"], "String"),
     "STRINGNAME_RET_STRING": (["receiver: GodotHandle", "name: String"], "String"),
@@ -2247,6 +2279,7 @@ EMIT_ORDER = [
     "STRINGNAME_LONG_ARG",
     "STRINGNAME_VECTOR2_ARG",
     "STRINGNAME_OBJECT_ARG",
+    "STRINGNAME_OBJECT_ARG_SINGLETON",
     "STRINGNAME_RET_VECTOR2",
     "NOARGS_RET_STRING",
     "STRINGNAME_RET_STRING",

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -1808,13 +1808,18 @@ def body_STRINGNAME_OBJECT_ARG_SINGLETON(calls):
         "commands.flush()",
         "// Task 64 tier 3: action name and event handle packed into one query string (unit",
         "// separator) on the active script's own query channel; the applier resolves the event",
-        "// from that script's handle table. Immediate so the queued keycode writes land first and",
-        "// the caller may close() the event right after.",
+        "// from that script's handle table and reports 1 only when it attached. Immediate so the",
+        "// queued keycode writes land first and the caller may close() the event right after.",
+        "check(",
         "immediateWebObjectQuery(",
         "descriptor.opcode,",
         "requireActiveWebScriptHandle(),",
         'name + "\u001f" + value.webId().toString(),',
-        ")",
+        ") == 1",
+        ") {",
+        '"Kanama Web ${descriptor.className}.${descriptor.methodName} did not attach the event '
+        '(handle ${value.webId()} unknown to the active script)"',
+        "}",
     ]
 
 

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4569,6 +4569,220 @@
       "semantics": "Custom starting value for a property tween, COLOR arm. Icone's fade runs from the opposite alpha rather than from wherever modulate happened to sit; without it the web override had to drop from() and animate differently than desktop.",
       "introducedBy": "64-tier2-property-tweener-from",
       "descriptorName": "PROPERTY_TWEENER_FROM_COLOR"
+    },
+    {
+      "opcode": 291,
+      "scope": "class",
+      "className": "InputMap",
+      "methodName": "has_action",
+      "hash": 2619796661,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "bool",
+      "shape": "STRINGNAME_RET_BOOL_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Does the InputMap singleton know this action? Third-person's Player registers its own bindings at startup only when they are missing, so the check must answer synchronously before the add.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 292,
+      "scope": "class",
+      "className": "InputMap",
+      "methodName": "add_action",
+      "hash": 1195233573,
+      "arguments": [
+        "StringName",
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Register an empty action on the InputMap singleton. Web bakes Godot's default deadzone 0.2 (the shape carries the name only); a caller wanting another deadzone fails loud in the wrapper rather than silently getting 0.2. Immediate so a following action_add_event sees the action.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 293,
+      "scope": "class",
+      "className": "InputMap",
+      "methodName": "action_add_event",
+      "hash": 518302593,
+      "arguments": [
+        "StringName",
+        "InputEvent"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_OBJECT_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Attach an InputEvent to a named action on the InputMap singleton. Action name and event handle ride one packed query string (unit separator); the applier resolves the event from the owning script's handle table. Immediate, so the caller may close() its event handle right after -- the InputMap holds its own reference by then.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 294,
+      "scope": "class",
+      "className": "InputMap",
+      "methodName": "erase_action",
+      "hash": 3304788590,
+      "arguments": [
+        "StringName"
+      ],
+      "returnType": "void",
+      "shape": "STRINGNAME_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Remove an action from the InputMap singleton (immediate, so a following has_action reads false).",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 295,
+      "scope": "class",
+      "className": "InputEventKey",
+      "methodName": "set_keycode",
+      "hash": 888074362,
+      "arguments": [
+        "enum::Key"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the logical keycode of a constructed InputEventKey (the Key enum crosses as its integer value). Ordered before the action_add_event that follows because the immediate call flushes the queue first.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 296,
+      "scope": "class",
+      "className": "InputEventKey",
+      "methodName": "get_keycode",
+      "hash": 1585896689,
+      "arguments": [],
+      "returnType": "enum::Key",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the logical keycode of a delivered or constructed InputEventKey (FullScreenHandler matches F11 / alt+Enter).",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 297,
+      "scope": "class",
+      "className": "InputEventKey",
+      "methodName": "set_physical_keycode",
+      "hash": 888074362,
+      "arguments": [
+        "enum::Key"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue the physical (layout-independent) keycode of a constructed InputEventKey.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 298,
+      "scope": "class",
+      "className": "InputEventKey",
+      "methodName": "get_physical_keycode",
+      "hash": 1585896689,
+      "arguments": [],
+      "returnType": "enum::Key",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the physical keycode of an InputEventKey.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 299,
+      "scope": "class",
+      "className": "InputEvent",
+      "methodName": "is_echo",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Is this a key-repeat echo? FullScreenHandler ignores echoes so a held F11 toggles once.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 300,
+      "scope": "class",
+      "className": "InputEventWithModifiers",
+      "methodName": "is_alt_pressed",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Alt modifier state of a delivered key/mouse event (alt+Enter fullscreen toggle).",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 301,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "set_process_mode",
+      "hash": 1841290486,
+      "arguments": [
+        "enum::Node.ProcessMode"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a node's process mode (the ProcessMode enum crosses as its integer value). FullScreenHandler sets PROCESS_MODE_ALWAYS so F11 still works while the tree is paused.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 302,
+      "scope": "class",
+      "className": "Window",
+      "methodName": "set_mode",
+      "hash": 3095236531,
+      "arguments": [
+        "enum::Window.Mode"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a window mode change on a tracked Window handle (the root viewport from SceneTree.get_root). The browser decides what fullscreen means; the engine call is still made so the value the script reads back is the engine's, not a Kotlin-side mirror.",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 303,
+      "scope": "class",
+      "className": "Window",
+      "methodName": "get_mode",
+      "hash": 2566346114,
+      "arguments": [],
+      "returnType": "enum::Window.Mode",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read a tracked Window's mode (FullScreenHandler toggles between WINDOWED and FULLSCREEN).",
+      "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 304,
+      "scope": "class",
+      "className": "Node",
+      "methodName": "get_process_mode",
+      "hash": 739966102,
+      "arguments": [],
+      "returnType": "enum::Node.ProcessMode",
+      "shape": "NOARGS_RET_LONG",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read a node's process mode back from the engine. Exists so the web3d probe proves set_process_mode delivered its VALUE rather than trusting a Kotlin-side mirror.",
+      "introducedBy": "64-tier3-inputmap"
     }
   ],
   "compositions": [
@@ -4600,6 +4814,13 @@
         288
       ],
       "semantics": "When the query payload carries a non-empty child path, compose Node.get_node_or_null on the receiver with Label.get_text on the resolved child; an empty payload (the shape's own spelling) reads the receiver itself. A missing or non-Label target publishes no string result, so the bridge's immediate string query fails loud rather than returning something that could pass as text."
+    },
+    {
+      "name": "ClassDB.instantiate_InputEventKey",
+      "opcodes": [
+        12
+      ],
+      "semantics": "Compose the existing ClassDB.instantiate call with class name InputEventKey; the returned handle is OWNED (a NODE-kind constructed handle in the Web bookkeeping, released with the constructed-object release, never the resource release). Attach it with InputMap.action_add_event, then close() it -- the InputMap keeps its own reference."
     }
   ]
 }

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4783,6 +4783,23 @@
       "returnOwnership": "BORROWED",
       "semantics": "Read a node's process mode back from the engine. Exists so the web3d probe proves set_process_mode delivered its VALUE rather than trusting a Kotlin-side mirror.",
       "introducedBy": "64-tier3-inputmap"
+    },
+    {
+      "opcode": 305,
+      "scope": "class",
+      "className": "InputEvent",
+      "methodName": "is_action",
+      "hash": 1558498928,
+      "arguments": [
+        "StringName",
+        "bool"
+      ],
+      "returnType": "bool",
+      "shape": "STRINGNAME_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Does the InputMap bind this event to the named action (exact_match baked to Godot's default false)? Unlike is_action_pressed it ignores the pressed flag, so a freshly constructed, never-pressed InputEventKey answers true right after action_add_event -- the VALUE proof that the attach landed.",
+      "introducedBy": "64-tier3-inputmap"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -233,6 +233,19 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
   trace(`generic: ${JSON.stringify(generic)}`);
 
+  // Task 64 tier 3: InputMap / InputEventKey / process mode / Window mode (see Main.input_map_probe).
+  // Runs AFTER generic_probe on purpose: the probe wraps the root Window through the typed
+  // SceneTree.get_root path, which TRACKS that window in Main's handle table, and the generic
+  // probe's genericMintsNodeHandle check needs the same window still UNTRACKED when it asks
+  // get_window (an already-tracked object is reported "tracked", not minted). Same object, two
+  // proofs -- order is the coupling, stated here and in Main.kt.
+  const inputMapProbe = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("input_map_probe")}, 0)`,
+    ),
+  );
+  trace(`inputMapProbe: ${inputMapProbe}`);
+
   // Task 82 coroutine conformance probe. Main.coroutine_probe (method#19) launches ONE coroutine
   // on the script's own scope that awaits both delay shapes gameplay uses -- the wait-one-frame
   // safe point delaySeconds(0.0) and a timed delaySeconds -- then posts to the main thread.
@@ -315,6 +328,11 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     // Task 64 tier 2: from() returned the SAME tweener, which is what the fluent contract
     // promises -- a dropped call returns null and clears this.
     propertyTweenerFromDelivers: tweenerFrom === 1,
+    // Task 64 tier 3: every InputMap / InputEventKey / process-mode / Window-mode family delivered
+    // its VALUE -- has_action flips on add and erase, two queued keycodes read back, is_action
+    // flips on attach, the new action presses, process_mode reads 3, the root window reports a
+    // legal mode. Any dropped call clears a bit.
+    inputMapFamiliesDeliverValues: inputMapProbe === 255,
     // Task 80 slice 2: every admitted dispatch shape round-tripped its VALUE, not just its call.
     dispatchShapesRoundTrip: dispatchProbe === 127,
     // _process ran many frames (the spinner) with its Node3D.rotation mutations applied.

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -184,6 +184,10 @@
         {
           "member": "Main.coroutine_probe",
           "reason": "The task-82 coroutine frame-scheduler conformance probe the driver calls explicitly."
+        },
+        {
+          "member": "Main.input_map_probe",
+          "reason": "The task-64 tier-3 InputMap / InputEventKey / process-mode / Window-mode conformance probe the driver calls explicitly and asserts to the full 255 mask."
         }
       ],
       "todo": [

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCharacterApi.kt
@@ -194,10 +194,6 @@ open class RigidBody3D(godotObject: GodotHandle) : PhysicsBody3D(godotObject) {
       )
     }
 
-  fun show() {
-    visible = true
-  }
-
   /** Fresh engine-side angular velocity (the sphere racer's drive train). */
   var angularVelocity: Vector3
     get() =

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -234,6 +234,21 @@ open class Node internal constructor(backendHandle: BackendGodotHandle) : GodotO
   fun setProcessInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
 
   fun setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+
+  /** Process mode as its enum integer (task 64 tier 3); see the PROCESS_MODE_* constants. */
+  fun setProcessMode(mode: Long) {
+    NodeBackendContractProbe(backendHandle).setProcessMode(mode)
+  }
+
+  fun getProcessMode(): Long = NodeBackendContractProbe(backendHandle).getProcessMode()
+
+  companion object {
+    const val PROCESS_MODE_INHERIT = 0L
+    const val PROCESS_MODE_PAUSABLE = 1L
+    const val PROCESS_MODE_WHEN_PAUSED = 2L
+    const val PROCESS_MODE_ALWAYS = 3L
+    const val PROCESS_MODE_DISABLED = 4L
+  }
 }
 
 open class CanvasItem internal constructor(backendHandle: BackendGodotHandle) : Node(backendHandle) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebInputApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebInputApi.kt
@@ -1,0 +1,119 @@
+@file:OptIn(InternalKanamaBackendApi::class)
+
+package net.multigesture.kanama.api
+
+import net.multigesture.kanama.backend.ClassDBBackendContractProbe
+import net.multigesture.kanama.backend.GodotObjectBackendContractProbe
+import net.multigesture.kanama.backend.InputEventKeyBackendContractProbe
+import net.multigesture.kanama.backend.InputEventWithModifiersBackendContractProbe
+import net.multigesture.kanama.backend.InputMapBackendContractProbe
+import net.multigesture.kanama.backend.InternalKanamaBackendApi
+import net.multigesture.kanama.web.WebObjectId
+
+/**
+ * Web API surface for runtime input-map registration and key events (task 64 tier 3).
+ *
+ * Third-person's shared Player.kt registers its own bindings at startup (`hasAction` ->
+ * `addAction` -> `actionAddEvent` on a constructed [InputEventKey], then `close()`), and its
+ * FullScreenHandler.kt matches F11 / alt+Enter on delivered key events. Every InputMap call is
+ * immediate, so the sequence composes in order and the temporary event may be closed right after
+ * it is attached -- the InputMap holds its own reference by then (the create/close contract).
+ */
+object InputMap {
+  fun hasAction(action: String): Boolean = InputMapBackendContractProbe.hasAction(action)
+
+  /**
+   * Web carries the action name only and the engine applies Godot's default deadzone (0.2). Any
+   * other deadzone fails loud here rather than silently registering with 0.2.
+   */
+  fun addAction(action: String, deadzone: Double = 0.2) {
+    require(deadzone == 0.2) {
+      "Web InputMap.add_action supports only Godot's default deadzone 0.2 (got $deadzone)"
+    }
+    InputMapBackendContractProbe.addAction(action)
+  }
+
+  /** Attach [event] to [action]; the call fails loud if the engine did not attach it. */
+  fun actionAddEvent(action: String, event: InputEvent) {
+    InputMapBackendContractProbe.actionAddEvent(action, event.backendHandle)
+  }
+
+  fun eraseAction(action: String) {
+    InputMapBackendContractProbe.eraseAction(action)
+  }
+}
+
+/** Modifier-carrying input event (key and mouse); Web exposes the alt read the corpus uses. */
+open class InputEventWithModifiers(godotObject: GodotHandle) : InputEvent(godotObject) {
+  fun isAltPressed(): Boolean =
+    InputEventWithModifiersBackendContractProbe(backendHandle).isAltPressed()
+}
+
+/**
+ * Keyboard event. Delivered events are wrapped with [from]; runtime bindings are built with
+ * [create], configured, attached through [InputMap.actionAddEvent], and released with [close].
+ * The keycode setters are queued and the getters read the engine value back, so a read after a
+ * write sees what the engine holds, not a Kotlin-side echo.
+ */
+class InputEventKey(godotObject: GodotHandle) : InputEventWithModifiers(godotObject) {
+  var keycode: Long
+    get() = getKeycode()
+    set(value) = setKeycode(value)
+
+  var physicalKeycode: Long
+    get() = getPhysicalKeycode()
+    set(value) = setPhysicalKeycode(value)
+
+  fun setKeycode(keycode: Long) {
+    InputEventKeyBackendContractProbe(backendHandle).setKeycode(keycode)
+  }
+
+  fun getKeycode(): Long = InputEventKeyBackendContractProbe(backendHandle).getKeycode()
+
+  fun setPhysicalKeycode(physicalKeycode: Long) {
+    InputEventKeyBackendContractProbe(backendHandle).setPhysicalKeycode(physicalKeycode)
+  }
+
+  fun getPhysicalKeycode(): Long =
+    InputEventKeyBackendContractProbe(backendHandle).getPhysicalKeycode()
+
+  /**
+   * Release the handle [create] handed out. A ClassDB-constructed object is NODE-kind in the Web
+   * bookkeeping (the ButtonGroup / ConfigFile precedent), so this is the constructed-object
+   * release, not the resource release. Only call it on a created event, never on a delivered one.
+   */
+  fun close() {
+    releaseWebConstructedObject(handle.value)
+  }
+
+  companion object {
+    fun create(): InputEventKey {
+      val handle =
+        checkNotNull(ClassDBBackendContractProbe.instantiate("InputEventKey")) {
+          "Godot could not instantiate InputEventKey"
+        }
+      return InputEventKey(WebObjectId(handle.backendToken().toInt()))
+    }
+
+    /** Engine-side class check, the desktop `from` contract: null when [value] is not a key event. */
+    fun from(value: GodotObject): InputEventKey? =
+      value
+        .takeIf { GodotObjectBackendContractProbe(it.backendHandle).isClass("InputEventKey") }
+        ?.let { InputEventKey(it.handle) }
+
+    const val KEY_ESCAPE = 4194305L
+    const val KEY_TAB = 4194306L
+    const val KEY_ENTER = 4194309L
+    const val KEY_F10 = 4194341L
+    const val KEY_F11 = 4194342L
+    const val KEY_SPACE = 32L
+    const val KEY_A = 65L
+    const val KEY_D = 68L
+    const val KEY_E = 69L
+    const val KEY_F = 70L
+    const val KEY_Q = 81L
+    const val KEY_R = 82L
+    const val KEY_S = 83L
+    const val KEY_W = 87L
+  }
+}

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -761,6 +761,7 @@ class InputEventMouseButton private constructor(backendHandle: BackendGodotHandl
 
   companion object {
     const val MOUSE_BUTTON_LEFT = 1L
+    const val MOUSE_BUTTON_RIGHT = 2L
 
     fun from(event: GodotObject): InputEventMouseButton? =
       event
@@ -856,6 +857,16 @@ class SceneTree internal constructor(backendHandle: BackendGodotHandle) : GodotO
   fun callGroup(group: String, method: String) {
     SceneTreeBackendContractProbe(backendHandle).callGroup(group, method)
   }
+
+  /**
+   * Root window as a tracked handle -- desktop's `getRoot()` spelling (task 64 tier 3); wrap it
+   * with [Window] to reach the mode calls. The typed [root] extension stays for the tps corpus.
+   */
+  fun getRoot(): GodotHandle =
+    checkNotNull(SceneTreeBackendContractProbe(backendHandle).getRoot()) {
+        "SceneTree has no root window"
+      }
+      .let { WebObjectId(it.backendToken().toInt()) }
 
   fun setPaused(paused: Boolean) {
     GodotBackendCalls.invokeBoolArg(

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebPlatformerApi.kt
@@ -90,6 +90,15 @@ open class Node3D(godotObject: GodotHandle) : Node(godotObject.toBackendHandle()
     visible = false
   }
 
+  fun show() {
+    visible = true
+  }
+
+  /** Desktop's setter spelling (task 64 tier 3: Player toggles the grenade aim controller). */
+  fun setVisible(value: Boolean) {
+    visible = value
+  }
+
   /**
    * Position the node and orient the forward axis at [target]: -Z (camera forward) by default,
    * +Z (asset front) when [useModelFront] is true — the desktop/Godot signature (task 64). Web

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebSquashApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebSquashApi.kt
@@ -55,11 +55,22 @@ class KinematicCollision3D internal constructor(private var collisionHandle: Bac
     checkNotNull(collisionHandle) { "KinematicCollision3D is closed" }
 }
 
-/** Generic input event wrapper: squash retries on ui_accept from _unhandled_input. */
-class InputEvent(godotObject: GodotHandle) : GodotObject(godotObject) {
+/**
+ * Generic input event wrapper: squash retries on ui_accept from _unhandled_input. Open since task
+ * 64 tier 3 so the key / modifier events ([InputEventWithModifiers], [InputEventKey]) subclass it
+ * the way desktop's do.
+ */
+open class InputEvent(godotObject: GodotHandle) : GodotObject(godotObject) {
   /** allow_echo/exact_match are baked to Godot defaults (false), the only values demos pass. */
   fun isActionPressed(action: String): Boolean =
     InputEventBackendContractProbe(backendHandle).isActionPressed(action)
+
+  fun isPressed(): Boolean = InputEventBackendContractProbe(backendHandle).isPressed()
+
+  fun isReleased(): Boolean = InputEventBackendContractProbe(backendHandle).isReleased()
+
+  /** Key-repeat echo (task 64 tier 3: FullScreenHandler ignores echoes so a held F11 toggles once). */
+  fun isEcho(): Boolean = InputEventBackendContractProbe(backendHandle).isEcho()
 }
 
 internal expect fun releaseWebCollision(collisionHandle: Int)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebSquashApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebSquashApi.kt
@@ -71,6 +71,15 @@ open class InputEvent(godotObject: GodotHandle) : GodotObject(godotObject) {
 
   /** Key-repeat echo (task 64 tier 3: FullScreenHandler ignores echoes so a held F11 toggles once). */
   fun isEcho(): Boolean = InputEventBackendContractProbe(backendHandle).isEcho()
+
+  /**
+   * Is this event bound to [action] by the InputMap, pressed or not (task 64 tier 3)? Web bakes
+   * exact_match to Godot's default false, the only value the corpus passes.
+   */
+  fun isAction(action: String, exactMatch: Boolean = false): Boolean {
+    require(!exactMatch) { "Web InputEvent.is_action supports only exact_match=false" }
+    return InputEventBackendContractProbe(backendHandle).isAction(action)
+  }
 }
 
 internal expect fun releaseWebCollision(collisionHandle: Int)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebTpsApi.kt
@@ -7,6 +7,7 @@ import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.GodotVector2
 import net.multigesture.kanama.backend.GodotVector3
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
+import net.multigesture.kanama.backend.WindowBackendContractProbe
 import net.multigesture.kanama.types.Basis
 import net.multigesture.kanama.types.Quaternion
 import net.multigesture.kanama.types.Vector2
@@ -401,9 +402,8 @@ fun Node.getChild(index: Int): GodotObject? =
     GodotObject(WebObjectId(it.backendToken().toInt()))
   }
 
-fun Node3D.show() {
-  visible = true
-}
+/** Import-compat alias for shared demo sources; delegates to the [Node3D] member (task 64). */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") fun Node3D.show() = show()
 
 /** Godot's Node3D.orthonormalize: re-orthonormalize the local basis in place. */
 fun Node3D.orthonormalize() {
@@ -810,9 +810,41 @@ object IP {
 // tps graphics menu, so those writes are no-ops rather than fake successes.
 // ---------------------------------------------------------------------------
 
-/** Window settings facade: mode and 3D scaling are fixed by the browser canvas. */
+/**
+ * Window. Two shapes share the class:
+ * - **Handle-backed** (task 64 tier 3): `Window(getTree().getRoot())` wraps the tracked root
+ *   window, and [setMode] / [getMode] (and the [mode] property) are real engine calls --
+ *   FullScreenHandler's F11 toggle reads the mode the engine reports.
+ * - **Handle-less facade** ([Node.getWindow]): the tps settings menu's target. Mode and 3D
+ *   scaling are fixed by the browser canvas there, so those writes are mirrored Kotlin-side and
+ *   never reach the engine (the pre-existing facade contract, documented here and unchanged).
+ */
 class Window internal constructor() {
-  var mode: Long = MODE_WINDOWED
+  private var windowHandle: GodotHandle? = null
+
+  /** Desktop's handle-taking constructor: wrap a tracked Window handle (the tree root). */
+  constructor(godotObject: GodotHandle) : this() {
+    windowHandle = godotObject
+  }
+
+  /** Facade mirror for the handle-less window; unused when a handle is present. */
+  private var facadeMode: Long = MODE_WINDOWED
+
+  var mode: Long
+    get() = getMode()
+    set(value) = setMode(value)
+
+  fun setMode(mode: Long) {
+    val handle = windowHandle
+    if (handle == null) facadeMode = mode
+    else WindowBackendContractProbe(handle.toBackendHandle()).setMode(mode)
+  }
+
+  fun getMode(): Long {
+    val handle = windowHandle ?: return facadeMode
+    return WindowBackendContractProbe(handle.toBackendHandle()).getMode()
+  }
+
   var scaling3dScale: Double = 1.0
   var scaling3dMode: Long = 0L
   var useTaa: Boolean = false

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -168,7 +168,10 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.QUEUED_MUTATION)
-    require(descriptor.opcode in setOf(52, 115, 129, 140, 185, 189, 209, 273, 274, 285, 286))
+    require(
+      descriptor.opcode in
+        setOf(52, 115, 129, 140, 185, 189, 209, 273, 274, 285, 286, 295, 297, 301, 302)
+    )
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} argument must fit Godot's int32 ABI"
     }
@@ -1132,7 +1135,7 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(86, 87, 190))
+    require(descriptor.opcode in setOf(86, 87, 190, 292, 294))
     commands.flush()
     immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value)
   }
@@ -1680,6 +1683,27 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       receiver.webId(),
       name,
       value.webId(),
+    )
+  }
+
+  override fun invokeStringNameObjectArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    name: String,
+    value: GodotHandle,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 293)
+    commands.flush()
+    // Task 64 tier 3: action name and event handle packed into one query string (unit
+    // separator) on the active script's own query channel; the applier resolves the event
+    // from that script's handle table. Immediate so the queued keycode writes land first and
+    // the caller may close() the event right after.
+    immediateWebObjectQuery(
+      descriptor.opcode,
+      requireActiveWebScriptHandle(),
+      name + "" + value.webId().toString(),
     )
   }
 

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -1698,13 +1698,17 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     commands.flush()
     // Task 64 tier 3: action name and event handle packed into one query string (unit
     // separator) on the active script's own query channel; the applier resolves the event
-    // from that script's handle table. Immediate so the queued keycode writes land first and
-    // the caller may close() the event right after.
-    immediateWebObjectQuery(
-      descriptor.opcode,
-      requireActiveWebScriptHandle(),
-      name + "" + value.webId().toString(),
-    )
+    // from that script's handle table and reports 1 only when it attached. Immediate so the
+    // queued keycode writes land first and the caller may close() the event right after.
+    check(
+      immediateWebObjectQuery(
+        descriptor.opcode,
+        requireActiveWebScriptHandle(),
+        name + "" + value.webId().toString(),
+      ) == 1
+    ) {
+      "Kanama Web ${descriptor.className}.${descriptor.methodName} did not attach the event (handle ${value.webId()} unknown to the active script)"
+    }
   }
 
   override fun invokeStringNameRetVector2(

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -17,17 +17,21 @@ import net.multigesture.kanama.api.DirectionalLight3D
 import net.multigesture.kanama.api.GodotHandle
 import net.multigesture.kanama.api.GodotObject
 import net.multigesture.kanama.api.Input
+import net.multigesture.kanama.api.InputEventKey
+import net.multigesture.kanama.api.InputMap
 import net.multigesture.kanama.api.KanamaCoroutineOwner
 import net.multigesture.kanama.api.KanamaScope
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.MainThread
 import net.multigesture.kanama.api.ManualGodotLifetimeApi
+import net.multigesture.kanama.api.Node
 import net.multigesture.kanama.api.Node3D
 import net.multigesture.kanama.api.OS
 import net.multigesture.kanama.api.RenderingServer
 import net.multigesture.kanama.api.Resource
 import net.multigesture.kanama.api.ResourceLoader
 import net.multigesture.kanama.api.SceneTree
+import net.multigesture.kanama.api.Window
 import net.multigesture.kanama.api.WorldEnvironment
 import net.multigesture.kanama.api.genericWebGameplayFallback
 import net.multigesture.kanama.api.lookAt
@@ -415,6 +419,70 @@ class Main(godotObject: GodotHandle) :
       tween.tweenProperty(sun, "light_color", Color(1f, 1f, 1f, 1f), 0.05) ?: return 0L
     val chained = tweener.from(Color(0.5f, 0.5f, 0.5f, 1f))
     return if (chained.handle.value == tweener.handle.value) 1L else 0L
+  }
+
+  /**
+   * Task 64 tier 3: the InputMap / InputEventKey / process-mode / Window-mode families third-person's
+   * shared Player.kt and FullScreenHandler.kt need. Every bit proves a VALUE came back through the
+   * engine, not that a call dispatched:
+   * - 1: `has_action` is false before `add_action` and true after it.
+   * - 2: a constructed InputEventKey reads its keycode back as F11 and its physical keycode as F10
+   *   (two QUEUED setters landed before the immediate reads).
+   * - 4: `is_echo` is false on that event.
+   * - 8: `is_action` is false BEFORE `action_add_event` and true AFTER it, on the same event -- the
+   *   attach bound the key, rather than merely returning.
+   * - 16: `Input.action_press` on the new action reads back `is_action_pressed` true (the action is
+   *   real), then released.
+   * - 32: `erase_action` makes `has_action` false again.
+   * - 64: `set_process_mode(ALWAYS)` reads back 3 (then restored to INHERIT).
+   * - 128: `Window(getTree().getRoot()).getMode()` is a legal Window.Mode.
+   *
+   * A healthy run returns 255. The event handle is closed in `finally`, after the attach: the
+   * InputMap keeps its own reference (the create/close contract on Web, see web-internals).
+   *
+   * Ordering: the driver calls this AFTER generic_probe. Bit 128 tracks the root Window through
+   * the typed get_root path, and the generic probe's minting check needs that same window still
+   * untracked when it asks `get_window` -- see the driver comment.
+   */
+  @RegisterFunction("input_map_probe")
+  fun inputMapProbe(value: Long): Long {
+    var mask = 0L
+    val action = "kanama_probe_action"
+    val hadBefore = InputMap.hasAction(action)
+    InputMap.addAction(action)
+    if (!hadBefore && InputMap.hasAction(action)) mask = mask or 1L
+
+    val key = InputEventKey.create()
+    try {
+      key.keycode = InputEventKey.KEY_F11
+      key.physicalKeycode = InputEventKey.KEY_F10
+      if (
+        key.getKeycode() == InputEventKey.KEY_F11 && key.getPhysicalKeycode() == InputEventKey.KEY_F10
+      ) {
+        mask = mask or 2L
+      }
+      if (!key.isEcho()) mask = mask or 4L
+      val boundBefore = key.isAction(action)
+      InputMap.actionAddEvent(action, key)
+      if (!boundBefore && key.isAction(action)) mask = mask or 8L
+    } finally {
+      key.close()
+    }
+
+    Input.actionPress(action)
+    if (Input.isActionPressed(action)) mask = mask or 16L
+    Input.actionRelease(action)
+
+    InputMap.eraseAction(action)
+    if (!InputMap.hasAction(action)) mask = mask or 32L
+
+    self.setProcessMode(Node.PROCESS_MODE_ALWAYS)
+    if (self.getProcessMode() == Node.PROCESS_MODE_ALWAYS) mask = mask or 64L
+    self.setProcessMode(Node.PROCESS_MODE_INHERIT)
+
+    val root = Window(self.getTree().getRoot())
+    if (root.getMode() in Window.MODE_WINDOWED..Window.MODE_EXCLUSIVE_FULLSCREEN) mask = mask or 128L
+    return mask
   }
 
   @RegisterFunction("signal_probe")

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 21;
+  const KANAMA_WEB_PROTOCOL_VERSION = 22;
 
   function commandWordCount(opcode) {
     if (
@@ -58,6 +58,12 @@
       opcode === 284 ||
       opcode === 285 ||
       opcode === 286 ||
+      // Task 64 tier 3: InputEventKey.set_keycode / set_physical_keycode, Node.set_process_mode,
+      // Window.set_mode -- one int32 argument each (opcode, handle, value).
+      opcode === 295 ||
+      opcode === 297 ||
+      opcode === 301 ||
+      opcode === 302 ||
       opcode === 66
     ) return 3;
     if (


### PR DESCRIPTION
## What & why

Task 64 parcel 1. The third-person demo's shared `Player.kt` and `FullScreenHandler.kt` still need `web/kotlin-src` overrides because the Web backend had no `InputMap`, `InputEventKey`, `Node.set_process_mode`, or `Window` mode calls. This admits those families so the two files can converge in a follow-up demos PR (the Icone pattern: families here → demos convergence → `DEMOS_REF` bump). `CameraMode.kt` is **not** unlocked by this set (it needs eight more families) and stays with the spec's Camera3D/Window parcel.

**Opcodes 291–305, Web protocol 21 → 22.** `InputMap.has_action / add_action / action_add_event / erase_action`, `InputEventKey` keycode and physical-keycode get/set, `InputEvent.is_echo / is_action`, `InputEventWithModifiers.is_alt_pressed`, `Node.set_process_mode / get_process_mode`, `Window.set_mode / get_mode`, plus a `ClassDB.instantiate` composition for `InputEventKey`. One new contract shape (`STRINGNAME_OBJECT_ARG_SINGLETON`) carries the action-plus-event call over the existing object-query channel; the GDScript arm resolves the event from the owning script's handle table and the Kotlin side fails loud if it did not attach. Web wrappers: `InputMap`, `InputEventKey`/`InputEventWithModifiers`, `Node.setProcessMode`, `SceneTree.getRoot()`, a handle-taking `Window` (the tps facade is unchanged), `Node3D.setVisible`/`show()` as members, `MOUSE_BUTTON_RIGHT`.

**Evidence, not dispatch counts.** The in-repo `web3d` fixture gains `Main.input_map_probe` (a required member for the smoke gate) that proves each family delivers a *value*: `has_action` flips on add and erase, `get_keycode` returns the value set, `is_action` flips from false to true on the same event when `action_add_event` attaches it, `get_process_mode` reads back `PROCESS_MODE_ALWAYS`. Opcodes 304 and 305 exist for those two read-backs; without them the probe could only assert "the applier said OK".

Deliberate limits, stated: `add_action` bakes Godot's default deadzone and `require`s it (no float-arg singleton shape yet); `is_action` bakes `exact_match=false`; `Window.set_mode` is dispatch-proven but not value-proven on Web because a headless fullscreen request can log an engine error and fail the zero-console-error gate. Existing Web exports must be rebuilt (protocol 22).

## Checklist

- [ ] `scripts/local_ci.sh <godot>` — NOT run in full; the stages this change touches were run directly (below), and the PR's `local-ci (linux)` lane runs the whole script.
- [x] Up to date with the latest `main` (built on the 4.7.2 re-pin).
- [x] No ABI / memory-ownership change on the FFI backends (Web bridge only; the shared contract gains appended opcodes and one shape with a default-error SPI body).
- [x] CHANGELOG and docs protocol claims updated (`check_doc_claims`, `check_protocol_pins` PASS).

## Testing

Run on macOS arm64 with Godot 4.7.2 and its `web_nothreads_release` template (results under `/tmp/task64/` on the authoring machine):
- `:processor:test :kanama-common-api:allTests :web-runtime:checkWebBackendDispatch ktfmtCheck` → PASS (re-run by the reviewer).
- `:web-runtime:generateWebGameplayCoverage` → 0 blocking calls; `[kanama:web-dispatch]` census 0 degraded on web3d (54 members), thirdperson (132), match3 (38).
- `web3d` export + `web_export_smoke.sh`: **PASS on Chrome and Firefox**, protocol 22, teardown to zero, zero console errors, probe mask 255.
- **Falsification:** with `actionAddEvent` skipped in the probe, a rebuilt export (different `buildId`) **FAILS** the Chrome smoke on exactly `inputMapFamiliesDeliverValues` (mask 247); restored, PASS/PASS again.
- Regression: thirdperson and match3 exports + Chrome smoke PASS (both still use their overrides; this proves no regression, not the new families).
- Desktop unaffected: `./gradlew jar` + `scripts/runtime_smoke.sh` PASS on 4.7.2.
- `scripts/audit_claims.sh` PASS 5/5; docs local-path guard clean. Safari and the full `web_ci_matrix.sh` were not run.

## AI assistance

Implemented by a Claude Code worker from a measured plan; reviewed by falsifying the load-bearing claims (result files, checkers, the two riskiest hunks, tests re-run); reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)