### PR TITLE
Web processor: emit the typed <Script>Methods helpers — third-person's physics-family scripts ride the shared kotlin-src (task 64, parcel 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added — Web: typed cross-script call helpers (task 64, parcel 5)
+
+- The Web script processor now emits the `<Script>Methods` objects desktop has always had (one
+  overload per `@RegisterFunction` taking the Kotlin instance, one resolving it from a
+  `GodotObject` through `kotlinScriptInstance`), so a shared demo file can call another script the
+  typed way on every platform — third-person's `BeetleBot` hits the player through
+  `PlayerMethods.damage` on desktop and Web alike, and the runtime node-lookup audit's "no dynamic
+  `call` in per-frame functions" rule holds on the shared file. No protocol change (a direct Kotlin
+  call through the script-instance registry; no Godot crossing).
+
 ### Added — Web: the CameraMode family (task 64, parcel 4)
 
 - **Web protocol 24 → 25.** The Kotlin/Wasm backend admits `Input.is_key_pressed` (opcode 313, a

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -942,9 +942,64 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     }
   }
 
+  /**
+   * `object <Script>Methods`: the typed cross-script call helpers, identical in shape to the
+   * desktop CodeEmitter's (`appendMethodHelpers`): one overload takes the Kotlin instance, one
+   * resolves it from a `GodotObject` through `kotlinScriptInstance` and answers whether the target
+   * hosted the script. Types are spelled fully qualified, as everything else in this file.
+   */
+  private fun StringBuilder.appendWebMethodHelpers(model: ScriptModel) {
+    val regularMethods = model.methods.filter { it.kind == MethodKind.REGULAR }
+    if (regularMethods.isEmpty()) return
+    val fq = model.fqName
+    appendLine()
+    appendLine("object ${model.simpleName}Methods {")
+    for (method in regularMethods) {
+      val kotlinParams = method.args.joinToString(", ") { "${it.name}: ${it.kotlinType}" }
+      val params = if (kotlinParams.isNotEmpty()) ", $kotlinParams" else ""
+      val argNames = method.args.joinToString(", ") { it.name }
+      val helperArgs = if (argNames.isNotEmpty()) ", $argNames" else ""
+      val returnType = method.returnType?.kotlinType
+      if (returnType == null) {
+        appendLine("  fun ${method.kotlinName}(instance: $fq$params) {")
+        appendLine("    instance.${method.kotlinName}($argNames)")
+        appendLine("  }")
+        appendLine()
+        appendLine(
+          "  fun ${method.kotlinName}(target: net.multigesture.kanama.api.GodotObject$params): Boolean {"
+        )
+        appendLine("    val instance = target.kotlinScriptInstance<$fq>() ?: return false")
+        appendLine("    ${method.kotlinName}(instance$helperArgs)")
+        appendLine("    return true")
+        appendLine("  }")
+      } else {
+        appendLine("  fun ${method.kotlinName}(instance: $fq$params): $returnType =")
+        appendLine("    instance.${method.kotlinName}($argNames)")
+        appendLine()
+        appendLine(
+          "  fun ${method.kotlinName}(target: net.multigesture.kanama.api.GodotObject$params): $returnType? ="
+        )
+        appendLine(
+          "    target.kotlinScriptInstance<$fq>()?.let { ${method.kotlinName}(it$helperArgs) }"
+        )
+      }
+      appendLine()
+    }
+    appendLine("}")
+  }
+
   fun constantsSource(): String = buildString {
     appendLine("package net.multigesture.kanama.generated")
     appendLine()
+    if (scripts.any { input -> input.model.methods.any { it.kind == MethodKind.REGULAR } }) {
+      // Task 64 parcel 5: the `<Script>Methods` typed cross-script helpers exist on Web too, so a
+      // shared demo file can call another script the typed way on every platform (desktop's
+      // CodeEmitter emits the same object per script). Direct Kotlin calls through the script
+      // instance registry -- no Godot crossing, which is also what the runtime node-lookup audit
+      // wants inside per-frame functions.
+      appendLine("import net.multigesture.kanama.api.kotlinScriptInstance")
+      appendLine()
+    }
     appendLine("@Suppress(\"unused\")")
     appendLine(
       "private fun emitWebSignal(instance: Any, signalName: String, args: Array<out Any?>) {"
@@ -975,6 +1030,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         }
         appendLine("}")
       }
+      appendWebMethodHelpers(model)
       if (
         model.methods.isNotEmpty() || model.properties.isNotEmpty() || model.signals.isNotEmpty()
       ) {


### PR DESCRIPTION
## What & why

Task 64 (single-source demo scripts), parcel 5 — the third-person "physics families" turned out to need **no new Web opcode**: compiling the shared `BeeBot` / `BeetleBot` / `CharacterSkin` / `DemoScenes` on Web with their overrides set aside left only the desktop constructor type, `handle.address()` identity checks, one `warmUp(String)` overload — and `PlayerMethods`, the typed cross-script helper the desktop processor emits per script and the Web processor did not.

- **Web `<Script>Methods` helpers.** `WebScriptCodeEmitter.constantsSource()` now emits, per script with `@RegisterFunction` methods, the same `object <Script>Methods` desktop's `CodeEmitter.appendMethodHelpers` does: `fun m(instance: <Script>, …)` and `fun m(target: GodotObject, …): Boolean` (or `R?`) resolving the instance through `kotlinScriptInstance`. A direct Kotlin call through the script-instance registry — no Godot crossing, no protocol change (stays 25). It is what lets the shared `BeetleBot` keep `PlayerMethods.damage(collider, impactPoint, force)` inside `_physics_process` on Web, where the runtime node-lookup audit forbids a dynamic `.call(` (the Web override used to do exactly that).
- CHANGELOG entry.

Demos side (branch `single-source-parcel-5-task-64`, PR after this merges with `KANAMA_REF`): the four shared files converged (`GodotHandle` ctor, `isSameInstance`, the Web teardown guards ported, DemoScenes' Web reductions behind `OS.hasFeature("web")`), overrides 40 → 36.

## Checklist

- [x] Ran `scripts/local_ci.sh <godot>` to green — see Testing.
- [x] Up to date with the latest `main`.
- [ ] If this touches ABI / memory-ownership code — it does not (generated Kotlin only).
- [x] Updated docs / CHANGELOG.

## Testing

- `:processor:test` PASS (`p64p5/tests2.log`); `ktfmtFormat`.
- Third-person Web export from the converged demos branch, Chrome: PASS 14/14, no console errors, `object PlayerMethods` present in the generated Web constants file (`p64p5/thirdperson3.log`, `p64p5/tp/thirdperson-chrome.json`).
- `web3d` on Chrome: PASS (`p64p5/web3d.log`).
- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot`: PASS (`p64p5/local_ci.log`).
- Demos `./gradlew check` on the converged branch: parity audit (140 scripts), replicated-properties audit, runtime node-lookup audit all PASS (`p64p5/demos-check2.log`) — the node-lookup audit is what rejected the dynamic `.call(` in `_physics_process` and motivated the Web helpers.

## AI assistance

Written with Claude Code (Claude Fable 5.1, a forked worker under the coordinating session); reviewed and gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
