### PR TITLE
ios_device_gate: --console-seconds N — the demo steps watch the device console and fail on a crash (task 105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Changed — iOS device gate: the demo steps watch the device console (task 105)
+
+- `scripts/ios_device_gate.sh --console-seconds N` (default 30) makes every demo step stream the
+  phone's console for N seconds after launch and fail on a crash signature (`App terminated due
+  to signal`, `FATAL`) or when the runtime never reports; the log is kept as
+  `<output-dir>/<App>.console.log`. Until now the nine demo steps only checked that the launch
+  returned, so a crash seconds later read PASS (the third-person demo did exactly that on
+  2026-09-10). Needs a demos checkout whose `ios_device_run.sh` supports
+  `KANAMA_IOS_CONSOLE_SECONDS`; `--console-seconds 0` keeps the launch-only behaviour.
+
 ### Added — Web: the DemoPage set (task 64, parcel 3)
 
 - **Web protocol 23 → 24.** The Kotlin/Wasm backend admits `SceneTree.is_paused` (307),

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -172,7 +172,9 @@ export and launch are the validation target; simulator runs are optional compile
 checks and not a frame-rate signal.
 
 The evidence is the **full ten-step device gate** (`scripts/ios_device_gate.sh`: the
-fresh-project install path plus the nine-demo matrix), validated on two physical
+fresh-project install path plus the nine-demo matrix; since task 105 each demo step also
+streams the device console for 30 s after launch and fails on a crash signature, so a crash
+inside that window is no longer invisible), validated on two physical
 models — **iPhone 12** (iOS 26.5, 2026-06-25; 0 guardrail hits, per-frame Kanama
 script+binding overhead about 0.63 ms/frame measured there) and **iPhone 15 Pro**
 (iOS 26.5, 2026-07-10, on the full-breadth generated-wrapper runtime). The claim

--- a/scripts/ios_device_gate.sh
+++ b/scripts/ios_device_gate.sh
@@ -577,6 +577,11 @@ fi
 
 echo "[ios_device_gate] PASS"
 echo "[ios_device_gate] summary: $SUMMARY"
-# Ledger the run (task 99): the Godot pin + Kanama commit this device gate passed on.
-python3 "$ROOT_DIR/scripts/record_gate_evidence.py" --gate ios-device-gate --claim "iOS Supported" \
-  --result PASS --where "${DEVICE_LABEL:-$DEVICE_ID}" --source scripts/ios_device_gate.sh
+# Ledger the run (task 99): the Godot pin + Kanama commit this device gate passed on. A partial
+# matrix (--start-at) is not the full gate and must not be ledgered as one (task 105).
+if [[ -n "$START_AT" ]]; then
+  echo "[ios_device_gate] partial run (--start-at $START_AT): not recorded in evidence/gates.json"
+else
+  python3 "$ROOT_DIR/scripts/record_gate_evidence.py" --gate ios-device-gate --claim "iOS Supported" \
+    --result PASS --where "${DEVICE_LABEL:-$DEVICE_ID}" --source scripts/ios_device_gate.sh
+fi

--- a/scripts/ios_device_gate.sh
+++ b/scripts/ios_device_gate.sh
@@ -11,6 +11,7 @@ RUN_DEMOS=1
 ALLOW_PROVISIONING_UPDATES=0
 PAUSE_SECONDS=8
 BUILD_JOBS=1
+CONSOLE_SECONDS=30
 DEVICE_LABEL="${KANAMA_IOS_DEVICE_LABEL:-}"
 START_AT=""
 CLEAN_INSTALLED=1
@@ -62,6 +63,11 @@ Options:
                                order. Needs a demos checkout whose ios_device_run.sh supports
                                KANAMA_IOS_RUN_STAGE. The native link of each demo runs on one
                                core, so N=3 or 4 on a 10-core Mac cuts the run roughly N-fold.
+  --console-seconds N          After launching each demo, stream the device console for N
+                               seconds and FAIL the step on a crash signature (task 105; default
+                               30, 0 = launch-only as before). Needs a demos checkout whose
+                               ios_device_run.sh supports KANAMA_IOS_CONSOLE_SECONDS. The log is
+                               kept as <output-dir>/<App>.console.log. Costs 9 x N seconds per run.
   --help, -h                   Show this help.
 
 The script reads private device/signing values only from the environment. Do not
@@ -121,6 +127,10 @@ while [[ $# -gt 0 ]]; do
       BUILD_JOBS="${2:-}"
       shift 2
       ;;
+    --console-seconds)
+      CONSOLE_SECONDS="${2:-}"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -172,6 +182,16 @@ fi
 if ! [[ "$BUILD_JOBS" =~ ^[1-9][0-9]*$ ]]; then
   echo "[ios_device_gate] --build-jobs must be a positive integer." >&2
   exit 2
+fi
+if [[ ! "$CONSOLE_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "[ios_device_gate] --console-seconds must be a non-negative integer." >&2
+  exit 2
+fi
+if [[ "$CONSOLE_SECONDS" -gt 0 && "$RUN_DEMOS" -eq 1 ]]; then
+  if ! grep -q "KANAMA_IOS_CONSOLE_SECONDS" "$DEMOS_ROOT/scripts/ios_device_run.sh"; then
+    echo "[ios_device_gate] --console-seconds > 0 needs a demos checkout whose scripts/ios_device_run.sh supports KANAMA_IOS_CONSOLE_SECONDS (pass --console-seconds 0 for the launch-only behaviour)." >&2
+    exit 2
+  fi
 fi
 if [[ "$BUILD_JOBS" -gt 1 && "$RUN_DEMOS" -eq 1 ]]; then
   if ! grep -q "KANAMA_IOS_RUN_STAGE" "$DEMOS_ROOT/scripts/ios_device_run.sh"; then
@@ -247,6 +267,15 @@ warn_before_launch() {
     echo "[ios_device_gate] About to build/install/launch '$label' on the connected iPhone."
     echo "[ios_device_gate] Unlock the device and keep it awake. Continuing in ${PAUSE_SECONDS}s..."
     sleep "$PAUSE_SECONDS"
+  fi
+}
+
+# Task 105: the runner writes the demo's device console to <output-dir>/<App>/console.log; keep a
+# copy beside the step log so the summary's log column and the crash evidence sit together.
+keep_console_log() {
+  local app="$1"
+  if [[ -f "$OUTPUT_DIR/$app/console.log" ]]; then
+    cp "$OUTPUT_DIR/$app/console.log" "$OUTPUT_DIR/$app.console.log"
   fi
 }
 
@@ -336,6 +365,7 @@ write_summary() {
     fi
     echo "- Godot: $GODOT_BIN"
     echo "- Output: $OUTPUT_DIR"
+    echo "- Demo console window: ${CONSOLE_SECONDS}s per demo step (0 = launch-only; task 105)"
     echo
     echo "| Path | Status | Gate elapsed | Log |"
     echo "|---|---:|---:|---|"
@@ -364,6 +394,8 @@ cleanup_job_worktrees() {
 trap 'cleanup_job_worktrees; write_summary' EXIT
 
 export KANAMA_IOS_DEVICE="$DEVICE_ID"
+# Task 105: the demo steps stream the device console for this long and fail on a crash signature.
+export KANAMA_IOS_CONSOLE_SECONDS="$CONSOLE_SECONDS"
 export KANAMA_IOS_TEAM="$DEVELOPMENT_TEAM"
 export DEVELOPER_DIR="$XCODE_DEVELOPER_DIR"
 export KANAMA_ROOT="$ROOT_DIR"
@@ -421,6 +453,7 @@ run_demo_matrix_serial() {
       "$GATE_BUNDLE_ID" \
       "${demo_apps[$i]}" \
       "$OUTPUT_DIR/${demo_apps[$i]}" || true
+    keep_console_log "${demo_apps[$i]}"
   done
 }
 
@@ -518,6 +551,7 @@ run_demo_matrix_parallel() {
       "$GATE_BUNDLE_ID" \
       "$app" \
       "$OUTPUT_DIR/$app" || true
+    keep_console_log "$app"
   done
 }
 


### PR DESCRIPTION
## What & why

Task 105. The nine demo steps of `scripts/ios_device_gate.sh` only checked that `devicectl … launch` returned; a crash seconds later read PASS — the third-person demo did exactly that on the iPhone 12 on 2026-09-10 (`Object::_disconnect` from `SceneTree::_flush_delete_queue`), and every ledger entry since carried that blind spot.

- **`--console-seconds N`** (default 30, `0` = launch-only as before): exported to the demos runner as `KANAMA_IOS_CONSOLE_SECONDS`; each demo step streams the device console for N seconds after launch and fails on a crash signature (`App terminated due to signal`, `FATAL`) or when no `[kanama][ios]` line arrives (runtime never came up). The app stays running, `--keep-installed` unchanged.
- The console log is copied next to the step log (`<output-dir>/<App>.console.log`); the summary records the window; the gate refuses `N > 0` with a demos checkout whose runner lacks the knob (same pattern as the `--build-jobs` stage check).
- `docs/reference/version-support.md` says what the gate now sees; CHANGELOG entry.

Pairs with kanama-demos `ci/ios-device-run-console` (the runner half). Cost: 9 × N seconds per run.

## Checklist

- [x] Ran `scripts/local_ci.sh <godot>` to green — N/A beyond `bash -n` + `shellcheck` for this script; the gate itself is a local-only gate (see `docs/reference/generated/gates.md`).
- [x] Up to date with the latest `main`.
- [ ] If this touches ABI / memory-ownership code — it does not.
- [x] Updated docs / CHANGELOG.

## Testing

- `bash -n` (bash 3.2 and 5) + `shellcheck -S warning`: clean.
- **Full gate on the iPhone 12 with `--build-jobs 3 --console-seconds 30`:** four runs on 2026-09-11, all on main a2ea0d09 with the paired demos runner branch.
  - Run 1: every demo step FAILED on `App terminated due to signal 15` — stopping the console stream terminates the app with SIGTERM and devicectl reports it; the runner now judges a snapshot taken before the stream is stopped.
  - Run 2: **8/9 watched steps PASS**; **Match3 FAIL on a real crash** (`kotlin.IllegalStateException: tile_scene is not assigned` in `Main.ready`, SIGABRT 2 s after launch — the launch-only gate had passed it every day; filed as task 106); FPS FAIL on "no `[kanama][ios]` line in 30 s" — the runner now waits for the runtime's first line (`KANAMA_IOS_LAUNCH_TIMEOUT`, default 120 s) and only then watches the window.
  - Run 3: void, the phone had locked (every launch refused); the runner now names a refused launch instead of "runtime never reported".
  - Run 4 (`--start-at Starter-Kit-FPS`): fresh-starter, **FPS and third-person PASS** with their consoles watched (runtime reported after 2 s, 252 and 600 lines in the 30 s window, no crash signature). A `--start-at` run no longer records a ledger entry (partial matrix).
  
  Net: the gate now sees crashes inside the window (Match3 proves it), the device gate on main is red until task 106 is fixed, and the next full green run is the first honest iOS ledger entry.

## AI assistance

Written with Claude Code (Claude Fable 5.1); reviewed and gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
