### PR TITLE
One resource-ownership rule: getters are owned, @ManualGodotLifetimeApi deprecated (task 97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Changed — one resource-ownership rule, and `close()` no longer needs an opt-in
+
+- **Getters are owned; the docs now say so in one place and nowhere contradicts
+  it** (task 97). Every `RefCounted`-typed return — `create()`,
+  `ResourceLoader.load…`, and plain getters such as `getMesh()`,
+  `getAnimation(...)` or the `Tweener` a `tweenProperty(...)` hands back — is a
+  `+1` the caller closes; a wrapper you mint yourself over a handle you already
+  hold (`fromHandle`/`fromObject`) and a live `Tween` are the only things you never
+  close. `docs/game-dev/godot-api.md` "Resource Ownership" is the rule; the
+  style guide, `properties-resources.md` and the demo-porting rules lost the
+  sentences that still taught the pre-task-62 "do not close what you handed to a
+  setter" exception and link instead. The demos parity audit
+  (`kanama-demos/scripts/demo_parity_audit.py`) used to fail exactly the closes
+  the rule requires; it now enforces the same table.
+- **`@ManualGodotLifetimeApi` is deprecated and no longer applied.**
+  `RefCounted.close()` (desktop) and the Web `Texture2D`/`AudioStream`/
+  `PackedScene`/`ResourceLoader` members carried a `RequiresOptIn(WARNING)`
+  that warned on the one call the ownership rule tells you to make. An existing
+  `@OptIn(ManualGodotLifetimeApi::class)` still compiles, with a deprecation
+  warning; delete it, nothing replaces it. On iOS the annotation is an inert
+  marker until the generator stops emitting it on the generated `RefCounted`.
+- `GodotObject.call()`, `callDeferred()`, `callv()`, `get()`, `getMeta()` and
+  `getScript()` now document that an object result is a **borrowed** view of the
+  Variant-path decode — never `close()` it, and it may already be dead when the
+  call minted the object (`call("duplicate")`); use the typed wrapper getter or
+  `ClassDB.instantiate` to hold one. No behaviour change.
+
 ### Added — Web input-map, key-event, process-mode and window-mode families
 
 - **Web protocol 21 → 22.** The Kotlin/Wasm backend admits the call families the

--- a/docs/contributing/demo-porting-rules.md
+++ b/docs/contributing/demo-porting-rules.md
@@ -211,9 +211,11 @@ Handing a created resource to a node is safe to follow with `close()`: the
 setter takes its own reference, so after `meshInstance.setMesh(mesh)` a
 `mesh.close()` (or `use { }` around the whole handoff) releases only yours
 (tasks 61/62; issue #91 is what happened before that contract held).
-`RefCounted.close()` is annotated `@ManualGodotLifetimeApi` so every release is
-a visible decision: opt in where the wrapper is owned by the rules above, never
-for a borrowed view or a live engine-owned object.
+`RefCounted.close()` needs no opt-in: `@ManualGodotLifetimeApi` is deprecated
+and no longer applied, so drop any `@OptIn` for it from a port. The rule above
+is what `scripts/demo_parity_audit.py` in the demos repository enforces — it
+fails a `close()` on a borrowed view (`fromHandle`/`fromObject`) or on a live
+`Tween`, and never flags closing an owned return.
 
 ## Signals And Callbacks
 

--- a/docs/game-dev/godot-api.md
+++ b/docs/game-dev/godot-api.md
@@ -172,11 +172,17 @@ Same call, different outcome, because the number of other owners differs.
 |---|---|---|
 | **Owned** | `X.create()`, `ResourceLoader.load…`, every `RefCounted`-typed method return **including plain getters**, and `@ScriptProperty` reads of resource-typed fields and collections | `close()` it, or `use { }` |
 | **Borrowed view** | A wrapper *you* mint around a handle you already have: `Resource.fromHandle(...)`, `Resource.fromObject(...)`, a script-class constructor wrapping an existing handle | **Never** `close()` — it releases a reference you never took |
-| **Engine-owned, live** | A `createTween()` still running, anything assigned into the scene tree, a resource handed to a sink that took its own reference | Use the Godot lifecycle (`kill()`, `queueFree()`), not `close()` |
+| **Engine-owned, live** | A `createTween()` still running, anything living in the scene tree | Use the Godot lifecycle (`kill()`, `queueFree()`), not `close()` |
 | **Nodes and plain `Object`s** | Anything not `RefCounted` — no refcount exists, and `GodotObject` has no `close()` | `Node.queueFree()` |
 
 The awkward-looking case — a getter you must close — is the common one, and it is
-safe precisely because the node still holds its own reference.
+safe precisely because the node still holds its own reference. Handing an owned
+wrapper to a sink (`setMesh`, `setStream`, `ResourceSaver.save`) does not move
+it into the engine-owned row: the sink takes its own reference and yours is
+still yours to close. In the demos corpus this table is what
+`scripts/demo_parity_audit.py` enforces — it fails a `close()` on a borrowed
+view or a live tween and never flags closing an owned return; the audit
+conforms to this page, not the other way round.
 
 `@ScriptProperty` reads are **owned**: the generated registrar takes its own
 reference when it reads a resource out of a property, an `Array`, or a

--- a/docs/game-dev/properties-resources.md
+++ b/docs/game-dev/properties-resources.md
@@ -418,9 +418,10 @@ already imposes.
 Ownership mirrors GDScript `.new()`: the returned resource comes back with one
 owning reference, so it survives the `ResourceSaver.save` call above (which wraps
 it in a transient `Ref<>` internally). **Release that reference** with
-`owned.close()` — or `use { }` as above — once you are done, unless you have
-handed ownership on by assigning `owned.resource` into a node/scene or an
-exported `Resource` slot (then the engine keeps it alive). Pass `owned.resource`
+`owned.close()` — or `use { }` as above — once you are done, including after
+assigning `owned.resource` into a node/scene or an exported `Resource` slot: the
+engine takes its own reference there and `close()` drops only yours (the one
+rule in [Resource Ownership](godot-api.md#resource-ownership)). Pass `owned.resource`
 directly to `Resource`-typed APIs such as `ResourceSaver.save`; there is no
 `Resource.fromHandle` view to manage.
 

--- a/docs/game-dev/style-guide.md
+++ b/docs/game-dev/style-guide.md
@@ -322,12 +322,14 @@ fun fadeOut() {
 }
 ```
 
-The same ownership rule applies to generated meshes, materials, audio streams,
-and other `Resource`/`RefCounted` values. If a node property stores the object,
-for example `meshInstance.setMesh(mesh)`, do not immediately close that same
-resource unless you have verified the setter retained its own reference.
+Everything else — generated meshes, materials, audio streams, and every other
+`Resource`/`RefCounted` value you create or read back, plain getters included —
+follows the one rule in
+[Godot API → Resource Ownership](godot-api.md#resource-ownership): the wrapper
+is yours, so `close()` it (or `use { }`) once you are done. Handing it to a
+node first does not change that: after `meshInstance.setMesh(mesh)` the node
+holds its own reference and `mesh.close()` releases only yours (tasks 61/62).
 
-Kanama marks manual Godot lifetime APIs with `@ManualGodotLifetimeApi`. If a
-game script triggers that warning, treat it as a design review: either replace
-the call with a Godot lifecycle API, or add an explicit `@OptIn` only when the
-value is documented as caller-owned.
+`RefCounted.close()` carries no opt-in annotation. `@ManualGodotLifetimeApi`
+is deprecated and no longer applied anywhere; an `@OptIn` for it in a script
+compiles with a deprecation warning and can simply be deleted.

--- a/example_project/HelloScript.kt
+++ b/example_project/HelloScript.kt
@@ -49,7 +49,6 @@ import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.Label
 import net.multigesture.kanama.api.LineEdit
 import net.multigesture.kanama.api.MainThread
-import net.multigesture.kanama.api.ManualGodotLifetimeApi
 import net.multigesture.kanama.api.Mathf
 import net.multigesture.kanama.api.MeshInstance3D
 import net.multigesture.kanama.api.MethodName
@@ -103,7 +102,6 @@ enum class SmokeDifficulty {
 @ScriptClass(attachTo = "Node")
 @GlobalClass
 @Tool
-@OptIn(ManualGodotLifetimeApi::class)
 class HelloScript(godotObject: GodotHandle) :
   KanamaScript<Node>(godotObject, ::Node), KanamaCoroutineOwner {
   override val kanamaScope = KanamaScope()

--- a/example_project/ResourceForgeSmoke.kt
+++ b/example_project/ResourceForgeSmoke.kt
@@ -7,7 +7,6 @@ import net.multigesture.kanama.annotations.Tool
 import net.multigesture.kanama.api.Engine
 import net.multigesture.kanama.api.FileAccess
 import net.multigesture.kanama.api.KanamaScript
-import net.multigesture.kanama.api.ManualGodotLifetimeApi
 import net.multigesture.kanama.api.Node
 import net.multigesture.kanama.api.ResourceLoader
 import net.multigesture.kanama.api.ResourceSaver
@@ -23,7 +22,6 @@ import net.multigesture.kanama.api.newScriptInstance
 class ResourceForgeSmoke(godotObject: MemorySegment) : KanamaScript<Node>(godotObject, ::Node) {
 
   @OnReady
-  @OptIn(ManualGodotLifetimeApi::class)
   fun ready() {
     val path = "user://forged_smoke.tres"
     val owned =

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FileAccess.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/FileAccess.kt
@@ -76,7 +76,6 @@ class FileAccessHandle internal constructor(handle: MemorySegment) : RefCounted(
 
     fun storeString(text: String): Boolean = FileAccess.storeStringHandle(handle, text)
 
-    @OptIn(ManualGodotLifetimeApi::class)
     override fun close() {
         if (!fileClosed) {
             fileClosed = true

--- a/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
+++ b/ios-runtime/src/iosMain/kotlin/net/multigesture/kanama/api/IosGodotApi.kt
@@ -102,10 +102,14 @@ import kotlin.math.PI
 import kotlin.math.pow
 import kotlin.random.Random
 
-@RequiresOptIn(
-    message = "This API exposes a Godot object whose lifetime is owned outside Kotlin.",
-    level = RequiresOptIn.Level.WARNING,
-)
+/**
+ * Inert marker, no opt-in required (task 97): desktop and Web deprecated this annotation and
+ * stopped applying it. The generated iOS `RefCounted.close()` still carries it because the
+ * generator's `IOS_CUSTOM_MEMBER_SECTIONS["RefCounted"]` emits it; once that line is dropped
+ * (generator work, task 98) this class can be deprecated like its desktop twin.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class ManualGodotLifetimeApi
 
 abstract class KanamaScript<Self : Any>(

--- a/src/main/kotlin/net/multigesture/kanama/api/FileAccessHandle.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/FileAccessHandle.kt
@@ -78,7 +78,6 @@ class FileAccessHandle internal constructor(handle: MemorySegment) : RefCounted(
         FileAccess.flushHandle(handle)
     }
 
-    @OptIn(ManualGodotLifetimeApi::class)
     override fun close() {
         if (!fileClosed) {
             fileClosed = true

--- a/src/main/kotlin/net/multigesture/kanama/api/GodotObject.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/GodotObject.kt
@@ -63,6 +63,7 @@ open class GodotObject(val handle: MemorySegment) {
         ObjectCalls.ptrcallWithIntAndBoolArgs(notificationBind, handle, what, reversed)
     }
 
+    /** Variant-path read: the script comes back as a borrowed view, never `close()` it — see [call]. */
     fun getScript(): Any? =
         ObjectCalls.ptrcallNoArgsRetVariantScalar(getScriptBind, handle)
 
@@ -70,6 +71,7 @@ open class GodotObject(val handle: MemorySegment) {
         ObjectCalls.ptrcallWithStringNameAndVariantArg(setMetaBind, handle, name, value)
     }
 
+    /** Variant-path read: an object result is a borrowed view, never `close()` it — see [call]. */
     fun getMeta(name: String, defaultValue: Any? = null): Any? =
         ObjectCalls.ptrcallWithStringNameAndVariantArgRetVariantScalar(getMetaBind, handle, name, defaultValue)
 
@@ -185,6 +187,24 @@ open class GodotObject(val handle: MemorySegment) {
     fun canTranslateMessages(): Boolean =
         ObjectCalls.ptrcallNoArgsRetBool(canTranslateMessagesBind, handle)
 
+    /**
+     * Dynamic `Object.call`. Scalars come back as Kotlin values. An **object** result comes back
+     * as a *borrowed* `GodotObject` view: the Variant-path decode
+     * (`BuiltinTypes.variantToScalar`, `VariantType.OBJECT`) takes no reference for you, so
+     *
+     * - never `close()` it, and never `close()` a `Resource.fromObject(...)`/`X.fromObject(...)`
+     *   view you mint over it — that releases a reference you never took;
+     * - if the call *minted* the object and the return Variant held its only reference
+     *   (`call("duplicate")`, a static factory), the handle is already dead when you receive it;
+     *   use the typed wrapper method instead (an owned `+1` you close), or `ClassDB.instantiate`,
+     *   whose owned decode path retains before the Variant is destroyed.
+     *
+     * The same applies to every Variant-path read on this class: [callDeferred], [callv], [get],
+     * [getMeta], [getScript]. Typed wrapper getters (`getMesh()`, `getAnimation(...)`) are the
+     * other convention — an owned `+1` the caller closes. Both are spelled out in
+     * `docs/game-dev/godot-api.md` "Resource Ownership" and, for the ABI, in
+     * `docs/contributing/wrapper-maintenance.md` "RefCounted Return Ownership".
+     */
     fun call(method: String, vararg args: Any?): Any? {
         val result = ObjectCalls.callWithVariantArgs(callBind, handle, listOf(method, *args))
         if (method == "set" && args.size == 2) {
@@ -196,12 +216,19 @@ open class GodotObject(val handle: MemorySegment) {
         return result
     }
 
+    /** Variant-path call; an object result is a borrowed view, never `close()` it — see [call]. */
     fun callDeferred(method: String, vararg args: Any?): Any? =
         ObjectCalls.callWithVariantArgs(callDeferredBind, handle, listOf(method, *args))
 
+    /** Variant-path call; an object result is a borrowed view, never `close()` it — see [call]. */
     fun callv(method: String, arguments: List<Any?>): Any? =
         ObjectCalls.ptrcallWithStringNameArrayArgsRetVariantScalar(callvBind, handle, method, arguments)
 
+    /**
+     * Dynamic `Object.get`. A resource read this way (`get("mesh")`) is a *borrowed* view that
+     * lives only while this object keeps the property — never `close()` it (see [call]). The
+     * typed getter (`getMesh()`) is the owned `+1` you close.
+     */
     fun get(property: String): Any? =
         ObjectCalls.ptrcallWithStringNameArgRetVariantScalar(objectGetBind, handle, property)
 

--- a/src/main/kotlin/net/multigesture/kanama/api/ManualGodotLifetimeApi.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/ManualGodotLifetimeApi.kt
@@ -1,13 +1,17 @@
 package net.multigesture.kanama.api
 
 /**
- * Marks low-level Godot lifetime operations that are easy to misuse in gameplay code.
+ * Deprecated, no longer applied to any Kanama API (task 97).
  *
- * Most game scripts should release objects through Godot lifecycle APIs such as
- * `queueFree()`, `kill()`, clearing a node property, or dropping Kotlin references.
- * Opt in only when the value is known to be caller-owned and Godot will not keep
- * using it after the call.
+ * `RefCounted.close()` used to carry this opt-in requirement. It warned on the one
+ * thing the documented ownership rule tells you to do — close the wrapper you were
+ * handed — so it punished correct code and was opted into blindly (task 93, R6).
+ * The rule itself lives in `docs/game-dev/godot-api.md` "Resource Ownership".
+ *
+ * The class is kept so an existing `@OptIn(ManualGodotLifetimeApi::class)` still
+ * compiles (with a deprecation warning); delete the opt-in, nothing replaces it.
  */
+@Deprecated("No longer required; close() is the documented contract (docs/game-dev/godot-api.md#resource-ownership)")
 @RequiresOptIn(
     message = "Manual Godot lifetime APIs are for low-level interop. Gameplay scripts should use Godot lifecycle APIs unless this value is explicitly caller-owned.",
     level = RequiresOptIn.Level.WARNING,

--- a/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
+++ b/src/main/kotlin/net/multigesture/kanama/api/RefCounted.kt
@@ -48,14 +48,15 @@ open class RefCounted internal constructor(
     }
 
     /**
-     * Releases this Kotlin wrapper's reference to the underlying Godot object.
+     * Releases this Kotlin wrapper's reference to the underlying Godot object:
+     * `unreference()`, and destroy only if that dropped the count to zero.
      *
-     * This is a low-level lifetime operation. Do not use it as general gameplay
-     * cleanup for live Godot-owned values such as `Tween`, `Tweener`, `Material`,
-     * `Mesh`, `PackedScene`, audio streams, or anything assigned to the scene tree
-     * or scheduled to run later.
+     * Every `RefCounted`-typed return you receive — `create()`, `ResourceLoader.load…`,
+     * and plain getters such as `getMesh()` — is a `+1` you own and must close (or `use { }`).
+     * Do not close a wrapper you minted yourself over a handle you already had
+     * (`fromHandle`/`fromObject`) or a live `Tween` (use `kill()`); see
+     * `docs/game-dev/godot-api.md` "Resource Ownership".
      */
-    @ManualGodotLifetimeApi
     override fun close() {
         if (closed || wrapperReferenceReleased) return
         wrapperReferenceReleased = true

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebGodotApi.kt
@@ -31,6 +31,12 @@ import net.multigesture.kanama.web.KanamaWebScript
 import net.multigesture.kanama.web.WebObjectId
 import net.multigesture.kanama.web.webScriptInstance
 
+/**
+ * Deprecated, no longer applied to any Web API (task 97); kept so an existing
+ * `@OptIn(ManualGodotLifetimeApi::class)` in ported code still compiles. `close()` is the
+ * documented contract — see `docs/game-dev/godot-api.md` "Resource Ownership".
+ */
+@Deprecated("No longer required; close() is the documented contract (docs/game-dev/godot-api.md#resource-ownership)")
 @RequiresOptIn(
   level = RequiresOptIn.Level.WARNING,
   message = "This API exposes manual Godot resource lifetime management.",
@@ -386,7 +392,6 @@ open class Resource internal constructor(backendHandle: BackendGodotHandle) :
   }
 }
 
-@ManualGodotLifetimeApi
 class Texture2D internal constructor(private var resourceHandle: BackendGodotHandle?) :
   Resource(checkNotNull(resourceHandle)) {
   constructor(godotObject: GodotHandle) : this(godotObject.toBackendHandle())
@@ -411,7 +416,6 @@ object ResourceLoader {
     cacheMode: Long = CACHE_MODE_REUSE,
   ): Resource? = ResourceLoaderBackendContractProbe.load(path, typeHint, cacheMode)?.let(::Resource)
 
-  @ManualGodotLifetimeApi
   fun loadTexture2D(path: String, cacheMode: Long = CACHE_MODE_REUSE): Texture2D? =
     ResourceLoaderBackendContractProbe.load(path, "Texture2D", cacheMode)?.let(::Texture2D)
 
@@ -423,7 +427,6 @@ object ResourceLoader {
    * path for `AudioStreamPlayer.setStream` on an already-held stream (task 64). Same admitted
    * loader family (and "AudioStream" type hint) that `setStreamFromPath` already rides.
    */
-  @ManualGodotLifetimeApi
   fun loadAudioStream(path: String, cacheMode: Long = CACHE_MODE_REUSE): AudioStream? =
     ResourceLoaderBackendContractProbe.load(path, "AudioStream", cacheMode)?.let(::AudioStream)
 }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebMatch3Api.kt
@@ -488,7 +488,6 @@ open class AudioStream internal constructor(backendHandle: BackendGodotHandle) :
   constructor(godotObject: GodotHandle) : this(godotObject.toBackendHandle())
 
   /** Releases the stream's browser handle (already-released is an error). */
-  @ManualGodotLifetimeApi
   fun close() {
     releaseWebResource(handle.value)
   }
@@ -563,7 +562,6 @@ class PackedScene internal constructor(backendHandle: BackendGodotHandle) : Reso
   constructor(godotObject: GodotHandle) : this(godotObject.toBackendHandle())
 
   /** Harness-grade release of the scene's browser handle (already-released is an error). */
-  @ManualGodotLifetimeApi
   fun close() {
     releaseWebResource(handle.value)
   }

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -23,7 +23,6 @@ import net.multigesture.kanama.api.KanamaCoroutineOwner
 import net.multigesture.kanama.api.KanamaScope
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.MainThread
-import net.multigesture.kanama.api.ManualGodotLifetimeApi
 import net.multigesture.kanama.api.Node
 import net.multigesture.kanama.api.Node3D
 import net.multigesture.kanama.api.OS
@@ -174,7 +173,6 @@ class Main(godotObject: GodotHandle) :
    * global-rotation channel; a failed check throws before the aim, so the read-back only matches
    * when everything above it passed (and the throw itself surfaces as a callback fault).
    */
-  @OptIn(ManualGodotLifetimeApi::class)
   @RegisterFunction("parity_probe")
   fun parityProbe() {
     // Item 1: Resource.fromHandle round-trips an already-held handle to the same instance.


### PR DESCRIPTION
## What & why

Task 97, from the 2026-09 architecture review (finding R6, plus R10 partially). Kanama side; the demos half is falcon4ever/kanama-demos#46.

- **One ownership rule, stated once.** The docs contradicted each other: `godot-api.md` said every `RefCounted` return is an owned `+1` you close, while the style guide, `properties-resources.md` and the demo-porting rules still taught the pre-task-62 "do not close what you handed to a setter" exception, and the demos parity audit *failed* exactly the closes the rule requires. `godot-api.md` "Resource Ownership" is now the rule; the other three pages lost their contradicting sentences and link to it.
- **`@ManualGodotLifetimeApi` is deprecated and no longer applied.** It was a `RequiresOptIn(WARNING)` on `RefCounted.close()` and four Web members, so it warned on the one call the rule tells you to make. Existing `@OptIn` sites still compile with a deprecation warning. On iOS the class becomes an inert marker because the generator still emits the annotation on the generated `RefCounted`; the generator line to drop is named in the KDoc (task 98).
- **`GodotObject.call()`/`get()` family documents the borrow.** Object results of the Variant path are borrowed views that may already be dead; KDoc only, no behaviour change.

**Decision to confirm or reverse:** "getters are owned" was chosen because it matches what the desktop binding already does (every generated `RefCounted` return retains). Reversing it means inverting the docs and the demos audit and naming the borrowing getters. Nothing in the binding or generator changed.

**Not done, written up for follow-up:** `ClassDB.instantiate` still returns a base `RefCounted` (needs a generated class-name table, R10b); iOS `GodotObject : AutoCloseable` and the emitted `unreference()` need generator visibility work (R10c).

## Checklist

- [x] `scripts/local_ci.sh <godot 4.7.2>` — **PASS**, 195 s wall on the rebased branch (55 stages; mkdocs skipped locally, covered by this PR's docs job).
- [x] Rebased on `main` after #213/#214 merged.
- [x] No ABI / retain-release / marshalling change. `api/` files touched: hand-shaped `RefCounted.kt` (annotation and KDoc only), `GodotObject.kt` (KDoc), `FileAccessHandle.kt`, `ManualGodotLifetimeApi.kt`. Drift gate unchanged (desktop 988 / iOS 1013).
- [x] Docs and CHANGELOG updated; no paired constants touched.

## Testing

- `./gradlew jar ktfmtCheck`, `./gradlew :processor:test test`: PASS.
- `check_wrapper_generator.py` PASS with no generated change; `check_doc_claims.py` OK (4 claims, protocol 22); local-path guard clean.
- `scripts/runtime_smoke.sh` on 4.7.2: PASS.
- Demos corpus built against this branch (`KANAMA_ROOT` = this worktree): opt-in warnings in the `project-scripts` compile went 18 → 0; 15 warnings remain in the demo projects' own `compileKotlin` only because they resolve the stale `mavenLocal()` jar from `main`, cleared by republishing after merge.
- Not run: Android, iOS, Web device gates (no binding or backend change).

## AI assistance

Implemented by a Claude Code worker from the review's evidence; reviewed by re-running the drift gate, doc-claim check, ktfmt and the local gate on the rebased branch; reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
