### PR TITLE
Web: admit SceneTree.create_timer (protocol 27), postNextFrame and MultiplayerAPI.close — tps-demo's Player, Bullet, DebugLabel, PartDisappear and Main ride the shared kotlin-src (task 64, parcel 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added — Web SceneTree.create_timer (task 64, tps-demo parcel 7)
+
+- **Web protocol 26 → 27.** `SceneTree.create_timer(time_sec)` (opcode 321, new `DOUBLE_RET_HANDLE`
+  shape: the seconds ride the property-object channel, the applier registers the `SceneTreeTimer`
+  under the proposed OBJECT slot as a retained RefCounted, like a Tween), returned by the generated
+  `SceneTree.createTimer(timeSec, …)` as a `RefCounted` handle whose `timeout` is awaited through the
+  generic signal path, so the shared demo idiom
+  `getTree().createTimer(t)?.signal(Timer.Signals.timeout)?.await(self)` compiles and runs on Web
+  unchanged (the three flags must keep Godot's defaults). `MainThread.postNextFrame` is a member (was
+  an extension needing its own import); the Web multiplayer facade's `MultiplayerAPI` gains the
+  owned-handle `close()` the shared helpers call and `MultiplayerPeer` is `AutoCloseable`, so the
+  stdlib `use { }` resolves on both backends (the facade's own `use` extension is gone). The in-repo
+  `web3d` fixture proves the timer fires (`Main.timer_probe`, required by the smoke gate, must read 7).
+  **Existing Web exports must be rebuilt**: a protocol-26 export refuses to load against a
+  protocol-27 bridge, and vice versa.
+
 ### Added — Web node lifecycle queries (task 64, tps-demo parcel 6)
 
 - **Web protocol 25 → 26.** The Kotlin/Wasm backend admits `Node.is_inside_tree` (319) and

--- a/docs/contributing/backends/web.md
+++ b/docs/contributing/backends/web.md
@@ -72,7 +72,7 @@ see the Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 26); startup rejects a mismatch <!-- kanama-claim: protocol -->
+`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 27); startup rejects a mismatch <!-- kanama-claim: protocol -->
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -2,7 +2,7 @@
 
 The Web backend compiles Kanama project scripts to **Kotlin/Wasm** and runs
 them against a Godot Web export through a generated per-call proxy and a
-versioned JavaScript bridge (protocol 26). <!-- kanama-claim: protocol --> This page is the reproducible export
+versioned JavaScript bridge (protocol 27). <!-- kanama-claim: protocol --> This page is the reproducible export
 workflow: prerequisites, the build/export/serve/smoke/publish commands, the
 browser matrix and budgets you run, and the limitations you meet while
 shipping. The tier, the twelve-demo corpus evidence, the browser floors and

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -209,7 +209,7 @@ FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles
 to WebAssembly and talks to the Godot 4.7 Web export (Emscripten/Wasm) through a
 generated per-call proxy and a versioned JavaScript bridge
 (`web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js`, currently
-protocol 26). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
+protocol 27). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
 `scripts/platform_backend_calls.json`, and
 `scripts/generate_web_gameplay_coverage.py` fails loudly if a call the demo
 executes has no admitted backend family. See
@@ -227,7 +227,7 @@ calls that the backend does not model (`GodotObject.emit_signal_typed` among
 them) stay listed as explicit nonblocking unsupported entries rather than being
 pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 26). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 27). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -92,6 +92,7 @@ enum class GodotCallShape {
   LONG_RET_BOOL_SINGLETON,
   NOARGS_RET_VECTOR2_SINGLETON,
   STRINGNAME_RET_HANDLE_LIST,
+  DOUBLE_RET_HANDLE,
   LONG_OBJECT_ARG,
   LONG_TRANSFORM3D_ARG,
   LONG_RET_STRING,
@@ -606,6 +607,14 @@ interface GodotBackendSpi {
     receiver: GodotHandle,
     value: String,
   ): List<GodotHandle>
+
+  /** Double-argument handle query (a retained RefCounted result): e.g. SceneTree.create_timer. */
+  fun invokeDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Double,
+  ): GodotHandle?
 
   /** Signal emission carrying one Godot-object argument. */
   fun invokeStringNameObjectRetInt(
@@ -1533,6 +1542,22 @@ object GodotBackendCalls {
     val selected = requireBackend()
     selected.requireLive(receiver)
     return selected.invokeStringNameRetHandleList(
+      descriptor,
+      resolve(selected, descriptor),
+      receiver,
+      value,
+    )
+  }
+
+  fun invokeDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    receiver: GodotHandle,
+    value: Double,
+  ): GodotHandle? {
+    requireShape(descriptor, GodotCallShape.DOUBLE_RET_HANDLE)
+    val selected = requireBackend()
+    selected.requireLive(receiver)
+    return selected.invokeDoubleRetHandle(
       descriptor,
       resolve(selected, descriptor),
       receiver,

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3524,6 +3524,17 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.BORROWED,
     )
 
+  val SCENETREE_CREATE_TIMER =
+    GodotCallDescriptor(
+      opcode = 321,
+      className = "SceneTree",
+      methodName = "create_timer",
+      hash = 2709170273L,
+      shape = GodotCallShape.DOUBLE_RET_HANDLE,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 320
+  const val MAX_OPCODE = 321
 }

--- a/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
+++ b/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
@@ -1384,6 +1384,13 @@ class GodotBackendContractTest {
       value: String,
     ): List<GodotHandle> = unexercised(descriptor)
 
+    override fun invokeDoubleRetHandle(
+      descriptor: GodotCallDescriptor,
+      callSite: GodotCallSite,
+      receiver: GodotHandle,
+      value: Double,
+    ): GodotHandle? = unexercised(descriptor)
+
     override fun invokeStringNameObjectRetInt(
       descriptor: GodotCallDescriptor,
       callSite: GodotCallSite,

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -140,7 +140,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * `Input.get_connected_joypads` (a new NOARGS_RET_LONG_LIST_SINGLETON shape on the string
      * channel).
      */
-    const val PROTOCOL_VERSION = 26
+    const val PROTOCOL_VERSION = 27
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -4015,6 +4015,14 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = int((value as Node).is_inside_tree())")
     appendLine("\t\telif opcode == 320:")
     appendLine("\t\t\tresult = int(value.is_queued_for_deletion())")
+    // Task 64 tps-demo parcel 7 (protocol 27): SceneTree.create_timer -- a retained SceneTreeTimer
+    // under the proposed OBJECT slot; Kotlin awaits its `timeout` through the generic signal path.
+    appendLine("\t\telif opcode == 321 and value is SceneTree:")
+    appendLine("\t\t\tvar timer_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tvar scene_timer := (value as SceneTree).create_timer(float(timer_parts[0]))")
+    appendLine("\t\t\tif scene_timer != null:")
+    appendLine("\t\t\t\tresult = int(timer_parts[1])")
+    appendLine("\t\t\t\t_kanama_object_handles[result] = scene_timer")
     appendLine("\t\telif opcode == 317 and value is Camera3D:")
     appendLine("\t\t\tresult = int(round((value as Camera3D).fov * 1000.0))")
     appendLine("\t\telif opcode == 318 and value is SceneTree:")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 26"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 27"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -445,6 +445,9 @@ class WebScriptCodeEmitterTest {
     assertTrue(proxy.contains("elif opcode == 313:"))
     // Task 64 tps-demo parcel 6 (protocol 26): node lifecycle queries on the object-query channel.
     assertTrue(proxy.contains("elif opcode == 319 and value is Node:"))
+    // Task 64 tps-demo parcel 7 (protocol 27): SceneTree.create_timer registers a SceneTreeTimer.
+    assertTrue(proxy.contains("elif opcode == 321 and value is SceneTree:"))
+    assertTrue(proxy.contains("create_timer(float(timer_parts[0]))"))
     assertTrue(proxy.contains("result = int((value as Node).is_inside_tree())"))
     assertTrue(proxy.contains("elif opcode == 320:"))
     assertTrue(proxy.contains("result = int(value.is_queued_for_deletion())"))
@@ -723,7 +726,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 26"))
+    assertTrue(protocol.contains("\"protocolVersion\": 27"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -734,7 +737,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=26\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=27\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1744,7 +1747,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 26"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 27"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -363,6 +363,7 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     318: {},
     319: {},
     320: {},
+    321: {"ret": "browser"},
 }
 
 
@@ -1655,6 +1656,21 @@ def body_NOARGS_RET_VECTOR2_SINGLETON(calls):
         "immediateWebNoArgsVector2Y().toFloat(),",
         ")",
     ]
+def body_DOUBLE_RET_HANDLE(calls):
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(value.isFinite())",
+        "commands.flush()",
+        "// Task 64 tps-demo parcel 7: the seconds ride the property-object channel as their decimal",
+        "// spelling; the applier creates the SceneTreeTimer and registers it under the proposed",
+        "// OBJECT-kind slot (a retained RefCounted, like a Tween), so its timeout signal connects.",
+        "return registerReturnedBrowserObject(",
+        "immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), value.toString())",
+        ")",
+    ]
+
+
 def body_STRINGNAME_RET_HANDLE_LIST(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -2020,6 +2036,7 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
     "LONG_RET_BOOL_SINGLETON": (["value: Long"], "Boolean"),
     "NOARGS_RET_VECTOR2_SINGLETON": ([], "GodotVector2"),
     "STRINGNAME_RET_HANDLE_LIST": (["receiver: GodotHandle", "value: String"], "List<GodotHandle>"),
+    "DOUBLE_RET_HANDLE": (["receiver: GodotHandle", "value: Double"], "GodotHandle?"),
     "STRINGNAME_OBJECT_RET_INT": (
         ["receiver: GodotHandle", "name: String", "value: GodotHandle"],
         "Int",
@@ -2345,6 +2362,7 @@ EMIT_ORDER = [
     "LONG_RET_BOOL_SINGLETON",
     "NOARGS_RET_VECTOR2_SINGLETON",
     "STRINGNAME_RET_HANDLE_LIST",
+    "DOUBLE_RET_HANDLE",
     "LONG_OBJECT_ARG",
     "LONG_TRANSFORM3D_ARG",
     "LONG_RET_STRING",

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -5024,6 +5024,25 @@
       "returnOwnership": "BORROWED",
       "semantics": "Whether queue_free has been called on the object (tps-demo's Level / Part / Blast skip nodes that are on their way out).",
       "introducedBy": "64-parcel6-tps-lifecycle"
+    },
+    {
+      "opcode": 321,
+      "scope": "class",
+      "className": "SceneTree",
+      "methodName": "create_timer",
+      "hash": 2709170273,
+      "arguments": [
+        "float",
+        "bool",
+        "bool",
+        "bool"
+      ],
+      "returnType": "SceneTreeTimer",
+      "shape": "DOUBLE_RET_HANDLE",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "RETAINED_REFCOUNTED",
+      "semantics": "One-shot SceneTreeTimer (time in seconds; process_always/process_in_physics/ignore_time_scale keep Godot's defaults) as a retained browser handle; its `timeout` signal is awaited through the generic signal path (tps-demo's Level / Part / PartDisappear waits).",
+      "introducedBy": "64-parcel7-tps-timer"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -309,6 +309,11 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     evaluate(
       `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("coroutine_probe_mask")}, 0)`,
     ).then(Number);
+  // Task 64 tps-demo parcel 7: arm the SceneTree.create_timer probe before the coroutine section so
+  // the frames it pumps also carry the 50 ms timer to its timeout; read the mask after it.
+  await evaluate(
+    `globalThis.KanamaWebBridge.callNoArgs(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("timer_probe")}); true`,
+  );
   trace("coroutine_probe");
   const maskBeforeArm = await readCoroutineMask();
   await evaluate(
@@ -321,6 +326,12 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     coroutineMask = await readCoroutineMask();
   }
   const afterCoroutine = (await snapshot(evaluate)) ?? atPeak;
+  const timerMask = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("timer_probe_mask")}, 0)`,
+    ),
+  );
+  trace(`timerProbe: mask=${timerMask}`);
   trace(
     `coroutine: mask=${coroutineMask} (was ${maskBeforeArm}) pumps=${afterCoroutine.pumps} continuations=${afterCoroutine.continuations}`,
   );
