### PR TITLE
CI: change filter skipped the mobile and Web lanes on large PRs (pipefail + grep -q)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,11 @@ jobs:
           # `ios/` (the C shim + headers) and `gdextension/` (the bundled interface header the shim
           # includes) must trigger the mobile lanes — a change to `ios/bootstrap/kanama_ios_shim.c`
           # otherwise skipped the iOS xcframework build (only `ios-runtime/` was matched).
-          if printf '%s\n' "$changed" | grep -qE '^(src/|processor/|annotations/|ios/|ios-runtime/|gdextension/|android/|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/ci\.yml)'; then
+          # A here-string, not `printf | grep -q`: this step runs under `pipefail`, and `grep -q` exits on
+          # the first match, so on a diff larger than the pipe buffer (about 900 files) `printf` died with
+          # SIGPIPE, the pipeline reported 141, and the lanes were skipped exactly on the PRs that most
+          # needed them (kanama#217, 1,000 files: all mobile lanes skipped with `ios-runtime/` in the list).
+          if grep -qE '^(src/|processor/|annotations/|ios/|ios-runtime/|gdextension/|android/|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/ci\.yml)' <<<"$changed"; then
             echo "mobile=true" >> "$GITHUB_OUTPUT"
           else
             echo "mobile=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -84,7 +84,11 @@ jobs:
           # web-runtime and the shared contract are obvious; processor/ emits the
           # per-proxy GDScript, kanama-common-api carries the opcode table, and
           # scripts/web + the two smoke shells are the harness itself.
-          if printf '%s\n' "$changed" | grep -qE '^(web-runtime/|kanama-common-api/|processor/|annotations/|scripts/web/|scripts/web_.*\.sh|scripts/generate_web_backend\.py|scripts/platform_backend_calls\.json|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/web\.yml)'; then
+          # A here-string, not `printf | grep -q`: this step runs under `pipefail`, and `grep -q` exits on
+          # the first match, so on a diff larger than the pipe buffer (about 900 files) `printf` died with
+          # SIGPIPE, the pipeline reported 141, and the lanes were skipped exactly on the PRs that most
+          # needed them (kanama#217, 1,000 files: all mobile lanes skipped with `ios-runtime/` in the list).
+          if grep -qE '^(web-runtime/|kanama-common-api/|processor/|annotations/|scripts/web/|scripts/web_.*\.sh|scripts/generate_web_backend\.py|scripts/platform_backend_calls\.json|gradle/|build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties|\.github/workflows/web\.yml)' <<<"$changed"; then
             echo "web=true" >> "$GITHUB_OUTPUT"
           else
             echo "web=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Fixed — CI change filter skipped the mobile and Web lanes on large PRs
+
+- `ci.yml` and `web.yml` decide whether to run the Android/iOS lanes and the Web matrix
+  by grepping the PR's changed-file list. The step runs under `pipefail`, and
+  `printf | grep -q` exits on the first match, so on a diff larger than the pipe buffer
+  (about 900 files) `printf` died with SIGPIPE and the filter answered **false**: the
+  lanes were skipped exactly on the PRs that most needed them (kanama#217, 1,000 files,
+  every mobile lane skipped with `ios-runtime/` in the list). The filter now reads the
+  list from a here-string. Small PRs were never affected.
+
 ### Changed — one resource-ownership rule, and `close()` no longer needs an opt-in
 
 - **Getters are owned; the docs now say so in one place and nowhere contradicts


### PR DESCRIPTION
## What & why

The `detect changes` step in `ci.yml` (mobile lanes) and `web.yml` (Web matrix) greps the PR's changed-file list with `printf '%s\n' "$changed" | grep -qE …`. GitHub runs `shell: bash` steps with `pipefail`. `grep -q` exits on its first match, so once the list is larger than the pipe buffer (about 900 files) `printf` dies with SIGPIPE, the pipeline's status is 141, and the `if` takes the `else` branch: the lanes are skipped. Small PRs never hit it, which is why it went unnoticed.

Found on kanama #217 (task 98, 1,000 files): the step printed every `ios-runtime/` file and still set `mobile=false`, so the iOS shim change in that PR has not been compiled by CI yet. Both filters now read the list from a here-string.

Reproduced locally under `bash -eo pipefail` against #217's diff:

```
files: 1000 bytes: 73253
pipe form   -> mobile=false (exit 141)
here-string -> mobile=true
pipe form, 50 files -> mobile=true
```

`scripts/upgrade_godot.sh:234` has the same shape but pipes a one-line string, which cannot overrun the buffer; left alone.

## Checklist

- [x] `scripts/local_ci.sh` not run: the change is two workflow lines and a CHANGELOG entry. `actionlint` clean on both files; `generate_gates_index.py --check` PASS (the index does not depend on step bodies).
- [x] Up to date with `main`.
- [x] No ABI / ownership code.
- [x] CHANGELOG entry under Fixed.

## Testing

Reproduction above. Once merged, #217 will be rebased so its detect step runs the fixed filter and the iOS and Android lanes execute.

## AI assistance

Diagnosed from the job log while reviewing #217's check list; fix and reproduction by Claude Code; reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
