### PR TITLE
Web: render-quality, window and glue families at protocol 28 — tps-demo's Level, Menu, Settings, SafeArea and Part ride the shared kotlin-src (task 64, parcel 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ versioning once public releases begin.
 
 ## Unreleased
 
+### Added — Web render-quality, window and glue families (task 64, tps-demo parcel 8)
+
+- **Web protocol 27 → 28.** The Kotlin/Wasm backend admits the settings families tps-demo's
+  Settings / Menu / Level write on every graphics apply: `Environment.set_ssao_enabled` (322) and
+  `set_volumetric_fog_enabled` (323) as queued mutations, `RenderingServer.voxel_gi_set_quality`
+  (324), `environment_set_sdfgi_ray_count` (325) and the six-argument
+  `environment_set_ssao_quality` (326) / `environment_set_ssil_quality` (327) on a new
+  `LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON` shape (the six values ride the object-query
+  string channel joined by U+001F and the applier calls Godot with the full signature), plus
+  `RenderingServer.get_current_rendering_driver_name` (328) and `OS.get_name` (329) on the
+  immediate string channel, the queued `Viewport.set_input_as_handled` (330) and
+  `Control.set_position` / `set_size` (331/332). The Compatibility renderer ignores most of the
+  quality writes, but the calls reach the engine instead of a Kotlin-side stub. `Node.get_window`,
+  `Node.propagate_call("set", [property, bool])`, `ResourceLoader`'s threaded-load family and
+  `loadLightmapGIData`, and the `ENV_SSAO_/ENV_SSIL_/VOXEL_GI_/ENV_SDFGI_RAY_COUNT_` constants are
+  generated members of the Web wrappers now rather than hand-written extensions needing their own
+  imports — the shared demo sources spell them exactly as desktop does, and the threaded-load
+  status constants take Godot's own values (the old facade had `THREAD_LOAD_IN_PROGRESS` and
+  `THREAD_LOAD_LOADED` transposed). The `LONG_OBJECT_ARG` object slot is nullable, so
+  `Mesh.surface_set_material(i, null)` clears a surface material. The Web script processor also
+  emits the `<Script>Rpcs` helpers desktop has (the parcel-5 `<Script>Methods` precedent): a
+  browser build has a single local peer, so a broadcast or a call addressed to peer 0/1 runs the
+  local leg when `@Rpc(callLocal = true)` says so and any remote peer id fails loud. The in-repo
+  `web3d` fixture proves the new surface (`Main.render_settings_probe` = 63,
+  `Main.window_family_probe` = 31, both required by the smoke gate).
+  **Existing Web exports must be rebuilt**: a protocol-27 export refuses to load against a
+  protocol-28 bridge, and vice versa.
+
 ### Added — Web SceneTree.create_timer (task 64, tps-demo parcel 7)
 
 - **Web protocol 26 → 27.** `SceneTree.create_timer(time_sec)` (opcode 321, new `DOUBLE_RET_HANDLE`

--- a/docs/contributing/backends/web.md
+++ b/docs/contributing/backends/web.md
@@ -72,7 +72,7 @@ see the Backend-dispatch codegen section below.
 
 `web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js` is the seam between
 the Kanama Wasm module and Godot's Web export. It carries a
-`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 27); startup rejects a mismatch <!-- kanama-claim: protocol -->
+`KANAMA_WEB_PROTOCOL_VERSION` (currently protocol 28); startup rejects a mismatch <!-- kanama-claim: protocol -->
 between the bridge constant and the value the Wasm backend reports, so a bridge
 and a backend built from different revisions fail loudly instead of drifting.
 

--- a/docs/exporting/web.md
+++ b/docs/exporting/web.md
@@ -2,7 +2,7 @@
 
 The Web backend compiles Kanama project scripts to **Kotlin/Wasm** and runs
 them against a Godot Web export through a generated per-call proxy and a
-versioned JavaScript bridge (protocol 27). <!-- kanama-claim: protocol --> This page is the reproducible export
+versioned JavaScript bridge (protocol 28). <!-- kanama-claim: protocol --> This page is the reproducible export
 workflow: prerequisites, the build/export/serve/smoke/publish commands, the
 browser matrix and budgets you run, and the limitations you meet while
 shipping. The tier, the twelve-demo corpus evidence, the browser floors and

--- a/docs/reference/version-support.md
+++ b/docs/reference/version-support.md
@@ -209,7 +209,7 @@ FFM/PanamaPort path. It is a **Kotlin/Wasm** backend: project gameplay compiles
 to WebAssembly and talks to the Godot 4.7 Web export (Emscripten/Wasm) through a
 generated per-call proxy and a versioned JavaScript bridge
 (`web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js`, currently
-protocol 27). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
+protocol 28). <!-- kanama-claim: protocol --> The typed backend seam is shared with the other platforms through
 `scripts/platform_backend_calls.json`, and
 `scripts/generate_web_gameplay_coverage.py` fails loudly if a call the demo
 executes has no admitted backend family. See
@@ -227,7 +227,7 @@ calls that the backend does not model (`GodotObject.emit_signal_typed` among
 them) stay listed as explicit nonblocking unsupported entries rather than being
 pattern-hidden.
 
-Browser floors and the versions the corpus is driven on (protocol 27). <!-- kanama-claim: protocol --> The
+Browser floors and the versions the corpus is driven on (protocol 28). <!-- kanama-claim: protocol --> The
 floors are declared once, machine-readably, in `scripts/web/browser_floors.json`,
 and `web_export_smoke.sh` fails any run below them:
 

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/GodotBackendContract.kt
@@ -111,6 +111,7 @@ enum class GodotCallShape {
   STRINGNAME_RET_STRING,
   DOUBLE_RET_DOUBLE,
   VECTOR3_VECTOR3_LONG_OBJECT_RET_STRING,
+  LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON,
 }
 
 @InternalKanamaBackendApi
@@ -518,6 +519,21 @@ interface GodotBackendSpi {
   /** Singleton Long-argument void call (no receiver): e.g. RenderingServer shadow tuning. */
   fun invokeLongArgSingleton(descriptor: GodotCallDescriptor, callSite: GodotCallSite, value: Long)
 
+  /**
+   * Singleton six-value void call (no receiver): RenderingServer's SSAO/SSIL quality tuning
+   * (quality enum, half_size, adaptive_target, blur_passes, fadeout_from, fadeout_to).
+   */
+  fun invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    quality: Long,
+    halfSize: Boolean,
+    adaptiveTarget: Double,
+    blurPasses: Long,
+    fadeoutFrom: Double,
+    fadeoutTo: Double,
+  )
+
   /** Object-argument fluent call returning a handle: e.g. Tween.bind_node self-return. */
   fun invokeObjectRetHandle(
     descriptor: GodotCallDescriptor,
@@ -719,13 +735,16 @@ interface GodotBackendSpi {
     receiver: GodotHandle,
   ): List<GodotVector3i>
 
-  /** Indexed object write (mesh-library item mesh). */
+  /**
+   * Indexed object write (mesh-library item mesh, mesh surface material). Null clears the slot --
+   * Godot accepts it for both members.
+   */
   fun invokeLongObjectArg(
     descriptor: GodotCallDescriptor,
     callSite: GodotCallSite,
     receiver: GodotHandle,
     longValue: Long,
-    objectValue: GodotHandle,
+    objectValue: GodotHandle?,
   )
 
   /** Indexed transform write (mesh-library item transform). */
@@ -1509,6 +1528,30 @@ object GodotBackendCalls {
     selected.invokeLongArgSingleton(descriptor, resolve(selected, descriptor), value)
   }
 
+  fun invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+    descriptor: GodotCallDescriptor,
+    quality: Long,
+    halfSize: Boolean,
+    adaptiveTarget: Double,
+    blurPasses: Long,
+    fadeoutFrom: Double,
+    fadeoutTo: Double,
+  ) {
+    requireShape(descriptor, GodotCallShape.LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON)
+    require(adaptiveTarget.isFinite() && fadeoutFrom.isFinite() && fadeoutTo.isFinite())
+    val selected = requireBackend()
+    selected.invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+      descriptor,
+      resolve(selected, descriptor),
+      quality,
+      halfSize,
+      adaptiveTarget,
+      blurPasses,
+      fadeoutFrom,
+      fadeoutTo,
+    )
+  }
+
   fun invokeNoArgsRetLongSingleton(descriptor: GodotCallDescriptor): Long {
     requireShape(descriptor, GodotCallShape.NOARGS_RET_LONG_SINGLETON)
     val selected = requireBackend()
@@ -1729,12 +1772,12 @@ object GodotBackendCalls {
     descriptor: GodotCallDescriptor,
     receiver: GodotHandle,
     longValue: Long,
-    objectValue: GodotHandle,
+    objectValue: GodotHandle?,
   ) {
     requireShape(descriptor, GodotCallShape.LONG_OBJECT_ARG)
     val selected = requireBackend()
     selected.requireLive(receiver)
-    selected.requireLive(objectValue)
+    if (objectValue != null) selected.requireLive(objectValue)
     selected.invokeLongObjectArg(
       descriptor,
       resolve(selected, descriptor),

--- a/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
+++ b/kanama-common-api/src/commonMain/kotlin/net/multigesture/kanama/backend/InitialGodotCallDescriptors.generated.kt
@@ -3535,6 +3535,127 @@ object InitialGodotCallDescriptors {
       returnOwnership = GodotReturnOwnership.RETAINED_REFCOUNTED,
     )
 
+  val ENVIRONMENT_SET_SSAO_ENABLED =
+    GodotCallDescriptor(
+      opcode = 322,
+      className = "Environment",
+      methodName = "set_ssao_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val ENVIRONMENT_SET_VOLUMETRIC_FOG_ENABLED =
+    GodotCallDescriptor(
+      opcode = 323,
+      className = "Environment",
+      methodName = "set_volumetric_fog_enabled",
+      hash = 2586408642L,
+      shape = GodotCallShape.BOOL_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RENDERINGSERVER_VOXEL_GI_SET_QUALITY =
+    GodotCallDescriptor(
+      opcode = 324,
+      className = "RenderingServer",
+      methodName = "voxel_gi_set_quality",
+      hash = 1538689978L,
+      shape = GodotCallShape.LONG_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RENDERINGSERVER_ENVIRONMENT_SET_SDFGI_RAY_COUNT =
+    GodotCallDescriptor(
+      opcode = 325,
+      className = "RenderingServer",
+      methodName = "environment_set_sdfgi_ray_count",
+      hash = 340137951L,
+      shape = GodotCallShape.LONG_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RENDERINGSERVER_ENVIRONMENT_SET_SSAO_QUALITY =
+    GodotCallDescriptor(
+      opcode = 326,
+      className = "RenderingServer",
+      methodName = "environment_set_ssao_quality",
+      hash = 189753569L,
+      shape = GodotCallShape.LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RENDERINGSERVER_ENVIRONMENT_SET_SSIL_QUALITY =
+    GodotCallDescriptor(
+      opcode = 327,
+      className = "RenderingServer",
+      methodName = "environment_set_ssil_quality",
+      hash = 1713836683L,
+      shape = GodotCallShape.LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val RENDERINGSERVER_GET_CURRENT_RENDERING_DRIVER_NAME =
+    GodotCallDescriptor(
+      opcode = 328,
+      className = "RenderingServer",
+      methodName = "get_current_rendering_driver_name",
+      hash = 201670096L,
+      shape = GodotCallShape.NOARGS_RET_STRING_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val OS_GET_NAME =
+    GodotCallDescriptor(
+      opcode = 329,
+      className = "OS",
+      methodName = "get_name",
+      hash = 201670096L,
+      shape = GodotCallShape.NOARGS_RET_STRING_SINGLETON,
+      executionMode = GodotExecutionMode.IMMEDIATE_RESULT,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val VIEWPORT_SET_INPUT_AS_HANDLED =
+    GodotCallDescriptor(
+      opcode = 330,
+      className = "Viewport",
+      methodName = "set_input_as_handled",
+      hash = 3218959716L,
+      shape = GodotCallShape.NOARGS_VOID,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_SET_POSITION =
+    GodotCallDescriptor(
+      opcode = 331,
+      className = "Control",
+      methodName = "set_position",
+      hash = 2436320129L,
+      shape = GodotCallShape.VECTOR2_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
+  val CONTROL_SET_SIZE =
+    GodotCallDescriptor(
+      opcode = 332,
+      className = "Control",
+      methodName = "set_size",
+      hash = 2436320129L,
+      shape = GodotCallShape.VECTOR2_ARG,
+      executionMode = GodotExecutionMode.QUEUED_MUTATION,
+      returnOwnership = GodotReturnOwnership.BORROWED,
+    )
+
   /** Highest opcode in the shared contract; sizes the call-site resolution cache. */
-  const val MAX_OPCODE = 321
+  const val MAX_OPCODE = 332
 }

--- a/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
+++ b/kanama-common-api/src/commonTest/kotlin/net/multigesture/kanama/backend/GodotBackendContractTest.kt
@@ -1314,6 +1314,17 @@ class GodotBackendContractTest {
       value: Long,
     ) = unexercised(descriptor)
 
+    override fun invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+      descriptor: GodotCallDescriptor,
+      callSite: GodotCallSite,
+      quality: Long,
+      halfSize: Boolean,
+      adaptiveTarget: Double,
+      blurPasses: Long,
+      fadeoutFrom: Double,
+      fadeoutTo: Double,
+    ) = unexercised(descriptor)
+
     override fun invokeObjectRetHandle(
       descriptor: GodotCallDescriptor,
       callSite: GodotCallSite,
@@ -1487,7 +1498,7 @@ class GodotBackendContractTest {
       callSite: GodotCallSite,
       receiver: GodotHandle,
       longValue: Long,
-      objectValue: GodotHandle,
+      objectValue: GodotHandle?,
     ) = unexercised(descriptor)
 
     override fun invokeLongTransform3dArg(

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/KanamaProcessor.kt
@@ -1881,7 +1881,7 @@ private fun uniqueConstantIdentifier(name: String, seen: MutableSet<String>): St
   }
 }
 
-private fun signalHelperSuffix(godotName: String): String {
+internal fun signalHelperSuffix(godotName: String): String {
   val id = constantIdentifier(godotName).removeSurrounding("`")
   return id.replaceFirstChar { it.uppercase() }
 }

