### PR TITLE
Web: the DemoPage set (protocol 24) — pause, joypads, focus, Environment toggles, postAfterFrames ride the shared kotlin-src (task 64, parcel 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added — Web: the DemoPage set (task 64, parcel 3)
+
+- **Web protocol 23 → 24.** The Kotlin/Wasm backend admits `SceneTree.is_paused` (307),
+  `Control.release_focus` (308), `Environment.set_ssil_enabled` / `set_sdfgi_enabled` (309/310),
+  `SceneTree.unload_current_scene` (311) and `Input.get_connected_joypads` (312, a new
+  `NOARGS_RET_LONG_LIST_SINGLETON` shape: comma-joined ids on the string channel). The Web
+  `MainThread` gains `postAfterFrames(frames) { }` (one scheduler post per frame) and `SceneTree`
+  the companion `quit()` / `unloadCurrentScene()` calls through the executing script's tree, so
+  third-person's shared `DemoPage.kt` compiles and runs on Web without an override (the browser
+  branches — Exit resumes instead of quitting, the deferred-lighting upgrade is skipped on the
+  Compatibility renderer — are `OS.hasFeature("web")` gates in the shared file). The in-repo
+  `web3d` fixture proves the set (`Main.demo_page_probe` = 31, `demo_page_probe_after` = 1).
+  **Existing Web exports must be rebuilt**: a protocol-23 export refuses to load against a
+  protocol-24 bridge, and vice versa.
+
 ### Changed — iOS shape gap page: desktop-only-by-design members recorded (task 100 close-out)
 
 - The generated gap page (`docs/reference/generated/ios-shape-gap.md`) now separates members that

