### PR TITLE
Bump DEMOS_REF to the converged thirdperson; require FullScreenHandler._ready (task 64 parcel 1 close-out)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -53,7 +53,7 @@ env:
   # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
   # Task 64: adds the converged Icone (demos#40), which calls PropertyTweener.from -- an arm
   # that only exists from kanama#204 onward. Both sides pin together or neither is green.
-  DEMOS_REF: fa4cb1b6608f36142872e0ac14a4d052deb3d70f
+  DEMOS_REF: 40739ce547c3ab4155070023a8a580bb9a6e4240
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -235,6 +235,10 @@
         {
           "member": "Coin._collect",
           "reason": "The vacuum tween's terminal callback (tween_callback), one per collected coin, and the ONLY boundary-crossing evidence that the coin actually reached the player: it is what re-enters Player.collectCoin -> CoinsContainer.updateCoinsAmount -> the scalar tween. Exactly one per coin on both engines, so unlike _follow this one IS counted: MEASURED chrome (3 runs) and firefox 2026-08-20, 5 dispatches for 5 spilled coins, callbackErrors 0."
+        },
+        {
+          "member": "FullScreenHandler._ready",
+          "reason": "Task 64 parcel 1 (kanama#212 + demos#45): the shared FullScreenHandler converged onto Web and its @OnReady sets PROCESS_MODE_ALWAYS through the new set_process_mode family (opcode 301). The deleted web override never had a _ready, so this virtual is new Web surface; requiring it keeps the convergence honest -- if the autoload stops constructing or the ready path stops crossing, the gate says so."
         }
       ],
       "todo": [


### PR DESCRIPTION
## What & why

Closes out task 64 parcel 1 after kanama#212 and kanama-demos#45 merged. Pins the Web workflow's `DEMOS_REF` to demos `main` at 40739ce (the converged thirdperson) and adds `FullScreenHandler._ready` to the thirdperson required members: the shared file's `@OnReady` sets `PROCESS_MODE_ALWAYS` through the new family, and the deleted web override never had a `_ready`, so this is new Web surface the gate should keep honest.

## Testing

- thirdperson exported from this tree against demos `main`, driven on Chrome with the new required member in force: `web_export_smoke: PASS`, and the envelope's census lists `FullScreenHandler._ready` as exercised (the schema gate fails on a required member that did not dispatch — proven against this very envelope: a bogus `FullScreenHandler._does_not_exist` requirement is rejected with `required registered member(s) did not run`).
- The PR subset (match3, web3d, dodge) runs in this PR's Web matrix against the new pin; the `ci` set on `main`/nightly covers thirdperson on the runner.

## AI assistance

Drafted with Claude Code; reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