--- a/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
+++ b/processor/src/main/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitter.kt
@@ -138,9 +138,17 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
      * set) adds opcodes 307-312: `SceneTree.is_paused`, `Control.release_focus`,
      * `Environment.set_ssil_enabled` / `set_sdfgi_enabled`, `SceneTree.unload_current_scene` and
      * `Input.get_connected_joypads` (a new NOARGS_RET_LONG_LIST_SINGLETON shape on the string
-     * channel).
+     * channel). 28 (task 64, tps-demo parcel 8) adds opcodes 322-330: the render-quality settings
+     * (`Environment.set_ssao_enabled` / `set_volumetric_fog_enabled`, RenderingServer's
+     * `voxel_gi_set_quality` / `environment_set_sdfgi_ray_count` and the six-value
+     * `environment_set_ssao_quality` / `environment_set_ssil_quality` on a new
+     * LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON shape), the immediate string reads
+     * `RenderingServer.get_current_rendering_driver_name` / `OS.get_name`,
+     * `Viewport.set_input_as_handled` and the Control window family `Control.set_position` /
+     * `set_size` (331-332). The LONG_OBJECT_ARG slot also became nullable in 28, so
+     * `Mesh.surface_set_material(i, null)` clears the slot (handle id 0).
      */
-    const val PROTOCOL_VERSION = 27
+    const val PROTOCOL_VERSION = 28
 
     /**
      * Shape version of `KanamaWebProtocol.generated.json` itself — independent of
@@ -988,6 +996,67 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("}")
   }
 
+  /**
+   * `object <Script>Rpcs` (task 64 parcel 8): desktop's `appendRpcHelpers` twin, one `rpc…` /
+   * `rpcId…` (and `callLocal…` when the `@Rpc` declares it) per RPC method. Web has a single local
+   * peer (id 1, no transport), so the helpers apply Godot's own rules for an RPC that stays on the
+   * caller: a broadcast or a call addressed to peer 0/1 runs the method locally when `callLocal` is
+   * set, a call to yourself without `callLocal` is the engine's "not allowed by selected mode"
+   * error, and a remote peer id fails loud -- none can exist here. tps-demo's Menu only reaches
+   * these on the lobby paths a Web build never enters; the helpers make the shared file compile.
+   */
+  private fun StringBuilder.appendWebRpcHelpers(model: ScriptModel) {
+    val rpcMethods = model.methods.filter { it.kind == MethodKind.REGULAR && it.rpc != null }
+    if (rpcMethods.isEmpty()) return
+    val fq = model.fqName
+    appendLine()
+    appendLine("object ${model.simpleName}Rpcs {")
+    for (method in rpcMethods) {
+      val suffix = signalHelperSuffix(method.godotName)
+      val kotlinParams = method.args.joinToString(", ") { "${it.name}: ${it.kotlinType}" }
+      val params = if (kotlinParams.isNotEmpty()) ", $kotlinParams" else ""
+      val argNames = method.args.joinToString(", ") { it.name }
+      val callLocal = method.rpc?.callLocal == true
+      val godotName = method.godotName
+      val localCall = "instance.${method.kotlinName}($argNames)"
+      val instanceParam =
+        if (callLocal) "instance: $fq" else "@Suppress(\"UNUSED_PARAMETER\") instance: $fq"
+      appendLine(
+        "  /** Broadcast (peer 0): no remote peers on Web, so only the local leg can run. */"
+      )
+      appendLine("  fun rpc$suffix($instanceParam$params): Long {")
+      if (callLocal) appendLine("    $localCall")
+      appendLine("    return 0L")
+      appendLine("  }")
+      appendLine()
+      appendLine("  fun rpcId$suffix(instance: $fq, peerId: Long$params): Long {")
+      appendLine("    if (peerId != 0L && peerId != 1L) {")
+      appendLine(
+        "      error(\"Kanama Web has no remote peers: rpc_id(\$peerId, \\\"$godotName\\\") on ${model.simpleName}\")"
+      )
+      appendLine("    }")
+      if (callLocal) {
+        appendLine("    $localCall")
+      } else {
+        appendLine("    if (peerId == 1L) {")
+        appendLine(
+          "      error(\"RPC \\\"$godotName\\\" on yourself is not allowed by its @Rpc mode (callLocal = false)\")"
+        )
+        appendLine("    }")
+      }
+      appendLine("    return 0L")
+      appendLine("  }")
+      if (callLocal) {
+        appendLine()
+        appendLine("  fun callLocal$suffix(instance: $fq$params) {")
+        appendLine("    $localCall")
+        appendLine("  }")
+      }
+      appendLine()
+    }
+    appendLine("}")
+  }
+
   fun constantsSource(): String = buildString {
     appendLine("package net.multigesture.kanama.generated")
     appendLine()
@@ -1031,6 +1100,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
         appendLine("}")
       }
       appendWebMethodHelpers(model)