--- a/docs/contributing/backends/web.md
+++ b/docs/contributing/backends/web.md
@@ -72,7 +72,7 @@ see the Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 23); startup rejects a mismatch <!-- kanama-claim: protocol -->
+`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 24); startup rejects a mismatch <!-- kanama-claim: protocol -->
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -2,7 +2,7 @@
 
 The Web backend compiles Kanama project scripts to **Kotlin/Wasm** and runs
 them against a Godot Web export through a generated per-call proxy and a
-versioned JavaScript bridge (protocol 23). <!-- kanama-claim: protocol --> This page is the reproducible export
+versioned JavaScript bridge (protocol 24). <!-- kanama-claim: protocol --> This page is the reproducible export
 workflow: prerequisites, the build/export/serve/smoke/publish commands, the
 browser matrix and budgets you run, and the limitations you meet while
 shipping. The tier, the twelve-demo corpus evidence, the browser floors and

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -207,7 +207,7 @@ FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles
 to WebAssembly and talks to the Godot 4.7 Web export (Emscripten/Wasm) through a
 generated per-call proxy and a versioned JavaScript bridge
 (`web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js`, currently
-protocol 23). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
+protocol 24). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
 `scripts/platform_backend_calls.json`, and
 `scripts/generate_web_gameplay_coverage.py` fails loudly if a call the demo
 executes has no admitted backend family. See
@@ -225,7 +225,7 @@ calls that the backend does not model (`GodotObject.emit_signal_typed` among
 them) stay listed as explicit nonblocking unsupported entries rather than being
 pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 23). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 24). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -88,6 +88,7 @@ enum class GodotCallShape {
   VECTOR3I_RET_LONG,
   BASIS_RET_LONG,
   NOARGS_RET_VECTOR3I_LIST,
+  NOARGS_RET_LONG_LIST_SINGLETON,
   LONG_OBJECT_ARG,
   LONG_TRANSFORM3D_ARG,
   LONG_RET_STRING,
@@ -575,6 +576,12 @@ interface GodotBackendSpi {
 
   /** Singleton no-args Long query (no receiver): e.g. Input.get_mouse_mode. */
   fun invokeNoArgsRetLongSingleton(descriptor: GodotCallDescriptor, callSite: GodotCallSite): Long
+
+  /** Singleton no-args Long-list query (no receiver): e.g. Input.get_connected_joypads. */
+  fun invokeNoArgsRetLongListSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): List<Long>
 
   /** Signal emission carrying one Godot-object argument. */
   fun invokeStringNameObjectRetInt(
@@ -1473,6 +1480,12 @@ object GodotBackendCalls {
     requireShape(descriptor, GodotCallShape.NOARGS_RET_LONG_SINGLETON)
     val selected = requireBackend()
     return selected.invokeNoArgsRetLongSingleton(descriptor, resolve(selected, descriptor))
+  }
+
+  fun invokeNoArgsRetLongListSingleton(descriptor: GodotCallDescriptor): List<Long> {
+    requireShape(descriptor, GodotCallShape.NOARGS_RET_LONG_LIST_SINGLETON)
+    val selected = requireBackend()
+    return selected.invokeNoArgsRetLongListSingleton(descriptor, resolve(selected, descriptor))
   }
 
   fun invokeStringNameObjectRetInt(

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3370,6 +3370,72 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
 
+  val SCENETREE_IS_PAUSED =
+    GodotCallDescriptor(
+      opcode = 307,
+      className = "SceneTree",
+      methodName = "is_paused",
+      hash = 36873697L,
+      shape = GodotCallShape.NOARGS_RET_BOOL,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_RELEASE_FOCUS =
+    GodotCallDescriptor(
+      opcode = 308,
+      className = "Control",
+      methodName = "release_focus",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENVIRONMENT_SET_SSIL_ENABLED =
+    GodotCallDescriptor(
+      opcode = 309,
+      className = "Environment",
+      methodName = "set_ssil_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENVIRONMENT_SET_SDFGI_ENABLED =
+    GodotCallDescriptor(
+      opcode = 310,
+      className = "Environment",
+      methodName = "set_sdfgi_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val SCENETREE_UNLOAD_CURRENT_SCENE =
+    GodotCallDescriptor(
+      opcode = 311,
+      className = "SceneTree",
+      methodName = "unload_current_scene",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val INPUT_GET_CONNECTED_JOYPADS =
+    GodotCallDescriptor(
+      opcode = 312,
+      className = "Input",
+      methodName = "get_connected_joypads",
+      hash = 2915620761L,
+      shape = GodotCallShape.NOARGS_RET_LONG_LIST_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 306
+  const val MAX_OPCODE = 312
 }

--- a/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
+++ b/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
@@ -1361,6 +1361,11 @@ class GodotBackendContractTest {
       callSite: GodotCallSite,
     ): Long = unexercised(descriptor)
 
+    override fun invokeNoArgsRetLongListSingleton(
+      descriptor: GodotCallDescriptor,
+      callSite: GodotCallSite,
+    ): List<Long> = unexercised(descriptor)
+
     override fun invokeStringNameObjectRetInt(
       descriptor: GodotCallDescriptor,
       callSite: GodotCallSite,

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -134,9 +134,13 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * once per engine frame in every demo instead of only the four whose "Main" handle the bridge
      * happened to name. 23 (task 64, Curve + Resource-typed hydration parcel) adds opcode 306,
      * `Curve.sample` — the one method call thirdperson's Bullet needs once its `scaleDecay: Curve?`
-     * property hydrates over the existing generic OBJECT property arm.
+     * property hydrates over the existing generic OBJECT property arm. 24 (task 64, the DemoPage
+     * set) adds opcodes 307-312: `SceneTree.is_paused`, `Control.release_focus`,
+     * `Environment.set_ssil_enabled` / `set_sdfgi_enabled`, `SceneTree.unload_current_scene` and
+     * `Input.get_connected_joypads` (a new NOARGS_RET_LONG_LIST_SINGLETON shape on the string
+     * channel).
      */
-    const val PROTOCOL_VERSION = 23
+    const val PROTOCOL_VERSION = 24
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -2436,6 +2440,18 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\t(target_object as CanvasItem).visible = bytes.decode_s32(offset + 8) != 0")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 309 and target_object is Environment:")
+    appendLine(
+      "\t\t\t(target_object as Environment).ssil_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 310 and target_object is Environment:")
+    appendLine(
+      "\t\t\t(target_object as Environment).sdfgi_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
     appendLine("\t\telif opcode == 55 and target_object is AnimatedSprite2D:")
     appendLine(
       "\t\t\t(target_object as AnimatedSprite2D).flip_v = bytes.decode_s32(offset + 8) != 0"
@@ -2486,6 +2502,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\toffset += 8")
     appendLine("\t\telif opcode == 64 and target_object is AudioStreamPlayer:")
     appendLine("\t\t\t(target_object as AudioStreamPlayer).stop()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 308 and target_object is Control:")
+    appendLine("\t\t\t(target_object as Control).release_focus()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    appendLine("\t\telif opcode == 311 and target_object is SceneTree:")
+    appendLine("\t\t\t(target_object as SceneTree).unload_current_scene()")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 8")
     appendLine("\t\telif opcode == 65 and target_object is PathFollow2D:")
@@ -3818,6 +3842,8 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int((value as InputEventKey).physical_keycode)")
     appendLine("\t\telif opcode == 299 and value is InputEvent:")
     appendLine("\t\t\tresult = int((value as InputEvent).is_echo())")
+    appendLine("\t\telif opcode == 307 and value is SceneTree:")
+    appendLine("\t\t\tresult = int((value as SceneTree).paused)")
     appendLine("\t\telif opcode == 305 and value is InputEvent:")
     appendLine("\t\t\tresult = int((value as InputEvent).is_action(StringName(String(args[2]))))")
     appendLine("\t\telif opcode == 300 and value is InputEventWithModifiers:")
@@ -3910,6 +3936,12 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 145:")
     appendLine("\t\t\tresult = int(Input.mouse_mode)")
+    appendLine("\t\telif opcode == 312:")
+    appendLine("\t\t\tvar joypad_ids := PackedStringArray()")
+    appendLine("\t\t\tfor joypad_id in Input.get_connected_joypads():")
+    appendLine("\t\t\t\tjoypad_ids.append(str(joypad_id))")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(\",\".join(joypad_ids))")
+    appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 148 and value != null:")
     appendLine("\t\t\tvar emit_parts := String(args[2]).split(\"\\u001f\")")
     appendLine("\t\t\tvar emit_arg_handle := int(emit_parts[1])")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 23"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 24"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -426,6 +426,19 @@ class WebScriptCodeEmitterTest {
     assertTrue(proxy.contains("result = int((value as InputEventKey).physical_keycode)"))
     assertTrue(proxy.contains("elif opcode == 299 and value is InputEvent:"))
     assertTrue(proxy.contains("result = int((value as InputEvent).is_echo())"))
+    // Task 64 DemoPage set (protocol 24): the pause read-back, the focus release command, the
+    // Environment toggles, the unload command and the joypad enumeration on the string channel.
+    assertTrue(proxy.contains("elif opcode == 307 and value is SceneTree:"))
+    assertTrue(proxy.contains("result = int((value as SceneTree).paused)"))
+    assertTrue(proxy.contains("elif opcode == 308 and target_object is Control:"))
+    assertTrue(proxy.contains("elif opcode == 309 and target_object is Environment:"))
+    assertTrue(
+      proxy.contains(
+        "(target_object as Environment).ssil_enabled = bytes.decode_s32(offset + 8) != 0"
+      )
+    )
+    assertTrue(proxy.contains("elif opcode == 311 and target_object is SceneTree:"))
+    assertTrue(proxy.contains("for joypad_id in Input.get_connected_joypads():"))
     assertTrue(proxy.contains("elif opcode == 305 and value is InputEvent:"))
     assertTrue(
       proxy.contains("result = int((value as InputEvent).is_action(StringName(String(args[2]))))")
@@ -684,7 +697,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 23"))
+    assertTrue(protocol.contains("\"protocolVersion\": 24"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -695,7 +708,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=23\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=24\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1705,7 +1718,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 23"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 24"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -349,6 +349,12 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     304: {},
     305: {},
     306: {},
+    307: {},
+    308: {},
+    309: {},
+    310: {},
+    311: {},
+    312: {},
 }
 
 
@@ -1604,6 +1610,19 @@ def body_NOARGS_RET_VECTOR3I_LIST(calls):
     ]
 
 
+def body_NOARGS_RET_LONG_LIST_SINGLETON(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "commands.flush()",
+        "// The applier joins the ids with commas on the string channel; an empty string is no joypad.",
+        'return immediateWebStringQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")',
+        ".split(',')",
+        ".filter { it.isNotEmpty() }",
+        ".map { it.toLong() }",
+    ]
+
+
 def body_LONG_OBJECT_ARG(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -1953,6 +1972,7 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         "GodotHandle?",
     ),
     "NOARGS_RET_LONG_SINGLETON": ([], "Long"),
+    "NOARGS_RET_LONG_LIST_SINGLETON": ([], "List<Long>"),
     "STRINGNAME_OBJECT_RET_INT": (
         ["receiver: GodotHandle", "name: String", "value: GodotHandle"],
         "Int",
@@ -2274,6 +2294,7 @@ EMIT_ORDER = [
     "VECTOR3I_RET_LONG",
     "BASIS_RET_LONG",
     "NOARGS_RET_VECTOR3I_LIST",
+    "NOARGS_RET_LONG_LIST_SINGLETON",
     "LONG_OBJECT_ARG",
     "LONG_TRANSFORM3D_ARG",
     "LONG_RET_STRING",

--- a/scripts/generate_web_wrappers.py
+++ b/scripts/generate_web_wrappers.py
@@ -231,6 +231,8 @@ def api_return(tree: Tree, godot_type: str, meta: str, spi_ret: str) -> tuple[st
         return "Long", ""
     if spi_ret == "List<String>":
         return "List<String>", ""
+    if spi_ret == "List<Long>":
+        return "List<Long>", ""
     if spi_ret == "List<GodotVector3i>":
         return "List<Vector3i>", ".map { it.toApi() }"
     if spi_ret in SPI_TO_API:
@@ -968,6 +970,20 @@ fun Node3D.rotateObjectLocal(axis: Vector3, angle: Double) = rotateObjectLocal(a
         continuation.invokeOnCancellation { WebFrameScheduler.cancelTask(taskId) }
       }
     }
+
+    /**
+     * Desktop parity (task 64, the DemoPage set): the static `SceneTree.quit()` /
+     * `unloadCurrentScene()` calls reach the tree through the script that is currently executing
+     * (the scheduler's owner), so they must be called from a script callback -- which is where
+     * the shared demo scripts call them. The shared DemoPage takes its browser branch before
+     * reaching them (a page has no app to quit); the members exist so it compiles on Web.
+     */
+    fun quit(exitCode: Long = 0L) = currentOwnerTree().quit(exitCode)
+
+    fun unloadCurrentScene() = currentOwnerTree().unloadCurrentScene()
+
+    private fun currentOwnerTree(): SceneTree =
+      Node(GodotHandle(WebFrameScheduler.requireCurrentOwner())).getTree()
 """,
         "top_level": """
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -4816,6 +4816,94 @@
       "returnOwnership": "BORROWED",
       "semantics": "Sample the curve's baked value at offset (0..1 domain by convention, unclamped past it). Unlocks Resource-typed @ScriptProperty hydration for Curve exports (thirdperson Bullet's scale_decay) -- the property push itself already rides the generic OBJECT property arm; this opcode is the one method call the converged demo needs.",
       "introducedBy": "64-tier3-curve-resource-hydration"
+    },
+    {
+      "opcode": 307,
+      "scope": "class",
+      "className": "SceneTree",
+      "methodName": "is_paused",
+      "hash": 36873697,
+      "arguments": [],
+      "returnType": "bool",
+      "shape": "NOARGS_RET_BOOL",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Whether the tree is paused (DemoPage toggles pause from the pause action and reads it back). Pairs with set_pause.",
+      "introducedBy": "64-tier3-demopage-set"
+    },
+    {
+      "opcode": 308,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "release_focus",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Give up keyboard focus (DemoPage drops focus from the instruction buttons after switching).",
+      "introducedBy": "64-tier3-demopage-set"
+    },
+    {
+      "opcode": 309,
+      "scope": "class",
+      "className": "Environment",
+      "methodName": "set_ssil_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle screen-space indirect lighting (DemoPage's deferred-lighting upgrade; a no-op on the Compatibility renderer, the shared script gates it on !web).",
+      "introducedBy": "64-tier3-demopage-set"
+    },
+    {
+      "opcode": 310,
+      "scope": "class",
+      "className": "Environment",
+      "methodName": "set_sdfgi_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle SDFGI (DemoPage's deferred-lighting upgrade; a no-op on the Compatibility renderer, the shared script gates it on !web).",
+      "introducedBy": "64-tier3-demopage-set"
+    },
+    {
+      "opcode": 311,
+      "scope": "class",
+      "className": "SceneTree",
+      "methodName": "unload_current_scene",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Unload the current scene (DemoPage's Exit path; the shared script takes the browser branch on web, so this is admitted for the shared file to compile and stays unexercised by the corpus).",
+      "introducedBy": "64-tier3-demopage-set"
+    },
+    {
+      "opcode": 312,
+      "scope": "class",
+      "className": "Input",
+      "methodName": "get_connected_joypads",
+      "hash": 2915620761,
+      "arguments": [],
+      "returnType": "typedarray::int",
+      "shape": "NOARGS_RET_LONG_LIST_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Ids of the connected joypads (DemoPage picks the joypad instructions when one is present). Comma-joined ids on the string channel; empty = none.",
+      "introducedBy": "64-tier3-demopage-set"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -142,6 +142,19 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
   trace(`curveProbe: mask=${curveProbe}`);
 
+  // Task 64 DemoPage set (protocol 24): Main.demo_page_probe (Int->Int) returns a mask -- bit 1 =
+  // SceneTree.is_paused read the pause back, bit 2 = Input.get_connected_joypads answered (the new
+  // Long-list singleton shape; empty on a headless runner), bit 4 = Environment SSIL/SDFGI toggles
+  // were queued, bit 8 = Control.release_focus was queued, bit 16 = a postAfterFrames(3) chain was
+  // scheduled; demo_page_probe_after reads 1 once that chain ran (checked after the coroutine
+  // section pumped frames). A healthy run returns 31 then 1.
+  const demoPageProbe = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("demo_page_probe")}, 0)`,
+    ),
+  );
+  trace(`demoPageProbe: mask=${demoPageProbe}`);
+
   // Task 80 slice 4: signal-shape conformance (see Main.signal_probe).
   const signalProbe = Number(
     await evaluate(
@@ -288,6 +301,13 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
 
   // Full teardown: SmokeQuit.smoke_teardown (method#1) frees the scene root, draining handles.
+  const demoPageProbeAfter = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("demo_page_probe_after")}, 0)`,
+    ),
+  );
+  trace(`demoPageProbeAfter: ${demoPageProbeAfter}`);
+
   trace("smoke_teardown");
   await evaluate(
     "globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.web3dSmokeQuitHandle, 1); true",
@@ -331,6 +351,9 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     // non-null and Curve.sample reads back the VALUE the linear probe curve predicts, not
     // merely a successful call.
     curveResourceHydrationDeliversValue: curveProbe === 3,
+    // Task 64 DemoPage set: pause read-back, joypad enumeration, Environment toggles, focus release
+    // and the postAfterFrames hop chain (the readback runs after the coroutine section's pumps).
+    demoPageSetDelivers: demoPageProbe === 31 && demoPageProbeAfter === 1,
     // Task 80 slice 4, signal shapes: bit 1 = a ZERO-argument signal reached a Kotlin lambda,
     // bit 2 = a ONE-OBJECT signal delivered a live handle. The scalar shape is dispatch_probe
     // bit 32. The two-argument shape is absent because it CANNOT BE DECLARED: slice 3 makes an

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -188,6 +188,14 @@
         {
           "member": "Main.input_map_probe",
           "reason": "The task-64 tier-3 InputMap / InputEventKey / process-mode / Window-mode conformance probe the driver calls explicitly and asserts to the full 255 mask."
+        },
+        {
+          "member": "Main.demo_page_probe",
+          "reason": "The task-64 DemoPage-set conformance probe (pause read-back, joypad enumeration, Environment toggles, focus release, postAfterFrames) the driver calls explicitly and asserts to the full 31 mask."
+        },
+        {
+          "member": "Main.demo_page_probe_after",
+          "reason": "The task-64 DemoPage-set readback the driver calls after the frame pumps (1 once the postAfterFrames chain ran)."
         }
       ],
       "todo": [

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCoroutines.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCoroutines.kt
@@ -60,6 +60,20 @@ object MainThread {
   fun post(block: () -> Unit) {
     WebFrameScheduler.post(block)
   }
+
+  /**
+   * Runs [block] after [frames] frame pumps, like desktop's `MainThread.postAfterFrames` (task 64,
+   * the DemoPage set): each hop is one scheduler post, so `frames = 0` is a plain [post]. Must be
+   * called from a script callback (the scheduler binds the work to the current owner).
+   */
+  fun postAfterFrames(frames: Int, block: () -> Unit) {
+    require(frames >= 0) { "MainThread.postAfterFrames requires a non-negative frame count" }
+    if (frames <= 1) {
+      post(block)
+    } else {
+      post { postAfterFrames(frames - 1, block) }
+    }
+  }
 }
 
 /** Frame-deferred work; the Web scheduler already runs posts on the next frame. */

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
@@ -279,19 +279,13 @@ fun RenderingServer.environmentSetSsilQuality(
 fun Viewport.setInputAsHandled() = Unit
 
 /**
- * Global-illumination and screen-space effect toggles. The Web export runs the compatibility
- * renderer, which has no SDFGI, VoxelGI, SSAO, SSIL, or volumetric fog: these stay inert rather
- * than pretending to apply.
+ * Screen-space effect toggles the compatibility renderer has no implementation for (SSAO,
+ * volumetric fog): these stay inert rather than pretending to apply. `ssilEnabled` and
+ * `sdfgiEnabled` are real (queued) members since protocol 24 — the engine ignores them on the
+ * Compatibility renderer — so the shared DemoPage compiles; their getters are the setter-only
+ * coverage markers of the generated wrapper.
  */
-var Environment.sdfgiEnabled: Boolean
-  get() = false
-  set(@Suppress("UNUSED_PARAMETER") value) = Unit
-
 var Environment.ssaoEnabled: Boolean
-  get() = false
-  set(@Suppress("UNUSED_PARAMETER") value) = Unit
-
-var Environment.ssilEnabled: Boolean
   get() = false
   set(@Suppress("UNUSED_PARAMETER") value) = Unit
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Control.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Control.kt
@@ -22,6 +22,10 @@ open class Control(godotObject: GodotHandle) : CanvasItem(godotObject) {
   fun getSize(): Vector2 =
     GodotBackendCalls.invokeNoArgsRetVector2(D.CONTROL_GET_SIZE, requireOpenHandle()).toApi()
 
+  fun releaseFocus() {
+    GodotBackendCalls.invokeNoArgsVoid(D.CONTROL_RELEASE_FOCUS, requireOpenHandle())
+  }
+
   val position: Vector2
     get() = getPosition()
 
@@ -37,6 +41,9 @@ fun Control.getPosition(): Vector2 = getPosition()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Control.getSize(): Vector2 = getSize()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Control.releaseFocus() = releaseFocus()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Control.position: Vector2

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Environment.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Environment.kt
@@ -22,6 +22,14 @@ class Environment(godotObject: GodotHandle) : Resource(godotObject) {
     GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_GLOW_ENABLED, requireOpenHandle(), enabled)
   }
 
+  fun setSsilEnabled(enabled: Boolean) {
+    GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_SSIL_ENABLED, requireOpenHandle(), enabled)
+  }
+
+  fun setSdfgiEnabled(enabled: Boolean) {
+    GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_SDFGI_ENABLED, requireOpenHandle(), enabled)
+  }
+
   var backgroundEnergyMultiplier: Double
     get() = unsupportedWebGameplayFamily("Environment.get_bg_energy_multiplier")
     set(newValue) = setBgEnergyMultiplier(newValue)
@@ -29,6 +37,14 @@ class Environment(godotObject: GodotHandle) : Resource(godotObject) {
   var glowEnabled: Boolean
     get() = unsupportedWebGameplayFamily("Environment.is_glow_enabled")
     set(newValue) = setGlowEnabled(newValue)
+
+  var ssilEnabled: Boolean
+    get() = unsupportedWebGameplayFamily("Environment.is_ssil_enabled")
+    set(newValue) = setSsilEnabled(newValue)
+
+  var sdfgiEnabled: Boolean
+    get() = unsupportedWebGameplayFamily("Environment.is_sdfgi_enabled")
+    set(newValue) = setSdfgiEnabled(newValue)
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
@@ -36,6 +52,12 @@ fun Environment.setBgEnergyMultiplier(energy: Double) = setBgEnergyMultiplier(en
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Environment.setGlowEnabled(enabled: Boolean) = setGlowEnabled(enabled)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Environment.setSsilEnabled(enabled: Boolean) = setSsilEnabled(enabled)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Environment.setSdfgiEnabled(enabled: Boolean) = setSdfgiEnabled(enabled)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Environment.backgroundEnergyMultiplier: Double
@@ -49,4 +71,18 @@ var Environment.glowEnabled: Boolean
   get() = glowEnabled
   set(newValue) {
     glowEnabled = newValue
+  }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+var Environment.ssilEnabled: Boolean
+  get() = ssilEnabled
+  set(newValue) {
+    ssilEnabled = newValue
+  }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+var Environment.sdfgiEnabled: Boolean
+  get() = sdfgiEnabled
+  set(newValue) {
+    sdfgiEnabled = newValue
   }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Input.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Input.kt
@@ -75,6 +75,9 @@ object Input {
     return GodotBackendCalls.invokeStringNameRetDoubleSingleton(D.INPUT_GET_ACTION_STRENGTH, action)
   }
 
+  fun getConnectedJoypads(): List<Long> =
+    GodotBackendCalls.invokeNoArgsRetLongListSingleton(D.INPUT_GET_CONNECTED_JOYPADS)
+
   var mouseMode: Long
     get() = getMouseMode()
     set(newValue) = setMouseMode(newValue)
@@ -141,6 +144,9 @@ fun Input.isActionJustReleased(action: String, exactMatch: Boolean = false): Boo
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Input.getActionStrength(action: String, exactMatch: Boolean = false): Double = getActionStrength(action, exactMatch)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Input.getConnectedJoypads(): List<Long> = getConnectedJoypads()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Input.mouseMode: Long

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/SceneTree.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/SceneTree.kt
@@ -45,8 +45,15 @@ class SceneTree(godotObject: GodotHandle) : MainLoop(godotObject) {
     return checkNotNull(returned) { "SceneTree has no root window" }
   }
 
+  fun isPaused(): Boolean =
+    GodotBackendCalls.invokeNoArgsRetBool(D.SCENETREE_IS_PAUSED, requireOpenHandle())
+
+  fun unloadCurrentScene() {
+    GodotBackendCalls.invokeNoArgsVoid(D.SCENETREE_UNLOAD_CURRENT_SCENE, requireOpenHandle())
+  }
+
   var paused: Boolean
-    get() = unsupportedWebGameplayFamily("SceneTree.is_paused")
+    get() = isPaused()
     set(newValue) = setPause(newValue)
 
   /** The root window as its Viewport face (the tps corpus's `getTree().root`). */
@@ -69,6 +76,20 @@ class SceneTree(godotObject: GodotHandle) : MainLoop(godotObject) {
         continuation.invokeOnCancellation { WebFrameScheduler.cancelTask(taskId) }
       }
     }
+
+    /**
+     * Desktop parity (task 64, the DemoPage set): the static `SceneTree.quit()` /
+     * `unloadCurrentScene()` calls reach the tree through the script that is currently executing
+     * (the scheduler's owner), so they must be called from a script callback -- which is where
+     * the shared demo scripts call them. The shared DemoPage takes its browser branch before
+     * reaching them (a page has no app to quit); the members exist so it compiles on Web.
+     */
+    fun quit(exitCode: Long = 0L) = currentOwnerTree().quit(exitCode)
+
+    fun unloadCurrentScene() = currentOwnerTree().unloadCurrentScene()
+
+    private fun currentOwnerTree(): SceneTree =
+      Node(GodotHandle(WebFrameScheduler.requireCurrentOwner())).getTree()
   }
 }
 
@@ -89,6 +110,12 @@ fun SceneTree.setPaused(enable: Boolean) = setPaused(enable)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun SceneTree.getRoot(): GodotHandle = getRoot()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun SceneTree.isPaused(): Boolean = isPaused()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun SceneTree.unloadCurrentScene() = unloadCurrentScene()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var SceneTree.paused: Boolean

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -117,6 +117,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
           254,
           256,
           261,
+          309,
+          310,
         )
     )
     val objectId = receiver.webId()
@@ -1429,6 +1431,21 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
         val parts = triple.split(',')
         GodotVector3i(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
       }
+  }
+
+  override fun invokeNoArgsRetLongListSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+  ): List<Long> {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 312)
+    commands.flush()
+    // The applier joins the ids with commas on the string channel; an empty string is no joypad.
+    return immediateWebStringQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")
+      .split(',')
+      .filter { it.isNotEmpty() }
+      .map { it.toLong() }
   }
 
   override fun invokeLongObjectArg(

--- a/web-runtime/src/web3dSmoke/main.tscn
+++ b/web-runtime/src/web3dSmoke/main.tscn
@@ -137,6 +137,10 @@ transform = Transform3D(1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0,
 
 [node name="MobileControls" type="CanvasLayer" parent="."]
 
+[node name="ProbeLabel" type="Label" parent="MobileControls"]
+text = "probe"
+focus_mode = 2
+
 [node name="SmokeQuit" type="Node" parent="."]
 script = ExtResource("2_smoke")
 

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -14,6 +14,7 @@ import net.multigesture.kanama.annotations.Signal
 import net.multigesture.kanama.api.AudioStreamPlayer
 import net.multigesture.kanama.api.CanvasLayer
 import net.multigesture.kanama.api.Curve
+import net.multigesture.kanama.api.Control
 import net.multigesture.kanama.api.DirectionalLight3D
 import net.multigesture.kanama.api.GodotHandle
 import net.multigesture.kanama.api.GodotObject
@@ -534,6 +535,48 @@ class Main(godotObject: GodotHandle) :
     if (curve != null && abs(curve.sample(0.5) - 0.5) < 1e-3) mask = mask or 2L
     return mask
   }
+
+  /**
+   * Task-64 DemoPage-set conformance probe (driver method after `curve_sample_probe`, protocol 24):
+   * bit 1 = `SceneTree.is_paused` (opcode 307) reads back the pause the probe sets and clears
+   * again, bit 2 = `Input.get_connected_joypads` (312, the new Long-list singleton shape on the
+   * string channel) answered (empty on a headless runner), bit 4 = the WorldEnvironment's
+   * Environment took `set_ssil_enabled` / `set_sdfgi_enabled` (309/310; queued, a Compatibility
+   * no-op), bit 8 = `Control.release_focus` (308) was issued on the probe Label, bit 16 = a
+   * `MainThread.postAfterFrames(3)` hop chain was scheduled (its arrival is read back through
+   * [demoPageProbeAfter]). A healthy run returns 31 and [demoPageProbeAfter] returns 1 later.
+   */
+  @RegisterFunction("demo_page_probe")
+  fun demoPageProbe(value: Long): Long {
+    var mask = 0L
+    val tree = self.getTree()
+    val pausedBefore = tree.isPaused()
+    tree.setPaused(true)
+    val pausedNow = tree.isPaused()
+    tree.setPaused(pausedBefore)
+    if (pausedNow && tree.isPaused() == pausedBefore) mask = mask or 1L
+    if (Input.getConnectedJoypads().isEmpty()) mask = mask or 2L
+    val environment = self.getAsOrNull("Environment", ::WorldEnvironment)?.environment
+    if (environment != null) {
+      environment.setSsilEnabled(false)
+      environment.setSdfgiEnabled(false)
+      mask = mask or 4L
+    }
+    val probeLabel = self.getAsOrNull("MobileControls/ProbeLabel", ::Control)
+    if (probeLabel != null) {
+      probeLabel.releaseFocus()
+      mask = mask or 8L
+    }
+    MainThread.postAfterFrames(3) { demoPageAfterFrames = true }
+    mask = mask or 16L
+    return mask
+  }
+
+  private var demoPageAfterFrames = false
+
+  /** Task-64 DemoPage-set readback: 1 once the `postAfterFrames(3)` hop chain has run. */
+  @RegisterFunction("demo_page_probe_after")
+  fun demoPageProbeAfter(value: Long): Long = if (demoPageAfterFrames) 1L else 0L
 
   // ---------- Task 80 slice 2: dispatch-shape conformance probe ----------
   //

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 23;
+  const KANAMA_WEB_PROTOCOL_VERSION = 24;
 
   function commandWordCount(opcode) {
     if (
@@ -19,6 +19,9 @@
       opcode === 59 ||
       opcode === 63 ||
       opcode === 64 ||
+      // Task 64 DemoPage set: Control.release_focus, SceneTree.unload_current_scene (no payload).
+      opcode === 308 ||
+      opcode === 311 ||
       opcode === 147 ||
       opcode === 251 ||
       opcode === 283 ||
@@ -75,6 +78,9 @@
       opcode === 50 ||
       opcode === 53 ||
       opcode === 54 ||
+      // Task 64 DemoPage set: Environment.set_ssil_enabled / set_sdfgi_enabled (one bool word).
+      opcode === 309 ||
+      opcode === 310 ||
       opcode === 55 ||
       opcode === 56 ||
       opcode === 60 ||


### PR DESCRIPTION
## What & why

Task 64 (single-source demo scripts), parcel 3 — the DemoPage set (tier 3). Third-person's shared `DemoPage.kt` (pause page, instructions, exit, deferred-lighting upgrade) needed five Web families it did not have; with them the Web override is deleted on the demos side (overrides 42 → 41).

- **Web call contract, protocol 23 → 24:** `SceneTree.is_paused` (307, `NOARGS_RET_BOOL`), `Control.release_focus` (308, `NOARGS_VOID`), `Environment.set_ssil_enabled` / `set_sdfgi_enabled` (309/310, `BOOL_ARG`), `SceneTree.unload_current_scene` (311, `NOARGS_VOID`), `Input.get_connected_joypads` (312) — the last one on a **new shape**, `NOARGS_RET_LONG_LIST_SINGLETON`: the applier joins the joypad ids with commas on the existing string channel (like the Vector3i-list shape), the backend splits them; contract enum + facade + test fake, generator body/signature, wrapper return mapping (`List<Long>`).
- **Web glue, no opcode:** `MainThread.postAfterFrames(frames) { }` (one scheduler post per frame, desktop parity) and `SceneTree.Companion.quit()` / `.unloadCurrentScene()` through the executing script's tree, so the shared file's exit path compiles (it takes the browser branch before reaching them).
- **Every protocol pin moved to 24:** emitter, its tests, the bridge, three docs pages.
- **Evidence:** the `web3d` fixture's `demo_page_probe` (mask 31: pause read-back, joypad enumeration answered, Environment toggles and focus release queued without a fault, `postAfterFrames(3)` scheduled) and `demo_page_probe_after` (1 once the hop chain ran, read after the coroutine pumps); a `Label` under `MobileControls` in the fixture scene is the focus target; both members are required in `scripts/web/required_members.json`.

Demos side (PR after this merges, `KANAMA_REF` bump): `godot-4-3d-third-person-controller/kotlin-src/DemoPage.kt` converges (`GodotHandle` ctor, `OS.hasFeature("web")` branches for Exit-resumes and the skipped SSIL/SDFGI upgrade, `resumeFromSmoke()` for the Web smoke), the Web `DemoScenes` override gains `warmUp(owner: Node?)`, and `web/kotlin-src/DemoPage.kt` + `.uid` are deleted.

## Checklist

- [x] Ran `scripts/local_ci.sh <godot>` to green — the full gate (see `AGENTS.md` → Validation).
- [x] Up to date with the latest `main` (branch protection also enforces this at merge time).
- [x] If this touches ABI / memory-ownership code (`processor/`, marshalling) — called out below.
- [x] Updated docs / CHANGELOG, and bumped every paired constant (protocol 24 everywhere).

**Review points:** the new shape is receiver-less (singleton) and rides `immediateWebStringQuery` with the active script handle, exactly like `NOARGS_RET_LONG_SINGLETON`; `SceneTree.unload_current_scene` is admitted for compilation and is not exercised by the corpus (the shared DemoPage never reaches it on Web) — said so in the contract's `semantics`.

## Testing

- `:web-runtime:generateWebBackendDispatch` + `:web-runtime:generateWebWrappers` + `ktfmtFormat`; `generate_web_wrappers.py --check` — PASS.
- `:processor:test` + `:kanama-common-api:allTests` — PASS (47 emitter tests incl. the new opcode-arm assertions; contract test fake extended for the new shape).
- `scripts/web_ci_matrix.sh --demo web3d --engine chrome` — PASS, 34/34 assertions (`demoPageSetDelivers` = `demo_page_probe === 31 && demo_page_probe_after === 1`, no console errors). The first two runs found the two missing halves the hard way: the descriptors had not been regenerated (`generate_platform_backend_contract.py`) and the bridge's command-width table did not know 308-311 (`Unknown Kanama Web command opcode=309`); both fixed in this PR.
- Third-person Web export against this branch with the converged demos branch, driven on Chrome — PASS, 14/14 assertions, no console errors: the Web smoke presses Resume through the shared file's `resumeFromSmoke()` and the game runs (the override is gone on that branch).
- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot` — green, all stages.

## AI assistance

Written with Claude Code (Claude Fable 5.1, a forked worker under the coordinating session); reviewed and gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