@@ -382,6 +393,8 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     // Task 64 CameraMode family: Kotlin-constructed camera + fov round-trip, group query identity,
     // key polling and mouse velocity, previous camera restored.
     cameraModeFamilyDelivers: cameraModeProbe === 31,
+    // Task 64 tps-demo parcel 7: SceneTree.create_timer handle + its timeout awaited (7).
+    sceneTreeTimerDelivers: timerMask === 7,
     // Task 64 tps-demo parcel 6: node lifecycle queries (is_inside_tree, is_queued_for_deletion).
     nodeLifecycleDelivers: nodeLifecycleProbe === 15,
     // Task 80 slice 4, signal shapes: bit 1 = a ZERO-argument signal reached a Kotlin lambda,

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -204,6 +204,14 @@
         {
           "member": "Main.node_lifecycle_probe",
           "reason": "node lifecycle queries (task 64 parcel 6): is_inside_tree / is_queued_for_deletion"
+        },
+        {
+          "member": "Main.timer_probe",
+          "reason": "The task-64 parcel-7 SceneTree.create_timer probe the driver arms explicitly (timeout awaited through the generic signal path)."
+        },
+        {
+          "member": "Main.timer_probe_mask",
+          "reason": "The task-64 parcel-7 timer probe's read-back the driver asserts to 7."
         }
       ],
       "todo": [

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCoroutines.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebCoroutines.kt
@@ -74,7 +74,11 @@ object MainThread {
       post { postAfterFrames(frames - 1, block) }
     }
   }