+      appendWebRpcHelpers(model)
       if (
         model.methods.isNotEmpty() || model.properties.isNotEmpty() || model.signals.isNotEmpty()
       ) {
@@ -2481,6 +2551,20 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tlast_value = int(position_x)")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
+    // Task 64 tps-demo parcel 8 (protocol 28): SafeArea nudges a Control inside the display
+    // safe area; keep_offsets stays Godot's default (the wrapper rejects anything else).
+    appendLine("\t\telif opcode == 331 and target_object is Control:")
+    appendLine(
+      "\t\t\t(target_object as Control).position = Vector2(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 332 and target_object is Control:")
+    appendLine(
+      "\t\t\t(target_object as Control).size = Vector2(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12))"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
     appendLine("\t\telif opcode == 30 and target_object is Node2D:")
     appendLine("\t\t\tvar target := target_object as Node2D")
     appendLine(
@@ -2505,6 +2589,19 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\telif opcode == 310 and target_object is Environment:")
     appendLine(
       "\t\t\t(target_object as Environment).sdfgi_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    // Task 64 tps-demo parcel 8 (protocol 28): the Settings menu's SSAO / volumetric-fog toggles.
+    appendLine("\t\telif opcode == 322 and target_object is Environment:")
+    appendLine(
+      "\t\t\t(target_object as Environment).ssao_enabled = bytes.decode_s32(offset + 8) != 0"
+    )
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 16")
+    appendLine("\t\telif opcode == 323 and target_object is Environment:")
+    appendLine(
+      "\t\t\t(target_object as Environment).volumetric_fog_enabled = bytes.decode_s32(offset + 8) != 0"
     )
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 16")
@@ -2575,6 +2672,11 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\toffset += 8")
     appendLine("\t\telif opcode == 311 and target_object is SceneTree:")
     appendLine("\t\t\t(target_object as SceneTree).unload_current_scene()")
+    appendLine("\t\t\tapplied += 1")
+    appendLine("\t\t\toffset += 8")
+    // Task 64 tps-demo parcel 8 (protocol 28): Settings consumes its fullscreen toggle.
+    appendLine("\t\telif opcode == 330 and target_object is Viewport:")
+    appendLine("\t\t\t(target_object as Viewport).set_input_as_handled()")
     appendLine("\t\t\tapplied += 1")
     appendLine("\t\t\toffset += 8")
     appendLine("\t\telif opcode == 65 and target_object is PathFollow2D:")
@@ -4259,7 +4361,7 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine(
       "\t\t\tvar item_mesh: Mesh = _kanama_object_handles.get(int(item_mesh_parts[1])) as Mesh"
     )
-    appendLine("\t\t\tif item_mesh != null:")
+    appendLine("\t\t\tif item_mesh != null or int(item_mesh_parts[1]) == 0:")
     appendLine("\t\t\t\t(value as MeshLibrary).set_item_mesh(int(item_mesh_parts[0]), item_mesh)")
     appendLine("\t\t\t\tresult = 1")
     appendLine("\t\telif opcode == 211 and value is MeshLibrary:")
@@ -4483,6 +4585,33 @@ internal class WebScriptCodeEmitter(inputs: List<WebScriptInput>) {
     appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 269:")
     appendLine("\t\t\tEngine.max_fps = int(String(args[2]))")
+    appendLine("\t\t\tresult = 1")
+    // Task 64 tps-demo parcel 8 (protocol 28): the render-quality singleton writes (Compatibility
+    // ignores them, the calls still reach the engine) and the two string reads.
+    appendLine("\t\telif opcode == 324:")
+    appendLine("\t\t\tRenderingServer.voxel_gi_set_quality(int(String(args[2])))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 325:")
+    appendLine("\t\t\tRenderingServer.environment_set_sdfgi_ray_count(int(String(args[2])))")
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 326 or opcode == 327:")
+    appendLine("\t\t\tvar quality_parts := String(args[2]).split(\"\\u001f\")")
+    appendLine("\t\t\tif opcode == 326:")
+    appendLine(
+      "\t\t\t\tRenderingServer.environment_set_ssao_quality(int(quality_parts[0]), quality_parts[1] == \"true\", float(quality_parts[2]), int(quality_parts[3]), float(quality_parts[4]), float(quality_parts[5]))"
+    )
+    appendLine("\t\t\telse:")
+    appendLine(
+      "\t\t\t\tRenderingServer.environment_set_ssil_quality(int(quality_parts[0]), quality_parts[1] == \"true\", float(quality_parts[2]), int(quality_parts[3]), float(quality_parts[4]), float(quality_parts[5]))"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 328:")
+    appendLine(
+      "\t\t\t_kanama_bridge.recordImmediateStringResult(RenderingServer.get_current_rendering_driver_name())"
+    )
+    appendLine("\t\t\tresult = 1")
+    appendLine("\t\telif opcode == 329:")
+    appendLine("\t\t\t_kanama_bridge.recordImmediateStringResult(OS.get_name())")
     appendLine("\t\t\tresult = 1")
     appendLine("\t\telif opcode == 270:")
     appendLine("\t\t\tresult = int(Engine.get_frames_per_second())")

--- a/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
+++ b/processor/src/test/kotlin/net/multigesture/kanama/processor/WebScriptCodeEmitterTest.kt
@@ -73,7 +73,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(firstDescriptor >= 0)
     assertTrue(secondDescriptor > firstDescriptor, "resource paths must define stable script IDs")
 
-    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 27"))
+    assertTrue(source.contains("const val PROTOCOL_VERSION: Int = 28"))
     assertTrue(source.contains("1 -> FirstScript(WebObjectId(objectId))"))
     assertTrue(source.contains("2 -> SecondScript(WebObjectId(objectId))"))
     assertTrue(source.contains("WebMemberDescriptor(1, \"greeting\")"))
@@ -448,6 +448,36 @@ class WebScriptCodeEmitterTest {
     // Task 64 tps-demo parcel 7 (protocol 27): SceneTree.create_timer registers a SceneTreeTimer.
     assertTrue(proxy.contains("elif opcode == 321 and value is SceneTree:"))
     assertTrue(proxy.contains("create_timer(float(timer_parts[0]))"))
+    // Task 64 tps-demo parcel 8 (protocol 28): the render-quality settings family, the two
+    // immediate string reads, and the queued Viewport.set_input_as_handled.
+    assertTrue(proxy.contains("elif opcode == 322 and target_object is Environment:"))
+    assertTrue(
+      proxy.contains(
+        "(target_object as Environment).volumetric_fog_enabled = bytes.decode_s32(offset + 8) != 0"
+      )
+    )
+    assertTrue(proxy.contains("RenderingServer.voxel_gi_set_quality(int(String(args[2])))"))
+    assertTrue(
+      proxy.contains("RenderingServer.environment_set_sdfgi_ray_count(int(String(args[2])))")
+    )
+    assertTrue(proxy.contains("elif opcode == 326 or opcode == 327:"))
+    assertTrue(proxy.contains("RenderingServer.environment_set_ssao_quality(int(quality_parts[0])"))
+    assertTrue(proxy.contains("RenderingServer.environment_set_ssil_quality(int(quality_parts[0])"))
+    assertTrue(
+      proxy.contains(
+        "_kanama_bridge.recordImmediateStringResult(RenderingServer.get_current_rendering_driver_name())"
+      )
+    )
+    assertTrue(proxy.contains("_kanama_bridge.recordImmediateStringResult(OS.get_name())"))
+    assertTrue(proxy.contains("elif opcode == 330 and target_object is Viewport:"))
+    assertTrue(proxy.contains("(target_object as Viewport).set_input_as_handled()"))
+    assertTrue(proxy.contains("elif opcode == 331 and target_object is Control:"))
+    assertTrue(proxy.contains("elif opcode == 332 and target_object is Control:"))
+    assertTrue(
+      proxy.contains(
+        "(target_object as Control).size = Vector2(bytes.decode_float(offset + 8), bytes.decode_float(offset + 12))"
+      )
+    )
     assertTrue(proxy.contains("result = int((value as Node).is_inside_tree())"))
     assertTrue(proxy.contains("elif opcode == 320:"))
     assertTrue(proxy.contains("result = int(value.is_queued_for_deletion())"))
@@ -726,7 +756,7 @@ class WebScriptCodeEmitterTest {
     assertFalse(tileProxy.contains("func _enter_tree()"), "Tile must not emit _enter_tree")
 
     val protocol = emitter.protocolManifest()
-    assertTrue(protocol.contains("\"protocolVersion\": 27"))
+    assertTrue(protocol.contains("\"protocolVersion\": 28"))
     assertTrue(protocol.contains("\"attachTo\": \"Area2D\""))
     assertTrue(protocol.contains("\"type\": \"List<net.multigesture.kanama.api.Texture2D>\""))
     assertTrue(protocol.contains("\"type\": \"net.multigesture.kanama.types.Vector2i\""))
@@ -737,7 +767,7 @@ class WebScriptCodeEmitterTest {
     assertTrue(constants.contains("fun tilePressed("))
     assertTrue(constants.contains("const val setTileType: String = \"set_tile_type\""))
     assertTrue(emitter.compatibilitySources().containsKey("net.multigesture.kanama.demos.match3"))
-    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=27\n"))
+    assertTrue(emitter.proxyManifest().startsWith("# kanama-web-protocol=28\n"))
 
     val registry = emitter.registrySource()
     assertTrue(registry.contains("(script as Main).width = value"))
@@ -1747,7 +1777,7 @@ class WebScriptCodeEmitterTest {
     // The manifest shape is unchanged by slice 2; the bridge contract is not, so the protocol
     // version moved and the schema version did not.
     assertTrue(protocol.contains("\"schemaVersion\": 2"), protocol)
-    assertTrue(protocol.contains("\"protocolVersion\": 27"), protocol)
+    assertTrue(protocol.contains("\"protocolVersion\": 28"), protocol)
 
     // Every shape slice 2 filled must read typed IN THE MANIFEST, not just in the arm table.
     assertTrue(

--- a/scripts/generate_web_backend.py
+++ b/scripts/generate_web_backend.py
@@ -364,6 +364,17 @@ WEB_POLICY: dict[int, dict[str, object]] = {
     319: {},
     320: {},
     321: {"ret": "browser"},
+    322: {},
+    323: {},
+    324: {},
+    325: {},
+    326: {},
+    327: {},
+    328: {},
+    329: {},
+    330: {},
+    331: {},
+    332: {},
 }
 
 
@@ -786,6 +797,24 @@ def body_LONG_ARG_SINGLETON(calls):
     ]
 
 
+def body_LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON(calls):
+    """Six values joined by U+001F on the object-query string channel (task 64 parcel 8): the
+    RenderingServer SSAO/SSIL quality tuning has no RID and no result; the GDScript arm splits
+    the payload and calls Godot with the full signature."""
+    return [
+        f"require(descriptor.executionMode == {_IMMEDIATE})",
+        f"require({_opcode_guard(calls)})",
+        "require(quality in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "require(blurPasses in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
+        "require(adaptiveTarget.isFinite() && fadeoutFrom.isFinite() && fadeoutTo.isFinite())",
+        "val packed =",
+        "listOf(quality, halfSize, adaptiveTarget, blurPasses, fadeoutFrom, fadeoutTo)",
+        '.joinToString("\\u001f")',
+        "commands.flush()",
+        "immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), packed)",
+    ]
+
+
 def body_STRINGNAME_ARG_SINGLETON(calls):
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
@@ -796,16 +825,40 @@ def body_STRINGNAME_ARG_SINGLETON(calls):
 
 
 def body_NOARGS_RET_STRING_SINGLETON(calls):
-    op = _only(calls).opcode
-    return [
-        f"require(descriptor.executionMode == {_SNAPSHOT})",
-        f"require(descriptor.opcode == {op})",
-        "return webRenderingMethodSnapshot(requireActiveWebScriptHandle())",
+    """One opcode reads the per-script snapshot the proxy seeds at ready (the rendering method,
+    85); the task-64 parcel-8 reads (rendering driver name, OS name) answer on the immediate
+    string channel like every other singleton query, so no new snapshot family per string."""
+    snapshot = [c for c in calls if c.execution_mode.value == "SNAPSHOT_READ"]
+    immediate = [c for c in calls if c.execution_mode.value == "IMMEDIATE_RESULT"]
+    snap = _only(snapshot).opcode
+    lines = [
+        f"require({_opcode_guard(calls)})",
+        "return when (descriptor.executionMode) {",
+        f"{_SNAPSHOT} -> {{",
+        f"require(descriptor.opcode == {snap})",
+        "webRenderingMethodSnapshot(requireActiveWebScriptHandle())",
         "?: error(",
         '"Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +',
         '"active script handle"',
         ")",
+        "}",
     ]
+    if immediate:
+        lines += [
+            f"{_IMMEDIATE} -> {{",
+            f"require({_opcode_guard(immediate)})",
+            "commands.flush()",
+            'immediateWebStringQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")',
+            "}",
+        ]
+    lines += [
+        "else -> error(",
+        '"Unsupported execution mode ${descriptor.executionMode} for " +',
+        '"${descriptor.className}.${descriptor.methodName}"',
+        ")",
+        "}",
+    ]
+    return lines
 
 
 def body_LONG_DOUBLE_ARG(calls):
@@ -1684,18 +1737,22 @@ def body_STRINGNAME_RET_HANDLE_LIST(calls):
         ".map { GodotHandle.fromBackendToken(it.toLong()) }",
     ]
 def body_LONG_OBJECT_ARG(calls):
+    """Godot lets both members of this shape clear the slot (`Mesh.surface_set_material(i, null)`
+    drops the mesh's reference to a duplicated material), so the object slot is nullable and null
+    rides as handle id 0 -- the GDScript arm already reads 0 as null (task 64 parcel 8)."""
     return [
         f"require(descriptor.executionMode == {_IMMEDIATE})",
         f"require({_opcode_guard(calls)})",
         "require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())",
-        "requireWebBrowserHandle(objectValue.webId(), WebBrowserHandleKind.OBJECT)",
+        "objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.OBJECT) }",
         "commands.flush()",
-        "// Item index and object handle packed into one query string (unit separator).",
+        "// Item index and object handle packed into one query string (unit separator);",
+        "// handle id 0 clears the slot.",
         "check(",
         "immediateWebObjectQuery(",
         "descriptor.opcode,",
         "receiver.webId(),",
-        'longValue.toString() + "" + objectValue.webId().toString(),',
+        'longValue.toString() + "" + (objectValue?.webId() ?: 0).toString(),',
         ") == 1",
         ") {",
         '"Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"',
@@ -2002,6 +2059,17 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
         "",
     ),
     "LONG_ARG_SINGLETON": (["value: Long"], ""),
+    "LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON": (
+        [
+            "quality: Long",
+            "halfSize: Boolean",
+            "adaptiveTarget: Double",
+            "blurPasses: Long",
+            "fadeoutFrom: Double",
+            "fadeoutTo: Double",
+        ],
+        "",
+    ),
     "OBJECT_RET_HANDLE": (["receiver: GodotHandle", "value: GodotHandle"], "GodotHandle?"),
     "OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE": (
         [
@@ -2191,7 +2259,7 @@ SIGNATURES: dict[str, tuple[list[str], str]] = {
     "BASIS_RET_LONG": (["receiver: GodotHandle", "value: GodotBasis"], "Long"),
     "NOARGS_RET_VECTOR3I_LIST": (["receiver: GodotHandle"], "List<GodotVector3i>"),
     "LONG_OBJECT_ARG": (
-        ["receiver: GodotHandle", "longValue: Long", "objectValue: GodotHandle"],
+        ["receiver: GodotHandle", "longValue: Long", "objectValue: GodotHandle?"],
         "",
     ),
     "LONG_TRANSFORM3D_ARG": (
@@ -2347,6 +2415,7 @@ EMIT_ORDER = [
     "STRINGNAME_STRINGNAME_RET_DOUBLE_SINGLETON",
     "VECTOR3_VECTOR3_ARG",
     "LONG_ARG_SINGLETON",
+    "LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON",
     "OBJECT_RET_HANDLE",
     "OBJECT_NODEPATH_VECTOR3_DOUBLE_RET_HANDLE",
     "OBJECT_NODEPATH_DOUBLE_DOUBLE_RET_HANDLE",

--- a/scripts/generate_web_wrappers.py
+++ b/scripts/generate_web_wrappers.py
@@ -692,7 +692,15 @@ WRAPPER_POLICY: dict[int, dict] = {
     # Resource.duplicate is open so Material can re-type the copy.
     222: {"open": True},
     # ResourceLoader.load: hand back the typed variants the corpus spells.
-    7: {"typed_loads": {"Texture2D": "loadTexture2D", "PackedScene": "loadPackedScene", "AudioStream": "loadAudioStream"}},
+    7: {
+        "typed_loads": {
+            "Texture2D": "loadTexture2D",
+            "PackedScene": "loadPackedScene",
+            "AudioStream": "loadAudioStream",
+            # Task 64 parcel 8: tps-demo's Level loads its baked lightmap through ResourceLoader.
+            "LightmapGIData": "loadLightmapGIData",
+        }
+    },
 }
 # Per-class hand-shaped content. `custom` is emitted inside the class body, `companion` inside the
 # companion object, `top_level` after the class (import-compat aliases for custom members, private
@@ -760,10 +768,41 @@ CLASS_POLICY: dict[str, dict] = {
   fun setProcessInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
 
   fun setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
+
+  /**
+   * The window this node lives in. Web has exactly one: the handle-less browser-window mirror in
+   * `WebFacades.kt` (mode and 3D scaling are fixed by the canvas, so those writes stay Kotlin-side).
+   * Desktop's nullable return is kept so shared call sites read the same on both backends.
+   */
+  fun getWindow(): Window? = browserWindow
+
+  /**
+   * Web narrows Godot's Variant-array `propagate_call` to the one form the corpus uses,
+   * `propagate_call("set", [property, bool])` -- opcode 279 carries a typed (StringName, bool)
+   * pair. Any other method, argument shape or `parentFirst` fails loud instead of silently
+   * dropping the sweep.
+   */
+  fun propagateCall(method: String, args: List<Any?> = emptyList(), parentFirst: Boolean = false) {
+    val property = args.getOrNull(0)
+    val value = args.getOrNull(1)
+    if (method == "set" && args.size == 2 && property is String && value is Boolean && !parentFirst) {
+      propagateSet(property, value)
+    } else {
+      unsupportedWebGameplayFamily(
+        "Node.propagate_call('$method', ${args.size} args, parentFirst=$parentFirst)"
+      )
+    }
+  }
 """,
         "top_level": """
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Node.getChildren(includeInternal: Boolean = false): List<Node> = getChildren(includeInternal)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") fun Node.getWindow(): Window? = getWindow()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.propagateCall(method: String, args: List<Any?> = emptyList(), parentFirst: Boolean = false) =
+  propagateCall(method, args, parentFirst)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Node.getPhysicsProcessDeltaTime(): Double = getPhysicsProcessDeltaTime()
@@ -1162,7 +1201,9 @@ fun AnimationMixer.setParameter(path: String, value: Long) = setParameter(path, 
     },
     "InputEventMouseButton": {"from_class_check": True, "enums": ["@GlobalScope.MouseButton"]},
     "InputEventMouseMotion": {"from_class_check": True},
-    "Mesh": {"from_object_checked": True},
+    # Task 64 parcel 8: MeshInstance3D.get_mesh hands back a tracked browser handle; tps-demo's
+    # shared Part reads it once and closes it (`mesh.use { }`), so the wrapper owns a close().
+    "Mesh": {"from_object_checked": True, "release": "tracked"},
     "Material": {
         "from_resource": True,
         "release": "tracked",
@@ -1195,8 +1236,52 @@ fun AnimationMixer.setParameter(path: String, value: Long) = setParameter(path, 
     "DirectionalLight3D": {"enums": ["SkyMode"]},
     "Animation": {"enums": ["LoopMode"]},
     "GridMap": {"constants": ["INVALID_CELL_ITEM"]},
-    "ResourceLoader": {"enums": ["CacheMode"]},
-    "RenderingServer": {"enums": ["ShadowQuality"]},
+    "ResourceLoader": {
+        "enums": ["CacheMode", "ThreadLoadStatus"],
+        "custom": """
+  /** Desktop's `ResourceLoader.ThreadLoadStatus`: the status enum value and the 0..1 progress. */
+  data class ThreadLoadStatus(val status: Long, val progress: Double?)
+
+  /**
+   * Threaded-load family (task 64 parcel 8) over the synchronous facade in `WebFacades.kt`: the
+   * Web export is a `nothreads` build, so a background load could never make progress. The
+   * request loads at once and every later poll reports THREAD_LOAD_LOADED with progress 1.0
+   * (tps-demo's loading screen completes on its first poll). Desktop's signatures; `typeHint`,
+   * `useSubThreads` and `cacheMode` are accepted and ignored; the result is Godot's OK.
+   */
+  fun loadThreadedRequest(
+    path: String,
+    @Suppress("UNUSED_PARAMETER") typeHint: String = "",
+    @Suppress("UNUSED_PARAMETER") useSubThreads: Boolean = false,
+    @Suppress("UNUSED_PARAMETER") cacheMode: Long = CACHE_MODE_REUSE,
+  ): Long {
+    ThreadedLoad.request(path)
+    return 0L
+  }
+
+  fun loadThreadedGetStatus(path: String): Long = ThreadedLoad.status(path)
+
+  fun loadThreadedGetStatusWithProgress(path: String): ThreadLoadStatus {
+    val status = ThreadedLoad.status(path)
+    return ThreadLoadStatus(status, if (status == THREAD_LOAD_LOADED) 1.0 else 0.0)
+  }
+
+  /** The loaded resource (an owned handle: close it, or hand it to the tree). */
+  fun loadThreadedGet(path: String): Resource? = ThreadedLoad.take(path)
+
+  fun loadThreadedGetPackedScene(path: String): PackedScene? = ThreadedLoad.take(path)
+""",
+    },
+    "RenderingServer": {
+        "enums": [
+            "ShadowQuality",
+            # Task 64 parcel 8: tps-demo's Settings / Menu / Level spell the quality tiers by name.
+            "EnvironmentSSAOQuality",
+            "EnvironmentSSILQuality",
+            "VoxelGIQuality",
+            "EnvironmentSDFGIRayCount",
+        ],
+    },
     "Viewport": {"enums": ["Scaling3DMode", "MSAA", "ScreenSpaceAA"]},
     "PhysicsBody3D": {"enums": ["PhysicsServer3D.BodyAxis"]},
     "OS": {
@@ -1457,7 +1542,12 @@ RELEASE_CALLS = {
 
 
 def emit_release(godot_name: str, class_policy: dict) -> list[str]:
-    """`close()` for owning wrappers; `guard` adds the closed flag + receiver guard (use-after-close)."""
+    """`close()` for owning wrappers; `guard` adds the closed flag + receiver guard (use-after-close).
+
+    Owning wrappers declare `AutoCloseable` (see `render_class`), so the stdlib `use { }` resolves on
+    them without an import -- the shared demo sources spell `resource.use { }` on both backends
+    (task 64 parcel 8; the `MultiplayerPeer` facade set the precedent in parcel 7).
+    """
     kind = class_policy.get("release")
     if not kind:
         return []
@@ -1473,7 +1563,7 @@ def emit_release(godot_name: str, class_policy: dict) -> list[str]:
             "  }",
             "",
             "  /** Releases the owned handle; a second close is a no-op, any later call fails loud. */",
-            "  fun close() {",
+            "  override fun close() {",
             "    if (closed) return",
             "    closed = true",
             f"    {release}(handle.value)",
@@ -1481,7 +1571,7 @@ def emit_release(godot_name: str, class_policy: dict) -> list[str]:
         ]
     return [
         "  /** Releases the owned handle (already-released is an error). */",
-        "  fun close() {",
+        "  override fun close() {",
         f"    {release}(handle.value)",
         "  }",
     ]
@@ -1520,7 +1610,8 @@ def render_class(tree: Tree, godot_name: str, calls: list[BackendCallPolicy]) ->
             lines.append("  /** The live backend handle; guarded wrappers (closeable resources) override this. */")
             lines.append("  internal open fun requireOpenHandle(): BackendGodotHandle = backendHandle")
         else:
-            lines.append(f"{open_}class {name}(godotObject: GodotHandle) : {kotlin_class_name(parent)}(godotObject) {{")
+            closeable = ", AutoCloseable" if class_policy.get("release") else ""
+            lines.append(f"{open_}class {name}(godotObject: GodotHandle) : {kotlin_class_name(parent)}(godotObject){closeable} {{")
             lines.append("  internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())")
     sections: list[list[str]] = [m.body for m in members]
     if class_policy.get("custom"):

--- a/scripts/platform_backend_calls.json
+++ b/scripts/platform_backend_calls.json
@@ -5043,6 +5043,188 @@
       "returnOwnership": "RETAINED_REFCOUNTED",
       "semantics": "One-shot SceneTreeTimer (time in seconds; process_always/process_in_physics/ignore_time_scale keep Godot's defaults) as a retained browser handle; its `timeout` signal is awaited through the generic signal path (tps-demo's Level / Part / PartDisappear waits).",
       "introducedBy": "64-parcel7-tps-timer"
+    },
+    {
+      "opcode": 322,
+      "scope": "class",
+      "className": "Environment",
+      "methodName": "set_ssao_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle screen-space ambient occlusion (tps-demo's Settings applies the player's SSAO choice; a no-op on the Compatibility renderer, which has no SSAO -- the call still reaches the engine rather than a Kotlin-side stub).",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 323,
+      "scope": "class",
+      "className": "Environment",
+      "methodName": "set_volumetric_fog_enabled",
+      "hash": 2586408642,
+      "arguments": [
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "BOOL_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Toggle volumetric fog (tps-demo's Settings; a no-op on the Compatibility renderer, which has no volumetric fog -- the call still reaches the engine rather than a Kotlin-side stub).",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 324,
+      "scope": "singleton",
+      "className": "RenderingServer",
+      "methodName": "voxel_gi_set_quality",
+      "hash": 1538689978,
+      "arguments": [
+        "enum::RenderingServer.VoxelGIQuality"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Global VoxelGI quality write (tps-demo's Level GI setup); Compatibility has no VoxelGI, so the engine ignores it there.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 325,
+      "scope": "singleton",
+      "className": "RenderingServer",
+      "methodName": "environment_set_sdfgi_ray_count",
+      "hash": 340137951,
+      "arguments": [
+        "enum::RenderingServer.EnvironmentSDFGIRayCount"
+      ],
+      "returnType": "void",
+      "shape": "LONG_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Global SDFGI ray-count write (tps-demo's Level GI setup); Compatibility has no SDFGI, so the engine ignores it there.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 326,
+      "scope": "singleton",
+      "className": "RenderingServer",
+      "methodName": "environment_set_ssao_quality",
+      "hash": 189753569,
+      "arguments": [
+        "enum::RenderingServer.EnvironmentSSAOQuality",
+        "bool",
+        "float",
+        "int",
+        "float",
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Global SSAO quality tuning (tps-demo's Settings). The six values ride the object-query string channel joined by U+001F; the arm splits them and calls Godot with the full signature. Compatibility has no SSAO, so the engine ignores it there.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 327,
+      "scope": "singleton",
+      "className": "RenderingServer",
+      "methodName": "environment_set_ssil_quality",
+      "hash": 1713836683,
+      "arguments": [
+        "enum::RenderingServer.EnvironmentSSILQuality",
+        "bool",
+        "float",
+        "int",
+        "float",
+        "float"
+      ],
+      "returnType": "void",
+      "shape": "LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Global SSIL quality tuning (tps-demo's Settings), same six-value string payload as environment_set_ssao_quality. Compatibility has no SSIL, so the engine ignores it there.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 328,
+      "scope": "singleton",
+      "className": "RenderingServer",
+      "methodName": "get_current_rendering_driver_name",
+      "hash": 201670096,
+      "arguments": [],
+      "returnType": "String",
+      "shape": "NOARGS_RET_STRING_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the active rendering driver name (opengl3 on the Web export) on the immediate string channel; tps-demo's Settings and Menu branch on \"metal\" for the MetalFX scale filters.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 329,
+      "scope": "singleton",
+      "className": "OS",
+      "methodName": "get_name",
+      "hash": 201670096,
+      "arguments": [],
+      "returnType": "String",
+      "shape": "NOARGS_RET_STRING_SINGLETON",
+      "executionMode": "IMMEDIATE_RESULT",
+      "returnOwnership": "BORROWED",
+      "semantics": "Read the OS name (\"Web\" in a browser) on the immediate string channel; tps-demo's Menu branches on iOS/Android for its mobile lobby defaults.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 330,
+      "scope": "class",
+      "className": "Viewport",
+      "methodName": "set_input_as_handled",
+      "hash": 3218959716,
+      "arguments": [],
+      "returnType": "void",
+      "shape": "NOARGS_VOID",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue marking the current input event handled (tps-demo's Settings consumes toggle_fullscreen); applied at the flush that ends the input callback, so the event stops propagating like it does on desktop.",
+      "introducedBy": "64-parcel8-tps-render-settings"
+    },
+    {
+      "opcode": 331,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "set_position",
+      "hash": 2436320129,
+      "arguments": [
+        "Vector2",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR2_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a Control's offset-anchored position (keep_offsets keeps Godot's default false); tps-demo's SafeArea nudges its UI root inside the display safe area with it.",
+      "introducedBy": "64-parcel8-tps-window"
+    },
+    {
+      "opcode": 332,
+      "scope": "class",
+      "className": "Control",
+      "methodName": "set_size",
+      "hash": 2436320129,
+      "arguments": [
+        "Vector2",
+        "bool"
+      ],
+      "returnType": "void",
+      "shape": "VECTOR2_ARG",
+      "executionMode": "QUEUED_MUTATION",
+      "returnOwnership": "BORROWED",
+      "semantics": "Queue a Control's size (keep_offsets keeps Godot's default false); the SafeArea shrink that follows set_position.",
+      "introducedBy": "64-parcel8-tps-window"
     }
   ],
   "compositions": [

--- a/scripts/web/drivers/demos/web3d.mjs
+++ b/scripts/web/drivers/demos/web3d.mjs
@@ -295,6 +295,27 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
   );
   trace(`nodeLifecycleProbe: mask=${nodeLifecycleProbe}`);
 
+  // Task 64 tps-demo parcel 8 (protocol 28): the render-quality family (322-327) plus the two
+  // immediate string reads (328/329) and the queued Viewport.set_input_as_handled (330).
+  // Runs AFTER generic_probe like the other viewport-wrapping probes. Healthy = 63.
+  const renderSettingsProbe = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("render_settings_probe")}, 0)`,
+    ),
+  );
+  trace(`renderSettingsProbe: mask=${renderSettingsProbe}`);
+
+  // Task 64 tps-demo parcel 8 (protocol 28): Node.get_window as a member, Control.set_position /
+  // set_size (331/332) round-tripped through get_position / get_size, the narrowed
+  // Node.propagate_call, and the now-nullable LONG_OBJECT_ARG slot
+  // (Mesh.surface_set_material(0, null)). Healthy = 31.
+  const windowFamilyProbe = Number(
+    await evaluate(
+      `globalThis.KanamaWebBridge.callInt(globalThis.KanamaWebBridge.web3dMainHandle, ${probeId("window_family_probe")}, 0)`,
+    ),
+  );
+  trace(`windowFamilyProbe: mask=${windowFamilyProbe}`);
+
   // Task 82 coroutine conformance probe. Main.coroutine_probe (method#19) launches ONE coroutine
   // on the script's own scope that awaits both delay shapes gameplay uses -- the wait-one-frame
   // safe point delaySeconds(0.0) and a timed delaySeconds -- then posts to the main thread.
@@ -397,6 +418,13 @@ export async function runWeb3d({ url, evaluate, navigate, deadline, exportDir })
     sceneTreeTimerDelivers: timerMask === 7,
     // Task 64 tps-demo parcel 6: node lifecycle queries (is_inside_tree, is_queued_for_deletion).
     nodeLifecycleDelivers: nodeLifecycleProbe === 15,
+    // Task 64 tps-demo parcel 8: the render-quality family reached the engine (driver name, OS
+    // name, the two Long writes, the two six-value quality writes, the queued Environment
+    // toggles, set_input_as_handled).
+    renderSettingsFamilyDelivers: renderSettingsProbe === 63,
+    // Task 64 tps-demo parcel 8: get_window, Control.set_position / set_size round-trips, the
+    // narrowed propagate_call, and the nullable object slot clearing a mesh surface material.
+    windowFamilyDelivers: windowFamilyProbe === 31,
     // Task 80 slice 4, signal shapes: bit 1 = a ZERO-argument signal reached a Kotlin lambda,
     // bit 2 = a ONE-OBJECT signal delivered a live handle. The scalar shape is dispatch_probe
     // bit 32. The two-argument shape is absent because it CANNOT BE DECLARED: slice 3 makes an

--- a/scripts/web/required_members.json
+++ b/scripts/web/required_members.json
@@ -212,7 +212,15 @@
         {
           "member": "Main.timer_probe_mask",
           "reason": "The task-64 parcel-7 timer probe's read-back the driver asserts to 7."
-        }
+        },
+    {
+      "member": "Main.render_settings_probe",
+      "reason": "The task-64 parcel-8 render-quality conformance probe (RenderingServer driver name / OS name, voxel_gi_set_quality, environment_set_sdfgi_ray_count, the six-value SSAO/SSIL quality writes, the queued Environment toggles and Viewport.set_input_as_handled) the driver calls explicitly and asserts to the full 63 mask."
+    },
+    {
+      "member": "Main.window_family_probe",
+      "reason": "The task-64 parcel-8 window / Control conformance probe (Node.get_window, Control.set_position / set_size round-trips, the narrowed Node.propagate_call, and Mesh.surface_set_material(0, null) on the now-nullable object slot) the driver calls explicitly and asserts to the full 31 mask."
+    }
       ],
       "todo": [
         {

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/WebFacades.kt
@@ -5,6 +5,8 @@ package net.multigesture.kanama.api
 import net.multigesture.kanama.backend.GodotBackendCalls
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
+import net.multigesture.kanama.types.Rect2i
+import net.multigesture.kanama.types.Vector2i
 
 /**
  * Hand-shaped facades for families the browser cannot host or the compatibility renderer ignores
@@ -211,9 +213,11 @@ class Window internal constructor() {
   }
 }
 
-private val browserWindow = Window()
-
-fun Node.getWindow(): Window = browserWindow
+/**
+ * The single browser window. `Node.getWindow()` is a generated member since task 64 parcel 8, and
+ * hands this mirror back, so the shared demo sources call it exactly the way desktop does.
+ */
+internal val browserWindow = Window()
 
 object DisplayServer {
   const val VSYNC_DISABLED = 0L
@@ -227,84 +231,32 @@ object DisplayServer {
   fun windowSetVsyncMode(@Suppress("UNUSED_PARAMETER") mode: Long) = Unit
 
   fun windowGetVsyncMode(): Long = VSYNC_ENABLED
+
+  /**
+   * Structural limit (task 64 parcel 8): a browser page has no OS window to measure and no notch
+   * to route around -- the canvas IS the usable area, and Godot's Web DisplayServer answers the
+   * whole window for both. The one caller in the corpus (tps-demo's `SafeArea`, a mobile
+   * notch/cutout helper) returns early on `OS.hasFeature("web")`, so these are never reached on
+   * Web; they fail loud rather than inventing a rectangle a caller would act on.
+   */
+  fun windowGetSize(@Suppress("UNUSED_PARAMETER") windowId: Int = 0): Vector2i =
+    unsupportedWebGameplayFamily("DisplayServer.window_get_size")
+
+  fun getDisplaySafeArea(): Rect2i = unsupportedWebGameplayFamily("DisplayServer.get_display_safe_area")
 }
-
-/**
- * Renderer settings the compatibility renderer has no equivalent for. They stay inert rather than
- * pretending to apply; the settings menu still records the player's choice in the config file.
- */
-object RenderingServerQuality {
-  const val ENV_SDFGI_RAY_COUNT_32 = 2L
-  const val ENV_SDFGI_RAY_COUNT_96 = 5L
-  const val VOXEL_GI_QUALITY_LOW = 0L
-  const val VOXEL_GI_QUALITY_HIGH = 1L
-  const val ENV_SSAO_QUALITY_MEDIUM = 1L
-  const val ENV_SSAO_QUALITY_HIGH = 2L
-  const val ENV_SSIL_QUALITY_MEDIUM = 1L
-  const val ENV_SSIL_QUALITY_HIGH = 2L
-}
-
-fun RenderingServer.getCurrentRenderingDriverName(): String = "opengl3"
-
-fun RenderingServer.environmentSetSdfgiRayCount(@Suppress("UNUSED_PARAMETER") count: Long) = Unit
-
-fun RenderingServer.voxelGiSetQuality(@Suppress("UNUSED_PARAMETER") quality: Long) = Unit
-
-fun RenderingServer.environmentSetSsaoQuality(
-  @Suppress("UNUSED_PARAMETER") quality: Long,
-  @Suppress("UNUSED_PARAMETER") halfSize: Boolean,
-  @Suppress("UNUSED_PARAMETER") adaptiveTarget: Double,
-  @Suppress("UNUSED_PARAMETER") blurPasses: Int,
-  @Suppress("UNUSED_PARAMETER") fadeOutFrom: Double,
-  @Suppress("UNUSED_PARAMETER") fadeOutTo: Double,
-) = Unit
-
-fun RenderingServer.environmentSetSsilQuality(
-  @Suppress("UNUSED_PARAMETER") quality: Long,
-  @Suppress("UNUSED_PARAMETER") halfSize: Boolean,
-  @Suppress("UNUSED_PARAMETER") adaptiveTarget: Double,
-  @Suppress("UNUSED_PARAMETER") blurPasses: Int,
-  @Suppress("UNUSED_PARAMETER") fadeOutFrom: Double,
-  @Suppress("UNUSED_PARAMETER") fadeOutTo: Double,
-) = Unit
-
-/** The browser canvas owns fullscreen; the demo's own toggle stays inert. */
-fun Viewport.setInputAsHandled() = Unit
-
-/**
- * Screen-space effect toggles the compatibility renderer has no implementation for (SSAO,
- * volumetric fog): these stay inert rather than pretending to apply. `ssilEnabled` and
- * `sdfgiEnabled` are real (queued) members since protocol 24 — the engine ignores them on the
- * Compatibility renderer — so the shared DemoPage compiles; their getters are the setter-only
- * coverage markers of the generated wrapper.
- */
-var Environment.ssaoEnabled: Boolean
-  get() = false
-  set(@Suppress("UNUSED_PARAMETER") value) = Unit
-
-var Environment.volumetricFogEnabled: Boolean
-  get() = false
-  set(@Suppress("UNUSED_PARAMETER") value) = Unit
 
 // ---------------------------------------------------------------------------
 // Resource loading facades.
 // ---------------------------------------------------------------------------
 
-/** Baked lightmap data load (the LightmapGI settings path). */
-fun ResourceLoader.loadLightmapGIData(path: String): LightmapGIData? =
-  load(path, "LightmapGIData")?.let { LightmapGIData(it.handle) }
-
 /**
- * Threaded-load facade. The Web export is a `nothreads` build, so a background load would never
- * make progress: the request loads synchronously and then reports LOADED. The demo's loading
- * screen still runs its normal status/progress path, it just completes on the first poll.
+ * Threaded-load store behind `ResourceLoader.loadThreadedRequest` / `loadThreadedGetStatus…` /
+ * `loadThreadedGet…` (generated members since task 64 parcel 8). The Web export is a `nothreads`
+ * build, so a background load would never make progress: the request loads synchronously and
+ * every later poll reports LOADED. The demo's loading screen still runs its normal status /
+ * progress path, it just completes on the first poll.
  */
-object ThreadedLoad {
-  const val THREAD_LOAD_IN_PROGRESS = 0L
-  const val THREAD_LOAD_FAILED = 1L
-  const val THREAD_LOAD_INVALID_RESOURCE = 2L
-  const val THREAD_LOAD_LOADED = 3L
-
+internal object ThreadedLoad {
   private val loaded = mutableMapOf<String, PackedScene?>()
 
   fun request(path: String) {
@@ -313,27 +265,10 @@ object ThreadedLoad {
 
   fun status(path: String): Long =
     when {
-      !loaded.containsKey(path) -> THREAD_LOAD_IN_PROGRESS
-      loaded[path] == null -> THREAD_LOAD_FAILED
-      else -> THREAD_LOAD_LOADED
+      !loaded.containsKey(path) -> ResourceLoader.THREAD_LOAD_IN_PROGRESS
+      loaded[path] == null -> ResourceLoader.THREAD_LOAD_FAILED
+      else -> ResourceLoader.THREAD_LOAD_LOADED
     }
 
   fun take(path: String): PackedScene? = loaded[path]
 }
-
-class ThreadedLoadStatus internal constructor(val status: Long, val progress: Double?)
-
-fun ResourceLoader.loadThreadedRequest(
-  path: String,
-  @Suppress("UNUSED_PARAMETER") typeHint: String = "",
-  @Suppress("UNUSED_PARAMETER") useSubThreads: Boolean = false,
-) {
-  ThreadedLoad.request(path)
-}
-
-fun ResourceLoader.loadThreadedGetStatusWithProgress(path: String): ThreadedLoadStatus {
-  val status = ThreadedLoad.status(path)
-  return ThreadedLoadStatus(status, if (status == ThreadedLoad.THREAD_LOAD_LOADED) 1.0 else 0.0)
-}
-
-fun ResourceLoader.loadThreadedGetPackedScene(path: String): PackedScene? = ThreadedLoad.take(path)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/AudioStream.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/AudioStream.kt
@@ -6,10 +6,10 @@ package net.multigesture.kanama.api
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class AudioStream(godotObject: GodotHandle) : Resource(godotObject) {
+class AudioStream(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebResource(handle.value)
   }
 }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ButtonGroup.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ButtonGroup.kt
@@ -6,10 +6,10 @@ package net.multigesture.kanama.api
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class ButtonGroup(godotObject: GodotHandle) : Resource(godotObject) {
+class ButtonGroup(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebConstructedObject(handle.value)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ConfigFile.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ConfigFile.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class ConfigFile(godotObject: GodotHandle) : RefCounted(godotObject) {
+class ConfigFile(godotObject: GodotHandle) : RefCounted(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun load(path: String) {
     GodotBackendCalls.invokeStringNameArg(D.CONFIGFILE_LOAD, requireOpenHandle(), path)
@@ -56,7 +56,7 @@ class ConfigFile(godotObject: GodotHandle) : RefCounted(godotObject) {
   }
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebConstructedObject(handle.value)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Control.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Control.kt
@@ -26,6 +26,20 @@ open class Control(godotObject: GodotHandle) : CanvasItem(godotObject) {
     GodotBackendCalls.invokeNoArgsVoid(D.CONTROL_RELEASE_FOCUS, requireOpenHandle())
   }
 
+  fun setPosition(position: Vector2, keepOffsets: Boolean = false) {
+    require(keepOffsets == false) { "Web Control.set_position supports only keepOffsets = false" }
+    GodotBackendCalls.invokeVector2Arg(
+      D.CONTROL_SET_POSITION,
+      requireOpenHandle(),
+      position.toBackend(),
+    )
+  }
+
+  fun setSize(size: Vector2, keepOffsets: Boolean = false) {
+    require(keepOffsets == false) { "Web Control.set_size supports only keepOffsets = false" }
+    GodotBackendCalls.invokeVector2Arg(D.CONTROL_SET_SIZE, requireOpenHandle(), size.toBackend())
+  }
+
   val position: Vector2
     get() = getPosition()
 
@@ -44,6 +58,12 @@ fun Control.getSize(): Vector2 = getSize()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Control.releaseFocus() = releaseFocus()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Control.setPosition(position: Vector2, keepOffsets: Boolean = false) = setPosition(position, keepOffsets)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Control.setSize(size: Vector2, keepOffsets: Boolean = false) = setSize(size, keepOffsets)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Control.position: Vector2

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Environment.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Environment.kt
@@ -30,6 +30,18 @@ class Environment(godotObject: GodotHandle) : Resource(godotObject) {
     GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_SDFGI_ENABLED, requireOpenHandle(), enabled)
   }
 
+  fun setSsaoEnabled(enabled: Boolean) {
+    GodotBackendCalls.invokeBoolArg(D.ENVIRONMENT_SET_SSAO_ENABLED, requireOpenHandle(), enabled)
+  }
+
+  fun setVolumetricFogEnabled(enabled: Boolean) {
+    GodotBackendCalls.invokeBoolArg(
+      D.ENVIRONMENT_SET_VOLUMETRIC_FOG_ENABLED,
+      requireOpenHandle(),
+      enabled,
+    )
+  }
+
   var backgroundEnergyMultiplier: Double
     get() = unsupportedWebGameplayFamily("Environment.get_bg_energy_multiplier")
     set(newValue) = setBgEnergyMultiplier(newValue)
@@ -45,6 +57,14 @@ class Environment(godotObject: GodotHandle) : Resource(godotObject) {
   var sdfgiEnabled: Boolean
     get() = unsupportedWebGameplayFamily("Environment.is_sdfgi_enabled")
     set(newValue) = setSdfgiEnabled(newValue)
+
+  var ssaoEnabled: Boolean
+    get() = unsupportedWebGameplayFamily("Environment.is_ssao_enabled")
+    set(newValue) = setSsaoEnabled(newValue)
+
+  var volumetricFogEnabled: Boolean
+    get() = unsupportedWebGameplayFamily("Environment.is_volumetric_fog_enabled")
+    set(newValue) = setVolumetricFogEnabled(newValue)
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
@@ -58,6 +78,12 @@ fun Environment.setSsilEnabled(enabled: Boolean) = setSsilEnabled(enabled)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Environment.setSdfgiEnabled(enabled: Boolean) = setSdfgiEnabled(enabled)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Environment.setSsaoEnabled(enabled: Boolean) = setSsaoEnabled(enabled)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Environment.setVolumetricFogEnabled(enabled: Boolean) = setVolumetricFogEnabled(enabled)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 var Environment.backgroundEnergyMultiplier: Double
@@ -85,4 +111,18 @@ var Environment.sdfgiEnabled: Boolean
   get() = sdfgiEnabled
   set(newValue) {
     sdfgiEnabled = newValue
+  }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+var Environment.ssaoEnabled: Boolean
+  get() = ssaoEnabled
+  set(newValue) {
+    ssaoEnabled = newValue
+  }
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+var Environment.volumetricFogEnabled: Boolean
+  get() = volumetricFogEnabled
+  set(newValue) {
+    volumetricFogEnabled = newValue
   }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/FastNoiseLite.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/FastNoiseLite.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class FastNoiseLite(godotObject: GodotHandle) : Noise(godotObject) {
+class FastNoiseLite(godotObject: GodotHandle) : Noise(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun setSeed(seed: Int) {
     GodotBackendCalls.invokeLongArg(D.FASTNOISELITE_SET_SEED, requireOpenHandle(), seed.toLong())
@@ -43,7 +43,7 @@ class FastNoiseLite(godotObject: GodotHandle) : Noise(godotObject) {
     set(newValue) = setFractalLacunarity(newValue)
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebConstructedObject(handle.value)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/InputEventKey.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/InputEventKey.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class InputEventKey(godotObject: GodotHandle) : InputEventWithModifiers(godotObject) {
+class InputEventKey(godotObject: GodotHandle) : InputEventWithModifiers(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun setKeycode(keycode: Long) {
     GodotBackendCalls.invokeLongArg(D.INPUTEVENTKEY_SET_KEYCODE, requireOpenHandle(), keycode)
@@ -37,7 +37,7 @@ class InputEventKey(godotObject: GodotHandle) : InputEventWithModifiers(godotObj
     set(newValue) = setPhysicalKeycode(newValue)
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebConstructedObject(handle.value)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/KinematicCollision3D.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/KinematicCollision3D.kt
@@ -9,7 +9,7 @@ import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.types.Vector3
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class KinematicCollision3D(godotObject: GodotHandle) : RefCounted(godotObject) {
+class KinematicCollision3D(godotObject: GodotHandle) : RefCounted(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun getCollider(collisionIndex: Int = 0): GodotObject? {
     require(collisionIndex == 0) { "Web KinematicCollision3D.get_collider supports only collisionIndex = 0" }
@@ -35,7 +35,7 @@ class KinematicCollision3D(godotObject: GodotHandle) : RefCounted(godotObject) {
   }
 
   /** Releases the owned handle; a second close is a no-op, any later call fails loud. */
-  fun close() {
+  override fun close() {
     if (closed) return
     closed = true
     releaseWebCollision(handle.value)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Material.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Material.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-open class Material(godotObject: GodotHandle) : Resource(godotObject) {
+open class Material(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun getNextPass(): Material? =
     GodotBackendCalls.invokeNoArgsRetHandle(
@@ -32,7 +32,7 @@ open class Material(godotObject: GodotHandle) : Resource(godotObject) {
   override fun duplicate(deep: Boolean): Material? = super.duplicate(deep)?.let { Material(it.handle) }
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebTrackedObject(handle.value)
   }
 

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Mesh.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Mesh.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class Mesh(godotObject: GodotHandle) : Resource(godotObject) {
+class Mesh(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun surfaceGetMaterial(surfIdx: Int): Material? =
     GodotBackendCalls.invokeLongRetHandle(
@@ -17,13 +17,18 @@ class Mesh(godotObject: GodotHandle) : Resource(godotObject) {
       surfIdx.toLong(),
     )?.let { Material(it.toWebId()) }
 
-  fun surfaceSetMaterial(surfIdx: Int, material: Material) {
+  fun surfaceSetMaterial(surfIdx: Int, material: Material?) {
     GodotBackendCalls.invokeLongObjectArg(
       D.MESH_SURFACE_SET_MATERIAL,
       requireOpenHandle(),
       surfIdx.toLong(),
-      material.requireOpenHandle(),
+      material?.requireOpenHandle(),
     )
+  }
+
+  /** Releases the owned handle (already-released is an error). */
+  override fun close() {
+    releaseWebTrackedObject(handle.value)
   }
 
   companion object {
@@ -36,4 +41,4 @@ class Mesh(godotObject: GodotHandle) : Resource(godotObject) {
 fun Mesh.surfaceGetMaterial(surfIdx: Int): Material? = surfaceGetMaterial(surfIdx)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-fun Mesh.surfaceSetMaterial(surfIdx: Int, material: Material) = surfaceSetMaterial(surfIdx, material)
+fun Mesh.surfaceSetMaterial(surfIdx: Int, material: Material?) = surfaceSetMaterial(surfIdx, material)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/MeshLibrary.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/MeshLibrary.kt
@@ -9,18 +9,18 @@ import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.types.Transform3D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class MeshLibrary(godotObject: GodotHandle) : Resource(godotObject) {
+class MeshLibrary(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun createItem(id: Int) {
     GodotBackendCalls.invokeLongArg(D.MESHLIBRARY_CREATE_ITEM, requireOpenHandle(), id.toLong())
   }
 
-  fun setItemMesh(id: Int, mesh: Mesh) {
+  fun setItemMesh(id: Int, mesh: Mesh?) {
     GodotBackendCalls.invokeLongObjectArg(
       D.MESHLIBRARY_SET_ITEM_MESH,
       requireOpenHandle(),
       id.toLong(),
-      mesh.requireOpenHandle(),
+      mesh?.requireOpenHandle(),
     )
   }
 
@@ -34,7 +34,7 @@ class MeshLibrary(godotObject: GodotHandle) : Resource(godotObject) {
   }
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebConstructedObject(handle.value)
   }
 
@@ -49,7 +49,7 @@ class MeshLibrary(godotObject: GodotHandle) : Resource(godotObject) {
 fun MeshLibrary.createItem(id: Int) = createItem(id)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-fun MeshLibrary.setItemMesh(id: Int, mesh: Mesh) = setItemMesh(id, mesh)
+fun MeshLibrary.setItemMesh(id: Int, mesh: Mesh?) = setItemMesh(id, mesh)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun MeshLibrary.setItemMeshTransform(id: Int, meshTransform: Transform3D) = setItemMeshTransform(id, meshTransform)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Node.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Node.kt
@@ -177,6 +177,31 @@ open class Node(godotObject: GodotHandle) : GodotObject(godotObject) {
 
   fun setProcessUnhandledInput(@Suppress("UNUSED_PARAMETER") enable: Boolean) = Unit
 
+  /**
+   * The window this node lives in. Web has exactly one: the handle-less browser-window mirror in
+   * `WebFacades.kt` (mode and 3D scaling are fixed by the canvas, so those writes stay Kotlin-side).
+   * Desktop's nullable return is kept so shared call sites read the same on both backends.
+   */
+  fun getWindow(): Window? = browserWindow
+
+  /**
+   * Web narrows Godot's Variant-array `propagate_call` to the one form the corpus uses,
+   * `propagate_call("set", [property, bool])` -- opcode 279 carries a typed (StringName, bool)
+   * pair. Any other method, argument shape or `parentFirst` fails loud instead of silently
+   * dropping the sweep.
+   */
+  fun propagateCall(method: String, args: List<Any?> = emptyList(), parentFirst: Boolean = false) {
+    val property = args.getOrNull(0)
+    val value = args.getOrNull(1)
+    if (method == "set" && args.size == 2 && property is String && value is Boolean && !parentFirst) {
+      propagateSet(property, value)
+    } else {
+      unsupportedWebGameplayFamily(
+        "Node.propagate_call('$method', ${args.size} args, parentFirst=$parentFirst)"
+      )
+    }
+  }
+
   companion object {
     const val PROCESS_MODE_INHERIT: Long = 0L
     const val PROCESS_MODE_PAUSABLE: Long = 1L
@@ -270,6 +295,12 @@ var Node.processMode: Long
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Node.getChildren(includeInternal: Boolean = false): List<Node> = getChildren(includeInternal)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") fun Node.getWindow(): Window? = getWindow()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Node.propagateCall(method: String, args: List<Any?> = emptyList(), parentFirst: Boolean = false) =
+  propagateCall(method, args, parentFirst)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Node.getPhysicsProcessDeltaTime(): Double = getPhysicsProcessDeltaTime()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/OS.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/OS.kt
@@ -18,6 +18,9 @@ object OS {
   fun getStaticMemoryUsage(): Long =
     GodotBackendCalls.invokeNoArgsRetLongSingleton(D.OS_GET_STATIC_MEMORY_USAGE)
 
+  fun getName(): String =
+    GodotBackendCalls.invokeNoArgsRetStringSingleton(D.OS_GET_NAME)
+
   /** Web ships the release template; debug-gated tooling stays off. */
   fun isDebugBuild(): Boolean = false
 }
@@ -30,3 +33,6 @@ fun OS.shellOpen(uri: String) = shellOpen(uri)
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun OS.getStaticMemoryUsage(): Long = getStaticMemoryUsage()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun OS.getName(): String = getName()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/PackedScene.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/PackedScene.kt
@@ -8,7 +8,7 @@ import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InitialGodotCallDescriptors as D
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class PackedScene(godotObject: GodotHandle) : Resource(godotObject) {
+class PackedScene(godotObject: GodotHandle) : Resource(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   fun instantiate(editState: Long = 0L): Node? =
     GodotBackendCalls.invokeLongRetHandle(
@@ -24,7 +24,7 @@ class PackedScene(godotObject: GodotHandle) : Resource(godotObject) {
     )?.let { SceneState(it.toWebId()) }
 
   /** Releases the owned handle (already-released is an error). */
-  fun close() {
+  override fun close() {
     releaseWebResource(handle.value)
   }
 }

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/RenderingServer.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/RenderingServer.kt
@@ -18,6 +18,60 @@ object RenderingServer {
     )
   }
 
+  fun voxelGiSetQuality(quality: Long) {
+    GodotBackendCalls.invokeLongArgSingleton(D.RENDERINGSERVER_VOXEL_GI_SET_QUALITY, quality)
+  }
+
+  fun environmentSetSdfgiRayCount(rayCount: Long) {
+    GodotBackendCalls.invokeLongArgSingleton(
+      D.RENDERINGSERVER_ENVIRONMENT_SET_SDFGI_RAY_COUNT,
+      rayCount,
+    )
+  }
+
+  fun environmentSetSsaoQuality(
+    quality: Long,
+    halfSize: Boolean,
+    adaptiveTarget: Double,
+    blurPasses: Int,
+    fadeoutFrom: Double,
+    fadeoutTo: Double,
+  ) {
+    GodotBackendCalls.invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+      D.RENDERINGSERVER_ENVIRONMENT_SET_SSAO_QUALITY,
+      quality,
+      halfSize,
+      adaptiveTarget,
+      blurPasses.toLong(),
+      fadeoutFrom,
+      fadeoutTo,
+    )
+  }
+
+  fun environmentSetSsilQuality(
+    quality: Long,
+    halfSize: Boolean,
+    adaptiveTarget: Double,
+    blurPasses: Int,
+    fadeoutFrom: Double,
+    fadeoutTo: Double,
+  ) {
+    GodotBackendCalls.invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+      D.RENDERINGSERVER_ENVIRONMENT_SET_SSIL_QUALITY,
+      quality,
+      halfSize,
+      adaptiveTarget,
+      blurPasses.toLong(),
+      fadeoutFrom,
+      fadeoutTo,
+    )
+  }
+
+  fun getCurrentRenderingDriverName(): String =
+    GodotBackendCalls.invokeNoArgsRetStringSingleton(
+      D.RENDERINGSERVER_GET_CURRENT_RENDERING_DRIVER_NAME,
+    )
+
   const val SHADOW_QUALITY_HARD: Long = 0L
   const val SHADOW_QUALITY_SOFT_VERY_LOW: Long = 1L
   const val SHADOW_QUALITY_SOFT_LOW: Long = 2L
@@ -25,6 +79,26 @@ object RenderingServer {
   const val SHADOW_QUALITY_SOFT_HIGH: Long = 4L
   const val SHADOW_QUALITY_SOFT_ULTRA: Long = 5L
   const val SHADOW_QUALITY_MAX: Long = 6L
+  const val ENV_SSAO_QUALITY_VERY_LOW: Long = 0L
+  const val ENV_SSAO_QUALITY_LOW: Long = 1L
+  const val ENV_SSAO_QUALITY_MEDIUM: Long = 2L
+  const val ENV_SSAO_QUALITY_HIGH: Long = 3L
+  const val ENV_SSAO_QUALITY_ULTRA: Long = 4L
+  const val ENV_SSIL_QUALITY_VERY_LOW: Long = 0L
+  const val ENV_SSIL_QUALITY_LOW: Long = 1L
+  const val ENV_SSIL_QUALITY_MEDIUM: Long = 2L
+  const val ENV_SSIL_QUALITY_HIGH: Long = 3L
+  const val ENV_SSIL_QUALITY_ULTRA: Long = 4L
+  const val VOXEL_GI_QUALITY_LOW: Long = 0L
+  const val VOXEL_GI_QUALITY_HIGH: Long = 1L
+  const val ENV_SDFGI_RAY_COUNT_4: Long = 0L
+  const val ENV_SDFGI_RAY_COUNT_8: Long = 1L
+  const val ENV_SDFGI_RAY_COUNT_16: Long = 2L
+  const val ENV_SDFGI_RAY_COUNT_32: Long = 3L
+  const val ENV_SDFGI_RAY_COUNT_64: Long = 4L
+  const val ENV_SDFGI_RAY_COUNT_96: Long = 5L
+  const val ENV_SDFGI_RAY_COUNT_128: Long = 6L
+  const val ENV_SDFGI_RAY_COUNT_MAX: Long = 7L
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
@@ -32,3 +106,32 @@ fun RenderingServer.getCurrentRenderingMethod(): String = getCurrentRenderingMet
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun RenderingServer.directionalSoftShadowFilterSetQuality(quality: Long) = directionalSoftShadowFilterSetQuality(quality)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun RenderingServer.voxelGiSetQuality(quality: Long) = voxelGiSetQuality(quality)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun RenderingServer.environmentSetSdfgiRayCount(rayCount: Long) = environmentSetSdfgiRayCount(rayCount)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun RenderingServer.environmentSetSsaoQuality(
+  quality: Long,
+  halfSize: Boolean,
+  adaptiveTarget: Double,
+  blurPasses: Int,
+  fadeoutFrom: Double,
+  fadeoutTo: Double,
+) = environmentSetSsaoQuality(quality, halfSize, adaptiveTarget, blurPasses, fadeoutFrom, fadeoutTo)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun RenderingServer.environmentSetSsilQuality(
+  quality: Long,
+  halfSize: Boolean,
+  adaptiveTarget: Double,
+  blurPasses: Int,
+  fadeoutFrom: Double,
+  fadeoutTo: Double,
+) = environmentSetSsilQuality(quality, halfSize, adaptiveTarget, blurPasses, fadeoutFrom, fadeoutTo)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun RenderingServer.getCurrentRenderingDriverName(): String = getCurrentRenderingDriverName()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ResourceLoader.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/ResourceLoader.kt
@@ -22,11 +22,49 @@ object ResourceLoader {
 
   fun loadAudioStream(path: String, cacheMode: Long = 1L): AudioStream? = load(path, "AudioStream", cacheMode)?.let { AudioStream(it.handle) }
 
+  fun loadLightmapGIData(path: String, cacheMode: Long = 1L): LightmapGIData? = load(path, "LightmapGIData", cacheMode)?.let { LightmapGIData(it.handle) }
+
+  /** Desktop's `ResourceLoader.ThreadLoadStatus`: the status enum value and the 0..1 progress. */
+  data class ThreadLoadStatus(val status: Long, val progress: Double?)
+
+  /**
+   * Threaded-load family (task 64 parcel 8) over the synchronous facade in `WebFacades.kt`: the
+   * Web export is a `nothreads` build, so a background load could never make progress. The
+   * request loads at once and every later poll reports THREAD_LOAD_LOADED with progress 1.0
+   * (tps-demo's loading screen completes on its first poll). Desktop's signatures; `typeHint`,
+   * `useSubThreads` and `cacheMode` are accepted and ignored; the result is Godot's OK.
+   */
+  fun loadThreadedRequest(
+    path: String,
+    @Suppress("UNUSED_PARAMETER") typeHint: String = "",
+    @Suppress("UNUSED_PARAMETER") useSubThreads: Boolean = false,
+    @Suppress("UNUSED_PARAMETER") cacheMode: Long = CACHE_MODE_REUSE,
+  ): Long {
+    ThreadedLoad.request(path)
+    return 0L
+  }
+
+  fun loadThreadedGetStatus(path: String): Long = ThreadedLoad.status(path)
+
+  fun loadThreadedGetStatusWithProgress(path: String): ThreadLoadStatus {
+    val status = ThreadedLoad.status(path)
+    return ThreadLoadStatus(status, if (status == THREAD_LOAD_LOADED) 1.0 else 0.0)
+  }
+
+  /** The loaded resource (an owned handle: close it, or hand it to the tree). */
+  fun loadThreadedGet(path: String): Resource? = ThreadedLoad.take(path)
+
+  fun loadThreadedGetPackedScene(path: String): PackedScene? = ThreadedLoad.take(path)
+
   const val CACHE_MODE_IGNORE: Long = 0L
   const val CACHE_MODE_REUSE: Long = 1L
   const val CACHE_MODE_REPLACE: Long = 2L
   const val CACHE_MODE_IGNORE_DEEP: Long = 3L
   const val CACHE_MODE_REPLACE_DEEP: Long = 4L
+  const val THREAD_LOAD_INVALID_RESOURCE: Long = 0L
+  const val THREAD_LOAD_IN_PROGRESS: Long = 1L
+  const val THREAD_LOAD_FAILED: Long = 2L
+  const val THREAD_LOAD_LOADED: Long = 3L
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
@@ -40,3 +78,6 @@ fun ResourceLoader.loadPackedScene(path: String, cacheMode: Long = 1L): PackedSc
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun ResourceLoader.loadAudioStream(path: String, cacheMode: Long = 1L): AudioStream? = loadAudioStream(path, cacheMode)
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun ResourceLoader.loadLightmapGIData(path: String, cacheMode: Long = 1L): LightmapGIData? = loadLightmapGIData(path, cacheMode)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Texture2D.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Texture2D.kt
@@ -6,7 +6,7 @@ package net.multigesture.kanama.api
 import net.multigesture.kanama.backend.GodotHandle as BackendGodotHandle
 import net.multigesture.kanama.backend.InternalKanamaBackendApi
 
-class Texture2D(godotObject: GodotHandle) : Texture(godotObject) {
+class Texture2D(godotObject: GodotHandle) : Texture(godotObject), AutoCloseable {
   internal constructor(backendHandle: BackendGodotHandle) : this(backendHandle.toWebId())
   private var closed = false
 
@@ -16,7 +16,7 @@ class Texture2D(godotObject: GodotHandle) : Texture(godotObject) {
   }
 
   /** Releases the owned handle; a second close is a no-op, any later call fails loud. */
-  fun close() {
+  override fun close() {
     if (closed) return
     closed = true
     releaseWebResource(handle.value)

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Viewport.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/api/generated/Viewport.kt
@@ -29,6 +29,10 @@ class Viewport(godotObject: GodotHandle) : Node(godotObject) {
       requireOpenHandle(),
     ).toApi()
 
+  fun setInputAsHandled() {
+    GodotBackendCalls.invokeNoArgsVoid(D.VIEWPORT_SET_INPUT_AS_HANDLED, requireOpenHandle())
+  }
+
   companion object {
     const val SCALING_3D_MODE_BILINEAR: Long = 0L
     const val SCALING_3D_MODE_FSR: Long = 1L
@@ -60,3 +64,6 @@ fun Viewport.getCamera3D(): Camera3D? = getCamera3D()
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun Viewport.getMousePosition(): Vector2 = getMousePosition()
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun Viewport.setInputAsHandled() = setInputAsHandled()

--- a/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
+++ b/web-runtime/src/commonMain/kotlin/net/multigesture/kanama/types/WebValueTypes.kt
@@ -179,6 +179,16 @@ data class Vector2i(val x: Int, val y: Int) {
   }
 }
 
+/** Integer axis-aligned rectangle; mirrors desktop's `Rect2i` (position + size, derived `end`). */
+data class Rect2i(val position: Vector2i, val size: Vector2i) {
+  val end: Vector2i
+    get() = Vector2i(position.x + size.x, position.y + size.y)
+
+  companion object {
+    val ZERO = Rect2i(Vector2i(0, 0), Vector2i(0, 0))
+  }
+}
+
 /** Rotation quaternion backing Basis decomposition and slerp (Godot layout: x, y, z, w). */
 data class Quaternion(val x: Double, val y: Double, val z: Double, val w: Double) {
   fun normalized(): Quaternion {

--- a/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
+++ b/web-runtime/src/wasmJsMain/kotlin/net/multigesture/kanama/web/WebCommonGodotBackend.generated.kt
@@ -120,6 +120,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
           309,
           310,
           315,
+          322,
+          323,
         )
     )
     val objectId = receiver.webId()
@@ -224,6 +226,8 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
       3 -> webWriteVector2Snapshot(objectId, WebVector2Slot.POSITION, value)
       30 -> webWriteVector2Snapshot(objectId, WebVector2Slot.SCALE, value)
       60 -> {}
+      331 -> {}
+      332 -> {}
       else -> error("Unsupported Web Vector2 mutation opcode=${descriptor.opcode}")
     }
   }
@@ -1122,13 +1126,27 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     callSite: GodotCallSite,
   ): String {
     requireOpcode(descriptor, callSite)
-    require(descriptor.executionMode == GodotExecutionMode.SNAPSHOT_READ)
-    require(descriptor.opcode == 85)
-    return webRenderingMethodSnapshot(requireActiveWebScriptHandle())
-      ?: error(
-        "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
-          "active script handle"
-      )
+    require(descriptor.opcode in setOf(85, 328, 329))
+    return when (descriptor.executionMode) {
+      GodotExecutionMode.SNAPSHOT_READ -> {
+        require(descriptor.opcode == 85)
+        webRenderingMethodSnapshot(requireActiveWebScriptHandle())
+          ?: error(
+            "Missing Web ${descriptor.className}.${descriptor.methodName} snapshot for " +
+              "active script handle"
+          )
+      }
+      GodotExecutionMode.IMMEDIATE_RESULT -> {
+        require(descriptor.opcode in setOf(328, 329))
+        commands.flush()
+        immediateWebStringQuery(descriptor.opcode, requireActiveWebScriptHandle(), "")
+      }
+      else ->
+        error(
+          "Unsupported execution mode ${descriptor.executionMode} for " +
+            "${descriptor.className}.${descriptor.methodName}"
+        )
+    }
   }
 
   override fun invokeStringNameArgSingleton(
@@ -1203,10 +1221,33 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
-    require(descriptor.opcode in setOf(116, 126, 269))
+    require(descriptor.opcode in setOf(116, 126, 269, 324, 325))
     require(value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
     commands.flush()
     immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), value.toString())
+  }
+
+  override fun invokeLongBoolDoubleLongDoubleDoubleArgSingleton(
+    descriptor: GodotCallDescriptor,
+    callSite: GodotCallSite,
+    quality: Long,
+    halfSize: Boolean,
+    adaptiveTarget: Double,
+    blurPasses: Long,
+    fadeoutFrom: Double,
+    fadeoutTo: Double,
+  ) {
+    requireOpcode(descriptor, callSite)
+    require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
+    require(descriptor.opcode in setOf(326, 327))
+    require(quality in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(blurPasses in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+    require(adaptiveTarget.isFinite() && fadeoutFrom.isFinite() && fadeoutTo.isFinite())
+    val packed =
+      listOf(quality, halfSize, adaptiveTarget, blurPasses, fadeoutFrom, fadeoutTo)
+        .joinToString("\u001f")
+    commands.flush()
+    immediateWebObjectQuery(descriptor.opcode, requireActiveWebScriptHandle(), packed)
   }
 
   override fun invokeObjectRetHandle(
@@ -1524,20 +1565,21 @@ internal object WebCommonGodotBackend : GodotBackendSpi {
     callSite: GodotCallSite,
     receiver: GodotHandle,
     longValue: Long,
-    objectValue: GodotHandle,
+    objectValue: GodotHandle?,
   ) {
     requireOpcode(descriptor, callSite)
     require(descriptor.executionMode == GodotExecutionMode.IMMEDIATE_RESULT)
     require(descriptor.opcode in setOf(210, 245))
     require(longValue in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
-    requireWebBrowserHandle(objectValue.webId(), WebBrowserHandleKind.OBJECT)
+    objectValue?.let { requireWebBrowserHandle(it.webId(), WebBrowserHandleKind.OBJECT) }
     commands.flush()
-    // Item index and object handle packed into one query string (unit separator).
+    // Item index and object handle packed into one query string (unit separator);
+    // handle id 0 clears the slot.
     check(
       immediateWebObjectQuery(
         descriptor.opcode,
         receiver.webId(),
-        longValue.toString() + "" + objectValue.webId().toString(),
+        longValue.toString() + "" + (objectValue?.webId() ?: 0).toString(),
       ) == 1
     ) {
       "Kanama Web ${descriptor.className}.${descriptor.methodName} was not applied"

--- a/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
+++ b/web-runtime/src/web3dSmoke/web/kotlin-src/Main.kt
@@ -26,6 +26,7 @@ import net.multigesture.kanama.api.KanamaCoroutineOwner
 import net.multigesture.kanama.api.KanamaScope
 import net.multigesture.kanama.api.KanamaScript
 import net.multigesture.kanama.api.MainThread
+import net.multigesture.kanama.api.MeshInstance3D
 import net.multigesture.kanama.api.Node
 import net.multigesture.kanama.api.Node3D
 import net.multigesture.kanama.api.OS
@@ -645,6 +646,129 @@ class Main(godotObject: GodotHandle) :
     return mask
   }
 
+  /**
+   * Task-64 tps-demo parcel 8 render-quality probe (protocol 28). tps-demo's Settings / Menu /
+   * Level write these on every graphics-settings apply; the Compatibility renderer the Web export
+   * uses ignores most of them, so the proof is that the call REACHED THE ENGINE, not that a pixel
+   * changed: 324-327 are immediate queries whose GDScript arm answers 1 only after the engine call
+   * returned, so reaching the next line is the observation (a dropped arm throws
+   * "was not applied").
+   *
+   * Bit 1 = `RenderingServer.get_current_rendering_driver_name` (328) answered a non-empty driver
+   * name on the immediate string channel; bit 2 = `OS.get_name` (329) answered "Web"; bit 4 =
+   * `voxel_gi_set_quality` (324) and `environment_set_sdfgi_ray_count` (325) applied; bit 8 = the
+   * six-value `environment_set_ssao_quality` (326) and `environment_set_ssil_quality` (327) applied
+   * (the U+001F payload split engine-side into Godot's full signature); bit 16 = the scene's
+   * Environment took the queued `set_ssao_enabled` / `set_volumetric_fog_enabled` (322/323), both
+   * restored; bit 32 = the queued `Viewport.set_input_as_handled` (330) was issued. A healthy run
+   * returns 63.
+   *
+   * Runs AFTER `generic_probe` (it wraps the viewport, which TRACKS the root window -- the same
+   * coupling `input_map_probe` and `camera_mode_probe` state).
+   */
+  @RegisterFunction("render_settings_probe")
+  fun renderSettingsProbe(value: Long): Long {
+    var mask = 0L
+    if (RenderingServer.getCurrentRenderingDriverName().isNotEmpty()) mask = mask or 1L
+    if (OS.getName() == "Web") mask = mask or 2L
+
+    RenderingServer.voxelGiSetQuality(RenderingServer.VOXEL_GI_QUALITY_LOW)
+    RenderingServer.environmentSetSdfgiRayCount(RenderingServer.ENV_SDFGI_RAY_COUNT_32)
+    mask = mask or 4L
+
+    RenderingServer.environmentSetSsaoQuality(
+      RenderingServer.ENV_SSAO_QUALITY_MEDIUM,
+      true,
+      0.5,
+      2,
+      50.0,
+      300.0,
+    )
+    RenderingServer.environmentSetSsilQuality(
+      RenderingServer.ENV_SSIL_QUALITY_MEDIUM,
+      false,
+      0.5,
+      2,
+      50.0,
+      300.0,
+    )
+    mask = mask or 8L
+
+    val environment = self.getAsOrNull("Environment", ::WorldEnvironment)?.environment
+    if (environment != null) {
+      environment.ssaoEnabled = true
+      environment.volumetricFogEnabled = true
+      environment.ssaoEnabled = false
+      environment.volumetricFogEnabled = false
+      mask = mask or 16L
+    }
+
+    val viewport = self.getViewport()
+    if (viewport != null) {
+      viewport.setInputAsHandled()
+      mask = mask or 32L
+    }
+    return mask
+  }
+
+  /**
+   * Task-64 tps-demo parcel 8 window / Control probe (protocol 28). Bit 1 = `Node.get_window` is a
+   * member on both backends now and answers the browser-window mirror; bit 2 = `Control.set_position`
+   * (331, queued) round-trips through `Control.get_position` (252, immediate -- it flushes the queue
+   * first), bit 4 = the same for `set_size` (332) / `get_size` (253), both restored afterwards;
+   * bit 8 = `Node.propagate_call("set", [property, bool])` narrowed onto the typed propagate_set
+   * arm without throwing; bit 16 = `Mesh.surface_set_material(0, null)` CLEARED the slot -- the
+   * LONG_OBJECT_ARG object slot became nullable in protocol 28 and a null rides as handle id 0 --
+   * and the original material went back. A healthy run returns 31.
+   *
+   * Runs AFTER `generic_probe`, like the other viewport-wrapping probes.
+   */
+  @RegisterFunction("window_family_probe")
+  fun windowFamilyProbe(value: Long): Long {
+    var mask = 0L
+    if (self.getWindow() != null) mask = mask or 1L
+
+    val probeLabel = self.getAsOrNull("MobileControls/ProbeLabel", ::Control)
+    if (probeLabel != null) {
+      val originalPosition = probeLabel.position
+      val originalSize = probeLabel.size
+      probeLabel.setPosition(PROBE_CONTROL_POSITION)
+      if (
+        abs(probeLabel.position.x - PROBE_CONTROL_POSITION.x) < 1e-3 &&
+          abs(probeLabel.position.y - PROBE_CONTROL_POSITION.y) < 1e-3
+      ) {
+        mask = mask or 2L
+      }
+      probeLabel.setSize(PROBE_CONTROL_SIZE)
+      if (
+        abs(probeLabel.size.x - PROBE_CONTROL_SIZE.x) < 1e-3 &&
+          abs(probeLabel.size.y - PROBE_CONTROL_SIZE.y) < 1e-3
+      ) {
+        mask = mask or 4L
+      }
+      probeLabel.setSize(originalSize)
+      probeLabel.setPosition(originalPosition)
+    }
+
+    self.propagateCall("set", listOf("visible", true))
+    mask = mask or 8L
+
+    val box = self.getAsOrNull("Spinner/Box", ::MeshInstance3D)
+    val boxMesh = box?.mesh
+    if (boxMesh != null) {
+      try {
+        val original = boxMesh.surfaceGetMaterial(0)
+        boxMesh.surfaceSetMaterial(0, null)
+        boxMesh.surfaceSetMaterial(0, original)
+        original?.close()
+        mask = mask or 16L
+      } finally {
+        boxMesh.close()
+      }
+    }
+    return mask
+  }
+
   // ---------- Task 80 slice 2: dispatch-shape conformance probe ----------
   //
   // The shapes slice 2 admitted are exercised HERE, through the real crossing, because a shape
@@ -897,6 +1021,8 @@ class Main(godotObject: GodotHandle) :
   }
 
   private companion object {
+    val PROBE_CONTROL_POSITION = Vector2(23.0, 41.0)
+    val PROBE_CONTROL_SIZE = Vector2(320.0, 64.0)
     const val ENTER_TREE_EXPORTED = "web3d-enter-tree"
     const val PROBE_NUMBER = 12.25
     const val PROBE_TEXT = "kanama-packed-return"

--- a/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
+++ b/web-runtime/src/webSpikeGodot/assets/kanama-web-bridge.js
@@ -9,7 +9,7 @@
   const BROWSER_HANDLE_NAMESPACE = 0x40000000;
   const BROWSER_HANDLE_SLOT_MASK = 0xffff;
   const BROWSER_HANDLE_GENERATION_MASK = 0x3fff;
-  const KANAMA_WEB_PROTOCOL_VERSION = 27;
+  const KANAMA_WEB_PROTOCOL_VERSION = 28;
 
   function commandWordCount(opcode) {
     if (
@@ -22,6 +22,8 @@
       // Task 64 DemoPage set: Control.release_focus, SceneTree.unload_current_scene (no payload).
       opcode === 308 ||
       opcode === 311 ||
+      // Task 64 tps-demo parcel 8: Viewport.set_input_as_handled (no payload).
+      opcode === 330 ||
       opcode === 147 ||
       opcode === 251 ||
       opcode === 283 ||
@@ -71,6 +73,9 @@
     ) return 3;
     if (
       opcode === 3 ||
+      // Task 64 tps-demo parcel 8: Control.set_position / set_size (one Vector2 each).
+      opcode === 331 ||
+      opcode === 332 ||
       opcode === 30 ||
       opcode === 43 ||
       opcode === 48 ||
@@ -81,6 +86,9 @@
       // Task 64 DemoPage set: Environment.set_ssil_enabled / set_sdfgi_enabled (one bool word).
       opcode === 309 ||
       opcode === 310 ||
+      // Task 64 tps-demo parcel 8: Environment.set_ssao_enabled / set_volumetric_fog_enabled.
+      opcode === 322 ||
+      opcode === 323 ||
       // Task 64 CameraMode family: Camera3D.set_current (one bool word), set_fov (one double).
       opcode === 315 ||
       opcode === 316 ||


### PR DESCRIPTION
## What & why

Task 64 (single-source demo scripts), tps-demo parcel 8 — the last one, still option A ("the Web surface grows members"). The parcel-7 measurement listed five convertible tps-demo files; this parcel lands every family they needed, so tps-demo reaches its floor and task 64's measurement closes. RedRobot, PlayerInputSynchronizer and TpsScenes stay overridden by decision (the RID boundary, task 107 filed, not scheduled).

- **Web call contract, protocol 27 → 28.** Eleven opcodes in four families:
  - *Render quality* — `Environment.set_ssao_enabled` (322) and `set_volumetric_fog_enabled` (323) as queued mutations; `RenderingServer.voxel_gi_set_quality` (324) and `environment_set_sdfgi_ray_count` (325) as immediate singleton writes; `environment_set_ssao_quality` (326) / `environment_set_ssil_quality` (327) on a **new `LONG_BOOL_DOUBLE_LONG_DOUBLE_DOUBLE_ARG_SINGLETON` shape** — the six values ride the object-query string channel joined by U+001F and the GDScript arm splits them back into Godot's full signature. The Compatibility renderer the Web export uses ignores most of these, but the call reaches the engine instead of a Kotlin-side stub, which is what the contract asks for.
  - *Immediate string reads* — `RenderingServer.get_current_rendering_driver_name` (328) and `OS.get_name` (329). `NOARGS_RET_STRING_SINGLETON` now carries both the per-script snapshot read (85) and immediate reads, branching on the descriptor's execution mode.
  - *Window / Control* — `Viewport.set_input_as_handled` (330, queued, 2 words) and `Control.set_position` / `set_size` (331/332, queued, 4 words each; the contract declares Godot's full `Vector2, bool` signature and the wrapper keeps `keep_offsets` at Godot's default).
  - *Nullable object slot* — `LONG_OBJECT_ARG` takes `GodotHandle?`, so `Mesh.surface_set_material(i, null)` clears a surface material the way Godot allows. Null rides as handle id 0; the GDScript arm already read 0 as null, and `MeshLibrary.set_item_mesh` now does too.
- **Facades become generated members.** The shared demo sources can spell these exactly as desktop does instead of importing extensions by name: `Node.get_window`, `Node.propagate_call("set", [property, bool])` (narrowed onto the typed `propagate_set` arm — any other method, arity or `parentFirst` fails loud), `ResourceLoader`'s threaded-load family and `loadLightmapGIData`, the `ENV_SSAO_*` / `ENV_SSIL_*` / `VOXEL_GI_*` / `ENV_SDFGI_RAY_COUNT_*` constants (an `enums` policy on `RenderingServer`), `Environment.ssao_enabled` / `volumetric_fog_enabled`, `Viewport.set_input_as_handled`. **Bug found on the way:** the old threaded-load facade had `THREAD_LOAD_IN_PROGRESS` = 0 and `THREAD_LOAD_LOADED` = 3 with `FAILED`/`INVALID_RESOURCE` transposed against Godot's own values; the generated constants come from `extension_api.json`, so that class of drift is now impossible. Owning wrappers declare `AutoCloseable`, so the stdlib `use { }` resolves on `Mesh` / `Material` on both backends (the `MultiplayerPeer` precedent from parcel 7).
- **`<Script>Rpcs` on the Web processor** (processor-only, the parcel-5 `<Script>Methods` precedent). A browser build has a single local peer and no transport, so the helpers apply Godot's own rules for an RPC that stays on the caller: a broadcast or a call addressed to peer 0/1 runs the local leg when `@Rpc(callLocal = true)` says so, a call to yourself without `callLocal` is the engine's "not allowed by selected mode" error, and a remote peer id fails loud — none can exist here. tps-demo's Menu only reaches these on lobby paths a Web build never enters.
- **Left unsupported, loudly:** `DisplayServer.window_get_size` / `get_display_safe_area`. A browser page has no OS window to measure and no notch to route around; their one caller in the corpus (tps-demo's `SafeArea`, a mobile cutout helper) returns early on `OS.hasFeature("web")`, so they fail loud rather than inventing a rectangle a caller would act on. `Rect2i` joins the Web value types for the signature.
- **Evidence:** two new `web3d` fixture probes, both required members with driver assertions placed after `generic_probe` (the viewport-tracking coupling the other probes state): `Main.render_settings_probe` = **63** (driver name non-empty, `OS.get_name` = "Web", 324/325 applied, the two six-value quality writes applied, the queued Environment toggles issued and restored, `set_input_as_handled` issued) and `Main.window_family_probe` = **31** (`get_window` non-null, `set_position`/`set_size` round-tripped through `get_position`/`get_size` and restored, the narrowed `propagate_call`, and `surface_set_material(0, null)` clearing a mesh surface material before putting the original back).
- **Existing Web exports must be rebuilt** (a protocol-27 export refuses to load against a protocol-28 bridge, and vice versa).

Demos side (committed on `single-source-parcel-8-task-64`, PR after this merges with `KANAMA_REF`): Level, Menu, Settings, SafeArea and Part converge — tps-demo overrides **8 → 3**, the corpus **27 → 22**. Only two shared-file edits were needed, both neutral on desktop: Level's reload-smoke marker moves off `java.io.File` onto Godot's `ConfigFile` (the file API both backends share; the marker is a counter the harness only deletes, so its on-disk shape is internal to Level), and SafeArea returns early on `OS.hasFeature("web")` and spells its arithmetic in Double (desktop vectors carry `real_t`, the Web mirrors carry Double). Menu, Settings and Part converged with no source change at all.

**After this parcel tps-demo is at its floor** — three overrides, all by decision: RedRobot, PlayerInputSynchronizer and TpsScenes do ray queries through `get_rid` / `get_world_3d` / `intersect_ray` excluding a body, and RIDs never cross the Web boundary by rule (task 107 designs a ray-query-by-handle shape if it is ever scheduled). Task 64's per-file measurement is closed.

## Checklist

- [x] Ran `scripts/local_ci.sh <godot>` to green — the full gate, not just the in-editor smoke (see `AGENTS.md` → Validation).
- [x] Up to date with the latest `main` (branch protection also enforces this at merge time).
- [x] If this touches ABI / memory-ownership code (`src/main/kotlin/binding/`, `processor/`, retain/release, marshalling), I've called it out below so it gets a careful review.
- [x] Updated docs / CHANGELOG if behavior changed, and bumped any paired constants I touched (see `AGENTS.md` → synchronized invariants).

**Marshalling review points:** (a) the `LONG_OBJECT_ARG` object slot is nullable now — `GodotBackendCalls` only calls `requireLive` when the handle is present, the backend only registers a browser handle when it is present, and a null is encoded as id 0, which both GDScript arms already read as null; nothing frees anything on this path. (b) `Mesh` becomes a `release: "tracked"` owning wrapper, so `MeshInstance3D.get_mesh` hands back a +1 the caller closes — tps-demo's Part already spelled `mesh.use { }` on desktop and now does the same on Web. (c) The six-value quality shape carries only primitives; no handles cross.

## Testing

- `scripts/generate_platform_backend_contract.py` (descriptors) + `:web-runtime:generateWebBackendDispatch` + `generateWebWrappers` regen; `python3 scripts/generate_web_wrappers.py --check` PASS; `ktfmtFormat --rerun-tasks`.
- `:processor:test` + `:kanama-common-api:allTests` — PASS (emitter tests include the new 322/323/326-332 arms and every protocol-28 pin).
- `web3d` on Chrome at protocol 28 — PASS, 39/39 assertions; `render_settings_probe` = **63**, `window_family_probe` = **31**, every earlier probe unchanged (`timer_probe` 7, `coroutine_probe` 31, `camera_mode_probe` 31, `node_lifecycle_probe` 15, `input_map_probe` 255, `dispatch_probe` 127).
- tps-demo Web export from the converged demos branch, Chrome — PASS 12/12 (menu → Play → level → teardown to zero live handles, zero stale-handle rejections), no console errors.
- Desktop side of the converged demos: `:tps-demo-kanama:buildScripts` compiles and the tps reload smoke is green (the new `ConfigFile` marker reads `level_ready_count=2`). Both needed a local workaround for a pre-existing break on demos `main` — see the demos PR.
- `scripts/local_ci.sh /Applications/Godot.app/Contents/MacOS/Godot` — green.
- demos `./gradlew check` (parity audit, replicated properties, runtime node lookup) — PASS.

Falsification on the way: the first regen refused with `opcode 322 has no Web policy entry` (the WIP had added the contract rows but not the generator's per-opcode policy table), and the first generated `Node.kt` failed to parse because the hand-shaped `propagate_call` message lost its escaped quotes through the Python template. The interesting one is Part: `meshInstance?.mesh?.use { it.surfaceSetMaterial(0, null) }` did not compile because the Web `LONG_OBJECT_ARG` slot was non-null — the shape was admitted with a non-null slot when its only caller passed a real mesh, and `Mesh.surface_set_material(i, null)` is exactly how the demo drops the duplicated material it owns. Making the slot nullable is the fix, and the probe's bit 16 is there so a regression cannot pass silently.

## AI assistance

Written with Claude Code (Claude Opus 5); reviewed and gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxxMxPAwCcCaoCC5n88E3
