### PR TITLE
ios-runtime: disable the unused KMP metadata compilation and publications (root build/publish were failing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Fixed — root `build` / `publishToMavenLocal` no longer compile ios-runtime metadata
+
+- `ios-runtime` ships as a static xcframework and is not a Maven/KMP library, but the
+  Kotlin Multiplatform plugin still registered a publication for it, and a root `./gradlew
+  build` or `publishToMavenLocal` compiled its intermediate `iosMain` source set to Kotlin
+  metadata for that publication. That compilation rejects the `@JvmName`/`@JvmStatic` the
+  generated wrappers carry ("Declaration annotated with '@OptionalExpectation' can only be
+  used in common module sources"), so those two root commands failed while every platform
+  compile, the static link and the xcframework lane were green. Pre-existing (the iOS tree
+  carried `@JvmName` before the shared tree); found while republishing after #220. The unused
+  metadata compilation and publications are disabled; `publishKanamaToMavenLocal` (the gate's
+  task) was never affected.
+
 ### Changed — one shared generated wrapper tree (task 103)
 
 - **The generated Godot API wrappers are emitted once.** The shared tree

--- a/ios-runtime/build.gradle.kts
+++ b/ios-runtime/build.gradle.kts
@@ -76,6 +76,20 @@ kotlin {
     }
 }
 
+// ios-runtime ships as a static xcframework, never as a Maven/KMP library. The intermediate
+// `iosMain` source set (shared by the device and simulator targets) would otherwise be compiled
+// to Kotlin *metadata* for a publication nobody consumes, and that compilation rejects the
+// `@JvmName`/`@JvmStatic` annotations the generated wrappers carry ("Declaration annotated with
+// '@OptionalExpectation' can only be used in common module sources"), so a root
+// `./gradlew build` or `publishToMavenLocal` failed here while every platform compile, the
+// static link and the xcframework lane were green. The platform compilations are untouched.
+tasks.matching {
+    it.name == "compileIosMainKotlinMetadata" ||
+        it.name == "allMetadataJar" ||
+        it.name == "generateProjectStructureMetadata" ||
+        it.name.startsWith("publish")
+}.configureEach { enabled = false }
+
 tasks.configureEach {
     if (name.startsWith("compileKotlinIos")) {
         inputs.property("kanamaPrecision", kanamaPrecision)


### PR DESCRIPTION
## What & why

A root `./gradlew build` or `publishToMavenLocal` fails in `:ios-runtime:compileIosMainKotlinMetadata` with 10,503 errors of one kind: `Declaration annotated with '@OptionalExpectation' can only be used in common module sources`. The Kotlin Multiplatform plugin registers a Maven publication for `ios-runtime` and compiles its intermediate `iosMain` source set (shared by the device and simulator targets) to Kotlin metadata for it; that compilation rejects the `@JvmName` and `@JvmStatic` the generated wrappers carry, which the Kotlin/Native platform compilations accept.

Nobody consumes that publication: `ios-runtime` ships as a static xcframework. The metadata compilation, metadata jar, structure-metadata task and publish tasks of `ios-runtime` are disabled, with the reason in the build file. Platform compilations, the static link and the xcframework lane are untouched.

This is pre-existing, not a #220 regression: the iOS tree carried `@JvmName` on most files before the shared tree landed. It surfaced because I republished to `mavenLocal` with the root task after #220; the gate's `publishKanamaToMavenLocal` publishes only the JVM artifacts and was never affected.

## Checklist

- [x] `scripts/local_ci.sh` not run: one Gradle block plus a CHANGELOG entry. Verified directly: root `./gradlew publishToMavenLocal` PASS (was failing), `:ios-runtime:compileKotlinIosArm64` PASS.
- [x] Up to date with `main`.
- [x] No ABI / ownership code.
- [x] CHANGELOG under Fixed.

## Testing

Root `publishToMavenLocal` before: BUILD FAILED in the metadata compile. After: BUILD SUCCESSFUL; iOS device compile still passes. This PR's `ios` lane builds the xcframework as before.

## AI assistance

Diagnosed and fixed by Claude Code while republishing after #220; reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