-}
 
-/** Frame-deferred work; the Web scheduler already runs posts on the next frame. */
-fun MainThread.postNextFrame(block: () -> Unit) = post(block)
+  /**
+   * Frame-deferred work; the Web scheduler already runs posts on the next frame. A member, not an
+   * extension, so a shared demo file that imports only `MainThread` resolves it as on desktop
+   * (task 64, tps-demo parcel 7).
+   */
+  fun postNextFrame(block: () -> Unit) = post(block)
+}

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
@@ -52,10 +52,14 @@ inline fun <R> ButtonGroup.use(block: (ButtonGroup) -> R): R {
 // Multiplayer facade.
 // ---------------------------------------------------------------------------
 
-open class MultiplayerPeer internal constructor() {
+/**
+ * `AutoCloseable` like desktop's `RefCounted`, so the shared demo sources' `peer.use { }` resolves
+ * to the stdlib `use` on both backends without an import.
+ */
+open class MultiplayerPeer internal constructor() : AutoCloseable {
   open fun closeConnection() = Unit
 
-  open fun close() = Unit
+  override fun close() = Unit
 }
 
 class OfflineMultiplayerPeer internal constructor() : MultiplayerPeer() {
@@ -82,6 +86,9 @@ class ENetMultiplayerPeer internal constructor() : MultiplayerPeer() {
 
 class MultiplayerAPI internal constructor() {
   fun isServer(): Boolean = true
+
+  /** Owned-handle idiom of the shared demo helpers (`withMultiplayer` closes what it got); a no-op here. */
+  fun close() = Unit
 
   fun getUniqueId(): Int = 1
 
@@ -134,15 +141,6 @@ private val multiplayerApi = MultiplayerAPI()
 
 /** Nullable to match the desktop shape, so ported call sites keep their `?.` chains. */
 fun Node.getMultiplayer(): MultiplayerAPI? = multiplayerApi
-
-/** Mirrors the desktop owned-peer idiom ("close what you create", task 61). */
-inline fun <T : MultiplayerPeer, R> T.use(block: (T) -> R): R {
-  try {
-    return block(this)
-  } finally {
-    close()
-  }
-}
 
 /** Replication node; with a single local peer there is nothing to synchronize. */
 class MultiplayerSynchronizer(godotObject: GodotHandle) : Node(godotObject) {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/SceneTree.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/SceneTree.kt
@@ -59,6 +59,22 @@ class SceneTree(godotObject: GodotHandle) : MainLoop(godotObject) {
       group,
     ).map { Node(it.toWebId()) }
 
+  fun createTimer(
+    timeSec: Double,
+    processAlways: Boolean = true,
+    processInPhysics: Boolean = false,
+    ignoreTimeScale: Boolean = false,
+  ): RefCounted? {
+    require(processAlways == true) { "Web SceneTree.create_timer supports only processAlways = true" }
+    require(processInPhysics == false) { "Web SceneTree.create_timer supports only processInPhysics = false" }
+    require(ignoreTimeScale == false) { "Web SceneTree.create_timer supports only ignoreTimeScale = false" }
+    return GodotBackendCalls.invokeDoubleRetHandle(
+      D.SCENETREE_CREATE_TIMER,
+      requireOpenHandle(),
+      timeSec,
+    )?.let { RefCounted(it.toWebId()) }
+  }
+
   var paused: Boolean
     get() = isPaused()
     set(newValue) = setPause(newValue)
@@ -126,6 +142,14 @@ fun SceneTree.unloadCurrentScene() = unloadCurrentScene()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun SceneTree.getNodesInGroup(group: String): List<Node> = getNodesInGroup(group)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun SceneTree.createTimer(
+  timeSec: Double,
+  processAlways: Boolean = true,
+  processInPhysics: Boolean = false,
+  ignoreTimeScale: Boolean = false,
+): RefCounted? = createTimer(timeSec, processAlways, processInPhysics, ignoreTimeScale)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var SceneTree.paused: Boolean

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -1500,6 +1500,25 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       .map { GodotHandle.fromBackendToken(it.toLong()) }
   }
 
+  override fun invokeDoubleRetHandle(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    receiver: GodotHandle,
+    value: Double,
+  ): GodotHandle? {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode == 321)
+    require(value.isFinite())
+    commands.flush()
+    // Task 64 tps-demo parcel 7: the seconds ride the property-object channel as their decimal
+    // spelling; the applier creates the SceneTreeTimer and registers it under the proposed
+    // OBJECT-kind slot (a retained RefCounted, like a Tween), so its timeout signal connects.
+    return registerReturnedBrowserObject(
+      immediateWebPropertyObjectQuery(descriptor.opcode, receiver.webId(), value.toString())
+    )
+  }
+
   override fun invokeLongObjectArg(
     descriptor: GodotCallDescriptor,
     callSite: GodotCallSite,

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -33,6 +33,7 @@ import net.multigesture.kanama.api.RenderingServer
 import net.multigesture.kanama.api.Resource
 import net.multigesture.kanama.api.ResourceLoader
 import net.multigesture.kanama.api.SceneTree
+import net.multigesture.kanama.api.Timer
 import net.multigesture.kanama.api.Window
 import net.multigesture.kanama.api.WorldEnvironment
 import net.multigesture.kanama.api.genericWebGameplayFallback
@@ -680,6 +681,7 @@ class Main(godotObject: GodotHandle) :
   private var probeJoinId = -1L
   private var probeJoinNodeWasNull = false
   private var coroutineMask = 0L
+  private var timerMask = 0L
 
   @RegisterFunction("dispatch_probe_float")
   fun dispatchProbeFloat(amount: Double) {
@@ -821,6 +823,27 @@ class Main(godotObject: GodotHandle) :
    * body unrun and throws nothing at all. That is exactly why the assertion has to be a positive
    * observation of resumption, read back through [coroutineProbeMask], and never "no error".
    */
+  /**
+   * Task-64 tps-demo parcel 7 (protocol 27): `SceneTree.create_timer` as a retained browser handle
+   * whose `timeout` is awaited through the generic signal path. Bit 1 = the probe ran, 2 = the
+   * timer handle came back non-null, 4 = the coroutine resumed past `await` on its timeout (the
+   * engine fired the one-shot timer and the connection delivered it). Read back through
+   * [timerProbeMask] after the driver's coroutine section has pumped frames; a healthy run reads 7.
+   */
+  @RegisterFunction("timer_probe")
+  fun timerProbe() {
+    timerMask = 1L
+    kanamaScope.launch {
+      val timer = self.getTree().createTimer(0.05)
+      if (timer != null) timerMask = timerMask or 2L
+      timer?.signal(Timer.Signals.timeout)?.await(self, argumentCount = 0)
+      timerMask = timerMask or 4L
+    }
+  }
+
+  @RegisterFunction("timer_probe_mask")
+  fun timerProbeMask(value: Long): Long = timerMask
+
   @RegisterFunction("coroutine_probe")
   fun coroutineProbe() {
     coroutineMask = 1L

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 26;
+  const KANAMA_WEB_PROTOCOL_VERSION = 27;
 
   function commandWordCount(opcode) {
     if (


### PR DESCRIPTION
## What & why

Task 64 (single-source demo scripts), tps-demo parcel 7 — option A ("the Web surface grows members"). The parcel-6 measurement listed six families for the twelve remaining tps-demo overrides; this parcel lands the ones that converge whole files — the timer family plus the glue — and ships the measured list for the rest (below). The RID-boundary family (RedRobot, PlayerInputSynchronizer, TpsScenes' ray queries) stays overridden by decision (task 107 filed, not scheduled).

- **Web call contract, protocol 26 → 27.** One opcode, `SceneTree.create_timer` (321), on a new `DOUBLE_RET_HANDLE` shape: the seconds travel as a decimal string on the existing property-object query channel with a proposed OBJECT-kind slot; the GDScript arm mints the `SceneTreeTimer` into that slot; the backend registers it as a retained RefCounted browser handle whose `timeout` signal is awaited through the generic signal path (`createTimer(0.2)?.signal(Timer.Signals.timeout)?.await(self, 0)`). The contract entry declares Godot's full signature (`float, bool, bool, bool`), so the generated wrapper takes the three flags with Godot's defaults and refuses anything else — the same admit-and-gate pattern as `AnimationPlayer.seek`. Contract JSON + generated backend + descriptors + contract interface/dispatcher + test fake, emitter arm + tests, bridge / docs / CHANGELOG pins. Immediate result, so no `commandWordCount` entry.
- **Glue.** `MainThread.postNextFrame` becomes a member of `object MainThread` (it was an extension, so `import net.multigesture.kanama.api.MainThread` did not bring it in — Bullet, Level). The offline `MultiplayerAPI` facade gains `close()` so the shared `withMultiplayer { }` helper's `finally` compiles on Web (Main, Player, Bullet, DebugLabel), and the facade `MultiplayerPeer` is `AutoCloseable` like desktop's `RefCounted`, so the shared `peer.use { }` resolves to the stdlib `use` on both backends without an import (the facade's own `use` extension is removed; the generated wrapper returns the timer as a `RefCounted` handle — its only Web use is the `timeout` signal).
- **Evidence:** the `web3d` fixture's `Main.timer_probe` / `timer_probe_mask` (required members; driver assertion `sceneTreeTimerDelivers` = 7): the coroutine started, `create_timer(0.05)` returned a handle, and its `timeout` signal resumed the coroutine.
- **Existing Web exports must be rebuilt** (protocol mismatch refuses to load).

Demos side (committed on `single-source-parcel-7-task-64`, PR after this merges with `KANAMA_REF`): Player, Bullet, DebugLabel, PartDisappear and Main converge (overrides **32 → 27**); the Web TpsScenes override carries the shared multiplayer helpers verbatim over the facade; two shared-file edits are neutral on desktop (Player's `Basis(...)` axis arguments positional — the Web constructor names them `xAxis/yAxis/zAxis`; Main's `replace_main_scene` handler uses `connectObject` and hands the emitted PackedScene back through `call_deferred`, because the Web object-signal channel delivers an untyped handle); the browser-harness entry points the tps-demo smoke driver presses (`Main.smoke_start_game` / `smoke_teardown`, methods #1 and #2) move from the old Web override into the shared Main, with the two teardown helpers they call (`TpsScenes.releaseCachedScenes`, `TpsSettings.releaseConfigFile`) added to the shared TpsScenes / Settings exactly as the Web overrides already had them.

**Parcel 8 (measured, not in this PR):** Level (`java.io.File` in the shared file — a JVM-only path that needs a shared-file rewrite before anything Web-side helps; facade `signal()` on `MultiplayerAPI`; `get_window`; `RenderingServer.voxel_gi_set_quality` / `environment_set_sdfgi_ray_count`); Menu (the processor-emitted `MenuRpcs` helpers — processor-only, like parcel 5's `<Script>Methods`; `get_window`, `get_name`; the `ENV_*_QUALITY_*` constants via an `enums` CLASS_POLICY entry on `RenderingServer`; facade signals); Settings (`environment_set_ssao_quality` / `ssil_quality` are six-argument calls — a new shape; `Environment.ssao_enabled` / `volumetric_fog_enabled`; `propagate_call`; `get_window`; `get_current_rendering_driver_name`); SafeArea (the Window / DisplayServer family: `window_get_size`, `get_display_safe_area`, `set_position`, plus Float-vs-Double signature edits in the shared file); Part (`Material.next_pass` read and two `use { }` type-inference cascades). Family 6 (RedRobot, PlayerInputSynchronizer, TpsScenes) stays overridden by design.

## Checklist

- [x] Ran `scripts/local_ci.sh <godot>` to green — the full gate, not just the in-editor smoke (see `AGENTS.md` → Validation).
- [x] Up to date with the latest `main` (branch protection also enforces this at merge time).
- [x] If this touches ABI / memory-ownership code (`src/main/kotlin/binding/`, `processor/`, retain/release, marshalling), I've called it out below so it gets a careful review.
- [x] Updated docs / CHANGELOG if behavior changed, and bumped any paired constants I touched (see `AGENTS.md` → synchronized invariants).

**Marshalling review points:** one new shape (`DOUBLE_RET_HANDLE`) and one minted handle: the proposed OBJECT-kind slot is allocated by the bridge's property-object query path (the `Tween` precedent), the GDScript arm stores the `SceneTreeTimer` under it only when `create_timer` returned non-null, and the backend registers it through `registerReturnedBrowserObject` as `RETAINED_REFCOUNTED`. The Kotlin side never frees it; the browser handle table owns the reference until the script instance is torn down.

## Testing

- `scripts/generate_platform_backend_contract.py` (descriptors) + `:web-runtime:generateWebBackendDispatch` + `generateWebWrappers` regen; `generate_web_wrappers.py --check` PASS; ktfmt (`--rerun-tasks`).
- `:processor:test` + `:kanama-common-api:allTests` — PASS (emitter tests incl. the new 321 arm assertions and every protocol-27 pin).
- `web3d` on Chrome — PASS at protocol 27; `timer_probe` = 7 (`KANAMA_WEB_SMOKE_DEBUG=1` trace), `coroutine_probe` still 31.
- tps-demo Web export from the converged demos branch, Chrome — PASS 12/12 (menu → Play → level with 4 robots / 12 parts → teardown, live handles 0, callback faults 0), no console errors.
- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot` — green.
- demos `./gradlew check` (parity audit, replicated properties, runtime node lookup) — PASS.

Falsification on the way: the first tps-demo export against the converged sources compiled but the smoke driver's Play press went nowhere — the harness entry points had lived only in the Web Main override (they are now shared, like Level's smoke logic). Before that it failed on three Web-vs-desktop surface differences (`peer.use { }` not resolving without the facade import, the `(List<Any?>) -> Unit` signal lambda the Web `connect` lacks, named `Basis` axis arguments) — the first became the `AutoCloseable` facade change, the other two the shared-file edits above. Before that, the first contract entry declared only the `float` argument and the descriptor generator refused it as Godot API drift (the validator compares the full `extension_api.json` signature); declaring `float, bool, bool, bool` made the wrapper generator emit the three defaulted flags with `require` guards, which is the behaviour we want on Web.

## AI assistance

Written with Claude Code (Claude Fable 5.1, a forked worker under the coordinating session); reviewed and gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
