### PR TITLE
Bump DEMOS_REF to the demos main carrying the shared-tree imports (after tasks 103 and 96)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -53,7 +53,7 @@ env:
   # Task 64: thirdperson single-source slice 2 (kanama-demos#34 merge).
   # Task 64: adds the converged Icone (demos#40), which calls PropertyTweener.from -- an arm
   # that only exists from kanama#204 onward. Both sides pin together or neither is green.
-  DEMOS_REF: 40739ce547c3ab4155070023a8a580bb9a6e4240
+  DEMOS_REF: ad824c80fff1c40edea181edb14d9e14ffa147f9
 
 jobs:
   # Skip the whole matrix for PRs that cannot affect a Web build. A skipped job


### PR DESCRIPTION
## What & why

`web.yml` pinned the demos at 40739ce (task 64 parcel 1). Demos main is now ad824c8: demos#46 (ownership coherence), #47 (`check` green + CI) and #48 (named imports of desktop-only wrapper members for kanama#220). On the Web side those imported names resolve only through the import-compat aliases kanama#222 generates, so this bump makes the Web lane prove the third-person and City-Builder Web builds against the demos as they are, which the old pin could not show.

## Checklist

- [x] `scripts/local_ci.sh` not run: one pin line. `check_godot_version_pin.py` PASS, `actionlint` clean.
- [x] Up to date with `main` (after #222).
- [x] No ABI / ownership code.
- [x] No CHANGELOG entry (CI pin only, as for #213).

## Testing

This PR's `web matrix (chrome + firefox)` lane is the test: the PR subset builds and smokes against demos ad824c8.

## AI assistance

Pin bump by Claude Code after the 103/96 merges; reviewed by the author.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
