### PR TITLE
Web matrix: extend the dodge/firefox quarantine to 2027-03-31 (task 71 stays parked)

### DIFF
--- a/scripts/web/demos.sh
+++ b/scripts/web/demos.sh
@@ -195,8 +195,11 @@ kanama_web_quarantine_reason() {
 # citing task is re-planned; the matrix warns loudly once today is past it.
 kanama_web_quarantine_until() {
   case "$1" in
-    # quarantined 2026-07-28 (task 71 parked); maintainer sets the real date.
-    dodge:firefox) echo "2026-10-31" ;;
+    # quarantined 2026-07-28 (task 71 parked). Extended 2026-09-12 by the maintainer: the cell
+    # still fails on GitHub's Linux runners and reproduces nowhere else (both Linux VMs, macOS),
+    # so task 71 stays parked with no work planned until it shows on hardware we control;
+    # the quarantine keeps the evidence visible without blocking the lane.
+    dodge:firefox) echo "2027-03-31" ;;
     *) : ;;
   esac
 }


### PR DESCRIPTION
## What & why

Task 71 (dodge's mobs never free on a Linux host) stays parked: the `dodge:firefox` cell still fails on GitHub's Linux runners and reproduces nowhere else (both Linux VMs, macOS). Its quarantine was set to expire 2026-10-31; this extends it to 2027-03-31 with the reason in the table, so the matrix keeps running and reporting the cell without blocking, and nobody has to re-derive why in October. The scheduled control lane (plain GDScript notifier) is unchanged: it has no expiry and never blocks.

Maintainer decision 2026-09-11: keep the task, no energy until it reproduces on hardware we control.

## Checklist

- [x] `bash -n scripts/web/demos.sh`; no runtime change, no CHANGELOG entry (CI bookkeeping).
- [x] Up to date with the latest `main`.

## AI assistance

Written with Claude Code (Claude Fable 5.1); reviewed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
